### PR TITLE
Add basic docs structure to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+build
+
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
+build
+docs
+script
 test

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,6 @@
+= APM Node.js Agent Reference
+
+
+== APM Node.js Agent
+
+Welcome to the APM Node.js agent docs.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "scripts": {
+    "docs": "./script/build_docs.sh apm-agent-nodejs ./docs ./build",
     "lint": "standard",
     "lint-fix": "standard --fix",
     "pretest": "test/pretest.sh",

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+name=$1
+path=$2
+build_dir=$3
+
+docs_dir=$build_dir/docs
+html_dir=$build_dir/html_docs
+
+# Checks if docs clone already exists
+if [ ! -d $docs_dir ]; then
+    # Only head is cloned
+    git clone --depth=1 https://github.com/elastic/docs.git $docs_dir
+else
+    echo "$docs_dir already exists. Not cloning."
+fi
+
+
+index="${path}/index.asciidoc"
+
+echo "Building docs for ${name}..."
+echo "Index document: ${index}"
+
+dest_dir="$html_dir/${name}"
+mkdir -p "$dest_dir"
+params=""
+if [ "$PREVIEW" = "1" ]; then
+  params="--chunk=1 -open chunk=1 -open"
+fi
+$docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"


### PR DESCRIPTION
This is the basic doc structure needed for the elastic docs build. For convenience I added a script that can be executed with `npm run docs` to build the docs locally to see if the doc build passes and how the docs will look like.

As soon as we have Jenkins added as CI we should also add a build step for `npm run docs` to make sure we do not break the doc build.