### PR TITLE
Add simple Elasticsearch instrumentation

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -65,3 +65,6 @@ koa-router:
   peerDependencies: koa@2
   versions: '>=5.2.0 <8'
   commands: node test/instrumentation/modules/koa-router/index.js
+elasticsearch:
+  versions: '>=8.0.0'
+  commands: node test/instrumentation/modules/elasticsearch.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ services:
 - mongodb
 - redis-server
 - postgresql
+- elasticsearch
 
 # There's a bug npm@5 which ships with Node 8 that means we get a currupted
 # install when using the test-all-versions command. For details see:
@@ -20,6 +21,9 @@ services:
 # https://github.com/npm/npm/issues/17212
 before_install:
   - 'if [ "${TRAVIS_NODE_VERSION}" == "8" ]; then npm install -g npm@4; fi'
+
+before_script:
+  - wait-on tcp:9200
 
 node_js:
   - '8'
@@ -55,7 +59,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '8'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
     # Node.js 7
@@ -73,7 +77,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '7'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
     # Node.js 6
@@ -91,7 +95,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '6'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
     # Node.js 5
@@ -109,7 +113,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '5'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
     # Node.js 4
@@ -127,7 +131,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '4'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
     # Node.js 0.12
@@ -145,7 +149,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '0.12'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
     # Node.js 0.10
@@ -163,7 +167,7 @@ jobs:
       script: tav --quiet
     -
       node_js: '0.10'
-      env: TAV=knex,ws,graphql,express-graphql
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
       script: tav --quiet
 
 addons:

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ them on the [Discuss forum](https://discuss.elastic.co/c/apm).
 
 ## Testing
 
-The test suite expects the databases PostgreSQL, MySQL, MongoDB and
-Redis to be present. The `npm test` command will try and start them all
-automatically before running the tests. This should work on OS X if the
-databases are all installed using [Homebrew](http://brew.sh).
+The test suite expects the databases PostgreSQL, MySQL, MongoDB,
+Elasticsearch and Redis to be present. The `npm test` command will try
+and start them all automatically before running the tests. This should
+work on OS X if the databases are all installed using
+[Homebrew](http://brew.sh).
 
 To run the linter without running any tests, run `npm run lint`. To
 automatically fix linting errors run `npm run lint-fix`.

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -8,7 +8,7 @@ var Queue = require('./queue')
 var debug = require('debug')('elastic-apm')
 var request = require('../request')
 
-var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'mysql', 'express', 'hapi', 'redis', 'ioredis', 'bluebird', 'knex', 'koa-router', 'ws', 'graphql', 'express-graphql']
+var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'mysql', 'express', 'hapi', 'redis', 'ioredis', 'bluebird', 'knex', 'koa-router', 'ws', 'graphql', 'express-graphql', 'elasticsearch']
 
 module.exports = Instrumentation
 

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var debug = require('debug')('elastic-apm')
+var shimmer = require('../shimmer')
+
+module.exports = function (elasticsearch, agent, version) {
+  debug('shimming elasticsearch.Transport.prototype.request')
+  shimmer.wrap(elasticsearch.Transport && elasticsearch.Transport.prototype, 'request', wrapRequest)
+
+  return elasticsearch
+
+  function wrapRequest (original) {
+    return function wrappedRequest (params, cb) {
+      var trace = agent.buildTrace()
+      var id = trace && trace.transaction.id
+      var method = params && params.method
+      var path = params && params.path
+      var query = params && params.query
+
+      debug('intercepted call to elasticsearch.Transport.prototype.request %o', {id: id, method: method, path: path})
+
+      if (trace && method && path) {
+        trace.start('Elasticsearch: ' + method + ' ' + path, 'db.elasticsearch.request')
+
+        if (query) trace.setDbContext({statement: JSON.stringify(query), type: 'elasticsearch'})
+
+        if (typeof cb === 'function') {
+          var args = Array.prototype.slice.call(arguments)
+          args[1] = function () {
+            trace.end()
+            return cb.apply(this, arguments)
+          }
+          return original.apply(this, args)
+        } else {
+          var p = original.apply(this, arguments)
+          p.then(function () {
+            trace.end()
+          })
+          return p
+        }
+      } else {
+        debug('could not trace elasticsearch request %o', {id: id})
+        return original.apply(this, arguments)
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "bluebird": "^3.4.6",
     "connect": "^3.6.3",
+    "elasticsearch": "^13.0.0-rc2",
     "express": "^4.14.0",
     "express-graphql": "^0.6.11",
     "generic-pool": "^3.1.5",
@@ -101,6 +102,7 @@
     "tape": "^4.8.0",
     "test-all-versions": "^3.1.0",
     "untildify": "^3.0.2",
+    "wait-on": "^1.5.4",
     "ws": "^3.0.0"
   },
   "greenkeeper": {

--- a/test/instrumentation/modules/elasticsearch.js
+++ b/test/instrumentation/modules/elasticsearch.js
@@ -1,0 +1,110 @@
+'use strict'
+
+process.env.ELASTIC_APM_TEST = true
+
+var agent = require('../../..').start({
+  appName: 'test',
+  secretToken: 'test',
+  captureExceptions: false
+})
+
+// In Node.js v0.10 there's no built-in Promise library
+if (!global.Promise) global.Promise = require('bluebird')
+
+var semver = require('semver')
+var esVersion = require('elasticsearch/package').version
+
+var test = require('tape')
+var elasticsearch = require('elasticsearch')
+
+test('client.ping with callback', function userLandCode (t) {
+  resetAgent(done(t, 'HEAD', '/'))
+
+  agent.startTransaction('foo1')
+
+  var client = new elasticsearch.Client()
+
+  client.ping(function (err) {
+    t.error(err)
+    agent.endTransaction()
+    agent._instrumentation._queue._flush()
+    cleanup(client)
+  })
+})
+
+test('client.ping with promise', function userLandCode (t) {
+  resetAgent(done(t, 'HEAD', '/'))
+
+  agent.startTransaction('foo2')
+
+  var client = new elasticsearch.Client()
+
+  client.ping().then(function () {
+    agent.endTransaction()
+    agent._instrumentation._queue._flush()
+    cleanup(client)
+  }, function (err) {
+    t.error(err)
+    cleanup(client)
+  })
+})
+
+test('client.search with callback', function userLandCode (t) {
+  resetAgent(done(t, 'POST', '/_search', '{"q":"pants"}'))
+
+  agent.startTransaction('foo3')
+
+  var client = new elasticsearch.Client()
+  var query = {q: 'pants'}
+
+  client.search(query, function (err) {
+    t.error(err)
+    agent.endTransaction()
+    agent._instrumentation._queue._flush()
+    cleanup(client)
+  })
+})
+
+function cleanup (client) {
+  // When running Node.js 0.10 together with elasticsearch pre v13, the process
+  // never quits unless the connection to the Elasticsearch database is
+  // manually closed
+  if (semver.satisfies(process.version, '^0.10.0') && semver.satisfies(esVersion, '<13')) {
+    client.close()
+  }
+}
+
+function done (t, method, path, query) {
+  return function (endpoint, headers, data, cb) {
+    t.equal(data.transactions.length, 1)
+
+    var trans = data.transactions[0]
+
+    t.ok(/^foo\d$/.test(trans.name))
+    t.equal(trans.type, 'custom')
+
+    t.equal(trans.traces.length, 2)
+
+    t.equal(trans.traces[0].name, method + ' localhost:9200' + path)
+    t.equal(trans.traces[0].type, 'ext.http.http')
+
+    t.equal(trans.traces[1].name, 'Elasticsearch: ' + method + ' ' + path)
+    t.equal(trans.traces[1].type, 'db.elasticsearch.request')
+    t.ok(trans.traces[1].stacktrace.some(function (frame) {
+      return frame.function === 'userLandCode'
+    }), 'include user-land code frame')
+    t.deepEqual(trans.traces[1].context.db, {statement: query || '{}', type: 'elasticsearch'})
+
+    t.ok(trans.traces[0].start > trans.traces[1].start, 'http trace should start after elasticsearch trace')
+    t.ok(trans.traces[0].start + trans.traces[0].duration < trans.traces[1].start + trans.traces[1].duration, 'http trace should end before elasticsearch trace')
+
+    t.end()
+  }
+}
+
+function resetAgent (cb) {
+  agent._instrumentation._queue._clear()
+  agent._instrumentation.currentTransaction = null
+  agent._httpClient = { request: cb || function () {} }
+  agent.captureError = function (err) { throw err }
+}

--- a/test/posttest.sh
+++ b/test/posttest.sh
@@ -3,6 +3,7 @@
 if [ "$TRAVIS" != "true" ]; then
   killall postgres
   killall mongod
+  kill `cat /tmp/elasticsearch.pid`
   redis-cli shutdown
   mysql.server stop
 fi

--- a/test/pretest.sh
+++ b/test/pretest.sh
@@ -3,6 +3,7 @@
 if [ "$TRAVIS" != "true" ]; then
   postgres -D /usr/local/var/postgres >/tmp/postgres.log 2>&1 &
   mongod --fork --config /usr/local/etc/mongod.conf >/tmp/mongod.log 2>&1
+  elasticsearch -p /tmp/elasticsearch.pid --daemonize && echo 'waiting for elasticsearch to start...' && wait-on tcp:9200
   redis-server /usr/local/etc/redis.conf --daemonize yes
   mysql.server start
 fi


### PR DESCRIPTION
This adds traces for all Elasticsearch queries. The query is logged as well, but for now the index is not logged as that isn't easily available from the Elasticsearch driver.

Example of new Elasticsearch trace:

```js
{
  name: 'Elasticsearch: POST /_search',
  type: 'db.elasticsearch.request',
  start: 2.241679,
  duration: 8.883929,
  stacktrace: [...],
  context: {
    db: { statement: '{"q":"pants"}', type: 'elasticsearch' }
  }
}
```