### PR TITLE
Fix setting of custom flushInterval

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -13,24 +13,27 @@ var MODULES = ['http', 'https', 'generic-pool', 'mongodb-core', 'pg', 'mysql', '
 module.exports = Instrumentation
 
 function Instrumentation (agent) {
-  var self = this
   this._agent = agent
-  this._queue = new Queue({flushInterval: agent._flushInterval}, function (err, transactions) {
-    if (err) {
-      debug('queue returned error: %s', err.message)
-    } else if (self._agent.active && transactions) {
-      request.transactions(self._agent, transactions)
-    }
-  })
+  this._queue = null
+  this._started = false
   this.currentTransaction = null
 }
 
 Instrumentation.prototype.start = function () {
   if (!this._agent.instrument) return
 
-  require('./async-hooks')(this)
-
   var self = this
+  this._started = true
+
+  this._queue = new Queue({flushInterval: this._agent._flushInterval}, function (err, transactions) {
+    if (err) {
+      debug('queue returned error: %s', err.message)
+    } else if (self._agent.active && transactions) {
+      request.transactions(self._agent, transactions)
+    }
+  })
+
+  require('./async-hooks')(this)
 
   debug('shimming Module._load function')
   hook(MODULES, function (exports, name, basedir) {
@@ -54,7 +57,7 @@ Instrumentation.prototype.start = function () {
 }
 
 Instrumentation.prototype.addEndedTransaction = function (transaction) {
-  if (this._agent.instrument) {
+  if (this._started) {
     debug('adding transaction to queue %o', {id: transaction.id})
     this._queue.add(transaction)
   } else {


### PR DESCRIPTION
Previously the queue was initialized prior to the agent configuration being processed. This meant that agent._flushInterval wasn't available. This commit moves the initialization of the queue to a later stage where the agent configuration have already been processed.