### PR TITLE
Handle edge case where flushInterval < 5s

### DIFF
--- a/lib/instrumentation/queue.js
+++ b/lib/instrumentation/queue.js
@@ -16,6 +16,13 @@ function Queue (opts, onFlush) {
   this._sampled = {}
   this._timeout = null
   this._flushInterval = (opts.flushInterval || 60) * 1000
+
+  // The purpose of the boot flush time is to be lower than the normal flush
+  // time in order to get a result quickly when the app first boots. But if a
+  // custom flush interval is provided and it's lower than the boot flush time,
+  // it doesn't make much sense anymore. In that case, just pretend we have
+  // already used the boot flush time.
+  if (this._flushInterval < MAX_FLUSH_DELAY_ON_BOOT) boot = false
 }
 
 Queue.prototype.add = function (transaction) {


### PR DESCRIPTION
The purpose of the boot flush time is to be lower than the normal flush time in order to get a result quickly when the app first boots. But if a custom flush interval is provided and it's lower than the boot flush time, it doesn't make much sense anymore. In that case, just pretend we have already used the boot flush time.