### PR TITLE
Only truncate config options once

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,6 +5,8 @@ var fs = require('fs')
 var path = require('path')
 var objectAssign = require('object-assign')
 var bool = require('normalize-bool')
+var trunc = require('unicode-byte-truncate')
+var request = require('./request')
 
 module.exports = config
 
@@ -76,6 +78,7 @@ function config (opts) {
 
   normalizeIgnoreOptions(opts)
   normalizeBools(opts)
+  truncate(opts)
 
   return opts
 }
@@ -118,4 +121,10 @@ function normalizeBools (opts) {
   BOOL_OPTS.forEach(function (key) {
     if (key in opts) opts[key] = bool(opts[key])
   })
+}
+
+function truncate (opts) {
+  if (opts.appVersion) opts.appVersion = trunc(String(opts.appVersion), request._ES_KEYWORD_MAX_SIZE)
+  if (opts.appGitRef) opts.appGitRef = trunc(String(opts.appGitRef), request._ES_KEYWORD_MAX_SIZE)
+  if (opts.hostname) opts.hostname = trunc(String(opts.hostname), request._ES_KEYWORD_MAX_SIZE)
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,7 +8,6 @@ var trunc = require('unicode-byte-truncate')
 var logger = require('./logger')
 
 var AGENT_VERSION = require('../package').version
-var OS_HOSTNAME = os.hostname()
 var ES_KEYWORD_MAX_SIZE = 1024
 var noop = function () {}
 
@@ -213,19 +212,14 @@ function envelope (agent) {
       }
     },
     system: {
-      hostname: trunc(String(OS_HOSTNAME), ES_KEYWORD_MAX_SIZE),
+      hostname: agent.hostname,
       architecture: trunc(String(process.arch), ES_KEYWORD_MAX_SIZE),
       platform: trunc(String(process.platform), ES_KEYWORD_MAX_SIZE)
     }
   }
 
-  if (agent.appVersion) {
-    payload.app.version = trunc(String(agent.appVersion), ES_KEYWORD_MAX_SIZE)
-  }
-
-  if (agent.appGitRef) {
-    payload.app.git_ref = trunc(String(agent.appGitRef), ES_KEYWORD_MAX_SIZE)
-  }
+  if (agent.appVersion) payload.app.version = agent.appVersion
+  if (agent.appGitRef) payload.app.git_ref = agent.appGitRef
 
   if (agent._platform.framework) {
     payload.app.framework = {


### PR DESCRIPTION
Previously these options were truncated for every request to the intake API. Now they are only truncated once the agent is started.