### PR TITLE
Remove appGitRef config option

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -60,7 +60,6 @@ Agent.prototype._config = function (opts) {
   this.secretToken = opts.secretToken
   this.serverUrl = opts.serverUrl
   this.appVersion = opts.appVersion
-  this.appGitRef = opts.appGitRef
   this.active = opts.active
   this.logLevel = opts.logLevel
   this.hostname = opts.hostname

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,7 +41,6 @@ var ENV_TABLE = {
   secretToken: 'ELASTIC_APM_SECRET_TOKEN',
   serverUrl: 'ELASTIC_APM_SERVER_URL',
   appVersion: 'ELASTIC_APM_APP_VERSION',
-  appGitRef: 'ELASTIC_APM_APP_GIT_REF',
   active: 'ELASTIC_APM_ACTIVE',
   logLevel: 'ELASTIC_APM_LOG_LEVEL',
   hostname: 'ELASTIC_APM_HOSTNAME',
@@ -126,6 +125,5 @@ function normalizeBools (opts) {
 
 function truncate (opts) {
   if (opts.appVersion) opts.appVersion = trunc(String(opts.appVersion), config.INTAKE_STRING_MAX_SIZE)
-  if (opts.appGitRef) opts.appGitRef = trunc(String(opts.appGitRef), config.INTAKE_STRING_MAX_SIZE)
   if (opts.hostname) opts.hostname = trunc(String(opts.hostname), config.INTAKE_STRING_MAX_SIZE)
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -218,7 +218,6 @@ function envelope (agent) {
   }
 
   if (agent.appVersion) payload.app.version = agent.appVersion
-  if (agent.appGitRef) payload.app.git_ref = agent.appGitRef
 
   if (agent._platform.framework) {
     payload.app.framework = {

--- a/test/agent.js
+++ b/test/agent.js
@@ -21,7 +21,6 @@ var optionFixtures = [
   ['appName', 'APP_NAME'],
   ['secretToken', 'SECRET_TOKEN'],
   ['appVersion', 'APP_VERSION'],
-  ['appGitRef', 'APP_GIT_REF'],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME', os.hostname()],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', Infinity],

--- a/test/request.js
+++ b/test/request.js
@@ -14,7 +14,6 @@ var opts = {
   appName: 'some-app-name',
   secretToken: 'secret',
   appVersion: 'my-app-version',
-  appGitRef: 'my-git-ref',
   captureExceptions: false,
   logLevel: 'error'
 }
@@ -198,7 +197,6 @@ function assertRoot (t, payload) {
   t.deepEqual(payload.app.runtime, {name: 'node', version: process.version})
   t.deepEqual(payload.app.agent, {name: 'nodejs', version: agentVersion})
   t.equal(payload.app.version, 'my-app-version')
-  t.equal(payload.app.git_ref, 'my-git-ref')
   t.deepEqual(payload.system, {
     hostname: os.hostname(),
     architecture: process.arch,


### PR DESCRIPTION
It's been decided by the Elastic APM project to no longer support logging of a git reference. Instead it's recommend to use the appVersion config option.