### PR TITLE
Don't kill all databases after testing

### DIFF
--- a/test/posttest.sh
+++ b/test/posttest.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [[ "$CI" != "true" ]]; then
-  killall postgres
-  killall mongod
+  pg_ctl -D /usr/local/var/postgres stop
+  kill `cat /tmp/mongod.pid`
   kill `cat /tmp/elasticsearch.pid`
   redis-cli shutdown
   mysql.server stop

--- a/test/pretest.sh
+++ b/test/pretest.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [[ "$CI" != "true" ]]; then
-  postgres -D /usr/local/var/postgres >/tmp/postgres.log 2>&1 &
-  mongod --fork --config /usr/local/etc/mongod.conf >/tmp/mongod.log 2>&1
+  pg_ctl -D /usr/local/var/postgres start
+  mongod --fork --config /usr/local/etc/mongod.conf --pidfilepath /tmp/mongod.pid >/tmp/mongod.log 2>&1
   elasticsearch -p /tmp/elasticsearch.pid --daemonize && echo 'waiting for elasticsearch to start...' && wait-on tcp:9200
   redis-server /usr/local/etc/redis.conf --daemonize yes
   mysql.server start


### PR DESCRIPTION
Be smarter about stopping database after local testing.  

For MongoDB we can use a pid file and for PostgreSQL we instead use the `pg_ctl` command to control the database as a daemon.