### PR TITLE
Support parsing http requests with full URI's

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -103,7 +103,10 @@ exports.getContextFromRequest = function (req, logBody) {
     headers: objectAssign({}, req.headers)
   }
 
-  if ('host' in req.headers) context.url.hostname = req.headers.host
+  if (url.protocol) context.url.protocol = url.protocol
+  if (url.hostname) context.url.hostname = url.hostname
+  else if ('host' in req.headers) context.url.hostname = req.headers.host
+  if (url.port) context.url.port = url.port
 
   var contentLength = parseInt(req.headers['content-length'], 10)
   var transferEncoding = req.headers['transfer-encoding']

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -157,6 +157,20 @@ test('#getContextFromRequest()', function (t) {
     t.end()
   })
 
+  t.test('full URI', function (t) {
+    mockReq.url = 'https://www.example.com:8080/some/path?key=value'
+    var parsed = parsers.getContextFromRequest(mockReq)
+    t.deepEqual(parsed.url, {
+      pathname: '/some/path',
+      search: '?key=value',
+      raw: 'https://www.example.com:8080/some/path?key=value',
+      protocol: 'https:',
+      hostname: 'www.example.com',
+      port: '8080'
+    })
+    t.end()
+  })
+
   t.test('empty query string', function (t) {
     mockReq.url = '/some/path?'
     var parsed = parsers.getContextFromRequest(mockReq)


### PR DESCRIPTION
Normally HTTP requests start with a line like this:

    GET /foo HTTP/1.1

But it is actually allowed to include both protocol and domain name in this line, eg:

    GET https://example.com:8080/foo HTTP/1.1

This commit adds support for extracing these extra bits of information in case they are provided.

For more information about these type of requests, see section 5.1.2 in RFC 2616: https://tools.ietf.org/html/rfc2616#section-5.1.2