### PR TITLE
Add validateServerCert config option

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -90,6 +90,17 @@ The secret token optionally expected by the APM Server.
 
 The URL to where the APM Server is deployed.
 
+[[validate-server-cert]]
+===== `validateServerCert`
+
+* *Type:* Boolean
+* *Default:* `true`
+* *Env:* `ELASTIC_APM_VALIDATE_SERVER_CERT`
+
+By default the agent will validate the TLS/SSL certificate of the APM Server if using HTTPS.
+You can switch this behavior off by setting this option to `false`.
+Disabling validation is normally required if using self-signed certificates.
+
 [[app-version]]
 ===== `appVersion`
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -59,6 +59,7 @@ Agent.prototype._config = function (opts) {
   this.appName = opts.appName
   this.secretToken = opts.secretToken
   this.serverUrl = opts.serverUrl
+  this.validateServerCert = opts.validateServerCert
   this.appVersion = opts.appVersion
   this.active = opts.active
   this.logLevel = opts.logLevel
@@ -111,7 +112,8 @@ Agent.prototype.start = function (opts) {
   this._httpClient = new ElasticAPMHttpClient({
     secretToken: this.secretToken,
     userAgent: userAgent,
-    serverUrl: this.serverUrl
+    serverUrl: this.serverUrl,
+    rejectUnauthorized: this.validateServerCert
   })
 
   Error.stackTraceLimit = this.stackTraceLimit

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,7 @@ if (fs.existsSync(confPath)) {
 }
 
 var DEFAULTS = {
+  validateServerCert: true,
   active: true,
   logLevel: 'info',
   hostname: os.hostname(),
@@ -40,6 +41,7 @@ var ENV_TABLE = {
   appName: 'ELASTIC_APM_APP_NAME',
   secretToken: 'ELASTIC_APM_SECRET_TOKEN',
   serverUrl: 'ELASTIC_APM_SERVER_URL',
+  validateServerCert: 'ELASTIC_APM_VALIDATE_SERVER_CERT',
   appVersion: 'ELASTIC_APM_APP_VERSION',
   active: 'ELASTIC_APM_ACTIVE',
   logLevel: 'ELASTIC_APM_LOG_LEVEL',
@@ -57,6 +59,7 @@ var ENV_TABLE = {
 }
 
 var BOOL_OPTS = [
+  'validateServerCert',
   'active',
   'captureExceptions',
   'filterHttpHeaders',

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "cookie": "^0.3.1",
     "core-util-is": "^1.0.2",
     "debug": "^3.0.0",
-    "elastic-apm-http-client": "^4.0.0",
+    "elastic-apm-http-client": "^4.1.0",
     "end-of-stream": "^1.1.0",
     "fast-safe-stringify": "^1.1.3",
     "http-headers": "^3.0.1",
@@ -82,6 +82,7 @@
     "express": "^4.14.0",
     "express-graphql": "^0.6.11",
     "generic-pool": "^3.1.5",
+    "get-port": "^2.1.0",
     "graphql": "^0.11.2",
     "hapi": "^16.5.2",
     "inquirer": "^0.12.0",
@@ -107,6 +108,7 @@
   },
   "greenkeeper": {
     "ignore": [
+      "get-port",
       "inquirer",
       "restify"
     ]

--- a/test/integration/abort-on-invalid-cert.js
+++ b/test/integration/abort-on-invalid-cert.js
@@ -1,0 +1,34 @@
+'use strict'
+
+var getPort = require('get-port')
+
+getPort().then(function (port) {
+  var agent = require('../../').start({
+    appName: 'test',
+    serverUrl: 'https://localhost:' + port
+  })
+
+  var https = require('https')
+  var pem = require('https-pem')
+  var test = require('tape')
+
+  test('should not allow self signed certificate', function (t) {
+    t.plan(1)
+
+    var server = https.createServer(pem, function (req, res) {
+      // Gotcha: there's no way to know if the agent failed except setting
+      // `logLevel < error` and looking at stderr, which is a bit cumbersome.
+      // This is easier.
+      t.fail('should not reach this point')
+    })
+
+    server.listen(port, function () {
+      agent.captureError(new Error('boom!'), function () {
+        server.close()
+        t.pass('agent.captureError callback called')
+      })
+    })
+  })
+}, function (err) {
+  throw err
+})

--- a/test/integration/allow-invalid-cert.js
+++ b/test/integration/allow-invalid-cert.js
@@ -1,0 +1,33 @@
+'use strict'
+
+var getPort = require('get-port')
+
+getPort().then(function (port) {
+  var agent = require('../../').start({
+    appName: 'test',
+    serverUrl: 'https://localhost:' + port,
+    validateServerCert: false
+  })
+
+  var https = require('https')
+  var pem = require('https-pem')
+  var test = require('tape')
+
+  test('should allow self signed certificate', function (t) {
+    t.plan(2)
+
+    var server = https.createServer(pem, function (req, res) {
+      t.pass('server received client request')
+      res.end()
+    })
+
+    server.listen(port, function () {
+      agent.captureError(new Error('boom!'), function () {
+        server.close()
+        t.pass('agent.captureError callback called')
+      })
+    })
+  })
+}, function (err) {
+  throw err
+})

--- a/test/test.sh
+++ b/test/test.sh
@@ -25,6 +25,11 @@ for file in $(files test/!(_*).js); do
   node "$file" || exit $?;
 done
 
+for file in $(files test/integration/!(_*).js); do
+  echo "running: node $file"
+  node "$file" || exit $?;
+done
+
 for file in $(files test/sourcemaps/!(_*).js); do
   echo "running: node $file"
   node "$file" || exit $?;


### PR DESCRIPTION
By default the agent will validate the SSL/TLS certificates used by the APM Server (if running on HTTPS). This validation can now be turned off by setting the `validateServerCert` option to `false`. This is particularly useful if the APM Server is using self-signed certificates.