### PR TITLE
Split up API reference into 3 separate pages

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -1,4 +1,3 @@
-[float]
 [[agent-api]]
 === `Agent` API
 
@@ -23,7 +22,6 @@ If you need to access the `Agent` in any part of your codebase,
 you can simply require `elastic-apm` to access the already started singleton.
 You therefore don't need to manage or pass around the started `Agent` yourself.
 
-[float]
 [[apm-start]]
 ==== `apm.start()`
 
@@ -66,7 +64,6 @@ require('elastic-apm').start({
 })
 ----
 
-[float]
 [[app-name]]
 ===== `appName`
 
@@ -76,7 +73,6 @@ require('elastic-apm').start({
 Your Elastic APM app name.
 Required unless set <<configuring-the-agent,via other means>>.
 
-[float]
 [[secret-token]]
 ===== `secretToken`
 
@@ -85,7 +81,6 @@ Required unless set <<configuring-the-agent,via other means>>.
 
 The secret token optionally expected by the APM Server.
 
-[float]
 [[server-url]]
 ===== `serverUrl`
 
@@ -95,7 +90,6 @@ The secret token optionally expected by the APM Server.
 
 The URL to where the APM Server is deployed.
 
-[float]
 [[app-version]]
 ===== `appVersion`
 
@@ -107,7 +101,6 @@ This could be the version from your `package.json` file,
 a git commit reference,
 or any other string that might help you pinpoint a specific version or deployment.
 
-[float]
 [[active]]
 ===== `active`
 
@@ -129,7 +122,6 @@ var options = {
 }
 ----
 
-[float]
 [[instrument]]
 ===== `instrument`
 
@@ -141,7 +133,6 @@ A boolean specifying if the agent should collect performance metrics for the app
 
 Note that both `active` and `instrument` needs to be `true` for instrumentation to be running.
 
-[float]
 [[ignore-urls]]
 ===== `ignoreUrls`
 
@@ -171,7 +162,6 @@ require('elastic-apm').start({
 })
 ----
 
-[float]
 [[ignore-user-agents]]
 ===== `ignoreUserAgents`
 
@@ -201,7 +191,6 @@ require('elastic-apm').start({
 })
 ----
 
-[float]
 [[log-body]]
 ===== `logBody`
 
@@ -213,7 +202,6 @@ The HTTP body of incoming HTTP requests is not recorded and sent to the APM Serv
 If you wish to collect the HTTP request body,
 set this config option to `true`.
 
-[float]
 [[timeout]]
 ===== `timeout`
 
@@ -224,7 +212,6 @@ set this config option to `true`.
 A boolean specifying if the agent should monitor for aborted TCP connections with un-ended HTTP requests.
 An error will be generated and sent to the APM Server if this happens.
 
-[float]
 [[timeout-error-threshold]]
 ===== `timeoutErrorThreshold`
 
@@ -236,7 +223,6 @@ Specify the threshold (in milliseconds) for when an aborted TCP connection with 
 
 If the `timeout` property is `false`, this property is ignored.
 
-[float]
 [[hostname]]
 ===== `hostname`
 
@@ -248,7 +234,6 @@ The OS hostname is automatically logged along with all errors and transactions.
 If you want to overwrite this,
 use this option.
 
-[float]
 [[log-level]]
 ===== `logLevel`
 
@@ -262,7 +247,6 @@ This only controls how chatty the agent is in your logs.
 
 Possible levels are: `trace`, `debug`, `info`, `warn`, `error`, and `fatal`.
 
-[float]
 [[logger]]
 ===== `logger`
 
@@ -284,7 +268,6 @@ The logger should expose the following functions: `trace`, `debug`,`info`, `warn
 
 Note that if a custom logger is provided, the `logLevel` option will be ignored.
 
-[float]
 [[capture-exceptions]]
 ===== `captureExceptions`
 
@@ -294,7 +277,6 @@ Note that if a custom logger is provided, the `logLevel` option will be ignored.
 
 Whether or not the agent should monitor for uncaught exceptions and send them to the APM Server automatically.
 
-[float]
 [[capture-trace-stack-traces]]
 ===== `captureTraceStackTraces`
 
@@ -304,7 +286,6 @@ Whether or not the agent should monitor for uncaught exceptions and send them to
 
 Set this option to `false` to disable capture of stack traces for measured traces during instrumentation.
 
-[float]
 [[stack-trace-limit]]
 ===== `stackTraceLimit`
 
@@ -316,7 +297,6 @@ Setting it to `0` will disable stack trace collection.
 Any finite integer value will be used as the maximum number of frames to collect.
 Setting it to `Infinity` means that all frames will be collected.
 
-[float]
 [[flush-interval]]
 ===== `flushInterval`
 
@@ -337,7 +317,6 @@ NOTE: The queue is flushed only 5 seconds after the first transaction has ended 
 This ensures that you don't have to wait for the entire `flushInterval` to pass for the first data to be sent to the APM Server.
 From there on the `flushInterval` option is used.
 
-[float]
 [[filter-http-headers]]
 ===== `filterHttpHeaders`
 
@@ -356,7 +335,6 @@ Currently the following HTTP headers are anonymized by default:
 * `Cookie` - The cookies inside the `Cookie` header are analyzed and their values redacted if they appear sensitive (like a session cookie).
 See the https://github.com/watson/is-secret[is-secret] module for details about which patterns are considered sensitive.
 
-[float]
 [[apm-add-filter]]
 ==== `apm.addFilter()`
 
@@ -403,7 +381,6 @@ See <<filter-http-headers,`filterHttpHeaders`>> for details.
 Though you can also use filter functions to add new contextual information to the `user` and `custom` properties,
 it's recommended that you use <<apm-set-user-context,`apm.setUserContext()`>> and <<apm-set-custom-context,`apm.setCustomContext()`>> for that purpose.
 
-[float]
 [[apm-set-user-context]]
 ==== `apm.setUserContext()`
 
@@ -435,7 +412,6 @@ and any custom context given as the 2nd argument to <<apm-capture-error,`apm.cap
 
 The provided user context is stored under `context.user` in Elasticsearch on both errors and transactions.
 
-[float]
 [[apm-set-custom-context]]
 ==== `apm.setCustomContext()`
 
@@ -463,7 +439,6 @@ If an error is captured,
 the context from the active transaction is used as context for the captured error,
 and any custom context given as the 2nd argument to <<apm-capture-error,`apm.captureError`>> takes precedence and is shallow merged on top.
 
-[float]
 [[apm-set-tag]]
 ==== `apm.setTag()`
 
@@ -487,7 +462,6 @@ Must not contain periods (`.`) as those have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-[float]
 [[apm-capture-error]]
 ==== `apm.captureError()`
 
@@ -511,7 +485,6 @@ For details see the <<metadata,metadata section>>.
 
 The optional `callback` will be called after the error has been sent to the APM Server.
 
-[float]
 [[message-strings]]
 ===== Message strings
 
@@ -526,7 +499,6 @@ apm.captureError('Something happened!')
 This will also be sent as an error to the APM Server,
 but will not be associated with an exception.
 
-[float]
 [[metadata]]
 ===== Metadata
 
@@ -563,7 +535,6 @@ apm.captureError(error, {
 To supply per-request metadata to all errors captured in one central location,
 use <<apm-set-user-context,`apm.setUserContext()`>> and <<apm-set-custom-context,`apm.setCustomContext()`>>.
 
-[float]
 [[http-requests]]
 ===== HTTP requests
 
@@ -585,7 +556,6 @@ In most cases this isn't needed though,
 as the agent is pretty smart at figuring out if your Node.js app is an HTTP server and if an error occurred during an incoming request.
 In which case it will automate this processes for you.
 
-[float]
 [[http-responses]]
 ===== HTTP responses
 
@@ -606,7 +576,6 @@ In most cases this isn't needed though,
 as the agent is pretty smart at figuring out if your Node.js app is an HTTP server and if an error occurred during an incoming request.
 In which case it will automate this processes for you.
 
-[float]
 [[apm-middleware-connect]]
 ==== `apm.middleware.connect()`
 
@@ -647,7 +616,6 @@ app.listen(3000)
 
 NOTE: `apm.middleware.express` or `apm.middleware.connect` _must_ be added to the middleware stack _before_ any other error handling middleware functions or there's a chance that the error will never get to the agent.
 
-[float]
 [[apm-start-transaction]]
 ==== `apm.startTransaction()`
 
@@ -676,7 +644,6 @@ There's a special `type` called `request` which is used by the agent for the tra
 
 See the <<transaction-api,Transaction API>> docs for details on how to use custom transactions.
 
-[float]
 [[apm-end-transaction]]
 ==== `apm.endTransaction()`
 
@@ -694,7 +661,6 @@ You only need to use this function to end custom transactions created by <<apm-s
 
 Alternatively you can call <<transaction-end,`end()`>> directly on an active transaction object.
 
-[float]
 [[apm-set-transaction-name]]
 ==== `apm.setTransactionName()`
 
@@ -713,7 +679,6 @@ the transaction name will default to `METHOD unknown route` (e.g. `POST unknown 
 
 Read more about naming routes manually in the <<custom-stack-route-naming,Get started with a custom Node.js stack>> article.
 
-[float]
 [[apm-build-trace]]
 ==== `apm.buildTrace()`
 
@@ -729,7 +694,6 @@ See <<trace-api,Trace API>> docs for details on how to use custom traces.
 NOTE: If there's no active transaction available,
 `null` will be returned.
 
-[float]
 [[apm-handle-uncaught-exceptions]]
 ==== `apm.handleUncaughtExceptions()`
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -1,6 +1,18 @@
 [[api]]
 == API Reference
 
+The API reference documentation is divided into three parts:
+
+* <<agent-api,The `Agent` API>> - All functions and properties on the `Agent` object.
+An instance of the `Agent` object is acquired by requiring/importing the Node.js APM Agent module.
+The `Agent` is a singleton and the instance is usually referred by the variable `apm` in this documentation
+
+* <<transaction-api,The `Transaction` API>> - All functions and properties on the `Transaction` object.
+An instance of the `Transaction` object is acquired by calling `apm.startTransaction()`
+
+* <<trace-api,The `Trace` API>> - All functions and properties on the `Trace` object.
+An instance of the `Trace` object is acquired by calling `apm.buildTrace()`
+
 include::./agent-api.asciidoc[Agent API documentation]
 
 include::./transaction-api.asciidoc[Transaction API documentation]

--- a/docs/trace-api.asciidoc
+++ b/docs/trace-api.asciidoc
@@ -1,4 +1,3 @@
-[float]
 [[trace-api]]
 === `Trace` API
 
@@ -10,7 +9,6 @@ you need to call <<apm-build-trace,`apm.buildTrace()`>>.
 To see an example of using custom traces,
 see the <<custom-traces,Custom Traces in Node.js>> article.
 
-[float]
 [[trace-transaction]]
 ==== `trace.transaction`
 
@@ -20,7 +18,6 @@ A reference to the parent transaction object.
 
 All traces belongs to a transaction.
 
-[float]
 [[trace-name]]
 ==== `trace.name`
 
@@ -30,7 +27,6 @@ All traces belongs to a transaction.
 The name of the trace.
 This can also be set via <<trace-start,`trace.start()`>>.
 
-[float]
 [[trace-type]]
 ==== `trace.type`
 
@@ -49,7 +45,6 @@ Though there are no naming restrictions for this prefix,
 the following are standardized across all Elastic APM agents:
 `app`, `db`, `cache`, `template`, and `ext`.
 
-[float]
 [[trace-start]]
 ==== `trace.start()`
 
@@ -72,7 +67,6 @@ Defaults to `custom.code`
 
 When a trace is started it will measure the time until <<trace-end,`trace.end()`>> or <<trace-truncate,`trace.truncate()`>> is called.
 
-[float]
 [[trace-end]]
 ==== `trace.end()`
 
@@ -87,7 +81,6 @@ nothing happens.
 
 A trace that isn't ended before the parent transaction ends will be <<trace-truncate,truncated>>.
 
-[float]
 [[trace-truncate]]
 ==== `trace.truncate()`
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -1,4 +1,3 @@
-[float]
 [[transaction-api]]
 === `Transaction` API
 
@@ -10,7 +9,6 @@ you need to call <<apm-start-transaction,`apm.startTransaction()`>>.
 To see an example of using custom transactions,
 see the <<custom-transactions,Custom Transactions in Node.js>> article.
 
-[float]
 [[transaction-name]]
 ==== `transaction.name`
 
@@ -25,7 +23,6 @@ you can also set the name using <<apm-set-transaction-name,`apm.setTransactionNa
 
 Transactions with the same name and <<transaction-type,type>> are grouped together.
 
-[float]
 [[transaction-type]]
 ==== `transaction.type`
 
@@ -36,7 +33,6 @@ The type of the transaction.
 
 There's a special type called `request` which is used by the agent for the transactions automatically created when an incoming HTTP request is detected.
 
-[float]
 [[transaction-result]]
 ==== `transaction.result`
 
@@ -47,7 +43,6 @@ The transaction result.
 
 Think of the transaction result as equivalent to the status code of an HTTP response.
 
-[float]
 [[transaction-end]]
 ==== `transaction.end()`
 


### PR DESCRIPTION
- This change gives direct access to each part of the API reference directly from the ToC:
   <img width="353" alt="screen shot 2017-09-19 at 08 58 49" src="https://user-images.githubusercontent.com/10602/30579400-d9fd20f0-9d18-11e7-8b5f-03702cacbb06.png">

- It also creates a new generic API page which needs some content, so I made this:
   <img width="783" alt="screen shot 2017-09-19 at 08 59 13" src="https://user-images.githubusercontent.com/10602/30579402-da008b5a-9d18-11e7-914e-84c5dbb06897.png">

- And it shows each function and property in the sidebar for each of the 3 new pages:
   <img width="284" alt="screen shot 2017-09-19 at 08 59 02" src="https://user-images.githubusercontent.com/10602/30579401-d9ff5ece-9d18-11e7-99e8-6ed231ae6869.png">