### PR TITLE
Fix docs link shown to GitHub users

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,12 +1,12 @@
 :branch: current
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-= APM Node.js Agent Reference (Experimental)
-
 ifdef::env-github[]
 NOTE: For the best reading experience,
-please view this documentation at {apm-node-ref}/index.html[elastic.co]
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs[elastic.co]
 endif::[]
+
+= APM Node.js Agent Reference (Experimental)
 
 include::./intro.asciidoc[]
 


### PR DESCRIPTION
The asciidoc reference doesn't resolve when rendered by GitHub, so we have to write the link in full.

The notice is also moved above the headline to make it more visible.

Example:

<img width="994" alt="screen shot 2017-09-19 at 10 18 28" src="https://user-images.githubusercontent.com/10602/30582418-e94857cc-9d23-11e7-8d4e-c99856a6756a.png">
