### PR TITLE
Don't sample transactions

### DIFF
--- a/lib/instrumentation/queue.js
+++ b/lib/instrumentation/queue.js
@@ -12,8 +12,7 @@ function Queue (opts, onFlush) {
   if (typeof opts === 'function') return new Queue(null, opts)
   if (!opts) opts = {}
   this._onFlush = onFlush
-  this._samples = []
-  this._sampled = {}
+  this._transactions = []
   this._timeout = null
   this._flushInterval = (opts.flushInterval || 60) * 1000
 
@@ -26,11 +25,7 @@ function Queue (opts, onFlush) {
 }
 
 Queue.prototype.add = function (transaction) {
-  var key = sampleKey(transaction)
-  if (!(key in this._sampled)) {
-    this._sampled[key] = true
-    this._samples.push(transaction)
-  }
+  this._transactions.push(transaction)
   if (!this._timeout) this._queueFlush()
 }
 
@@ -47,18 +42,12 @@ Queue.prototype._queueFlush = function () {
 
 Queue.prototype._flush = function () {
   debug('flushing transaction queue')
-  protocol.encode(this._samples, this._onFlush)
+  protocol.encode(this._transactions, this._onFlush)
   this._clear()
 }
 
 Queue.prototype._clear = function () {
   clearTimeout(this._timeout)
-  this._samples = []
-  this._sampled = {}
+  this._transactions = []
   this._timeout = null
-}
-
-function sampleKey (trans) {
-  var durationBucket = Math.floor(trans.duration() / 15)
-  return durationBucket + '|' + trans.type + '|' + trans.name
 }

--- a/test/instrumentation/modules/http/timeout-disabled.js
+++ b/test/instrumentation/modules/http/timeout-disabled.js
@@ -11,12 +11,12 @@ test('client-side timeout - call end', function (t) {
   resetAgent()
   var clientReq
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
       setTimeout(function () {
-        t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
         server.close()
         t.end()
       }, 100)
@@ -46,12 +46,12 @@ test('client-side timeout - don\'t call end', function (t) {
   resetAgent()
   var clientReq
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
       setTimeout(function () {
-        t.equal(agent._instrumentation._queue._samples.length, 0, 'should not add transactions to queue')
+        t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not add transactions to queue')
         server.close()
         t.end()
       }, 100)
@@ -79,7 +79,7 @@ test('server-side timeout - call end', function (t) {
   var timedout = false
   var closeEvent = false
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
@@ -92,7 +92,7 @@ test('server-side timeout - call end', function (t) {
       res.end('Hello World')
 
       setTimeout(function () {
-        t.equal(agent._instrumentation._queue._samples.length, 1, 'should not add transactions to queue')
+        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should not add transactions to queue')
         server.close()
         t.end()
       }, 50)
@@ -118,7 +118,7 @@ test('server-side timeout - don\'t call end', function (t) {
   var timedout = false
   var closeEvent = false
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
@@ -128,7 +128,7 @@ test('server-side timeout - don\'t call end', function (t) {
     setTimeout(function () {
       t.ok(timedout, 'should have closed socket')
       t.ok(closeEvent, 'res should emit close event')
-      t.equal(agent._instrumentation._queue._samples.length, 0, 'should not add transactions to queue')
+      t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not add transactions to queue')
       server.close()
       t.end()
     }, 200)

--- a/test/instrumentation/modules/http/timeout-enabled.js
+++ b/test/instrumentation/modules/http/timeout-enabled.js
@@ -15,7 +15,7 @@ test('client-side timeout below error threshold - call end', function (t) {
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -26,7 +26,7 @@ test('client-side timeout below error threshold - call end', function (t) {
   }
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
-    t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -59,7 +59,7 @@ test('client-side timeout above error threshold - call end', function (t) {
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -71,7 +71,7 @@ test('client-side timeout above error threshold - call end', function (t) {
   }
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
-    t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -102,7 +102,7 @@ test('client-side timeout below error threshold - don\'t call end', function (t)
   var clientReq
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -142,7 +142,7 @@ test('client-side timeout above error threshold - don\'t call end', function (t)
   var clientReq
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -184,7 +184,7 @@ test('server-side timeout below error threshold and socket closed - call end', f
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -195,7 +195,7 @@ test('server-side timeout below error threshold and socket closed - call end', f
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
     ended = true
-    t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -230,7 +230,7 @@ test('server-side timeout above error threshold and socket closed - call end', f
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -242,7 +242,7 @@ test('server-side timeout above error threshold and socket closed - call end', f
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
     ended = true
-    t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -277,7 +277,7 @@ test('server-side timeout below error threshold and socket closed - don\'t call 
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -318,7 +318,7 @@ test('server-side timeout above error threshold and socket closed - don\'t call 
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -358,7 +358,7 @@ test('server-side timeout below error threshold but socket not closed - call end
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -385,7 +385,7 @@ test('server-side timeout below error threshold but socket not closed - call end
     var port = server.address().port
     http.get('http://localhost:' + port, function (res) {
       res.on('end', function () {
-        t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
         agent._instrumentation._queue._flush()
       })
       res.resume()
@@ -398,7 +398,7 @@ test('server-side timeout above error threshold but socket not closed - call end
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._samples.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -425,7 +425,7 @@ test('server-side timeout above error threshold but socket not closed - call end
     var port = server.address().port
     http.get('http://localhost:' + port, function (res) {
       res.on('end', function () {
-        t.equal(agent._instrumentation._queue._samples.length, 1, 'should add transactions to queue')
+        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
         agent._instrumentation._queue._flush()
       })
       res.resume()

--- a/test/integration/no-sampling.js
+++ b/test/integration/no-sampling.js
@@ -1,0 +1,51 @@
+'use strict'
+
+var getPort = require('get-port')
+
+getPort().then(function (port) {
+  var agent = require('../../').start({
+    appName: 'test',
+    serverUrl: 'http://localhost:' + port,
+    captureExceptions: false,
+    flushInterval: 1
+  })
+
+  var http = require('http')
+  var zlib = require('zlib')
+  var test = require('tape')
+
+  test('should not sample', function (t) {
+    var server = http.createServer(function (req, res) {
+      var buffers = []
+      var gunzip = zlib.createGunzip()
+      var unzipped = req.pipe(gunzip)
+
+      unzipped.on('data', buffers.push.bind(buffers))
+      unzipped.on('end', function () {
+        res.end()
+        server.close()
+        var data = JSON.parse(Buffer.concat(buffers))
+        t.equal(data.transactions.length, 20, 'expect 20 transactions to be sent')
+        t.end()
+      })
+    })
+
+    server.listen(port, makeManyTransactions)
+  })
+
+  function makeManyTransactions (n) {
+    n = n || 0
+    if (++n > 20) return
+    makeTransaction(makeManyTransactions.bind(null, n))
+  }
+
+  function makeTransaction (cb) {
+    var trans = agent.startTransaction('foo', 'bar')
+    setTimeout(function () {
+      trans.end()
+      process.nextTick(cb)
+    }, 10)
+  }
+}, function (err) {
+  throw err
+})


### PR DESCRIPTION
In the old Opbeat agent we would sample transactions. This is no longer done and this commit removes the old sampling logic.

Fixes #30