### PR TITLE
Always log DEBUG_PAYLOAD info to STDOUT

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -189,8 +189,8 @@ function truncEach (arr, len) {
 function capturePayload (endpoint, payload) {
   var dumpfile = path.join(os.tmpdir(), 'elastic-apm-' + endpoint + '-' + Date.now() + '.json')
   fs.writeFile(dumpfile, JSON.stringify(payload), function (err) {
-    if (err) debug('could not capture intake payload: %s', err.message)
-    else debug('intake payload captured: %s', dumpfile)
+    if (err) console.log('could not capture intake payload: %s', err.message)
+    else console.log('intake payload captured: %s', dumpfile)
   })
 }
 


### PR DESCRIPTION
Before you'd need to run with `DEBUG=*` as well to get any output. Since this is only used during development it's ok to log directly to STDOUT.