### PR TITLE
Simplify queue API

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -5,6 +5,7 @@ var path = require('path')
 var hook = require('require-in-the-middle')
 var Transaction = require('./transaction')
 var Queue = require('./queue')
+var protocol = require('./protocol')
 var debug = require('debug')('elastic-apm')
 var request = require('../request')
 
@@ -25,12 +26,14 @@ Instrumentation.prototype.start = function () {
   var self = this
   this._started = true
 
-  this._queue = new Queue({flushInterval: this._agent._flushInterval}, function (err, transactions) {
-    if (err) {
-      debug('queue returned error: %s', err.message)
-    } else if (self._agent.active && transactions) {
-      request.transactions(self._agent, transactions)
-    }
+  this._queue = new Queue({flushInterval: this._agent._flushInterval}, function onFlush (transactions) {
+    protocol.encode(transactions, function onEncoded (err, payload) {
+      if (err) {
+        debug('queue returned error: %s', err.message)
+      } else if (self._agent.active && payload) {
+        request.transactions(self._agent, payload)
+      }
+    })
   })
 
   require('./async-hooks')(this)

--- a/lib/instrumentation/queue.js
+++ b/lib/instrumentation/queue.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var debug = require('debug')('elastic-apm')
-var protocol = require('./protocol')
 
 var MAX_FLUSH_DELAY_ON_BOOT = 5000
 var boot = true
@@ -12,7 +11,7 @@ function Queue (opts, onFlush) {
   if (typeof opts === 'function') return new Queue(null, opts)
   if (!opts) opts = {}
   this._onFlush = onFlush
-  this._transactions = []
+  this._items = []
   this._timeout = null
   this._flushInterval = (opts.flushInterval || 60) * 1000
 
@@ -24,15 +23,15 @@ function Queue (opts, onFlush) {
   if (this._flushInterval < MAX_FLUSH_DELAY_ON_BOOT) boot = false
 }
 
-Queue.prototype.add = function (transaction) {
-  this._transactions.push(transaction)
+Queue.prototype.add = function (obj) {
+  this._items.push(obj)
   if (!this._timeout) this._queueFlush()
 }
 
 Queue.prototype._queueFlush = function () {
   var self = this
   var ms = boot ? MAX_FLUSH_DELAY_ON_BOOT : this._flushInterval
-  debug('setting timer to flush transaction queue: %dms', ms)
+  debug('setting timer to flush queue: %dms', ms)
   this._timeout = setTimeout(function () {
     self._flush()
   }, ms)
@@ -41,13 +40,13 @@ Queue.prototype._queueFlush = function () {
 }
 
 Queue.prototype._flush = function () {
-  debug('flushing transaction queue')
-  protocol.encode(this._transactions, this._onFlush)
+  debug('flushing queue')
+  this._onFlush(this._items)
   this._clear()
 }
 
 Queue.prototype._clear = function () {
   clearTimeout(this._timeout)
-  this._transactions = []
+  this._items = []
   this._timeout = null
 }

--- a/test/instrumentation/modules/http/timeout-disabled.js
+++ b/test/instrumentation/modules/http/timeout-disabled.js
@@ -11,12 +11,12 @@ test('client-side timeout - call end', function (t) {
   resetAgent()
   var clientReq
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
       setTimeout(function () {
-        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+        t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
         server.close()
         t.end()
       }, 100)
@@ -46,12 +46,12 @@ test('client-side timeout - don\'t call end', function (t) {
   resetAgent()
   var clientReq
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
       setTimeout(function () {
-        t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not add transactions to queue')
+        t.equal(agent._instrumentation._queue._items.length, 0, 'should not add transactions to queue')
         server.close()
         t.end()
       }, 100)
@@ -79,7 +79,7 @@ test('server-side timeout - call end', function (t) {
   var timedout = false
   var closeEvent = false
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
@@ -92,7 +92,7 @@ test('server-side timeout - call end', function (t) {
       res.end('Hello World')
 
       setTimeout(function () {
-        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should not add transactions to queue')
+        t.equal(agent._instrumentation._queue._items.length, 1, 'should not add transactions to queue')
         server.close()
         t.end()
       }, 50)
@@ -118,7 +118,7 @@ test('server-side timeout - don\'t call end', function (t) {
   var timedout = false
   var closeEvent = false
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   var server = http.createServer(function (req, res) {
     res.on('close', function () {
@@ -128,7 +128,7 @@ test('server-side timeout - don\'t call end', function (t) {
     setTimeout(function () {
       t.ok(timedout, 'should have closed socket')
       t.ok(closeEvent, 'res should emit close event')
-      t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not add transactions to queue')
+      t.equal(agent._instrumentation._queue._items.length, 0, 'should not add transactions to queue')
       server.close()
       t.end()
     }, 200)

--- a/test/instrumentation/modules/http/timeout-enabled.js
+++ b/test/instrumentation/modules/http/timeout-enabled.js
@@ -15,7 +15,7 @@ test('client-side timeout below error threshold - call end', function (t) {
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -26,7 +26,7 @@ test('client-side timeout below error threshold - call end', function (t) {
   }
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
-    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -59,7 +59,7 @@ test('client-side timeout above error threshold - call end', function (t) {
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -71,7 +71,7 @@ test('client-side timeout above error threshold - call end', function (t) {
   }
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
-    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -102,7 +102,7 @@ test('client-side timeout below error threshold - don\'t call end', function (t)
   var clientReq
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -142,7 +142,7 @@ test('client-side timeout above error threshold - don\'t call end', function (t)
   var clientReq
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -184,7 +184,7 @@ test('server-side timeout below error threshold and socket closed - call end', f
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -195,7 +195,7 @@ test('server-side timeout below error threshold and socket closed - call end', f
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
     ended = true
-    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -230,7 +230,7 @@ test('server-side timeout above error threshold and socket closed - call end', f
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -242,7 +242,7 @@ test('server-side timeout above error threshold and socket closed - call end', f
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
     ended = true
-    t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+    t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
     agent._instrumentation._queue._flush()
   }
 
@@ -277,7 +277,7 @@ test('server-side timeout below error threshold and socket closed - don\'t call 
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -318,7 +318,7 @@ test('server-side timeout above error threshold and socket closed - don\'t call 
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     t.fail('should not send any data')
@@ -358,7 +358,7 @@ test('server-side timeout below error threshold but socket not closed - call end
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -385,7 +385,7 @@ test('server-side timeout below error threshold but socket not closed - call end
     var port = server.address().port
     http.get('http://localhost:' + port, function (res) {
       res.on('end', function () {
-        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+        t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
         agent._instrumentation._queue._flush()
       })
       res.resume()
@@ -398,7 +398,7 @@ test('server-side timeout above error threshold but socket not closed - call end
 
   resetAgent()
 
-  t.equal(agent._instrumentation._queue._transactions.length, 0, 'should not have any samples to begin with')
+  t.equal(agent._instrumentation._queue._items.length, 0, 'should not have any samples to begin with')
 
   agent._httpClient = {request: function (endpoint, headers, data, cb) {
     assert(t, data)
@@ -425,7 +425,7 @@ test('server-side timeout above error threshold but socket not closed - call end
     var port = server.address().port
     http.get('http://localhost:' + port, function (res) {
       res.on('end', function () {
-        t.equal(agent._instrumentation._queue._transactions.length, 1, 'should add transactions to queue')
+        t.equal(agent._instrumentation._queue._items.length, 1, 'should add transactions to queue')
         agent._instrumentation._queue._flush()
       })
       res.resume()

--- a/test/instrumentation/queue.js
+++ b/test/instrumentation/queue.js
@@ -1,43 +1,18 @@
 'use strict'
 
 var test = require('tape')
-var mockAgent = require('./_agent')
-var Transaction = require('../../lib/instrumentation/transaction')
 var Queue = require('../../lib/instrumentation/queue')
 
 test('queue flush isolation', function (t) {
-  var agent = mockAgent()
   var flush = 0
-  var t0 = new Transaction(agent, 'foo0', 'bar0')
-  var t1 = new Transaction(agent, 'foo1', 'bar1')
-  t0.result = 'baz0'
-  t1.result = 'baz1'
-
-  var queue = new Queue(function (err, transactions) {
-    t.error(err)
-    t.equal(transactions.length, 1, 'should have 1 transaction')
-    t.equal(transactions[0].traces.length, 0, 'should have 0 traces')
-
-    switch (++flush) {
-      case 1:
-        t.equal(transactions[0].name, 'foo0')
-        t.equal(transactions[0].type, 'bar0')
-        t.equal(transactions[0].result, 'baz0')
-        break
-      case 2:
-        t.equal(transactions[0].name, 'foo1')
-        t.equal(transactions[0].type, 'bar1')
-        t.equal(transactions[0].result, 'baz1')
-        t.end()
-        break
-    }
+  var queue = new Queue(function (arr) {
+    t.equal(arr.length, 1)
+    t.equal(arr[0], ++flush)
+    if (flush === 2) t.end()
   })
 
-  t0.end()
-  t1.end()
-
-  queue.add(t0)
+  queue.add(1)
   queue._flush()
-  queue.add(t1)
+  queue.add(2)
   queue._flush()
 })


### PR DESCRIPTION
The queue shouldn't have to know about transactions and what to do with them when it's flushed.

This commit makes the queue generic so it can hold any data. This makes it easier to test and is good practice in general (separation of concerns).