### PR TITLE
Rename timeout config options

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -219,26 +219,26 @@ The HTTP body of incoming HTTP requests is not recorded and sent to the APM Serv
 If you wish to collect the HTTP request body,
 set this config option to `true`.
 
-[[timeout]]
-===== `timeout`
+[[error-on-aborted-requests]]
+===== `errorOnAbortedRequests`
 
 * *Type:* Boolean
-* *Default:* `true`
-* *Env:* `ELASTIC_APM_TIMEOUT`
+* *Default:* `false`
+* *Env:* `ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS`
 
 A boolean specifying if the agent should monitor for aborted TCP connections with un-ended HTTP requests.
 An error will be generated and sent to the APM Server if this happens.
 
-[[timeout-error-threshold]]
-===== `timeoutErrorThreshold`
+[[aborted-error-threshold]]
+===== `abortedErrorThreshold`
 
 * *Type:* Number
 * *Default:* `25000`
-* *Env:* `ELASTIC_APM_TIMEOUT_ERROR_THRESHOLD`
+* *Env:* `ELASTIC_APM_ABORTED_ERROR_THRESHOLD`
 
 Specify the threshold (in milliseconds) for when an aborted TCP connection with an un-ended HTTP request is considered an error.
 
-If the `timeout` property is `false`, this property is ignored.
+If the `errorOnAbortedRequests` property is `false`, this property is ignored.
 
 [[hostname]]
 ===== `hostname`

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -67,9 +67,9 @@ Agent.prototype._config = function (opts) {
   this.stackTraceLimit = opts.stackTraceLimit
   this.captureExceptions = opts.captureExceptions
   this.captureTraceStackTraces = opts.captureTraceStackTraces
-  this.timeout = {
-    active: opts.timeout,
-    errorThreshold: opts.timeoutErrorThreshold
+  this.abortedRequests = {
+    active: opts.errorOnAbortedRequests,
+    errorThreshold: opts.abortedErrorThreshold
   }
   this.instrument = opts.instrument
   this._serverHost = this.serverUrl ? parseUrl(this.serverUrl).hostname : 'localhost'

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,8 +31,8 @@ var DEFAULTS = {
   filterHttpHeaders: true,
   captureTraceStackTraces: true,
   logBody: false,
-  timeout: true,
-  timeoutErrorThreshold: 25000,
+  errorOnAbortedRequests: false,
+  abortedErrorThreshold: 25000,
   instrument: true,
   ff_captureFrame: false
 }
@@ -51,8 +51,8 @@ var ENV_TABLE = {
   filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',
   captureTraceStackTraces: 'ELASTIC_APM_CAPTURE_TRACE_STACK_TRACES',
   logBody: 'ELASTIC_APM_LOG_BODY',
-  timeout: 'ELASTIC_APM_TIMEOUT',
-  timeoutErrorThreshold: 'ELASTIC_APM_TIMEOUT_ERROR_THRESHOLD',
+  errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
+  abortedErrorThreshold: 'ELASTIC_APM_ABORTED_ERROR_THRESHOLD',
   instrument: 'ELASTIC_APM_INSTRUMENT',
   flushInterval: 'ELASTIC_APM_FLUSH_INTERVAL',
   ff_captureFrame: 'ELASTIC_APM_FF_CAPTURE_FRAME'
@@ -65,7 +65,7 @@ var BOOL_OPTS = [
   'filterHttpHeaders',
   'captureTraceStackTraces',
   'logBody',
-  'timeout',
+  'errorOnAbortedRequests',
   'instrument',
   'ff_captureFrame'
 ]

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -26,10 +26,10 @@ exports.instrumentRequest = function (agent, moduleName) {
           eos(res, function (err) {
             if (!err) return trans.end()
 
-            if (agent.timeout.active && !trans.ended) {
+            if (agent.abortedRequests.active && !trans.ended) {
               var duration = Date.now() - trans._timer.start
-              if (duration > agent.timeout.errorThreshold) {
-                agent.captureError('Socket closed with active HTTP request (>' + (agent.timeout.errorThreshold / 1000) + ' sec)', {
+              if (duration > agent.abortedRequests.errorThreshold) {
+                agent.captureError('Socket closed with active HTTP request (>' + (agent.abortedRequests.errorThreshold / 1000) + ' sec)', {
                   request: req,
                   extra: { abortTime: duration }
                 })

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -15,7 +15,7 @@ module.exports = function mockAgent (cb) {
     active: true,
     instrument: true,
     captureTraceStackTraces: true,
-    timeout: {
+    abortedRequests: {
       active: false,
       errorThreshold: 250
     },

--- a/test/instrumentation/modules/http/aborted-requests-disabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-disabled.js
@@ -5,9 +5,9 @@ var agent = require('../../_agent')()
 var test = require('tape')
 var http = require('http')
 
-agent.timeout.active = false
+agent.abortedRequests.active = false
 
-test('client-side timeout - call end', function (t) {
+test('client-side abort - call end', function (t) {
   resetAgent()
   var clientReq
 
@@ -42,7 +42,7 @@ test('client-side timeout - call end', function (t) {
   })
 })
 
-test('client-side timeout - don\'t call end', function (t) {
+test('client-side abort - don\'t call end', function (t) {
   resetAgent()
   var clientReq
 
@@ -74,7 +74,7 @@ test('client-side timeout - don\'t call end', function (t) {
   })
 })
 
-test('server-side timeout - call end', function (t) {
+test('server-side abort - call end', function (t) {
   resetAgent()
   var timedout = false
   var closeEvent = false
@@ -113,7 +113,7 @@ test('server-side timeout - call end', function (t) {
   })
 })
 
-test('server-side timeout - don\'t call end', function (t) {
+test('server-side abort - don\'t call end', function (t) {
   resetAgent()
   var timedout = false
   var closeEvent = false

--- a/test/instrumentation/modules/http/basic.js
+++ b/test/instrumentation/modules/http/basic.js
@@ -109,7 +109,6 @@ function onRequest (req, res) {
 }
 
 function resetAgent (cb) {
-  agent.timeout.active = false
   agent._instrumentation._queue._clear()
   agent._instrumentation.currentTransaction = null
   agent._httpClient = { request: cb }

--- a/test/instrumentation/modules/http/outgoing.js
+++ b/test/instrumentation/modules/http/outgoing.js
@@ -35,7 +35,6 @@ transports.forEach(function (tuple) {
 })
 
 function resetAgent (cb) {
-  agent.timeout.active = false
   agent._instrumentation._queue._clear()
   agent._instrumentation.currentTransaction = null
   agent._httpClient = { request: cb }


### PR DESCRIPTION
The two config options `timeout` and `timeoutErrorTreshold` are renamed to `errorOnAbortedRequests` and `abortedErrorThreshold` respectively. The associated environment variables have been renamed as well.

The old names were poorly chosen as they indicated the options had something to do with an HTTP timeout where in fact all they did was listen for TCP sockets that closed prior to completion of their HTTP requests.