### PR TITLE
test(docker): enforce pulling latest docker image.

### DIFF
--- a/test/script/docker/run_docs.sh
+++ b/test/script/docker/run_docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-docker build -t node_docs --build-arg NODE_VERSION='latest' .
+docker build --pull -t node_docs --build-arg NODE_VERSION='latest' .
 docker run \
   -e CI=true \
   --rm node_docs \

--- a/test/script/docker/run_tests.sh
+++ b/test/script/docker/run_tests.sh
@@ -20,7 +20,7 @@ else
   CMD='npm test'
 fi
 
-docker-compose build --build-arg NODE_VERSION=$1 node_tests
+docker-compose build --pull --build-arg NODE_VERSION=$1 node_tests
 docker-compose run \
   -e NODE_VERSION=${NODE_VERSION} -e TAV=${TAV_VERSIONS} -e CI=true \
   -v ${npm_cache}:${docker_npm_cache} \


### PR DESCRIPTION
This enforces that the latest available docker image for the given version is pulled. 
E.g. nodejs version "8" should always be updated to latest version "8.x.y". 

It seems there was a bug in version 8.5 that prevented to properly work with npm4. Forcing to pull to latest node version should fix the issue, closes #61 . 