### PR TITLE
Add fuzziness to flushInterval

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -323,7 +323,7 @@ Setting it to `Infinity` means that all frames will be collected.
 
 The agent maintains an in-memory queue to which recorded transactions are added when they end.
 Unless empty,
-this queue is flushed and sent to the APM Server for processing every 60 seconds.
+this queue is flushed and sent to the APM Server for processing approximately every 60 seconds.
 
 Use this option to change that interval.
 The value is expected to be in seconds.
@@ -332,7 +332,7 @@ Lowering this interval can reduce memory usage on Node.js applications with a hi
 
 [NOTE]
 ====
-The queue is flushed only 5 seconds after the first transaction has ended on a newly started Node process.
+The queue is flushed approximately 5 seconds after the first transaction has ended on a newly started Node process.
 
 This ensures that you don't have to wait for the entire `flushInterval` to pass for the first data to be sent to the APM Server.
 From there on the `flushInterval` option is used.
@@ -344,6 +344,11 @@ After each flush of the queue,
 the next flush isn't scheduled until a transaction have ended.
 
 This is done to introduce variance and also ensures that empty queues are not scheduled for flushing.
+
+On top of that,
+the actual interval is ajusted by +/- 5% between each flush.
+
+This all helps to ensure that multiple servers started at the same time will not establish connections to the APM Server simultaneously.
 ====
 
 [[filter-http-headers]]

--- a/lib/instrumentation/queue.js
+++ b/lib/instrumentation/queue.js
@@ -31,6 +31,11 @@ Queue.prototype.add = function (obj) {
 Queue.prototype._queueFlush = function () {
   var self = this
   var ms = boot ? MAX_FLUSH_DELAY_ON_BOOT : this._flushInterval
+
+  // Randomize flush time to avoid servers started at the same time to
+  // all connect to the APM server simultaneously
+  ms = fuzzy(ms, 0.05) // +/- 5%
+
   debug('setting timer to flush queue: %dms', ms)
   this._timeout = setTimeout(function () {
     self._flush()
@@ -49,4 +54,10 @@ Queue.prototype._clear = function () {
   clearTimeout(this._timeout)
   this._items = []
   this._timeout = null
+}
+
+// TODO: Check if there's an existing algorithm for this we can use instead
+function fuzzy (n, pct) {
+  var variance = n * pct * 2
+  return Math.floor(n + (Math.random() * variance - variance / 2))
 }


### PR DESCRIPTION
Randomize flush time to avoid servers started at the same time to all connect to the APM server simultaneously.

## Discussion points

### Is this even a problem today?

If the queue flush timer was started as soon as the server booted, this PR would solve the problem where multiple servers started at the same time and hence also flushed their queue at the same time.

But since our queue flush timers actually doesn't start until the first transaction have been ended, we might not even have a problem? So this PR might be trying to solve a problem that doesn't exist. Thoughts?

### Better algorithm?

As noted by the TODO in the code, there might be an existing algorithm we can leverage instead of inventing our own