### PR TITLE
Add language to APM Server requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -205,6 +205,9 @@ function envelope (agent) {
         name: trunc(String((process.release && process.release.name) || process.argv[0]), config.INTAKE_STRING_MAX_SIZE), // process.release was introduced in v3.0.0
         version: trunc(String(process.version), config.INTAKE_STRING_MAX_SIZE)
       },
+      language: {
+        name: 'javascript'
+      },
       agent: {
         name: 'nodejs',
         version: AGENT_VERSION


### PR DESCRIPTION
Since the APM Server now allows `language.name` to be set without also specifying a version, we can just set the language as `javascript`.

I have on purpose not made this user configurable at the moment. After digging into the details of this I found that the subject was more complicated than simply adding a new configuration option. So I'd rather just get this in as a good sensible default that will cover most cases instead of trying to come up with the perfect solution that will take longer to get right.

Closes #6