### PR TITLE
Set default transaction.result to success

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -56,7 +56,7 @@ function Transaction (agent, name, type) {
   this._custom = null
   this._tags = null
   this.type = type || 'custom'
-  this.result = 200
+  this.result = 'success'
   this.traces = []
   this._buildTraces = []
   this.ended = false

--- a/test/instrumentation/modules/ioredis.js
+++ b/test/instrumentation/modules/ioredis.js
@@ -112,7 +112,7 @@ function done (t) {
 
     t.equal(trans.name, 'foo')
     t.equal(trans.type, 'bar')
-    t.equal(trans.result, '200')
+    t.equal(trans.result, 'success')
 
     t.equal(trans.traces.length, groups.length)
 

--- a/test/instrumentation/modules/mongodb-core.js
+++ b/test/instrumentation/modules/mongodb-core.js
@@ -27,7 +27,7 @@ test('trace simple command', function (t) {
 
     t.equal(trans.name, 'foo')
     t.equal(trans.type, 'bar')
-    t.equal(trans.result, '200')
+    t.equal(trans.result, 'success')
 
     t.equal(trans.traces.length, groups.length)
 

--- a/test/instrumentation/modules/redis.js
+++ b/test/instrumentation/modules/redis.js
@@ -26,7 +26,7 @@ test(function (t) {
 
     t.equal(trans.name, 'foo')
     t.equal(trans.type, 'bar')
-    t.equal(trans.result, '200')
+    t.equal(trans.result, 'success')
 
     t.equal(trans.traces.length, groups.length)
 

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -12,7 +12,7 @@ test('init', function (t) {
   var trans = new Transaction(ins._agent, 'name', 'type')
   t.equal(trans.name, 'name')
   t.equal(trans.type, 'type')
-  t.equal(trans.result, 200)
+  t.equal(trans.result, 'success')
   t.equal(trans.ended, false)
   t.deepEqual(trans.traces, [])
   t.end()


### PR DESCRIPTION
We're moving away from thinking of transaction results as HTTP status codes. In most non HTTP cases and transaction either fails or succeeds.

Bear in mind that this is only the default value. For HTTP transactions we will still overwrite this.