### PR TITLE
Log HTTP results in groups of 100

### DIFF
--- a/lib/instrumentation/modules/http.js
+++ b/lib/instrumentation/modules/http.js
@@ -27,7 +27,9 @@ module.exports = function (http, agent) {
       var trans = agent._instrumentation.currentTransaction
 
       if (trans) {
-        trans.result = this.statusCode
+        // It shouldn't be possible for the statusCode to be falsy, but just in
+        // case we're in a bad state we should avoid throwing
+        trans.result = 'HTTP ' + (this.statusCode || '').toString()[0] + 'xx'
 
         // End transacton early in case of SSE
         if (headers && typeof headers === 'object' && !Array.isArray(headers)) {

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -276,7 +276,7 @@ test('request error logging with Error', function (t) {
   var customError = new Error('custom error')
 
   resetAgent(function (endpoint, headers, data, cb) {
-    assert(t, data, { status: '200', name: 'GET /error' })
+    assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
     server.stop()
   })
@@ -322,7 +322,7 @@ test('request error logging with Error does not affect event tags', function (t)
   var customError = new Error('custom error')
 
   resetAgent(function (endpoint, headers, data, cb) {
-    assert(t, data, { status: '200', name: 'GET /error' })
+    assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
     server.stop()
   })
@@ -376,7 +376,7 @@ test('request error logging with String', function (t) {
   var customError = 'custom error'
 
   resetAgent(function (endpoint, headers, data, cb) {
-    assert(t, data, { status: '200', name: 'GET /error' })
+    assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
     server.stop()
   })
@@ -424,7 +424,7 @@ test('request error logging with Object', function (t) {
   }
 
   resetAgent(function (endpoint, headers, data, cb) {
-    assert(t, data, { status: '200', name: 'GET /error' })
+    assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
     server.stop()
   })
@@ -468,7 +468,7 @@ test('error handling', function (t) {
   t.plan(10)
 
   resetAgent(function (endpoint, headers, data, cb) {
-    assert(t, data, { status: '500', name: 'GET /error' })
+    assert(t, data, { status: 'HTTP 5xx', name: 'GET /error' })
     server.stop()
   })
 
@@ -534,7 +534,7 @@ function buildServer () {
 
 function assert (t, data, results) {
   if (!results) results = {}
-  results.status = results.status || '200'
+  results.status = results.status || 'HTTP 2xx'
   results.name = results.name || 'GET /hello'
 
   t.equal(data.transactions.length, 1)

--- a/test/instrumentation/modules/http/_assert.js
+++ b/test/instrumentation/modules/http/_assert.js
@@ -9,7 +9,7 @@ function assert (t, data) {
 
   t.equal(trans.name, 'GET unknown route')
   t.equal(trans.type, 'request')
-  t.equal(trans.result, '200')
+  t.equal(trans.result, 'HTTP 2xx')
   t.equal(trans.traces.length, 0)
   t.equal(trans.context.request.method, 'GET')
 }

--- a/test/instrumentation/modules/koa-router/index.js
+++ b/test/instrumentation/modules/koa-router/index.js
@@ -86,7 +86,7 @@ function buildServer () {
 
 function assert (t, data, results) {
   if (!results) results = {}
-  results.status = results.status || '200'
+  results.status = results.status || 'HTTP 2xx'
   results.name = results.name || 'GET /hello'
 
   t.equal(data.transactions.length, 1)


### PR DESCRIPTION
When recording an HTTP transaction we set its result to the HTTP status code. With this change we now only record the major group, e.g. `2xx` instead of `204` and `5xx` instead of `500` etc.

**Question:** This will obviously only work for HTTP status codes that are above 99 and less than 1000. Can we think of any case where people use an HTTP status code not in this range?