### PR TITLE
fix(docker): force volume prune when cleanup docker

### DIFF
--- a/test/script/docker/cleanup.sh
+++ b/test/script/docker/cleanup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 docker stop $(docker ps -a -q) 
-docker rm -v $(docker ps -q -a) 
+docker rm -v $(docker ps a -q) 
+docker volume prune -f
 
 exit 0


### PR DESCRIPTION
It looks like there are leftovers of volumes on Jenkins. Adding the prune command to enforece cleaning up volumes. 