### PR TITLE
Fix npm module name

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -6,7 +6,7 @@ For getting started,
 we recommend that you take a look at our framework specific documentation for either <<express,Express>>, <<hapi,hapi>>, <<koa,Koa>>, or <<custom-stack,custom frameworks>>.
 
 The Elastic APM agent for Node.js is a singleton.
-You get the agent instance by either requiring `elastic-apm-node` or `elastic-apm-node/start`.
+You get the agent instance by either requiring `elastic-apm` or `elastic-apm/start`.
 For details on the two approaches,
 see the <<advanced-setup,Setup and Configuration>> guide.
 
@@ -15,11 +15,11 @@ which allows you to require and start the agent on the same line:
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start(...)
+var apm = require('elastic-apm').start(...)
 ----
 
 If you need to access the `Agent` in any part of your codebase,
-you can simply require `elastic-apm-node` to access the already started singleton.
+you can simply require `elastic-apm` to access the already started singleton.
 You therefore don't need to manage or pass around the started `Agent` yourself.
 
 [[apm-start]]
@@ -55,7 +55,7 @@ Example usage configuring the agent to only be active in production:
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
-require('elastic-apm-node').start({
+require('elastic-apm').start({
   // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
   appName: '',
 
@@ -170,7 +170,7 @@ Example usage:
 
 [source,js]
 ----
-require('elastic-apm-node').start({
+require('elastic-apm').start({
   ignoreUrls: [
     '/ping',
     /^\/admin\//i,
@@ -199,7 +199,7 @@ Example usage:
 
 [source,js]
 ----
-require('elastic-apm-node').start({
+require('elastic-apm').start({
   ignoreUserAgents: [
     'curl/',
     /pingdom/i,
@@ -273,7 +273,7 @@ Set a custom logger, e.g. https://github.com/trentm/node-bunyan[bunyan]:
 
 [source,js]
 ----
-require('elastic-apm-node').start({
+require('elastic-apm').start({
   logger: require('bunyan')({ level: 'info' })
 })
 ----
@@ -628,7 +628,7 @@ The middleware must be added _after_ your router to pick up any errors that may 
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 var connect = require('connect')
 
 var app = connect()

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -18,11 +18,11 @@ follow the guide below and refer to the <<api,API documentation>> for all the ad
 [[custom-stack-installation]]
 === Installation
 
-Add the `elastic-apm-node` module as a dependency to your application:
+Add the `elastic-apm` module as a dependency to your application:
 
 [source,bash]
 ----
-npm install elastic-apm-node --save
+npm install elastic-apm --save
 ----
 
 [float]
@@ -38,7 +38,7 @@ Here's a simple example of how Elastic APM is normally required and started:
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
-var apm = require('elastic-apm-node').start({
+var apm = require('elastic-apm').start({
   // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
   appName: '',
 
@@ -73,7 +73,7 @@ And then just start the agent like so:
 [source,js]
 ----
 // Start the agent before any thing else in your app
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 ----
 
 See all possible ways to configure the agent <<configuring-the-agent,in the API documentation>>.
@@ -125,7 +125,7 @@ Except of an application using the https://github.com/watson/patterns[patterns] 
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 var http = require('http')
 var patterns = require('patterns')()
 
@@ -209,7 +209,7 @@ the agent error handler should be the first in the chain to ensure that it will 
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 var conncet = require('connect')
 
 var app = connect()

--- a/docs/custom-traces.asciidoc
+++ b/docs/custom-traces.asciidoc
@@ -15,7 +15,7 @@ In the example below we create an Express app that times how long it takes to:
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 var app = require('express')()
 
 // body reader middleware

--- a/docs/custom-transactions.asciidoc
+++ b/docs/custom-transactions.asciidoc
@@ -17,7 +17,7 @@ Example of a background job application polling the SQS queuing system for jobs:
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 var sqs = require('simple-sqs')()
 
 // listen for jobs on the queue

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -10,11 +10,11 @@ Follow the guide below and refer to the <<api,API documentation>> for all the ad
 [[express-installation]]
 === Installation
 
-Add the `elastic-apm-node` module as a dependency to your application:
+Add the `elastic-apm` module as a dependency to your application:
 
 [source,bash]
 ----
-npm install elastic-apm-node --save
+npm install elastic-apm --save
 ----
 
 [float]
@@ -30,7 +30,7 @@ Here's a simple Express example with the Elastic APM agent installed:
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
-var apm = require('elastic-apm-node').start({
+var apm = require('elastic-apm').start({
   // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
   appName: '',
 
@@ -76,7 +76,7 @@ And then just start the agent like so:
 [source,js]
 ----
 // Start the agent before any thing else in your app
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 ----
 
 See all possible ways to configure the agent <<configuring-the-agent,in the API documentation>>.
@@ -144,7 +144,7 @@ the Elastic APM error handler should be the first in the chain to ensure that it
 
 [source,js]
 ----
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 var express = require('express')
 
 var app = express()

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -10,11 +10,11 @@ Follow the guide below and refer to the <<api,API documentation>> for all the ad
 [[hapi-installation]]
 === Installation
 
-Add the `elastic-apm-node` module as a dependency to your application:
+Add the `elastic-apm` module as a dependency to your application:
 
 [source,bash]
 ----
-npm install elastic-apm-node --save
+npm install elastic-apm --save
 ----
 
 [float]
@@ -30,7 +30,7 @@ Here's a simple hapi example with the Elastic APM agent installed:
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
-var apm = require('elastic-apm-node').start({
+var apm = require('elastic-apm').start({
   // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
   appName: '',
 
@@ -84,7 +84,7 @@ And then just start the agent like so:
 [source,js]
 ----
 // Start the agent before any thing else in your app
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 ----
 
 See all possible ways to configure the agent <<configuring-the-agent,in the API documentation>>.

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -18,11 +18,11 @@ In the mean time you can <<custom-stack,configure Elastic APM to work with any s
 [[koa-installation]]
 === Installation
 
-Add the `elastic-apm-node` module as a dependency to your application:
+Add the `elastic-apm` module as a dependency to your application:
 
 [source,bash]
 ----
-npm install elastic-apm-node --save
+npm install elastic-apm --save
 ----
 
 [float]
@@ -38,7 +38,7 @@ Here's a simple Koa example with the Elastic APM agent installed:
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
-var apm = require('elastic-apm-node').start({
+var apm = require('elastic-apm').start({
   // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
   appName: '',
 
@@ -86,7 +86,7 @@ And then just start the agent like so:
 [source,js]
 ----
 // Start the agent before any thing else in your app
-var apm = require('elastic-apm-node').start()
+var apm = require('elastic-apm').start()
 ----
 
 See all possible ways to configure the agent <<configuring-the-agent,in the API documentation>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -10,26 +10,26 @@ This means that you should probably require and start it in your applications ma
 
 There are two ways to start the Elastic APM agent for Node.js:
 
-* Require the `elastic-apm-node` module and call the <<apm-start,`start`>> function on the returned agent:
+* Require the `elastic-apm` module and call the <<apm-start,`start`>> function on the returned agent:
 +
 [source,js]
 ----
-var apm = require('elastic-apm-node').start({
+var apm = require('elastic-apm').start({
   // add configuration options here
 })
 ----
-* Require the `elastic-apm-node/start` script:
+* Require the `elastic-apm/start` script:
 +
 [source,js]
 ----
-var apm = require('elastic-apm-node/start')
+var apm = require('elastic-apm/start')
 ----
 +
 If using this approach,
 you can't configure the agent by passing in an options object,
 but instead have to rely on <<configuring-the-agent,one of the other methods of configuration>>.
 
-NOTE: If you are using Babel, you need to use the `elastic-apm-node/start` approach.
+NOTE: If you are using Babel, you need to use the `elastic-apm/start` approach.
 <<es-modules,Read more>>.
 
 [float]
@@ -42,7 +42,7 @@ There are three ways to configure the Node.js agent:
 you can supply a configurations object as the first argument.
 The option parameters given here will take precedence over config options provided by other means
 
-2. If a given config option is not provided in the call to the <<apm-start,`start`>> function (or if requiring the `elastic-apm-node/start` script),
+2. If a given config option is not provided in the call to the <<apm-start,`start`>> function (or if requiring the `elastic-apm/start` script),
 the agent will look for the config option in the optional <<agent-configuration-file,agent configuration file>>
 
 3. If a config option is not provided in any of the above means,
@@ -89,11 +89,11 @@ for instance with the help of Babel,
 all import statements are evaluated prior to calling any functions.
 In that case you can't configure the agent by passing a configuration object to the `start` function,
 as this call will happen after all the modules have been loaded.
-Instead you need to import the `elastic-apm-node/start` module:
+Instead you need to import the `elastic-apm/start` module:
 
 [source,js]
 ----
-import apm from 'elastic-apm-node/start'
+import apm from 'elastic-apm/start'
 ----
 
 Then either configure the agent using the environment variables associated with each <<apm-start,config option>>,

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -59,7 +59,7 @@ See the API documentation on <<app-name,`appName`>> for details.
 Errors gets tracked just fine,
 but you don't see any performance metrics.
 
-First make sure you have https://www.npmjs.com/package/elastic-apm-node[the latest version] of the Elastic APM Node.js agent.
+First make sure you have https://www.npmjs.com/package/elastic-apm[the latest version] of the Elastic APM Node.js agent.
 Issues are fixed and support for new metrics are added all the time,
 so make sure you keep your dependency up to date.
 


### PR DESCRIPTION
Doc and examples are pointing to https://www.npmjs.com/package/elastic-apm-node (Not found) instead of https://www.npmjs.com/package/elastic-apm . Feel free to close the PR if it's not the case.

Probably also the file for configuration should be changed from:
`ELASTIC_APM_CONFIG_FILE=/path/to/elastic-apm-node.js`
to 
`ELASTIC_APM_CONFIG_FILE=/path/to/elastic-apm.js`

I can create an issue/PR for that if it makes sense.
