### PR TITLE
feat(parser): support sourceContext option

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -303,6 +303,15 @@ Whether or not the agent should monitor for uncaught exceptions and send them to
 
 Set this option to `false` to disable capture of stack traces for measured traces during instrumentation.
 
+[[source-context]]
+===== `sourceContext`
+
+* *Type:* Boolean
+* *Default:* `true`
+* *Env:* `ELASTIC_APM_SOURCE_CONTEXT`
+
+Set this option to `false` to disable collecting and reporting source code context with stack traces.
+
 [[stack-trace-limit]]
 ===== `stackTraceLimit`
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -81,6 +81,7 @@ Agent.prototype._config = function (opts) {
   this._ignoreUserAgentStr = opts.ignoreUserAgentStr
   this._ignoreUserAgentRegExp = opts.ignoreUserAgentRegExp
   this.ff_captureFrame = opts.ff_captureFrame
+  this.sourceContext = opts.sourceContext
 
   return opts
 }
@@ -175,7 +176,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
   if (!isError(err)) {
     prepareError(parsers.parseMessage(err))
   } else {
-    parsers.parseError(err, function (_, error) {
+    parsers.parseError(err, agent, function (_, error) {
       // As of now, parseError suppresses errors internally, but even if they
       // were passed on, we would want to suppress them here anyway
       prepareError(error)
@@ -239,7 +240,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
 
         if (callsites) {
           callsites.forEach(function (callsite) {
-            parsers.parseCallsite(callsite, next())
+            parsers.parseCallsite(callsite, agent, next())
           })
         }
       })

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,7 +34,8 @@ var DEFAULTS = {
   errorOnAbortedRequests: false,
   abortedErrorThreshold: 25000,
   instrument: true,
-  ff_captureFrame: false
+  ff_captureFrame: false,
+  sourceContext: true
 }
 
 var ENV_TABLE = {
@@ -56,7 +57,8 @@ var ENV_TABLE = {
   instrument: 'ELASTIC_APM_INSTRUMENT',
   flushInterval: 'ELASTIC_APM_FLUSH_INTERVAL',
   maxQueueSize: 'ELASTIC_APM_MAX_QUEUE_SIZE',
-  ff_captureFrame: 'ELASTIC_APM_FF_CAPTURE_FRAME'
+  ff_captureFrame: 'ELASTIC_APM_FF_CAPTURE_FRAME',
+  sourceContext: 'ELASTIC_APM_SOURCE_CONTEXT'
 }
 
 var BOOL_OPTS = [
@@ -68,7 +70,8 @@ var BOOL_OPTS = [
   'logBody',
   'errorOnAbortedRequests',
   'instrument',
-  'ff_captureFrame'
+  'ff_captureFrame',
+  'sourceContext'
 ]
 
 function config (opts) {

--- a/lib/instrumentation/protocol.js
+++ b/lib/instrumentation/protocol.js
@@ -49,7 +49,7 @@ function encode (transactions, cb) {
       var next2 = afterAll(next())
       trans.traces.forEach(function (trace) {
         // TODO: This is expensive! Consider if there's a way to caching some of this
-        traceFrames(trace, next2())
+        traceFrames(trace, trans._agent, next2())
       })
     })
   }
@@ -71,7 +71,7 @@ function encodeTraces (traces, frames) {
   })
 }
 
-function traceFrames (trace, cb) {
+function traceFrames (trace, agent, cb) {
   if (trace._stackObj.frames) {
     process.nextTick(function () {
       cb(null, trace._stackObj.frames)
@@ -96,7 +96,7 @@ function traceFrames (trace, cb) {
     })
 
     callsites.forEach(function (callsite) {
-      parsers.parseCallsite(callsite, next())
+      parsers.parseCallsite(callsite, agent, next())
     })
   })
 }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -35,7 +35,7 @@ exports.parseMessage = function (msg) {
   return error
 }
 
-exports.parseError = function (err, cb) {
+exports.parseError = function (err, agent, cb) {
   stackman.callsites(err, function (_err, callsites) {
     if (_err) {
       debug('error while getting error callsites: %s', _err.message)
@@ -79,7 +79,7 @@ exports.parseError = function (err, cb) {
 
     if (callsites) {
       callsites.forEach(function (callsite) {
-        exports.parseCallsite(callsite, next())
+        exports.parseCallsite(callsite, agent, next())
       })
     }
   })
@@ -174,7 +174,7 @@ exports.getUserContextFromRequest = function (req) {
   return context
 }
 
-exports.parseCallsite = function (callsite, cb) {
+exports.parseCallsite = function (callsite, agent, cb) {
   var filename = callsite.getFileName()
   var frame = {
     filename: callsite.getRelativeFileName() || '',
@@ -185,6 +185,12 @@ exports.parseCallsite = function (callsite, cb) {
   // TODO: Don't set it to zero if it's not an int
   if (!Number.isFinite(frame.lineno)) frame.lineno = 0 // this should be an int, but sometimes it's not?!
   if (filename) frame.abs_path = filename
+
+  // Allow skipping when sourceContext is not enabled.
+  if (!agent.sourceContext) {
+    setImmediate(cb, null, frame)
+    return
+  }
 
   callsite.sourceContext(function (err, context) {
     if (err) {


### PR DESCRIPTION
The sourceContext option allows disabling the inclusion of source
code lines with stack trace payloads, reducing payload size and
processing time.

This fixes #83.