### PR TITLE
refactor(*): rename app to service

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -48,7 +48,7 @@ Their equivalent environment variable name is listed together with each option.
 
 Properties on the `options` object will always take precedence over environment variables.
 
-The only required parameter is <<app-name,`appName`>>.
+The only required parameter is <<service-name,`serviceName`>>.
 
 Example usage configuring the agent to only be active in production:
 
@@ -56,8 +56,8 @@ Example usage configuring the agent to only be active in production:
 ----
 // Add this to the VERY top of the first file loaded in your app
 require('elastic-apm-node').start({
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',
@@ -70,13 +70,13 @@ require('elastic-apm-node').start({
 })
 ----
 
-[[app-name]]
-===== `appName`
+[[service-name]]
+===== `serviceName`
 
 * *Type:* String
-* *Env:* `ELASTIC_APM_APP_NAME`
+* *Env:* `ELASTIC_APM_SERVICE_NAME`
 
-Your Elastic APM app name.
+Your Elastic APM service name.
 Required unless set <<configuring-the-agent,via other means>>.
 
 [[secret-token]]
@@ -107,11 +107,11 @@ By default the agent will validate the TLS/SSL certificate of the APM Server if 
 You can switch this behavior off by setting this option to `false`.
 Disabling validation is normally required if using self-signed certificates.
 
-[[app-version]]
-===== `appVersion`
+[[service-version]]
+===== `serviceVersion`
 
 * *Type:* String
-* *Env:* `ELASTIC_APM_APP_VERSION`
+* *Env:* `ELASTIC_APM_SERVICE_VERSION`
 
 The version of the app currently running.
 This could be the version from your `package.json` file,

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -39,8 +39,8 @@ Here's a simple example of how Elastic APM is normally required and started:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',
@@ -63,7 +63,7 @@ So if you prefer, you can set the same configuration options using environment v
 
 [source,bash]
 ----
-ELASTIC_APM_APP_NAME=<app name>
+ELASTIC_APM_SERVICE_NAME=<service name>
 ELASTIC_APM_SECRET_TOKEN=<token>
 ELASTIC_APM_SERVER_URL=<server url>
 ----

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -31,8 +31,8 @@ Here's a simple Express example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',
@@ -66,7 +66,7 @@ So if you prefer, you can set the same configuration options using environment v
 
 [source,bash]
 ----
-ELASTIC_APM_APP_NAME=<app name>
+ELASTIC_APM_SERVICE_NAME=<service name>
 ELASTIC_APM_SECRET_TOKEN=<token>
 ELASTIC_APM_SERVER_URL=<server url>
 ----

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -31,8 +31,8 @@ Here's a simple hapi example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',
@@ -74,7 +74,7 @@ So if you prefer, you can set the same configuration options using environment v
 
 [source,bash]
 ----
-ELASTIC_APM_APP_NAME=<app name>
+ELASTIC_APM_SERVICE_NAME=<service name>
 ELASTIC_APM_SECRET_TOKEN=<token>
 ELASTIC_APM_SERVER_URL=<server url>
 ----

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -39,8 +39,8 @@ Here's a simple Koa example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',
@@ -76,7 +76,7 @@ So if you prefer, you can set the same configuration options using environment v
 
 [source,bash]
 ----
-ELASTIC_APM_APP_NAME=<app name>
+ELASTIC_APM_SERVICE_NAME=<service name>
 ELASTIC_APM_SECRET_TOKEN=<token>
 ELASTIC_APM_SERVER_URL=<server url>
 ----

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -69,8 +69,8 @@ to the <<apm-start,`start`>> function, e.g:
 [source,js]
 ----
 module.exports = {
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -26,31 +26,31 @@ Ensure that it's set to `true` and try again.
 See the API documentation about <<active,`active`>> for details.
 
 [float]
-[[message-missing-app-name]]
-===== Missing `appName`
+[[message-missing-service-name]]
+===== Missing `serviceName`
 
 ----
-Elastic APM isn't correctly configured: Missing appName
+Elastic APM isn't correctly configured: Missing serviceName
 ----
 
-Ensure that the agent is correctly configured with an `appName` config option either by passing it to the `start()` function,
+Ensure that the agent is correctly configured with an `serviceName` config option either by passing it to the `start()` function,
 by specifying it in the optional configuration file,
 or by using environment variables.
 
-See the API documentation on <<app-name,`appName`>> for details.
+See the API documentation on <<service-name,`serviceName`>> for details.
 
 [float]
-[[message-invalid-app-name]]
-===== Invalid `appName`
+[[message-invalid-service-name]]
+===== Invalid `serviceName`
 
 ----
-Elastic APM isn't correctly configured: appName "..." contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)
+Elastic APM isn't correctly configured: serviceName "..." contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)
 ----
 
-The `appName` you provided contained invalid characters.
+The `serviceName` you provided contained invalid characters.
 You can only use the the letters a-z (both upper and lowercase), numbers, underscore (`_`), hyphen (`-`), and space (` `).
 
-See the API documentation on <<app-name,`appName`>> for details.
+See the API documentation on <<service-name,`serviceName`>> for details.
 
 [float]
 [[missing-performance-metrics]]

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -56,11 +56,11 @@ Agent.prototype._config = function (opts) {
   logger.init({ level: opts.logLevel })
 
   // TODO: Make as much private as possible
-  this.appName = opts.appName
+  this.serviceName = opts.serviceName
   this.secretToken = opts.secretToken
   this.serverUrl = opts.serverUrl
   this.validateServerCert = opts.validateServerCert
-  this.appVersion = opts.appVersion
+  this.serviceVersion = opts.serviceVersion
   this.active = opts.active
   this.logLevel = opts.logLevel
   this.hostname = opts.hostname
@@ -97,16 +97,16 @@ Agent.prototype.start = function (opts) {
   if (!this.active) {
     logger.info('Elastic APM agent is inactive due to configuration')
     return this
-  } else if (!this.appName) {
-    logger.error('Elastic APM isn\'t correctly configured: Missing appName')
+  } else if (!this.serviceName) {
+    logger.error('Elastic APM isn\'t correctly configured: Missing serviceName')
     this.active = false
     return this
-  } else if (!/^[a-zA-Z0-9 _-]+$/.test(this.appName)) {
-    logger.error('Elastic APM isn\'t correctly configured: appName "%s" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)', this.appName)
+  } else if (!/^[a-zA-Z0-9 _-]+$/.test(this.serviceName)) {
+    logger.error('Elastic APM isn\'t correctly configured: serviceName "%s" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)', this.serviceName)
     this.active = false
     return this
   } else {
-    debug('agent configured correctly %o', { node: process.version, agent: version, app: this.appName, instrument: this.instrument })
+    debug('agent configured correctly %o', { node: process.version, agent: version, service: this.serviceName, instrument: this.instrument })
   }
 
   this._instrumentation.start()

--- a/lib/config.js
+++ b/lib/config.js
@@ -39,11 +39,11 @@ var DEFAULTS = {
 }
 
 var ENV_TABLE = {
-  appName: 'ELASTIC_APM_APP_NAME',
+  serviceName: 'ELASTIC_APM_SERVICE_NAME',
   secretToken: 'ELASTIC_APM_SECRET_TOKEN',
   serverUrl: 'ELASTIC_APM_SERVER_URL',
   validateServerCert: 'ELASTIC_APM_VALIDATE_SERVER_CERT',
-  appVersion: 'ELASTIC_APM_APP_VERSION',
+  serviceVersion: 'ELASTIC_APM_SERVICE_VERSION',
   active: 'ELASTIC_APM_ACTIVE',
   logLevel: 'ELASTIC_APM_LOG_LEVEL',
   hostname: 'ELASTIC_APM_HOSTNAME',
@@ -131,6 +131,6 @@ function normalizeBools (opts) {
 }
 
 function truncate (opts) {
-  if (opts.appVersion) opts.appVersion = trunc(String(opts.appVersion), config.INTAKE_STRING_MAX_SIZE)
+  if (opts.serviceVersion) opts.serviceVersion = trunc(String(opts.serviceVersion), config.INTAKE_STRING_MAX_SIZE)
   if (opts.hostname) opts.hostname = trunc(String(opts.hostname), config.INTAKE_STRING_MAX_SIZE)
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -196,8 +196,8 @@ function capturePayload (endpoint, payload) {
 
 function envelope (agent) {
   var payload = {
-    app: {
-      name: agent.appName,
+    service: {
+      name: agent.serviceName,
       pid: process.pid,
       process_title: trunc(String(process.title), config.INTAKE_STRING_MAX_SIZE),
       argv: process.argv,
@@ -220,10 +220,10 @@ function envelope (agent) {
     }
   }
 
-  if (agent.appVersion) payload.app.version = agent.appVersion
+  if (agent.serviceVersion) payload.service.version = agent.serviceVersion
 
   if (agent._platform.framework) {
-    payload.app.framework = {
+    payload.service.framework = {
       name: agent._platform.framework.name,
       version: agent._platform.framework.version
     }

--- a/test/agent.js
+++ b/test/agent.js
@@ -11,16 +11,16 @@ var request = require('../lib/request')
 var Agent = require('../lib/agent')
 
 var opts = {
-  appName: 'some-app-name',
+  serviceName: 'some-service-name',
   secretToken: 'secret',
   captureExceptions: false,
   logLevel: 'error'
 }
 
 var optionFixtures = [
-  ['appName', 'APP_NAME'],
+  ['serviceName', 'SERVICE_NAME'],
   ['secretToken', 'SECRET_TOKEN'],
-  ['appVersion', 'APP_VERSION'],
+  ['serviceVersion', 'SERVICE_VERSION'],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME', os.hostname()],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', Infinity],
@@ -89,7 +89,7 @@ falsyValues.forEach(function (val) {
   test('should be disabled by envrionment variable ELASTIC_APM_ACTIVE set to: ' + util.inspect(val), function (t) {
     setup()
     process.env.ELASTIC_APM_ACTIVE = val
-    agent.start({ appName: 'foo', secretToken: 'baz' })
+    agent.start({ serviceName: 'foo', secretToken: 'baz' })
     t.equal(agent.active, false)
     delete process.env.ELASTIC_APM_ACTIVE
     t.end()
@@ -100,7 +100,7 @@ truthyValues.forEach(function (val) {
   test('should be enabled by envrionment variable ELASTIC_APM_ACTIVE set to: ' + util.inspect(val), function (t) {
     setup()
     process.env.ELASTIC_APM_ACTIVE = val
-    agent.start({ appName: 'foo', secretToken: 'baz' })
+    agent.start({ serviceName: 'foo', secretToken: 'baz' })
     t.equal(agent.active, true)
     delete process.env.ELASTIC_APM_ACTIVE
     t.end()
@@ -109,7 +109,7 @@ truthyValues.forEach(function (val) {
 
 test('should overwrite ELASTIC_APM_ACTIVE by option property active', function (t) {
   setup()
-  var opts = { appName: 'foo', secretToken: 'baz', active: false }
+  var opts = { serviceName: 'foo', secretToken: 'baz', active: false }
   process.env.ELASTIC_APM_ACTIVE = '1'
   agent.start(opts)
   t.equal(agent.active, false)
@@ -119,7 +119,7 @@ test('should overwrite ELASTIC_APM_ACTIVE by option property active', function (
 
 test('should default active to true if required options have been specified', function (t) {
   setup()
-  agent.start({ appName: 'foo', secretToken: 'baz' })
+  agent.start({ serviceName: 'foo', secretToken: 'baz' })
   t.equal(agent.active, true)
   t.end()
 })
@@ -169,23 +169,23 @@ test('should separate strings and regexes into their own blacklist arrays', func
   t.end()
 })
 
-test('missing appName => inactive', function (t) {
+test('missing serviceName => inactive', function (t) {
   setup()
   agent.start()
   t.equal(agent.active, false)
   t.end()
 })
 
-test('invalid appName => inactive', function (t) {
+test('invalid serviceName => inactive', function (t) {
   setup()
-  agent.start({appName: 'foo&bar'})
+  agent.start({serviceName: 'foo&bar'})
   t.equal(agent.active, false)
   t.end()
 })
 
-test('valid appName => active', function (t) {
+test('valid serviceName => active', function (t) {
   setup()
-  agent.start({appName: 'fooBAR0123456789_- '})
+  agent.start({serviceName: 'fooBAR0123456789_- '})
   t.equal(agent.active, true)
   t.end()
 })
@@ -320,7 +320,7 @@ test('#captureError()', function (t) {
   t.test('should merge context', function (t) {
     setup()
     agent.start({
-      appName: 'foo',
+      serviceName: 'foo',
       secretToken: 'baz',
       filterHttpHeaders: false,
       logLevel: 'error'

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -11,7 +11,7 @@ var sharedInstrumentation
 
 module.exports = function mockAgent (cb) {
   var agent = {
-    appName: 'app-name',
+    serviceName: 'service-name',
     active: true,
     instrument: true,
     captureTraceStackTraces: true,

--- a/test/instrumentation/modules/bluebird/bluebird.js
+++ b/test/instrumentation/modules/bluebird/bluebird.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/bluebird/cancel.js
+++ b/test/instrumentation/modules/bluebird/cancel.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/elasticsearch.js
+++ b/test/instrumentation/modules/elasticsearch.js
@@ -4,7 +4,7 @@ process.env.ELASTIC_APM_TEST = true
 var host = (process.env.ES_HOST || 'localhost') + ':9200'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/express-graphql.js
+++ b/test/instrumentation/modules/express-graphql.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/generic-pool.js
+++ b/test/instrumentation/modules/generic-pool.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/graphql.js
+++ b/test/instrumentation/modules/graphql.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false,
   logLevel: 'fatal'

--- a/test/instrumentation/modules/ioredis.js
+++ b/test/instrumentation/modules/ioredis.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/koa-router/index.js
+++ b/test/instrumentation/modules/koa-router/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/mongodb-core.js
+++ b/test/instrumentation/modules/mongodb-core.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/mysql/mysql.js
+++ b/test/instrumentation/modules/mysql/mysql.js
@@ -2,7 +2,7 @@
 
 var host = process.env.MYSQL_HOST
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/mysql/pool-release-1.js
+++ b/test/instrumentation/modules/mysql/pool-release-1.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/pg/knex.js
+++ b/test/instrumentation/modules/pg/knex.js
@@ -3,7 +3,7 @@
 process.env.ELASTIC_APM_TEST = true
 
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/pg/pg.js
+++ b/test/instrumentation/modules/pg/pg.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/redis.js
+++ b/test/instrumentation/modules/redis.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/modules/ws.js
+++ b/test/instrumentation/modules/ws.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/instrumentation/native-promises.js
+++ b/test/instrumentation/native-promises.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var agent = require('../..').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false
 })

--- a/test/integration/abort-on-invalid-cert.js
+++ b/test/integration/abort-on-invalid-cert.js
@@ -4,7 +4,7 @@ var getPort = require('get-port')
 
 getPort().then(function (port) {
   var agent = require('../../').start({
-    appName: 'test',
+    serviceName: 'test',
     serverUrl: 'https://localhost:' + port
   })
 

--- a/test/integration/allow-invalid-cert.js
+++ b/test/integration/allow-invalid-cert.js
@@ -4,7 +4,7 @@ var getPort = require('get-port')
 
 getPort().then(function (port) {
   var agent = require('../../').start({
-    appName: 'test',
+    serviceName: 'test',
     serverUrl: 'https://localhost:' + port,
     validateServerCert: false
   })

--- a/test/integration/no-sampling.js
+++ b/test/integration/no-sampling.js
@@ -4,7 +4,7 @@ var getPort = require('get-port')
 
 getPort().then(function (port) {
   var agent = require('../../').start({
-    appName: 'test',
+    serviceName: 'test',
     serverUrl: 'http://localhost:' + port,
     captureExceptions: false,
     flushInterval: 1

--- a/test/request.js
+++ b/test/request.js
@@ -11,9 +11,9 @@ var request = require('../lib/request')
 var agentVersion = require('../package.json').version
 
 var opts = {
-  appName: 'some-app-name',
+  serviceName: 'some-service-name',
   secretToken: 'secret',
-  appVersion: 'my-app-version',
+  serviceVersion: 'my-service-version',
   captureExceptions: false,
   logLevel: 'error'
 }
@@ -188,16 +188,16 @@ test('#transactions()', function (t) {
 })
 
 function assertRoot (t, payload) {
-  t.equal(payload.app.name, 'some-app-name')
-  t.equal(payload.app.pid, process.pid)
-  t.ok(payload.app.pid > 0)
-  t.ok(payload.app.process_title)
-  t.ok(/(\/usr\/local\/bin\/)?node/.test(payload.app.process_title))
-  t.deepEqual(payload.app.argv, process.argv)
-  t.ok(payload.app.argv.length >= 2)
-  t.deepEqual(payload.app.runtime, {name: 'node', version: process.version})
-  t.deepEqual(payload.app.agent, {name: 'nodejs', version: agentVersion})
-  t.equal(payload.app.version, 'my-app-version')
+  t.equal(payload.service.name, 'some-service-name')
+  t.equal(payload.service.pid, process.pid)
+  t.ok(payload.service.pid > 0)
+  t.ok(payload.service.process_title)
+  t.ok(/(\/usr\/local\/bin\/)?node/.test(payload.service.process_title))
+  t.deepEqual(payload.service.argv, process.argv)
+  t.ok(payload.service.argv.length >= 2)
+  t.deepEqual(payload.service.runtime, {name: 'node', version: process.version})
+  t.deepEqual(payload.service.agent, {name: 'nodejs', version: agentVersion})
+  t.equal(payload.service.version, 'my-service-version')
   t.deepEqual(payload.system, {
     hostname: os.hostname(),
     architecture: process.arch,

--- a/test/script/cli.js
+++ b/test/script/cli.js
@@ -330,7 +330,7 @@ var saveConf = function (conf, cb) {
 loadConf(function (err, conf) {
   if (err) throw err
   var questions = [
-    { name: 'appName', message: 'App name', 'default': conf.appName },
+    { name: 'serviceName', message: 'Service name', 'default': conf.serviceName },
     { name: 'secretToken', message: 'Secret token', 'default': conf.secretToken },
     { name: 'serverUrl', message: 'APM Server URL', 'default': conf.serverUrl },
     { name: 'suite', message: 'Test suite', type: 'list', choices: ['standard', 'http', 'restify', 'connect', 'express', 'transaction'] },

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -4,7 +4,7 @@ var path = require('path')
 var test = require('tape')
 
 var agent = require('../../').start({
-  appName: 'test',
+  serviceName: 'test',
   secretToken: 'test',
   captureExceptions: false,
   logLevel: 'fatal'

--- a/test/start/env/test.js
+++ b/test/start/env/test.js
@@ -3,4 +3,4 @@
 var assert = require('assert')
 var agent = require('../../..')
 
-assert.equal(agent.appName, 'from-env')
+assert.equal(agent.serviceName, 'from-env')

--- a/test/start/file/elastic-apm-node.js
+++ b/test/start/file/elastic-apm-node.js
@@ -1,3 +1,3 @@
 module.exports = {
-  appName: 'from-file'
+  serviceName: 'from-file'
 }

--- a/test/start/file/test.js
+++ b/test/start/file/test.js
@@ -3,4 +3,4 @@
 var assert = require('assert')
 var agent = require('../../..')
 
-assert.equal(agent.appName, 'from-file')
+assert.equal(agent.serviceName, 'from-file')

--- a/test/test.js
+++ b/test/test.js
@@ -82,7 +82,7 @@ mapSeries(directories, readdir, function (err, directoryFiles) {
       file: 'test.js',
       cwd: 'test/start/env',
       env: {
-        ELASTIC_APM_APP_NAME: 'from-env'
+        ELASTIC_APM_SERVICE_NAME: 'from-env'
       }
     },
     {


### PR DESCRIPTION
This doesn't rename `in_app`, which will be renamed later.

**Breaking change:** The config options `appName` and `appVersion` have been renamed to `serviceName` and `serviceVersion` respectively (the associated environment variable have been renamed accordingly as well).

Closes #91