### PR TITLE
test(transaction): reduce risk of race condition

### DIFF
--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -113,14 +113,14 @@ test('#end() - with traces', function (t) {
 
 test('#duration()', function (t) {
   var ins = mockInstrumentation(function (added) {
-    t.ok(added.duration() > 24)
-    t.ok(added.duration() < 35)
+    t.ok(added.duration() > 40)
+    t.ok(added.duration() < 60)
     t.end()
   })
   var trans = new Transaction(ins._agent)
   setTimeout(function () {
     trans.end()
-  }, 25)
+  }, 50)
 })
 
 test('#duration() - un-ended transaction', function (t) {


### PR DESCRIPTION
It failed here: https://apm-ci.elastic.co/job/elastic+apm-agent-nodejs+pull-request+multijob-run-tests/65/NODEJS_VERSION=4,label=linux/console

It hasn't failed before, so this is probably really rare, but I like to improve these when I find them