### PR TITLE
test(*): add tests to test async await instrumentation

### DIFF
--- a/test/instrumentation/_async-await.js
+++ b/test/instrumentation/_async-await.js
@@ -1,0 +1,22 @@
+'use strict'
+
+exports.promise = promise
+exports.nonPromise = nonPromise
+
+async function promise (delay) {
+  var res = await promise2(delay)
+  return res.toUpperCase()
+}
+
+async function promise2 (delay) {
+  return new Promise(function (resolve) {
+    setTimeout(function () {
+      resolve('success')
+    }, delay)
+  })
+}
+
+async function nonPromise () {
+  var res = await 'success'
+  return res.toUpperCase()
+}

--- a/test/instrumentation/async-await.js
+++ b/test/instrumentation/async-await.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var agent = require('../..').start({
+  appName: 'test',
+  captureExceptions: false
+})
+var ins = agent._instrumentation
+
+var test = require('tape')
+var semver = require('semver')
+
+// async/await isn't supported in old versions of Node.js
+if (semver.lt(process.version, '7.0.0')) process.exit()
+
+var _async = require('./_async-await')
+
+test('await promise', function (t) {
+  t.plan(4)
+  var t1 = ins.startTransaction()
+  _async.promise(100).then(function (result) {
+    t.equal(result, 'SUCCESS')
+    t.equal(ins.currentTransaction && ins.currentTransaction.id, t1.id)
+  })
+  var t2 = ins.startTransaction()
+  _async.promise(50).then(function (result) {
+    t.equal(result, 'SUCCESS')
+    t.equal(ins.currentTransaction && ins.currentTransaction.id, t2.id)
+  })
+})
+
+test('await non-promise', function (t) {
+  t.plan(7)
+  var n = 0
+  var t1 = ins.startTransaction()
+  _async.nonPromise().then(function (result) {
+    t.equal(++n, 2) // this should be the first then-callback to execute
+    t.equal(result, 'SUCCESS')
+    t.equal(ins.currentTransaction && ins.currentTransaction.id, t1.id)
+  })
+  var t2 = ins.startTransaction()
+  _async.nonPromise().then(function (result) {
+    t.equal(++n, 3) // this should be the second then-callback to execute
+    t.equal(result, 'SUCCESS')
+    t.equal(ins.currentTransaction && ins.currentTransaction.id, t2.id)
+  })
+  t.equal(++n, 1) // this line should execute before any of the then-callbacks
+})


### PR DESCRIPTION
I wanted to get these tests into master to make sure that the switch to async-hooks doesn't break this functionality.

I think there shouldn't be any difference as (to the best of my knowledge) async/await is just syntactic sugar on top of native promises, so if our patching or async-hooks works with promises it should also work with async/await.

But I've never used this my self, and hence my knowledge is very very limited on this subject, so please correct me if I'm wrong or if the tests are actually not testing what I think they are testing 😅 

The idea of the test is to start one async operation and then start another that finishes before the first and hence potentially mess with the currently active transaction.