### PR TITLE
docs(compatibility): add handlebars to list of instrumented modules

### DIFF
--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -52,6 +52,8 @@ The Node.js agent will automatically instrument the following modules to give yo
 |Module |Version |Note
 |https://www.npmjs.com/package/graphql[graphql] |>=0.7.0 |Will trace all
 queries
+|https://www.npmjs.com/package/handlebars[handlebars] |* |Will trace compile
+and render calls
 |https://www.npmjs.com/package/ioredis[ioredis] |\^2.0.0 \|\| ^3.0.0 |Will
 trace all queries
 |https://www.npmjs.com/package/mongodb-core[mongodb-core]


### PR DESCRIPTION
Handlebars support was added in #98 

@Qard I forgot that we needed to update this page as well