### PR TITLE
docs(*): we're now in beta!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Elastic APM Node.js Agent (Alpha)
+# Elastic APM Node.js Agent (Beta)
 
 [![Build status](https://travis-ci.org/elastic/apm-agent-nodejs.svg?branch=master)](https://travis-ci.org/elastic/apm-agent-nodejs)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/standard/standard)
 
-**Warning: This project is currently in alpha. Use it at your own
+**Warning: This project is currently in beta. Use it at your own
 risk.**
 
 This is the official Node.js agent for Elastic APM. Read our

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -6,7 +6,7 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs[elastic.co]
 endif::[]
 
-= APM Node.js Agent Reference (Alpha)
+= APM Node.js Agent Reference (Beta)
 
 include::./intro.asciidoc[]
 

--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,1 +1,1 @@
-You are looking at the documentation for an alpha release.
+You are looking at the documentation for a beta release.


### PR DESCRIPTION
As Elastic APM 6.1 goes live we go into beta.

When this PR is merged into master, the official docs will be changed to show that we're in beta.

After merging this PR, do the following:

- [ ] Update the repo description
- [ ] Release a patch release of the agent so that the headline on npm doesn't say alpha any more