### PR TITLE
refactor(agent): make all config properties private

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -51,75 +51,48 @@ Agent.prototype.buildTrace = function () {
 }
 
 Agent.prototype._config = function (opts) {
-  opts = config(opts)
+  this._conf = config(opts)
 
-  logger.init({ level: opts.logLevel })
+  this._conf.serverHost = this._conf.serverUrl
+    ? parseUrl(this._conf.serverUrl).hostname
+    : 'localhost'
 
-  // TODO: Make as much private as possible
-  this.appName = opts.appName
-  this.secretToken = opts.secretToken
-  this.serverUrl = opts.serverUrl
-  this.validateServerCert = opts.validateServerCert
-  this.appVersion = opts.appVersion
-  this.active = opts.active
-  this.logLevel = opts.logLevel
-  this.hostname = opts.hostname
-  this.stackTraceLimit = opts.stackTraceLimit
-  this.captureExceptions = opts.captureExceptions
-  this.captureTraceStackTraces = opts.captureTraceStackTraces
-  this.abortedRequests = {
-    active: opts.errorOnAbortedRequests,
-    errorThreshold: opts.abortedErrorThreshold
-  }
-  this.instrument = opts.instrument
-  this._serverHost = this.serverUrl ? parseUrl(this.serverUrl).hostname : 'localhost'
-  this._logBody = opts.logBody
-  this._flushInterval = opts.flushInterval
-  this._maxQueueSize = opts.maxQueueSize
-  this._ignoreUrlStr = opts.ignoreUrlStr
-  this._ignoreUrlRegExp = opts.ignoreUrlRegExp
-  this._ignoreUserAgentStr = opts.ignoreUserAgentStr
-  this._ignoreUserAgentRegExp = opts.ignoreUserAgentRegExp
-  this.ff_captureFrame = opts.ff_captureFrame
-  this.sourceContext = opts.sourceContext
-
-  return opts
+  logger.init({level: this._conf.logLevel})
 }
 
 Agent.prototype.start = function (opts) {
   if (global._elastic_apm_initialized) throw new Error('Do not call .start() more than once')
   global._elastic_apm_initialized = true
 
-  opts = this._config(opts)
+  this._config(opts)
+  this._filters.config(this._conf)
 
-  this._filters.config(opts)
-
-  if (!this.active) {
+  if (!this._conf.active) {
     logger.info('Elastic APM agent is inactive due to configuration')
     return this
-  } else if (!this.appName) {
+  } else if (!this._conf.appName) {
     logger.error('Elastic APM isn\'t correctly configured: Missing appName')
-    this.active = false
+    this._conf.active = false
     return this
-  } else if (!/^[a-zA-Z0-9 _-]+$/.test(this.appName)) {
-    logger.error('Elastic APM isn\'t correctly configured: appName "%s" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)', this.appName)
-    this.active = false
+  } else if (!/^[a-zA-Z0-9 _-]+$/.test(this._conf.appName)) {
+    logger.error('Elastic APM isn\'t correctly configured: appName "%s" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)', this._conf.appName)
+    this._conf.active = false
     return this
   } else {
-    debug('agent configured correctly %o', { node: process.version, agent: version, app: this.appName, instrument: this.instrument })
+    debug('agent configured correctly %o', { node: process.version, agent: version, app: this._conf.appName, instrument: this._conf.instrument })
   }
 
   this._instrumentation.start()
 
   this._httpClient = new ElasticAPMHttpClient({
-    secretToken: this.secretToken,
+    secretToken: this._conf.secretToken,
     userAgent: userAgent,
-    serverUrl: this.serverUrl,
-    rejectUnauthorized: this.validateServerCert
+    serverUrl: this._conf.serverUrl,
+    rejectUnauthorized: this._conf.validateServerCert
   })
 
-  Error.stackTraceLimit = this.stackTraceLimit
-  if (this.captureExceptions) this.handleUncaughtExceptions()
+  Error.stackTraceLimit = this._conf.stackTraceLimit
+  if (this._conf.captureExceptions) this.handleUncaughtExceptions()
 
   return this
 }
@@ -168,7 +141,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
     : trans && trans.res
 
   // TODO: Make ff_captureFrame into a proper config option
-  if (this.ff_captureFrame && !(opts && opts.uncaught)) {
+  if (this._conf.ff_captureFrame && !(opts && opts.uncaught)) {
     // TODO: Use a more performance optimal approach to capture the frames
     var captureFrameError = new Error()
   }
@@ -210,7 +183,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
     }
 
     if (req) {
-      error.context.request = parsers.getContextFromRequest(req, agent._logBody)
+      error.context.request = parsers.getContextFromRequest(req, agent._conf.logBody)
     }
 
     if (res) {

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -23,10 +23,10 @@ exports.instrumentRequest = function (agent, moduleName) {
           eos(res, function (err) {
             if (!err) return trans.end()
 
-            if (agent.abortedRequests.active && !trans.ended) {
+            if (agent._conf.errorOnAbortedRequests && !trans.ended) {
               var duration = Date.now() - trans._timer.start
-              if (duration > agent.abortedRequests.errorThreshold) {
-                agent.captureError('Socket closed with active HTTP request (>' + (agent.abortedRequests.errorThreshold / 1000) + ' sec)', {
+              if (duration > agent._conf.abortedErrorThreshold) {
+                agent.captureError('Socket closed with active HTTP request (>' + (agent._conf.abortedErrorThreshold / 1000) + ' sec)', {
                   request: req,
                   extra: { abortTime: duration }
                 })
@@ -50,21 +50,21 @@ exports.instrumentRequest = function (agent, moduleName) {
 function isRequestBlacklisted (agent, req) {
   var i
 
-  for (i = 0; i < agent._ignoreUrlStr.length; i++) {
-    if (agent._ignoreUrlStr[i] === req.url) return true
+  for (i = 0; i < agent._conf.ignoreUrlStr.length; i++) {
+    if (agent._conf.ignoreUrlStr[i] === req.url) return true
   }
-  for (i = 0; i < agent._ignoreUrlRegExp.length; i++) {
-    if (agent._ignoreUrlRegExp[i].test(req.url)) return true
+  for (i = 0; i < agent._conf.ignoreUrlRegExp.length; i++) {
+    if (agent._conf.ignoreUrlRegExp[i].test(req.url)) return true
   }
 
   var ua = req.headers['user-agent']
   if (!ua) return false
 
-  for (i = 0; i < agent._ignoreUserAgentStr.length; i++) {
-    if (ua.indexOf(agent._ignoreUserAgentStr[i]) === 0) return true
+  for (i = 0; i < agent._conf.ignoreUserAgentStr.length; i++) {
+    if (ua.indexOf(agent._conf.ignoreUserAgentStr[i]) === 0) return true
   }
-  for (i = 0; i < agent._ignoreUserAgentRegExp.length; i++) {
-    if (agent._ignoreUserAgentRegExp[i].test(ua)) return true
+  for (i = 0; i < agent._conf.ignoreUserAgentRegExp.length; i++) {
+    if (agent._conf.ignoreUserAgentRegExp[i].test(ua)) return true
   }
 
   return false
@@ -82,7 +82,7 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
 
       var req = orig.apply(this, arguments)
       if (!trace) return req
-      if (req._headers.host === agent._serverHost) {
+      if (req._headers.host === agent._conf.serverHost) {
         debug('ignore %s request to intake API %o', moduleName, {id: id})
         return req
       } else {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -21,20 +21,20 @@ function Instrumentation (agent) {
 }
 
 Instrumentation.prototype.start = function () {
-  if (!this._agent.instrument) return
+  if (!this._agent._conf.instrument) return
 
   var self = this
   this._started = true
 
   var qopts = {
-    flushInterval: this._agent._flushInterval,
-    maxQueueSize: this._agent._maxQueueSize
+    flushInterval: this._agent._conf.flushInterval,
+    maxQueueSize: this._agent._conf.maxQueueSize
   }
   this._queue = new Queue(qopts, function onFlush (transactions) {
     protocol.encode(transactions, function onEncoded (err, payload) {
       if (err) {
         debug('queue returned error: %s', err.message)
-      } else if (self._agent.active && payload) {
+      } else if (self._agent._conf.active && payload) {
         request.transactions(self._agent, payload)
       }
     })

--- a/lib/instrumentation/protocol.js
+++ b/lib/instrumentation/protocol.js
@@ -34,7 +34,7 @@ function encode (transactions, cb) {
       }
 
       if (trans.req) {
-        payload.context.request = parsers.getContextFromRequest(trans.req, trans._agent._logBody)
+        payload.context.request = parsers.getContextFromRequest(trans.req, trans._agent._conf.logBody)
       }
       if (trans.res) {
         payload.context.response = parsers.getContextFromResponse(trans.res)
@@ -44,7 +44,7 @@ function encode (transactions, cb) {
     }))
   })
 
-  if (transactions[0]._agent.captureTraceStackTraces) {
+  if (transactions[0]._agent._conf.captureTraceStackTraces) {
     transactions.forEach(function (trans) {
       var next2 = afterAll(next())
       trans.traces.forEach(function (trace) {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -187,7 +187,7 @@ exports.parseCallsite = function (callsite, agent, cb) {
   if (filename) frame.abs_path = filename
 
   // Allow skipping when sourceContext is not enabled.
-  if (!agent.sourceContext) {
+  if (!agent._conf.sourceContext) {
     setImmediate(cb, null, frame)
     return
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,7 +16,7 @@ exports.transactions = sendTransactions
 exports._envelope = envelope // Expose for testing only
 
 var request = function (agent, endpoint, payload, cb) {
-  if (!agent.active) return cb()
+  if (!agent._conf.active) return cb()
 
   if (process.env.DEBUG_PAYLOAD) capturePayload(endpoint, payload)
 
@@ -197,7 +197,7 @@ function capturePayload (endpoint, payload) {
 function envelope (agent) {
   var payload = {
     app: {
-      name: agent.appName,
+      name: agent._conf.appName,
       pid: process.pid,
       process_title: trunc(String(process.title), config.INTAKE_STRING_MAX_SIZE),
       argv: process.argv,
@@ -214,13 +214,13 @@ function envelope (agent) {
       }
     },
     system: {
-      hostname: agent.hostname,
+      hostname: agent._conf.hostname,
       architecture: trunc(String(process.arch), config.INTAKE_STRING_MAX_SIZE),
       platform: trunc(String(process.platform), config.INTAKE_STRING_MAX_SIZE)
     }
   }
 
-  if (agent.appVersion) payload.app.version = agent.appVersion
+  if (agent._conf.appVersion) payload.app.version = agent._conf.appVersion
 
   if (agent._platform.framework) {
     payload.app.framework = {

--- a/test/agent.js
+++ b/test/agent.js
@@ -57,7 +57,7 @@ optionFixtures.forEach(function (fixture) {
       var value = bool ? (fixture[2] ? '0' : '1') : 'custom-value'
       process.env['ELASTIC_APM_' + fixture[1]] = value
       agent.start()
-      t.equal(agent[fixture[0]], bool ? !fixture[2] : value)
+      t.equal(agent._conf[fixture[0]], bool ? !fixture[2] : value)
       delete process.env['ELASTIC_APM_' + fixture[1]]
       t.end()
     })
@@ -71,7 +71,7 @@ optionFixtures.forEach(function (fixture) {
       opts[fixture[0]] = value1
       process.env['ELASTIC_APM_' + fixture[1]] = value2
       agent.start(opts)
-      t.equal(agent[fixture[0]], bool ? !fixture[2] : value1)
+      t.equal(agent._conf[fixture[0]], bool ? !fixture[2] : value1)
       delete process.env['ELASTIC_APM_' + fixture[1]]
       t.end()
     })
@@ -80,7 +80,7 @@ optionFixtures.forEach(function (fixture) {
   test('should default ' + fixture[0] + ' to ' + fixture[2], function (t) {
     setup()
     agent.start()
-    t.equal(agent[fixture[0]], fixture[2])
+    t.equal(agent._conf[fixture[0]], fixture[2])
     t.end()
   })
 })
@@ -90,7 +90,7 @@ falsyValues.forEach(function (val) {
     setup()
     process.env.ELASTIC_APM_ACTIVE = val
     agent.start({ appName: 'foo', secretToken: 'baz' })
-    t.equal(agent.active, false)
+    t.equal(agent._conf.active, false)
     delete process.env.ELASTIC_APM_ACTIVE
     t.end()
   })
@@ -101,7 +101,7 @@ truthyValues.forEach(function (val) {
     setup()
     process.env.ELASTIC_APM_ACTIVE = val
     agent.start({ appName: 'foo', secretToken: 'baz' })
-    t.equal(agent.active, true)
+    t.equal(agent._conf.active, true)
     delete process.env.ELASTIC_APM_ACTIVE
     t.end()
   })
@@ -112,7 +112,7 @@ test('should overwrite ELASTIC_APM_ACTIVE by option property active', function (
   var opts = { appName: 'foo', secretToken: 'baz', active: false }
   process.env.ELASTIC_APM_ACTIVE = '1'
   agent.start(opts)
-  t.equal(agent.active, false)
+  t.equal(agent._conf.active, false)
   delete process.env.ELASTIC_APM_ACTIVE
   t.end()
 })
@@ -120,31 +120,31 @@ test('should overwrite ELASTIC_APM_ACTIVE by option property active', function (
 test('should default active to true if required options have been specified', function (t) {
   setup()
   agent.start({ appName: 'foo', secretToken: 'baz' })
-  t.equal(agent.active, true)
+  t.equal(agent._conf.active, true)
   t.end()
 })
 
 test('should default active to false if required options have not been specified', function (t) {
   setup()
   agent.start()
-  t.equal(agent.active, false)
+  t.equal(agent._conf.active, false)
   t.end()
 })
 
 test('should force active to false if required options have not been specified', function (t) {
   setup()
   agent.start({ active: true })
-  t.equal(agent.active, false)
+  t.equal(agent._conf.active, false)
   t.end()
 })
 
 test('should default to empty request blacklist arrays', function (t) {
   setup()
   agent.start()
-  t.equal(agent._ignoreUrlStr.length, 0)
-  t.equal(agent._ignoreUrlRegExp.length, 0)
-  t.equal(agent._ignoreUserAgentStr.length, 0)
-  t.equal(agent._ignoreUserAgentRegExp.length, 0)
+  t.equal(agent._conf.ignoreUrlStr.length, 0)
+  t.equal(agent._conf.ignoreUrlRegExp.length, 0)
+  t.equal(agent._conf.ignoreUserAgentStr.length, 0)
+  t.equal(agent._conf.ignoreUserAgentRegExp.length, 0)
   t.end()
 })
 
@@ -155,16 +155,16 @@ test('should separate strings and regexes into their own blacklist arrays', func
     ignoreUserAgents: ['str2', /regex2/]
   })
 
-  t.deepEqual(agent._ignoreUrlStr, ['str1'])
-  t.deepEqual(agent._ignoreUserAgentStr, ['str2'])
+  t.deepEqual(agent._conf.ignoreUrlStr, ['str1'])
+  t.deepEqual(agent._conf.ignoreUserAgentStr, ['str2'])
 
-  t.equal(agent._ignoreUrlRegExp.length, 1)
-  t.ok(isRegExp(agent._ignoreUrlRegExp[0]))
-  t.equal(agent._ignoreUrlRegExp[0].toString(), '/regex1/')
+  t.equal(agent._conf.ignoreUrlRegExp.length, 1)
+  t.ok(isRegExp(agent._conf.ignoreUrlRegExp[0]))
+  t.equal(agent._conf.ignoreUrlRegExp[0].toString(), '/regex1/')
 
-  t.equal(agent._ignoreUserAgentRegExp.length, 1)
-  t.ok(isRegExp(agent._ignoreUserAgentRegExp[0]))
-  t.equal(agent._ignoreUserAgentRegExp[0].toString(), '/regex2/')
+  t.equal(agent._conf.ignoreUserAgentRegExp.length, 1)
+  t.ok(isRegExp(agent._conf.ignoreUserAgentRegExp[0]))
+  t.equal(agent._conf.ignoreUserAgentRegExp[0].toString(), '/regex2/')
 
   t.end()
 })
@@ -172,21 +172,21 @@ test('should separate strings and regexes into their own blacklist arrays', func
 test('missing appName => inactive', function (t) {
   setup()
   agent.start()
-  t.equal(agent.active, false)
+  t.equal(agent._conf.active, false)
   t.end()
 })
 
 test('invalid appName => inactive', function (t) {
   setup()
   agent.start({appName: 'foo&bar'})
-  t.equal(agent.active, false)
+  t.equal(agent._conf.active, false)
   t.end()
 })
 
 test('valid appName => active', function (t) {
   setup()
   agent.start({appName: 'fooBAR0123456789_- '})
-  t.equal(agent.active, true)
+  t.equal(agent._conf.active, true)
   t.end()
 })
 

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -11,23 +11,23 @@ var sharedInstrumentation
 
 module.exports = function mockAgent (cb) {
   var agent = {
-    appName: 'app-name',
-    active: true,
-    instrument: true,
-    captureTraceStackTraces: true,
-    abortedRequests: {
-      active: false,
-      errorThreshold: 250
+    _conf: {
+      appName: 'app-name',
+      active: true,
+      instrument: true,
+      captureTraceStackTraces: true,
+      errorOnAbortedRequests: false,
+      abortedErrorThreshold: 250,
+      ignoreUrlStr: [],
+      ignoreUrlRegExp: [],
+      ignoreUserAgentStr: [],
+      ignoreUserAgentRegExp: []
     },
+    _platform: {},
+    _filters: new Filters(),
     _httpClient: {
       request: cb || noop
-    },
-    _ignoreUrlStr: [],
-    _ignoreUrlRegExp: [],
-    _ignoreUserAgentStr: [],
-    _ignoreUserAgentRegExp: [],
-    _platform: {},
-    _filters: new Filters()
+    }
   }
 
   // We do not want to start the instrumentation multiple times during testing.

--- a/test/instrumentation/modules/http/aborted-requests-disabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-disabled.js
@@ -5,7 +5,7 @@ var agent = require('../../_agent')()
 var test = require('tape')
 var http = require('http')
 
-agent.abortedRequests.active = false
+agent._conf.errorOnAbortedRequests = false
 
 test('client-side abort - call end', function (t) {
   resetAgent()

--- a/test/instrumentation/modules/http/aborted-requests-enabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-enabled.js
@@ -7,7 +7,7 @@ var test = require('tape')
 var http = require('http')
 
 var addEndedTransaction = agent._instrumentation.addEndedTransaction
-agent.abortedRequests.active = true
+agent._conf.errorOnAbortedRequests = true
 
 test('client-side abort below error threshold - call end', function (t) {
   var clientReq
@@ -39,7 +39,7 @@ test('client-side abort below error threshold - call end', function (t) {
           res.end(' World')
         }, 10)
       }, 10)
-    }, agent.abortedRequests.errorThreshold / 2)
+    }, agent._conf.abortedErrorThreshold / 2)
   })
 
   server.listen(function () {
@@ -67,7 +67,7 @@ test('client-side abort above error threshold - call end', function (t) {
   }}
   agent.captureError = function (err, opts) {
     t.equal(err, 'Socket closed with active HTTP request (>0.25 sec)')
-    t.ok(opts.extra.abortTime > agent.abortedRequests.errorThreshold)
+    t.ok(opts.extra.abortTime > agent._conf.abortedErrorThreshold)
   }
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
@@ -84,7 +84,7 @@ test('client-side abort above error threshold - call end', function (t) {
           res.end(' World')
         }, 10)
       }, 10)
-    }, agent.abortedRequests.errorThreshold + 10)
+    }, agent._conf.abortedErrorThreshold + 10)
   })
 
   server.listen(function () {
@@ -124,7 +124,7 @@ test('client-side abort below error threshold - don\'t call end', function (t) {
           t.end()
         }, 10)
       }, 10)
-    }, agent.abortedRequests.errorThreshold / 2)
+    }, agent._conf.abortedErrorThreshold / 2)
   })
 
   server.listen(function () {
@@ -149,7 +149,7 @@ test('client-side abort above error threshold - don\'t call end', function (t) {
   }}
   agent.captureError = function (err, opts) {
     t.equal(err, 'Socket closed with active HTTP request (>0.25 sec)')
-    t.ok(opts.extra.abortTime > agent.abortedRequests.errorThreshold)
+    t.ok(opts.extra.abortTime > agent._conf.abortedErrorThreshold)
     server.close()
     t.end()
   }
@@ -163,7 +163,7 @@ test('client-side abort above error threshold - don\'t call end', function (t) {
       setTimeout(function () {
         res.write('Hello') // server emits clientError if written in same tick as abort
       }, 10)
-    }, agent.abortedRequests.errorThreshold + 10)
+    }, agent._conf.abortedErrorThreshold + 10)
   })
 
   server.listen(function () {
@@ -206,10 +206,10 @@ test('server-side abort below error threshold and socket closed - call end', fun
       res.end('Hello World')
       t.ok(ended, 'should have ended transaction')
       server.close()
-    }, agent.abortedRequests.errorThreshold / 2 + 100)
+    }, agent._conf.abortedErrorThreshold / 2 + 100)
   })
 
-  server.setTimeout(agent.abortedRequests.errorThreshold / 2)
+  server.setTimeout(agent._conf.abortedErrorThreshold / 2)
 
   server.listen(function () {
     var port = server.address().port
@@ -237,7 +237,7 @@ test('server-side abort above error threshold and socket closed - call end', fun
   }}
   agent.captureError = function (err, opts) {
     t.equal(err, 'Socket closed with active HTTP request (>0.25 sec)')
-    t.ok(opts.extra.abortTime > agent.abortedRequests.errorThreshold)
+    t.ok(opts.extra.abortTime > agent._conf.abortedErrorThreshold)
   }
   agent._instrumentation.addEndedTransaction = function () {
     addEndedTransaction.apply(this, arguments)
@@ -253,10 +253,10 @@ test('server-side abort above error threshold and socket closed - call end', fun
       res.end('Hello World')
       t.ok(ended, 'should have ended transaction')
       server.close()
-    }, agent.abortedRequests.errorThreshold + 100)
+    }, agent._conf.abortedErrorThreshold + 100)
   })
 
-  server.setTimeout(agent.abortedRequests.errorThreshold + 10)
+  server.setTimeout(agent._conf.abortedErrorThreshold + 10)
 
   server.listen(function () {
     var port = server.address().port
@@ -294,10 +294,10 @@ test('server-side abort below error threshold and socket closed - don\'t call en
       t.ok(timedout, 'should have closed socket')
       t.notOk(ended, 'should not have ended transaction')
       server.close()
-    }, agent.abortedRequests.errorThreshold / 2 + 100)
+    }, agent._conf.abortedErrorThreshold / 2 + 100)
   })
 
-  server.setTimeout(agent.abortedRequests.errorThreshold / 2)
+  server.setTimeout(agent._conf.abortedErrorThreshold / 2)
 
   server.listen(function () {
     var port = server.address().port
@@ -325,7 +325,7 @@ test('server-side abort above error threshold and socket closed - don\'t call en
   }}
   agent.captureError = function (err, opts) {
     t.equal(err, 'Socket closed with active HTTP request (>0.25 sec)')
-    t.ok(opts.extra.abortTime > agent.abortedRequests.errorThreshold)
+    t.ok(opts.extra.abortTime > agent._conf.abortedErrorThreshold)
   }
   agent._instrumentation.addEndedTransaction = function () {
     t.fail('should not end the transaction')
@@ -336,10 +336,10 @@ test('server-side abort above error threshold and socket closed - don\'t call en
       t.ok(timedout, 'should have closed socket')
       t.notOk(ended, 'should have ended transaction')
       server.close()
-    }, agent.abortedRequests.errorThreshold + 150)
+    }, agent._conf.abortedErrorThreshold + 150)
   })
 
-  server.setTimeout(agent.abortedRequests.errorThreshold + 50)
+  server.setTimeout(agent._conf.abortedErrorThreshold + 50)
 
   server.listen(function () {
     var port = server.address().port
@@ -376,10 +376,10 @@ test('server-side abort below error threshold but socket not closed - call end',
 
     setTimeout(function () {
       res.end('Hello World')
-    }, agent.abortedRequests.errorThreshold / 2 + 100)
+    }, agent._conf.abortedErrorThreshold / 2 + 100)
   })
 
-  server.setTimeout(agent.abortedRequests.errorThreshold / 2)
+  server.setTimeout(agent._conf.abortedErrorThreshold / 2)
 
   server.listen(function () {
     var port = server.address().port
@@ -416,10 +416,10 @@ test('server-side abort above error threshold but socket not closed - call end',
 
     setTimeout(function () {
       res.end('Hello World')
-    }, agent.abortedRequests.errorThreshold + 100)
+    }, agent._conf.abortedErrorThreshold + 100)
   })
 
-  server.setTimeout(agent.abortedRequests.errorThreshold + 10)
+  server.setTimeout(agent._conf.abortedErrorThreshold + 10)
 
   server.listen(function () {
     var port = server.address().port

--- a/test/instrumentation/modules/http/blacklisting.js
+++ b/test/instrumentation/modules/http/blacklisting.js
@@ -7,7 +7,7 @@ var http = require('http')
 
 test('ignore url string - no match', function (t) {
   resetAgent({
-    _ignoreUrlStr: ['/exact']
+    ignoreUrlStr: ['/exact']
   }, function (endpoint, headers, data, cb) {
     assertNoMatch(t, data)
     t.end()
@@ -17,7 +17,7 @@ test('ignore url string - no match', function (t) {
 
 test('ignore url string - match', function (t) {
   resetAgent({
-    _ignoreUrlStr: ['/exact']
+    ignoreUrlStr: ['/exact']
   }, function (endpoint, headers, data, cb) {
     t.fail('should not have any data')
   })
@@ -28,7 +28,7 @@ test('ignore url string - match', function (t) {
 
 test('ignore url regex - no match', function (t) {
   resetAgent({
-    _ignoreUrlRegExp: [/regex/]
+    ignoreUrlRegExp: [/regex/]
   }, function (endpoint, headers, data, cb) {
     assertNoMatch(t, data)
     t.end()
@@ -38,7 +38,7 @@ test('ignore url regex - no match', function (t) {
 
 test('ignore url regex - match', function (t) {
   resetAgent({
-    _ignoreUrlRegExp: [/regex/]
+    ignoreUrlRegExp: [/regex/]
   }, function (endpoint, headers, data, cb) {
     t.fail('should not have any data')
   })
@@ -49,7 +49,7 @@ test('ignore url regex - match', function (t) {
 
 test('ignore User-Agent string - no match', function (t) {
   resetAgent({
-    _ignoreUserAgentStr: ['exact']
+    ignoreUserAgentStr: ['exact']
   }, function (endpoint, headers, data, cb) {
     assertNoMatch(t, data)
     t.end()
@@ -59,7 +59,7 @@ test('ignore User-Agent string - no match', function (t) {
 
 test('ignore User-Agent string - match', function (t) {
   resetAgent({
-    _ignoreUserAgentStr: ['exact']
+    ignoreUserAgentStr: ['exact']
   }, function (endpoint, headers, data, cb) {
     t.fail('should not have any data')
   })
@@ -70,7 +70,7 @@ test('ignore User-Agent string - match', function (t) {
 
 test('ignore User-Agent regex - no match', function (t) {
   resetAgent({
-    _ignoreUserAgentRegExp: [/regex/]
+    ignoreUserAgentRegExp: [/regex/]
   }, function (endpoint, headers, data, cb) {
     assertNoMatch(t, data)
     t.end()
@@ -80,7 +80,7 @@ test('ignore User-Agent regex - no match', function (t) {
 
 test('ignore User-Agent regex - match', function (t) {
   resetAgent({
-    _ignoreUserAgentRegExp: [/regex/]
+    ignoreUserAgentRegExp: [/regex/]
   }, function (endpoint, headers, data, cb) {
     t.fail('should not have any data')
   })
@@ -118,10 +118,10 @@ function request (path, headers, cb) {
 
 function resetAgent (opts, cb) {
   agent._httpClient = { request: cb }
-  agent._ignoreUrlStr = opts._ignoreUrlStr || []
-  agent._ignoreUrlRegExp = opts._ignoreUrlRegExp || []
-  agent._ignoreUserAgentStr = opts._ignoreUserAgentStr || []
-  agent._ignoreUserAgentRegExp = opts._ignoreUserAgentRegExp || []
+  agent._conf.ignoreUrlStr = opts.ignoreUrlStr || []
+  agent._conf.ignoreUrlRegExp = opts.ignoreUrlRegExp || []
+  agent._conf.ignoreUserAgentStr = opts.ignoreUserAgentStr || []
+  agent._conf.ignoreUserAgentRegExp = opts.ignoreUserAgentRegExp || []
   agent._instrumentation._queue._clear()
   agent._instrumentation.currentTransaction = null
 }

--- a/test/instrumentation/protocol.js
+++ b/test/instrumentation/protocol.js
@@ -196,7 +196,7 @@ test('protocol.encode - http request meta data', function (t) {
 
 test('protocol.encode - disable stack traces', function (t) {
   var agent = mockAgent()
-  agent.captureTraceStackTraces = false
+  agent._conf.captureTraceStackTraces = false
 
   var t0 = new Transaction(agent, 'single-name0', 'type0')
   t0.result = 'result0'
@@ -241,7 +241,7 @@ test('protocol.encode - disable stack traces', function (t) {
 
 test('protocol.encode - truncated traces', function (t) {
   var agent = mockAgent()
-  agent.captureTraceStackTraces = false
+  agent._conf.captureTraceStackTraces = false
 
   var t0 = new Transaction(agent, 'single-name0', 'type0')
   t0.result = 'result0'

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -240,7 +240,7 @@ test('#getContextFromRequest()', function (t) {
 test('#parseError()', function (t) {
   t.test('should parse plain Error object', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
       t.error(err)
@@ -260,7 +260,7 @@ test('#parseError()', function (t) {
 
   t.test('should parse Error with message', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     parsers.parseError(new Error('Crap'), fakeAgent, function (err, parsed) {
       t.error(err)
@@ -280,7 +280,7 @@ test('#parseError()', function (t) {
 
   t.test('should parse TypeError with message', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     parsers.parseError(new TypeError('Crap'), fakeAgent, function (err, parsed) {
       t.error(err)
@@ -300,7 +300,7 @@ test('#parseError()', function (t) {
 
   t.test('should parse thrown Error', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     try {
       throw new Error('Derp')
@@ -324,7 +324,7 @@ test('#parseError()', function (t) {
 
   t.test('should parse caught real error', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     try {
       var o = {}
@@ -352,7 +352,7 @@ test('#parseError()', function (t) {
 
   t.test('should gracefully handle .stack already being accessed', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     var err = new Error('foo')
     t.ok(typeof err.stack === 'string')
@@ -374,7 +374,7 @@ test('#parseError()', function (t) {
 
   t.test('should gracefully handle .stack being overwritten', function (t) {
     var fakeAgent = {
-      sourceContext: true
+      _conf: {sourceContext: true}
     }
     var err = new Error('foo')
     err.stack = 'foo'
@@ -396,7 +396,7 @@ test('#parseError()', function (t) {
 
   t.test('should be able to exclude source context data', function (t) {
     var fakeAgent = {
-      sourceContext: false
+      _conf: {sourceContext: false}
     }
     parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
       t.error(err)

--- a/test/start/env/test.js
+++ b/test/start/env/test.js
@@ -3,4 +3,4 @@
 var assert = require('assert')
 var agent = require('../../..')
 
-assert.equal(agent.appName, 'from-env')
+assert.equal(agent._conf.appName, 'from-env')

--- a/test/start/file/test.js
+++ b/test/start/file/test.js
@@ -3,4 +3,4 @@
 var assert = require('assert')
 var agent = require('../../..')
 
-assert.equal(agent.appName, 'from-file')
+assert.equal(agent._conf.appName, 'from-file')


### PR DESCRIPTION
Previously the agent inadvertently exposed some of the config options set when the user configured the agent, e.g. `agent.appName`. All these properties have now been moved under an `agent._conf` namespace to indicate that they should be considered private.

It was never intended that the user could manipulate these properties, but since they wasn't prefixed with an underscore, this might not have been clear.