### PR TITLE
refactor(*): better format of error messages from the APM Server

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -25,8 +25,20 @@ var request = function (agent, endpoint, payload, cb) {
     if (err) {
       logger.error(err.stack)
     } else if (res.statusCode < 200 || res.statusCode > 299) {
-      // TODO: Parse error JSON body
-      logger.error('Elastic APM HTTP error (%d): %s', res.statusCode, body)
+      var errorMsg = body
+      if (res.headers['content-type'] === 'application/json') {
+        try {
+          errorMsg = JSON.parse(body).error || body
+        } catch (e) {
+          logger.error('Error parsing JSON error response from APM Server: %s', e.message)
+        }
+      }
+      // TODO: The error messages returned by the APM Server will most likely
+      // contain line-breaks. Consider if we actually want to output it as one
+      // line (less readable, but easier to process by a machine), or if we
+      // should output it like today where we just use the line-breaks given to
+      // us
+      logger.error('Elastic APM HTTP error (%d): %s', res.statusCode, errorMsg)
     } else {
       debug('%s payload successfully sent', endpoint)
     }


### PR DESCRIPTION
Example of error message outputtet by the agent after this change:

```
Elastic APM HTTP error (400): Problem validating JSON document against schema: I[#] S[#] doesn't validate with "error#"
  I[#] S[#/required] missing properties: "app", "errors"
```