### PR TITLE
chore(*): remove TODO

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -182,8 +182,7 @@ exports.parseCallsite = function (callsite, agent, cb) {
     function: callsite.getFunctionNameSanitized(),
     in_app: callsite.isApp()
   }
-  // TODO: Don't set it to zero if it's not an int
-  if (!Number.isFinite(frame.lineno)) frame.lineno = 0 // this should be an int, but sometimes it's not?!
+  if (!Number.isFinite(frame.lineno)) frame.lineno = 0 // this should be an int, but sometimes it's not?! ¯\_(ツ)_/¯
   if (filename) frame.abs_path = filename
 
   // Allow skipping when sourceContext is not enabled.


### PR DESCRIPTION
This check was added because we saw it in the wild. Maybe just a bug in an old version of V8, who knows, but let's keep the check. But let's also remove the TODO as the APM Server API requires the `lineno` property and it has to be an int, so there really isn't much within reason that we can do about it.