### PR TITLE
feat(conf): allow serverUrl to contain a sub-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "cookie": "^0.3.1",
     "core-util-is": "^1.0.2",
     "debug": "^3.0.0",
-    "elastic-apm-http-client": "^4.1.0",
+    "elastic-apm-http-client": "^5.1.0",
     "end-of-stream": "^1.1.0",
     "fast-safe-stringify": "^1.1.3",
     "http-headers": "^3.0.1",

--- a/test/integration/server-url-path.js
+++ b/test/integration/server-url-path.js
@@ -1,0 +1,29 @@
+'use strict'
+
+var getPort = require('get-port')
+
+getPort().then(function (port) {
+  var agent = require('../../').start({
+    appName: 'test',
+    serverUrl: 'http://localhost:' + port + '/sub',
+    captureExceptions: false
+  })
+
+  var http = require('http')
+  var test = require('tape')
+
+  test('should not sample', function (t) {
+    var server = http.createServer(function (req, res) {
+      t.equal(req.url, '/sub/v1/errors')
+      res.end()
+      server.close()
+      t.end()
+    })
+
+    server.listen(port, function () {
+      agent.captureError(new Error('foo'))
+    })
+  })
+}, function (err) {
+  throw err
+})


### PR DESCRIPTION
I've updated the elastic-apm-http-client module to support this feature and bumped the dependency.

Closes #115