### PR TITLE
test(ci): don't test GraphQL >=0.12.0

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -33,7 +33,7 @@ ws:
   commands: node test/instrumentation/modules/ws.js
 graphql:
   preinstall: rm -fr node_modules/express-graphql
-  versions: '>=0.7.0 <0.11.0 || >=0.11.1 <1.0.0' # 0.11.0 is buggy
+  versions: '>=0.7.0 <0.11.0 || >=0.11.1 <0.12.0' # 0.11.0 is buggy
   commands: node test/instrumentation/modules/graphql.js
 express-graphql-1:
   name: express-graphql


### PR DESCRIPTION
For the moment we do not support GraphQL 0.12.0 and above. Until support for these versions are added, we'll limit the TAV tests so that our builds don't break.