### PR TITLE
chore(travis): improve readability of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,18 +31,29 @@ jobs:
 
   include:
 
-    # Coverage
-    - stage: 'coverage'
+    ###########################################
+    #                TEST STAGE               #
+    ###########################################
+
+    # Docs
+    -
+      script: npm run docs
+      perl: '5.26'
+
+    ###########################################
+    #             CONVERAGE STAGE             #
+    ###########################################
+
+    - stage: coverage
       script:
         - npm run coverage
         - ./node_modules/.bin/nyc report --reporter=lcov > coverage.lcov
         - npm install -g codecov
         - codecov
 
-    # Docs
-    - stage: 'test'
-      script: npm run docs
-      perl: "5.26"
+    ###########################################
+    #            DEPENDENCY STAGE             #
+    ###########################################
 
     # Node.js 9
     - stage: dependencies


### PR DESCRIPTION
The order of the the different stages are now in the same order as they are executed on Travis and big headlines separate them so it's easier to read