### PR TITLE
test(hapi): fix hapi tests

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -66,3 +66,6 @@ elasticsearch:
 handlebars:
   versions: '*'
   commands: node test/instrumentation/modules/handlebars.js
+hapi:
+  versions: '>=9.0.1 <17.0.0'
+  commands: node test/instrumentation/modules/hapi.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
     -
       node_js: '9'
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
 
     # Node.js 8
@@ -77,7 +77,7 @@ jobs:
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
     -
       node_js: '8'
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
 
     # Node.js 7
@@ -95,7 +95,7 @@ jobs:
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
     -
       node_js: '7'
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
 
     # Node.js 6
@@ -113,7 +113,7 @@ jobs:
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
     -
       node_js: '6'
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
 
     # Node.js 5
@@ -131,7 +131,7 @@ jobs:
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
     -
       node_js: '5'
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
 
     # Node.js 4
@@ -149,7 +149,7 @@ jobs:
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
     -
       node_js: '4'
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi
       script: 'if ! [[ $TRAVIS_BRANCH == greenkeeper/* ]]; then tav --quiet; fi'
 
 addons:

--- a/test/.jenkins_tav.yml
+++ b/test/.jenkins_tav.yml
@@ -2,4 +2,4 @@ TAV:
   - generic-pool+mysql+redis+koa-router+handlebars
   - ioredis+pg
   - bluebird
-  - knex+ws+graphql+express-graphql+elasticsearch
+  - knex+ws+graphql+express-graphql+elasticsearch+hapi

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -10,8 +10,12 @@ var agent = require('../../..').start({
 var test = require('tape')
 var http = require('http')
 var Hapi = require('hapi')
+var semver = require('semver')
+var pkg = require('hapi/package.json')
 
 var originalCaptureError = agent.captureError
+
+function noop () {}
 
 test('extract URL from request', function (t) {
   resetAgent(function (endpoint, headers, data, cb) {
@@ -23,7 +27,7 @@ test('extract URL from request', function (t) {
     t.equal(request.url.hostname, 'localhost')
     t.equal(request.url.port, String(server.info.port))
     t.equal(request.socket.encrypted, false)
-    server.stop()
+    server.stop(noop)
     t.end()
   })
 
@@ -39,7 +43,7 @@ test('route naming', function (t) {
 
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data)
-    server.stop()
+    server.stop(noop)
   })
 
   var server = startServer(function (port) {
@@ -56,18 +60,30 @@ test('route naming', function (t) {
 })
 
 test('connectionless', function (t) {
+  if (semver.satisfies(pkg.version, '<15.0.2')) {
+    t.pass('skipping')
+    t.end()
+    return
+  }
+
   t.plan(1)
 
   resetAgent()
 
   var server = new Hapi.Server()
   server.initialize(function (err) {
-    server.stop()
+    server.stop(noop)
     t.error(err, 'start error')
   })
 })
 
 test('connectionless server error logging with Error', function (t) {
+  if (semver.satisfies(pkg.version, '<15.0.2')) {
+    t.pass('skipping')
+    t.end()
+    return
+  }
+
   t.plan(6)
 
   var customError = new Error('custom error')
@@ -75,7 +91,7 @@ test('connectionless server error logging with Error', function (t) {
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, customError)
     t.ok(opts.custom)
@@ -94,6 +110,12 @@ test('connectionless server error logging with Error', function (t) {
 })
 
 test('connectionless server error logging with String', function (t) {
+  if (semver.satisfies(pkg.version, '<15.0.2')) {
+    t.pass('skipping')
+    t.end()
+    return
+  }
+
   t.plan(6)
 
   var customError = 'custom error'
@@ -101,7 +123,7 @@ test('connectionless server error logging with String', function (t) {
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, customError)
     t.ok(opts.custom)
@@ -120,6 +142,12 @@ test('connectionless server error logging with String', function (t) {
 })
 
 test('connectionless server error logging with Object', function (t) {
+  if (semver.satisfies(pkg.version, '<15.0.2')) {
+    t.pass('skipping')
+    t.end()
+    return
+  }
+
   t.plan(6)
 
   var customError = {
@@ -129,7 +157,7 @@ test('connectionless server error logging with Object', function (t) {
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, 'hapi server emitted a log event tagged error')
     t.ok(opts.custom)
@@ -155,7 +183,7 @@ test('server error logging with Error', function (t) {
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, customError)
     t.ok(opts.custom)
@@ -182,7 +210,7 @@ test('server error logging with Error does not affect event tags', function (t) 
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, customError)
     t.ok(opts.custom)
@@ -217,7 +245,7 @@ test('server error logging with String', function (t) {
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, customError)
     t.ok(opts.custom)
@@ -246,7 +274,7 @@ test('server error logging with Object', function (t) {
   resetAgent()
 
   agent.captureError = function (err, opts) {
-    server.stop()
+    server.stop(noop)
 
     t.equal(err, 'hapi server emitted a log event tagged error')
     t.ok(opts.custom)
@@ -273,7 +301,7 @@ test('request error logging with Error', function (t) {
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
-    server.stop()
+    server.stop(noop)
   })
 
   agent.captureError = function (err, opts) {
@@ -319,7 +347,7 @@ test('request error logging with Error does not affect event tags', function (t)
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
-    server.stop()
+    server.stop(noop)
   })
 
   agent.captureError = function (err, opts) {
@@ -373,7 +401,7 @@ test('request error logging with String', function (t) {
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
-    server.stop()
+    server.stop(noop)
   })
 
   agent.captureError = function (err, opts) {
@@ -421,7 +449,7 @@ test('request error logging with Object', function (t) {
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 2xx', name: 'GET /error' })
 
-    server.stop()
+    server.stop(noop)
   })
 
   agent.captureError = function (err, opts) {
@@ -464,7 +492,7 @@ test('error handling', function (t) {
 
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 5xx', name: 'GET /error' })
-    server.stop()
+    server.stop(noop)
   })
 
   agent.captureError = function (err, opts) {


### PR DESCRIPTION
connectionless tests should not run before 15.0.2.
server.stop(...) requires a stop callback until 10.x.

Fixes #126