### PR TITLE
chore(*): move process fields to namespace

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -210,9 +210,6 @@ function envelope (agent) {
   var payload = {
     service: {
       name: agent._conf.serviceName,
-      pid: process.pid,
-      process_title: trunc(String(process.title), config.INTAKE_STRING_MAX_SIZE),
-      argv: process.argv,
       runtime: {
         name: trunc(String((process.release && process.release.name) || process.argv[0]), config.INTAKE_STRING_MAX_SIZE), // process.release was introduced in v3.0.0
         version: trunc(String(process.version), config.INTAKE_STRING_MAX_SIZE)
@@ -224,6 +221,11 @@ function envelope (agent) {
         name: 'nodejs',
         version: AGENT_VERSION
       }
+    },
+    process: {
+      pid: process.pid,
+      title: trunc(String(process.title), config.INTAKE_STRING_MAX_SIZE),
+      argv: process.argv
     },
     system: {
       hostname: agent._conf.hostname,

--- a/test/request.js
+++ b/test/request.js
@@ -189,12 +189,6 @@ test('#transactions()', function (t) {
 
 function assertRoot (t, payload) {
   t.equal(payload.service.name, 'some-service-name')
-  t.equal(payload.service.pid, process.pid)
-  t.ok(payload.service.pid > 0)
-  t.ok(payload.service.process_title)
-  t.ok(/(\/usr\/local\/bin\/)?node/.test(payload.service.process_title))
-  t.deepEqual(payload.service.argv, process.argv)
-  t.ok(payload.service.argv.length >= 2)
   t.deepEqual(payload.service.runtime, {name: 'node', version: process.version})
   t.deepEqual(payload.service.agent, {name: 'nodejs', version: agentVersion})
   t.equal(payload.service.version, 'my-service-version')
@@ -203,4 +197,12 @@ function assertRoot (t, payload) {
     architecture: process.arch,
     platform: process.platform
   })
+
+  t.ok(payload.process)
+  t.equal(payload.process.pid, process.pid)
+  t.ok(payload.process.pid > 0)
+  t.ok(payload.process.title)
+  t.ok(/(\/usr\/local\/bin\/)?node/.test(payload.process.title))
+  t.deepEqual(payload.process.argv, process.argv)
+  t.ok(payload.process.argv.length >= 2)
 }


### PR DESCRIPTION
The process fields pid, title and argv have been moved into
a process namespace in the message envelopes.

Fixes #149