### PR TITLE
Add `transaction.id` to all errors

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -177,6 +177,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
         opts && opts.custom
       )
     }
+    if (trans) error.transaction = {id: trans.id}
 
     if (opts && opts.uncaught && error.exception) {
       error.exception.uncaught = true


### PR DESCRIPTION
I've split this PR up into two commits on purpose to keep it clean. It should also merged using rebase.

Closes #147