### PR TITLE
Set default stack trace limit to 50 frames

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -337,7 +337,7 @@ Set this option to `false` to disable collecting and reporting source code conte
 ===== `stackTraceLimit`
 
 * *Type:* Number
-* *Default:* `Infinity`
+* *Default:* `50`
 * *Env:* `ELASTIC_APM_STACK_TRACE_LIMIT`
 
 Setting it to `0` will disable stack trace collection.

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,7 +26,7 @@ var DEFAULTS = {
   active: true,
   logLevel: 'info',
   hostname: os.hostname(),
-  stackTraceLimit: Infinity,
+  stackTraceLimit: 50,
   captureExceptions: true,
   filterHttpHeaders: true,
   captureTraceStackTraces: true,

--- a/lib/request.js
+++ b/lib/request.js
@@ -174,14 +174,7 @@ function truncContext (context) {
   }
 }
 
-// TODO: Reconsider truncation limits
 function truncFrames (frames) {
-  // max 300 stack frames
-  if (frames.length > 300) {
-    frames = frames.slice(0, 300)
-  }
-
-  // each line in stack trace must not exeed 1000 chars
   frames.forEach(function (frame, i) {
     if (frame.pre_context) frame.pre_context = truncEach(frame.pre_context, 1000)
     if (frame.context_line) frame.context_line = trunc(String(frame.context_line), 1000)


### PR DESCRIPTION
Fix #110 

BREAKING CHANGE: This changes the default stack trace limit. If the user doesn't already overwrite the `stackTraceLimit` config option, this commit will affect their setup.
