### PR TITLE
refactor(*): use native Object.assign

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -5,7 +5,6 @@ var ServerResponse = require('http').ServerResponse
 var parseUrl = require('url').parse
 var uuid = require('uuid')
 var ElasticAPMHttpClient = require('elastic-apm-http-client')
-var objectAssign = require('object-assign')
 var afterAll = require('after-all-results')
 var isError = require('core-util-is').isError
 var debug = require('debug')('elastic-apm')
@@ -160,18 +159,18 @@ Agent.prototype.captureError = function (err, opts, cb) {
     error.id = id
     error.timestamp = timestamp
     error.context = {
-      user: objectAssign(
+      user: Object.assign(
         {},
         req && parsers.getUserContextFromRequest(req),
         trans && trans._user,
         opts && opts.user
       ),
-      tags: objectAssign(
+      tags: Object.assign(
         {},
         trans && trans._tags,
         opts && opts.tags
       ),
-      custom: objectAssign(
+      custom: Object.assign(
         {},
         trans && trans._custom,
         opts && opts.custom

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,6 @@
 var os = require('os')
 var fs = require('fs')
 var path = require('path')
-var objectAssign = require('object-assign')
 var bool = require('normalize-bool')
 var trunc = require('unicode-byte-truncate')
 
@@ -78,7 +77,7 @@ var BOOL_OPTS = [
 ]
 
 function config (opts) {
-  opts = objectAssign(
+  opts = Object.assign(
     {},
     DEFAULTS,  // default options
     readEnv(), // options read from environment variables

--- a/lib/instrumentation/protocol.js
+++ b/lib/instrumentation/protocol.js
@@ -1,7 +1,6 @@
 'use stirct'
 
 var afterAll = require('after-all-results')
-var objectAssign = require('object-assign')
 var debug = require('debug')('elastic-apm')
 var stackman = require('../stackman')
 var parsers = require('../parsers')
@@ -22,7 +21,7 @@ function encode (transactions, cb) {
         timestamp: new Date(trans._timer.start).toISOString(),
         result: String(trans.result),
         context: {
-          user: objectAssign(
+          user: Object.assign(
             {},
             trans.req && parsers.getUserContextFromRequest(trans.req),
             trans._user

--- a/lib/instrumentation/trace.js
+++ b/lib/instrumentation/trace.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var objectAssign = require('object-assign')
 var debug = require('debug')('elastic-apm')
 var Timer = require('./timer')
 
@@ -92,7 +91,7 @@ Trace.prototype.offsetTime = function () {
 
 Trace.prototype.setDbContext = function (context) {
   if (!context) return
-  this._db = objectAssign(this._db || {}, context)
+  this._db = Object.assign(this._db || {}, context)
 }
 
 Trace.prototype._recordStackTrace = function (obj) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var uuid = require('uuid')
-var objectAssign = require('object-assign')
 var trunc = require('unicode-byte-truncate')
 var express = require('./express-utils')
 var debug = require('debug')('elastic-apm')
@@ -71,12 +70,12 @@ function Transaction (agent, name, type) {
 
 Transaction.prototype.setUserContext = function (context) {
   if (!context) return
-  this._user = objectAssign(this._user || {}, context)
+  this._user = Object.assign(this._user || {}, context)
 }
 
 Transaction.prototype.setCustomContext = function (context) {
   if (!context) return
-  this._custom = objectAssign(this._custom || {}, context)
+  this._custom = Object.assign(this._custom || {}, context)
 }
 
 Transaction.prototype.setTag = function (key, value) {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -3,7 +3,6 @@
 var parseUrl = require('url').parse
 var util = require('util')
 var stringify = require('fast-safe-stringify')
-var objectAssign = require('object-assign')
 var afterAll = require('after-all-results')
 var httpHeaders = require('http-headers')
 var debug = require('debug')('elastic-apm')
@@ -99,7 +98,7 @@ exports.getContextFromRequest = function (req, logBody) {
       remote_address: req.socket.remoteAddress,
       encrypted: !!req.socket.encrypted
     },
-    headers: objectAssign({}, req.headers)
+    headers: Object.assign({}, req.headers)
   }
 
   if (url.protocol) context.url.protocol = url.protocol

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "http-headers": "^3.0.1",
     "is-native": "^1.0.1",
     "normalize-bool": "^1.0.0",
-    "object-assign": "^4.1.1",
     "redact-secrets": "^1.0.0",
     "require-in-the-middle": "^2.1.2",
     "semver": "^5.3.0",

--- a/test/request.js
+++ b/test/request.js
@@ -4,7 +4,6 @@ var os = require('os')
 var zlib = require('zlib')
 var test = require('tape')
 var nock = require('nock')
-var objectAssign = require('object-assign')
 var Agent = require('../lib/agent')
 var request = require('../lib/request')
 
@@ -161,7 +160,7 @@ test('#errors()', function (t) {
   t.test('should not anonymize the http Authorization header if disabled', function (t) {
     global._elastic_apm_initialized = null
     var agent = new Agent()
-    agent.start(objectAssign({filterHttpHeaders: false}, opts))
+    agent.start(Object.assign({filterHttpHeaders: false}, opts))
 
     agent._httpClient.request = function (endpoint, headers, data, cb) {
       t.equal(data.errors.length, 1)


### PR DESCRIPTION
Since dropping support for versions of Node.js older than 4, we no longer need the object-assign polyfill.