### PR TITLE
feat(errors): add captureError call location stack trace

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -315,12 +315,12 @@ Note that if a custom logger is provided, the `logLevel` option will be ignored.
 
 Whether or not the agent should monitor for uncaught exceptions and send them to the APM Server automatically.
 
-[[capture-location-stack-traces]]
-===== `captureLocationStackTraces`
+[[capture-error-log-stack-traces]]
+===== `captureErrorLogStackTraces`
 
 * *Type:* String
-* *Default:* `non-errors`
-* *Env:* `ELASTIC_APM_CAPTURE_LOCATION_STACK_TRACES`
+* *Default:* `messages`
+* *Env:* `ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES`
 
 Normally only `Error` objects have a stack trace associated with them.
 This stack trace is stored along with the error message when the error is sent to the APM Server.
@@ -335,16 +335,16 @@ the location where the error bubbles up to,
 is sometimes more useful for debugging,
 than where the error occurred.
 
-Set this config option to `all` to --
+Set this config option to `always` to --
 besides the error stack trace --
 also capture a stack trace at the location where <<apm-capture-error,`captureError`>> was called.
 
 By default,
-this config option has the value `non-errors`,
-which means that a stack trace of the capture location will be recorded only when `captureError` is called with either a <<message-strings,string>> or the <<parameterized-error-object,special parameterized error object>>,
+this config option has the value `messages`,
+which means that a stack trace of the capture location will be recorded only when `captureError` is called with either a <<message-strings,string>> or the <<parameterized-message-object,special parameterized message object>>,
 in which case a normal stack trace isn't available.
 
-Set this config option to `off` to never record a capture location stack trace.
+Set this config option to `never` to never record a capture location stack trace.
 
 A capture location stack trace is never generated for uncaught exceptions.
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -340,7 +340,7 @@ besides the error stack trace --
 also capture a stack trace at the location where <<apm-capture-error,`captureError`>> was called.
 
 By default,
-this config option have the value `1`,
+this config option has the value `1`,
 which means that a stack trace of the capture location will be recorded only when `captureError` is called with either a <<message-strings,string>> or the <<parameterized-error-object,special parameterized error object>>,
 in which case a normal stack trace isn't available.
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -315,6 +315,39 @@ Note that if a custom logger is provided, the `logLevel` option will be ignored.
 
 Whether or not the agent should monitor for uncaught exceptions and send them to the APM Server automatically.
 
+[[capture-location-stack-traces]]
+===== `captureLocationStackTraces`
+
+* *Type:* Number
+* *Default:* `1`
+* *Env:* `ELASTIC_APM_CAPTURE_LOCATION_STACK_TRACES`
+
+Normally only `Error` objects have a stack trace associated with them.
+This stack trace is stored along with the error message when the error is sent to the APM Server.
+The stack trace points to the place where the `Error` object was instantiated.
+
+But sometimes its valuable to know,
+not where the `Error` was instantiated,
+but where it was detected.
+For instance,
+when an error happens deep within a database driver,
+the location where the error bubbles up to,
+is sometimes more useful for debugging,
+than where the error occurred.
+
+Set this config option to `2` to --
+besides the error stack trace --
+also capture a stack trace at the location where <<apm-capture-error,`captureError`>> was called.
+
+By default,
+this config option have the value `1`,
+which means that a stack trace of the capture location will be recorded only when `captureError` is called with either a <<message-strings,string>> or the <<parameterized-error-object,special parameterized error object>>,
+in which case a normal stack trace isn't available.
+
+Set this config option to `0` to never record a capture location stack trace.
+
+A capture location stack trace is never generated for uncaught exceptions.
+
 [[capture-trace-stack-traces]]
 ===== `captureTraceStackTraces`
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -318,8 +318,8 @@ Whether or not the agent should monitor for uncaught exceptions and send them to
 [[capture-location-stack-traces]]
 ===== `captureLocationStackTraces`
 
-* *Type:* Number
-* *Default:* `1`
+* *Type:* String
+* *Default:* `non-errors`
 * *Env:* `ELASTIC_APM_CAPTURE_LOCATION_STACK_TRACES`
 
 Normally only `Error` objects have a stack trace associated with them.
@@ -335,16 +335,16 @@ the location where the error bubbles up to,
 is sometimes more useful for debugging,
 than where the error occurred.
 
-Set this config option to `2` to --
+Set this config option to `all` to --
 besides the error stack trace --
 also capture a stack trace at the location where <<apm-capture-error,`captureError`>> was called.
 
 By default,
-this config option has the value `1`,
+this config option has the value `non-errors`,
 which means that a stack trace of the capture location will be recorded only when `captureError` is called with either a <<message-strings,string>> or the <<parameterized-error-object,special parameterized error object>>,
 in which case a normal stack trace isn't available.
 
-Set this config option to `0` to never record a capture location stack trace.
+Set this config option to `off` to never record a capture location stack trace.
 
 A capture location stack trace is never generated for uncaught exceptions.
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -141,8 +141,8 @@ Agent.prototype.captureError = function (err, opts, cb) {
   var _isError = isError(err)
 
   if (!(opts && opts.uncaught) &&
-      (agent._conf.captureLocationStackTraces === config.CAPTURE_LOCATION_STACK_TRACE_ALL ||
-       (!_isError && agent._conf.captureLocationStackTraces === config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS))
+      (agent._conf.captureErrorLogStackTraces === config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS ||
+       (!_isError && agent._conf.captureErrorLogStackTraces === config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES))
      ) {
     var captureLocation = {}
     Error.captureStackTrace(captureLocation, Agent.prototype.captureError)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -138,14 +138,17 @@ Agent.prototype.captureError = function (err, opts, cb) {
   var res = opts && opts.response instanceof ServerResponse
     ? opts.response
     : trans && trans.res
+  var _isError = isError(err)
 
-  // TODO: Make ff_captureFrame into a proper config option
-  if (this._conf.ff_captureFrame && !(opts && opts.uncaught)) {
-    // TODO: Use a more performance optimal approach to capture the frames
-    var captureFrameError = new Error()
+  if (!(opts && opts.uncaught) &&
+      ((_isError && agent._conf.captureLocationStackTraces === config.CAPTURE_LOCATION_STACK_TRACE_ALL) ||
+       (!_isError && agent._conf.captureLocationStackTraces >= config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS))
+     ) {
+    var captureLocation = {}
+    Error.captureStackTrace(captureLocation, Agent.prototype.captureError)
   }
 
-  if (!isError(err)) {
+  if (!_isError) {
     prepareError(parsers.parseMessage(err))
   } else {
     parsers.parseError(err, agent, function (_, error) {
@@ -190,13 +193,12 @@ Agent.prototype.captureError = function (err, opts, cb) {
       error.context.response = parsers.getContextFromResponse(res, true)
     }
 
-    if (captureFrameError) {
-      // prepare to add a top frame to the stack trace specifying the location
-      // where captureError was called from. This can make it easier to debug
-      // async stack traces.
-      stackman.callsites(captureFrameError, function (_err, callsites) {
+    if (captureLocation) {
+      // prepare to add a stack trace pointing to where captureError was called
+      // from. This can make it easier to debug async stack traces.
+      stackman.callsites(captureLocation, function (_err, callsites) {
         if (_err) {
-          debug('error while getting capture frame callsites: %s', _err.message)
+          debug('error while getting capture location callsites: %s', _err.message)
         }
 
         var next = afterAll(function (_, frames) {
@@ -204,7 +206,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
           // they were passed on, we would want to suppress them here anyway
 
           if (frames) {
-            frames.shift() // ignore the first frame as it will be this module
+            if (!error.log) error.log = {}
             error.log.stacktrace = frames
           }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -206,7 +206,10 @@ Agent.prototype.captureError = function (err, opts, cb) {
           // they were passed on, we would want to suppress them here anyway
 
           if (frames) {
-            if (!error.log) error.log = {}
+            // In case there isn't any log object, we'll make a dummy message
+            // as the APM Server requires a message to be present if a
+            // stacktrace also present
+            if (!error.log) error.log = {message: 'n/a'}
             error.log.stacktrace = frames
           }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -141,8 +141,8 @@ Agent.prototype.captureError = function (err, opts, cb) {
   var _isError = isError(err)
 
   if (!(opts && opts.uncaught) &&
-      ((_isError && agent._conf.captureLocationStackTraces === config.CAPTURE_LOCATION_STACK_TRACE_ALL) ||
-       (!_isError && agent._conf.captureLocationStackTraces >= config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS))
+      (agent._conf.captureLocationStackTraces === config.CAPTURE_LOCATION_STACK_TRACE_ALL ||
+       (!_isError && agent._conf.captureLocationStackTraces === config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS))
      ) {
     var captureLocation = {}
     Error.captureStackTrace(captureLocation, Agent.prototype.captureError)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -209,7 +209,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
             // In case there isn't any log object, we'll make a dummy message
             // as the APM Server requires a message to be present if a
             // stacktrace also present
-            if (!error.log) error.log = {message: 'n/a'}
+            if (!error.log) error.log = {message: error.exception.message}
             error.log.stacktrace = frames
           }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,9 +7,9 @@ var bool = require('normalize-bool')
 var trunc = require('unicode-byte-truncate')
 
 config.INTAKE_STRING_MAX_SIZE = 1024
-config.CAPTURE_LOCATION_STACK_TRACE_OFF = 0
-config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS = 1
-config.CAPTURE_LOCATION_STACK_TRACE_ALL = 2
+config.CAPTURE_LOCATION_STACK_TRACE_OFF = 'off'
+config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS = 'non-errors'
+config.CAPTURE_LOCATION_STACK_TRACE_ALL = 'all'
 
 module.exports = config
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,9 +7,9 @@ var bool = require('normalize-bool')
 var trunc = require('unicode-byte-truncate')
 
 config.INTAKE_STRING_MAX_SIZE = 1024
-config.CAPTURE_LOCATION_STACK_TRACE_OFF = 'off'
-config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS = 'non-errors'
-config.CAPTURE_LOCATION_STACK_TRACE_ALL = 'all'
+config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER = 'never'
+config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES = 'messages'
+config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS = 'always'
 
 module.exports = config
 
@@ -31,7 +31,7 @@ var DEFAULTS = {
   stackTraceLimit: 50,
   captureExceptions: true,
   filterHttpHeaders: true,
-  captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS,
+  captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
   captureTraceStackTraces: true,
   logBody: false,
   errorOnAbortedRequests: false,
@@ -57,7 +57,7 @@ var ENV_TABLE = {
   stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
   captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
   filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',
-  captureLocationStackTraces: 'ELASTIC_APM_CAPTURE_LOCATION_STACK_TRACES',
+  captureErrorLogStackTraces: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
   captureTraceStackTraces: 'ELASTIC_APM_CAPTURE_TRACE_STACK_TRACES',
   logBody: 'ELASTIC_APM_LOG_BODY',
   errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,9 @@ var bool = require('normalize-bool')
 var trunc = require('unicode-byte-truncate')
 
 config.INTAKE_STRING_MAX_SIZE = 1024
+config.CAPTURE_LOCATION_STACK_TRACE_OFF = 0
+config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS = 1
+config.CAPTURE_LOCATION_STACK_TRACE_ALL = 2
 
 module.exports = config
 
@@ -28,13 +31,13 @@ var DEFAULTS = {
   stackTraceLimit: 50,
   captureExceptions: true,
   filterHttpHeaders: true,
+  captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS,
   captureTraceStackTraces: true,
   logBody: false,
   errorOnAbortedRequests: false,
   abortedErrorThreshold: 25000,
   instrument: true,
   asyncHooks: true,
-  ff_captureFrame: false,
   sourceContextErrorAppFrames: 5,
   sourceContextErrorLibraryFrames: 5,
   sourceContextTraceAppFrames: 5,
@@ -54,6 +57,7 @@ var ENV_TABLE = {
   stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
   captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
   filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',
+  captureLocationStackTraces: 'ELASTIC_APM_CAPTURE_LOCATION_STACK_TRACES',
   captureTraceStackTraces: 'ELASTIC_APM_CAPTURE_TRACE_STACK_TRACES',
   logBody: 'ELASTIC_APM_LOG_BODY',
   errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
@@ -62,7 +66,6 @@ var ENV_TABLE = {
   flushInterval: 'ELASTIC_APM_FLUSH_INTERVAL',
   maxQueueSize: 'ELASTIC_APM_MAX_QUEUE_SIZE',
   asyncHooks: 'ELASTIC_APM_ASYNC_HOOKS',
-  ff_captureFrame: 'ELASTIC_APM_FF_CAPTURE_FRAME',
   sourceContextErrorAppFrames: 'ELASTIC_APM_SOURCE_CONTEXT_ERROR_APP_FRAMES',
   sourceContextErrorLibraryFrames: 'ELASTIC_APM_SOURCE_CONTEXT_ERROR_LIBRARY_FRAMES',
   sourceContextTraceAppFrames: 'ELASTIC_APM_SOURCE_CONTEXT_TRACE_APP_FRAMES',
@@ -78,8 +81,7 @@ var BOOL_OPTS = [
   'logBody',
   'errorOnAbortedRequests',
   'instrument',
-  'asyncHooks',
-  'ff_captureFrame'
+  'asyncHooks'
 ]
 
 function config (opts) {

--- a/test/agent.js
+++ b/test/agent.js
@@ -5,6 +5,7 @@ var test = require('tape')
 var isError = require('core-util-is').isError
 var Agent = require('./_agent')
 var APMServer = require('./_apm_server')
+var config = require('../lib/config')
 
 test('#setUserContext()', function (t) {
   t.test('no active transaction', function (t) {
@@ -186,7 +187,8 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - off (error)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: 0})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_OFF
+    })
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
       })
@@ -202,7 +204,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - off (string)', function (t) {
     t.plan(6)
-    APMServer({captureLocationStackTraces: 0})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_OFF})
       .on('listening', function () {
         this.agent.captureError('foo')
       })
@@ -218,7 +220,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - off (param msg)', function (t) {
     t.plan(6)
-    APMServer({captureLocationStackTraces: 0})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_OFF})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
       })
@@ -234,7 +236,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - non-errors (error)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: 1})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
       })
@@ -250,7 +252,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - non-errors (string)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: 1})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS})
       .on('listening', function () {
         this.agent.captureError('foo')
       })
@@ -266,7 +268,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - non-errors (param msg)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: 1})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
       })
@@ -282,7 +284,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - all (error)', function (t) {
     t.plan(13)
-    APMServer({captureLocationStackTraces: 2})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_ALL})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
       })
@@ -299,7 +301,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - all (string)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: 2})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_ALL})
       .on('listening', function () {
         this.agent.captureError('foo')
       })
@@ -315,7 +317,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - all (param msg)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: 2})
+    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_ALL})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
       })

--- a/test/agent.js
+++ b/test/agent.js
@@ -185,7 +185,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - off (error)', function (t) {
-    t.plan(8)
+    t.plan(9)
     APMServer({captureLocationStackTraces: 0})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
@@ -193,6 +193,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].exception.message, 'foo')
         t.notOk('log' in body.errors[0], 'should not have a log')
         assertStackTrace(t, body.errors[0].exception.stacktrace)
         t.end()
@@ -200,7 +201,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - off (string)', function (t) {
-    t.plan(5)
+    t.plan(6)
     APMServer({captureLocationStackTraces: 0})
       .on('listening', function () {
         this.agent.captureError('foo')
@@ -208,6 +209,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'foo')
         t.notOk('stacktrace' in body.errors[0].log, 'should not have a log.stacktrace')
         t.notOk('exception' in body.errors[0], 'should not have an exception')
         t.end()
@@ -215,7 +217,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - off (param msg)', function (t) {
-    t.plan(5)
+    t.plan(6)
     APMServer({captureLocationStackTraces: 0})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
@@ -223,6 +225,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'Hello World')
         t.notOk('stacktrace' in body.errors[0].log, 'should not have a log.stacktrace')
         t.notOk('exception' in body.errors[0], 'should not have an exception')
         t.end()
@@ -230,7 +233,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - non-errors (error)', function (t) {
-    t.plan(8)
+    t.plan(9)
     APMServer({captureLocationStackTraces: 1})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
@@ -238,6 +241,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].exception.message, 'foo')
         t.notOk('log' in body.errors[0], 'should not have a log')
         assertStackTrace(t, body.errors[0].exception.stacktrace)
         t.end()
@@ -245,7 +249,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - non-errors (string)', function (t) {
-    t.plan(8)
+    t.plan(9)
     APMServer({captureLocationStackTraces: 1})
       .on('listening', function () {
         this.agent.captureError('foo')
@@ -253,6 +257,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'foo')
         t.notOk('exception' in body.errors[0], 'should not have an exception')
         assertStackTrace(t, body.errors[0].log.stacktrace)
         t.end()
@@ -260,7 +265,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - non-errors (param msg)', function (t) {
-    t.plan(8)
+    t.plan(9)
     APMServer({captureLocationStackTraces: 1})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
@@ -268,6 +273,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'Hello World')
         t.notOk('exception' in body.errors[0], 'should not have an exception')
         assertStackTrace(t, body.errors[0].log.stacktrace)
         t.end()
@@ -275,7 +281,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - all (error)', function (t) {
-    t.plan(11)
+    t.plan(13)
     APMServer({captureLocationStackTraces: 2})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
@@ -283,6 +289,8 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'n/a')
+        t.equal(body.errors[0].exception.message, 'foo')
         assertStackTrace(t, body.errors[0].log.stacktrace)
         assertStackTrace(t, body.errors[0].exception.stacktrace)
         t.end()
@@ -290,7 +298,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - all (string)', function (t) {
-    t.plan(8)
+    t.plan(9)
     APMServer({captureLocationStackTraces: 2})
       .on('listening', function () {
         this.agent.captureError('foo')
@@ -298,6 +306,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'foo')
         t.notOk('exception' in body.errors[0], 'should not have an exception')
         assertStackTrace(t, body.errors[0].log.stacktrace)
         t.end()
@@ -305,7 +314,7 @@ test('#captureError()', function (t) {
   })
 
   t.test('capture location stack trace - all (param msg)', function (t) {
-    t.plan(8)
+    t.plan(9)
     APMServer({captureLocationStackTraces: 2})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
@@ -313,6 +322,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].log.message, 'Hello World')
         t.notOk('exception' in body.errors[0], 'should not have an exception')
         assertStackTrace(t, body.errors[0].log.stacktrace)
         t.end()

--- a/test/agent.js
+++ b/test/agent.js
@@ -183,6 +183,141 @@ test('#captureError()', function (t) {
         t.end()
       })
   })
+
+  t.test('capture location stack trace - off (error)', function (t) {
+    t.plan(8)
+    APMServer({captureLocationStackTraces: 0})
+      .on('listening', function () {
+        this.agent.captureError(new Error('foo'))
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('log' in body.errors[0], 'should not have a log')
+        assertStackTrace(t, body.errors[0].exception.stacktrace)
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - off (string)', function (t) {
+    t.plan(5)
+    APMServer({captureLocationStackTraces: 0})
+      .on('listening', function () {
+        this.agent.captureError('foo')
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('stacktrace' in body.errors[0].log, 'should not have a log.stacktrace')
+        t.notOk('exception' in body.errors[0], 'should not have an exception')
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - off (param msg)', function (t) {
+    t.plan(5)
+    APMServer({captureLocationStackTraces: 0})
+      .on('listening', function () {
+        this.agent.captureError({message: 'Hello %s', params: ['World']})
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('stacktrace' in body.errors[0].log, 'should not have a log.stacktrace')
+        t.notOk('exception' in body.errors[0], 'should not have an exception')
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - non-errors (error)', function (t) {
+    t.plan(8)
+    APMServer({captureLocationStackTraces: 1})
+      .on('listening', function () {
+        this.agent.captureError(new Error('foo'))
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('log' in body.errors[0], 'should not have a log')
+        assertStackTrace(t, body.errors[0].exception.stacktrace)
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - non-errors (string)', function (t) {
+    t.plan(8)
+    APMServer({captureLocationStackTraces: 1})
+      .on('listening', function () {
+        this.agent.captureError('foo')
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('exception' in body.errors[0], 'should not have an exception')
+        assertStackTrace(t, body.errors[0].log.stacktrace)
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - non-errors (param msg)', function (t) {
+    t.plan(8)
+    APMServer({captureLocationStackTraces: 1})
+      .on('listening', function () {
+        this.agent.captureError({message: 'Hello %s', params: ['World']})
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('exception' in body.errors[0], 'should not have an exception')
+        assertStackTrace(t, body.errors[0].log.stacktrace)
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - all (error)', function (t) {
+    t.plan(11)
+    APMServer({captureLocationStackTraces: 2})
+      .on('listening', function () {
+        this.agent.captureError(new Error('foo'))
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        assertStackTrace(t, body.errors[0].log.stacktrace)
+        assertStackTrace(t, body.errors[0].exception.stacktrace)
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - all (string)', function (t) {
+    t.plan(8)
+    APMServer({captureLocationStackTraces: 2})
+      .on('listening', function () {
+        this.agent.captureError('foo')
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('exception' in body.errors[0], 'should not have an exception')
+        assertStackTrace(t, body.errors[0].log.stacktrace)
+        t.end()
+      })
+  })
+
+  t.test('capture location stack trace - all (param msg)', function (t) {
+    t.plan(8)
+    APMServer({captureLocationStackTraces: 2})
+      .on('listening', function () {
+        this.agent.captureError({message: 'Hello %s', params: ['World']})
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.notOk('exception' in body.errors[0], 'should not have an exception')
+        assertStackTrace(t, body.errors[0].log.stacktrace)
+        t.end()
+      })
+  })
 })
 
 test('#handleUncaughtExceptions()', function (t) {
@@ -230,6 +365,13 @@ test('#handleUncaughtExceptions()', function (t) {
       })
   })
 })
+
+function assertStackTrace (t, stacktrace) {
+  t.ok(stacktrace !== undefined, 'should have a stack trace')
+  t.ok(Array.isArray(stacktrace), 'stack trace should be an array')
+  t.ok(stacktrace.length > 0, 'stack trace should have at least one frame')
+  t.equal(stacktrace[0].filename, 'test/agent.js')
+}
 
 function validateErrorRequest (t) {
   return function (req) {

--- a/test/agent.js
+++ b/test/agent.js
@@ -291,7 +291,7 @@ test('#captureError()', function (t) {
       .on('request', validateErrorRequest(t))
       .on('body', function (body) {
         t.equal(body.errors.length, 1)
-        t.equal(body.errors[0].log.message, 'n/a')
+        t.equal(body.errors[0].log.message, 'foo')
         t.equal(body.errors[0].exception.message, 'foo')
         assertStackTrace(t, body.errors[0].log.stacktrace)
         assertStackTrace(t, body.errors[0].exception.stacktrace)

--- a/test/agent.js
+++ b/test/agent.js
@@ -187,8 +187,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - off (error)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_OFF
-    })
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
       })
@@ -204,7 +203,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - off (string)', function (t) {
     t.plan(6)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_OFF})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER})
       .on('listening', function () {
         this.agent.captureError('foo')
       })
@@ -220,7 +219,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - off (param msg)', function (t) {
     t.plan(6)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_OFF})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
       })
@@ -236,7 +235,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - non-errors (error)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
       })
@@ -252,7 +251,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - non-errors (string)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES})
       .on('listening', function () {
         this.agent.captureError('foo')
       })
@@ -268,7 +267,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - non-errors (param msg)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
       })
@@ -284,7 +283,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - all (error)', function (t) {
     t.plan(13)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_ALL})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS})
       .on('listening', function () {
         this.agent.captureError(new Error('foo'))
       })
@@ -301,7 +300,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - all (string)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_ALL})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS})
       .on('listening', function () {
         this.agent.captureError('foo')
       })
@@ -317,7 +316,7 @@ test('#captureError()', function (t) {
 
   t.test('capture location stack trace - all (param msg)', function (t) {
     t.plan(9)
-    APMServer({captureLocationStackTraces: config.CAPTURE_LOCATION_STACK_TRACE_ALL})
+    APMServer({captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS})
       .on('listening', function () {
         this.agent.captureError({message: 'Hello %s', params: ['World']})
       })

--- a/test/config.js
+++ b/test/config.js
@@ -5,6 +5,7 @@ var util = require('util')
 var test = require('tape')
 var isRegExp = require('core-util-is').isRegExp
 var Agent = require('./_agent')
+var config = require('../lib/config')
 
 var optionFixtures = [
   ['appName', 'APP_NAME'],
@@ -12,7 +13,7 @@ var optionFixtures = [
   ['appVersion', 'APP_VERSION'],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME', os.hostname()],
-  ['captureLocationStackTraces', 'CAPTURE_LOCATION_STACK_TRACES', 1],
+  ['captureLocationStackTraces', 'CAPTURE_LOCATION_STACK_TRACES', config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', 50],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['instrument', 'INSTRUMENT', true],

--- a/test/config.js
+++ b/test/config.js
@@ -12,6 +12,7 @@ var optionFixtures = [
   ['appVersion', 'APP_VERSION'],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME', os.hostname()],
+  ['captureLocationStackTraces', 'CAPTURE_LOCATION_STACK_TRACES', 1],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', 50],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['instrument', 'INSTRUMENT', true],
@@ -19,8 +20,7 @@ var optionFixtures = [
   ['sourceContextErrorAppFrames', 'SOURCE_CONTEXT_ERROR_APP_FRAMES', 5],
   ['sourceContextErrorLibraryFrames', 'SOURCE_CONTEXT_ERROR_LIBRARY_FRAMES', 5],
   ['sourceContextTraceAppFrames', 'SOURCE_CONTEXT_TRACE_APP_FRAMES', 5],
-  ['sourceContextTraceLibraryFrames', 'SOURCE_CONTEXT_TRACE_LIBRARY_FRAMES', 0],
-  ['ff_captureFrame', 'FF_CAPTURE_FRAME', false]
+  ['sourceContextTraceLibraryFrames', 'SOURCE_CONTEXT_TRACE_LIBRARY_FRAMES', 0]
 ]
 
 var falsyValues = [false, 0, '', '0', 'false', 'no', 'off', 'disabled']

--- a/test/config.js
+++ b/test/config.js
@@ -13,7 +13,7 @@ var optionFixtures = [
   ['appVersion', 'APP_VERSION'],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME', os.hostname()],
-  ['captureLocationStackTraces', 'CAPTURE_LOCATION_STACK_TRACES', config.CAPTURE_LOCATION_STACK_TRACE_NON_ERRORS],
+  ['captureErrorLogStackTraces', 'CAPTURE_ERROR_LOG_STACK_TRACES', config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', 50],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['instrument', 'INSTRUMENT', true],


### PR DESCRIPTION
~~Depends on #178 + #180~~

Adds `captureErrorLogStackTraces` config option.

Normally only `Error` objects have a stack trace associated with them. This stack trace is stored along with the error message when the error is sent to the APM Server. The stack trace points to the place where the `Error` object was instantiated.

But sometimes its valuable to know, not where the `Error` was instantiated, but where it was detected. For instance, when an error happens deep within a database driver, the location where the error bubbles up to, is sometimes more useful for debugging, than where the error occurred.

Set the `captureErrorLogStackTraces` config option to `always` to &mdash; besides the error stack trace &mdash; also capture a stack trace at the location where `captureError` was called.

By default, the `captureErrorLogStackTraces` config option have the value `messages`, which means that a stack trace of the capture location will be recorded only when `captureError` is called with either a string or the special parameterized error object, in which case a normal stack trace isn't available.

Set the `captureErrorLogStackTraces` config option to `never` to never record a capture location stack trace.

A capture location stack trace is never generated for uncaught exceptions.

Closes #160, closes #112