### PR TITLE
Test on Windows using AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,26 @@
+environment:
+  PGUSER: "postgres"
+  PGPASSWORD: "Password12!"
+  MYSQL_PASSWORD: "Password12!"
+
+# Install scripts runs after repo cloning
+install:
+  - ps: .\test\script\appveyor\install-redis.ps1
+  - ps: .\test\script\appveyor\install-elasticsearch.ps1
+  - ps: Install-Product node 8 # Latest LTS
+  - npm install
+
+# Services are started after all install scripts have run
+services:
+  - mysql
+  - mongodb
+  - postgresql
+
+# Post-install test scripts
+test_script:
+  - node --version
+  - npm --version
+  - node test/test.js # we cannot run `npm test` because of https://github.com/elastic/apm-agent-nodejs/issues/199
+
+# Don't actually build
+build: off

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 # Files to ignore
+.appveyor.yml
 .dockerignore
 .tav.yml
 .travis.yml

--- a/test/_assert.js
+++ b/test/_assert.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var path = require('path')
+
 exports.stacktrace = function (t, topFunctionName, topAbsPath, stacktrace) {
   t.ok(Array.isArray(stacktrace), 'stacktrace should be an array')
   t.ok(stacktrace.length > 0, 'stacktrace should have at least one frame')
@@ -11,7 +13,7 @@ exports.stacktrace = function (t, topFunctionName, topAbsPath, stacktrace) {
 
 function stackFrameValidator (t) {
   return function (frame) {
-    var nodeCore = frame.abs_path.indexOf('/') === -1
+    var nodeCore = frame.abs_path.indexOf(path.sep) === -1
     var shouldHaveSource = !nodeCore && frame.in_app
 
     var expectedKeys = shouldHaveSource

--- a/test/agent.js
+++ b/test/agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var path = require('path')
 var http = require('http')
 var test = require('tape')
 var isError = require('core-util-is').isError
@@ -381,7 +382,7 @@ function assertStackTrace (t, stacktrace) {
   t.ok(stacktrace !== undefined, 'should have a stack trace')
   t.ok(Array.isArray(stacktrace), 'stack trace should be an array')
   t.ok(stacktrace.length > 0, 'stack trace should have at least one frame')
-  t.equal(stacktrace[0].filename, 'test/agent.js')
+  t.equal(stacktrace[0].filename, path.join('test', 'agent.js'))
 }
 
 function validateErrorRequest (t) {

--- a/test/instrumentation/modules/mysql/_utils.js
+++ b/test/instrumentation/modules/mysql/_utils.js
@@ -3,9 +3,25 @@
 var mysql = require('mysql')
 
 exports.reset = reset
+exports.credentials = credentials
+
+var DEFAULTS = {
+  host: process.env.MYSQL_HOST || 'localhost',
+  user: process.env.MYSQL_USER || 'root',
+  password: process.env.MYSQL_PASSWORD,
+  database: process.env.MYSQL_DATABASE || 'test_elastic_apm'
+}
+
+function credentials (conf) {
+  return Object.assign(
+    {},
+    DEFAULTS,
+    conf
+  )
+}
 
 function reset (cb) {
-  var client = mysql.createConnection({user: 'root', database: 'mysql', host: process.env.MYSQL_HOST})
+  var client = mysql.createConnection(credentials({database: 'mysql'}))
 
   client.connect(function (err) {
     if (err) throw err

--- a/test/instrumentation/modules/mysql/mysql.js
+++ b/test/instrumentation/modules/mysql/mysql.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var host = process.env.MYSQL_HOST
 var agent = require('../../../..').start({
   appName: 'test',
   secretToken: 'test',
@@ -451,11 +450,7 @@ function createConnection (cb) {
       }
     }
 
-    queryable = mysql.createConnection({
-      host: host,
-      user: 'root',
-      database: 'test_elastic_apm'
-    })
+    queryable = mysql.createConnection(utils.credentials())
     queryable.connect()
 
     cb()
@@ -471,11 +466,7 @@ function createPool (cb) {
       }
     }
 
-    var pool = mysql.createPool({
-      host: host,
-      user: 'root',
-      database: 'test_elastic_apm'
-    })
+    var pool = mysql.createPool(utils.credentials())
     queryable = pool
 
     cb()
@@ -491,11 +482,7 @@ function createPoolAndGetConnection (cb) {
       }
     }
 
-    var pool = mysql.createPool({
-      host: host,
-      user: 'root',
-      database: 'test_elastic_apm'
-    })
+    var pool = mysql.createPool(utils.credentials())
     pool.getConnection(function (err, conn) {
       if (err) throw err
       queryable = conn
@@ -514,11 +501,7 @@ function createPoolClusterAndGetConnection (cb) {
     }
 
     var cluster = mysql.createPoolCluster()
-    cluster.add({
-      host: host,
-      user: 'root',
-      database: 'test_elastic_apm'
-    })
+    cluster.add(utils.credentials())
     cluster.getConnection(function (err, conn) {
       if (err) throw err
       queryable = conn
@@ -534,11 +517,7 @@ function createPoolClusterAndGetConnectionViaOf (cb) {
     }
 
     var cluster = mysql.createPoolCluster()
-    cluster.add({
-      host: host,
-      user: 'root',
-      database: 'test_elastic_apm'
-    })
+    cluster.add(utils.credentials())
     cluster.of('*').getConnection(function (err, conn) {
       if (err) throw err
       queryable = conn

--- a/test/instrumentation/modules/mysql/pool-release-1.js
+++ b/test/instrumentation/modules/mysql/pool-release-1.js
@@ -31,13 +31,7 @@ test('release connection prior to transaction', function (t) {
 
 function createPool (cb) {
   setup(function () {
-    var pool = mysql.createPool({
-      host: process.env.MYSQL_HOST,
-      user: 'root',
-      database: 'test_elastic_apm'
-    })
-
-    cb(pool)
+    cb(mysql.createPool(utils.credentials()))
   })
 }
 

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var path = require('path')
 var http = require('http')
 var test = require('tape')
 var semver = require('semver')
@@ -248,7 +249,7 @@ test('#parseError()', function (t) {
     }
     parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
       t.error(err)
-      t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+      t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
       t.ok('exception' in parsed)
       t.equal(parsed.exception.message, '')
@@ -271,7 +272,7 @@ test('#parseError()', function (t) {
     }
     parsers.parseError(new Error('Crap'), fakeAgent, function (err, parsed) {
       t.error(err)
-      t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+      t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
       t.ok('exception' in parsed)
       t.equal(parsed.exception.message, 'Crap')
@@ -294,7 +295,7 @@ test('#parseError()', function (t) {
     }
     parsers.parseError(new TypeError('Crap'), fakeAgent, function (err, parsed) {
       t.error(err)
-      t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+      t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
       t.ok('exception' in parsed)
       t.equal(parsed.exception.message, 'Crap')
@@ -320,7 +321,7 @@ test('#parseError()', function (t) {
     } catch (e) {
       parsers.parseError(e, fakeAgent, function (err, parsed) {
         t.error(err)
-        t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+        t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
         t.notOk('log' in parsed)
         t.ok('exception' in parsed)
         t.equal(parsed.exception.message, 'Derp')
@@ -351,7 +352,7 @@ test('#parseError()', function (t) {
         var msg = semver.lt(process.version, '0.11.0')
           ? 'Cannot call method \'Derp\' of undefined'
           : 'Cannot read property \'Derp\' of undefined'
-        t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+        t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
         t.notOk('log' in parsed)
         t.ok('exception' in parsed)
         t.equal(parsed.exception.message, msg)
@@ -377,7 +378,7 @@ test('#parseError()', function (t) {
     t.ok(typeof err.stack === 'string')
     parsers.parseError(err, fakeAgent, function (err, parsed) {
       t.error(err)
-      t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+      t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
       t.ok('exception' in parsed)
       t.equal(parsed.exception.message, 'foo')
@@ -425,7 +426,7 @@ test('#parseError()', function (t) {
     }
     parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
       t.error(err)
-      t.equal(parsed.culprit, 'Test.<anonymous> (test/parsers.js)')
+      t.equal(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
       t.ok('exception' in parsed)
       t.equal(parsed.exception.message, '')
@@ -488,7 +489,7 @@ test('#parseError()', function (t) {
       t.error(err)
       t.ok(parsed.exception.stacktrace.length > 0)
       parsed.exception.stacktrace.forEach(function (callsite) {
-        var nodeCore = !/\//.test(callsite.abs_path)
+        var nodeCore = callsite.abs_path.indexOf(path.sep) === -1
         if (!callsite.in_app && !nodeCore) {
           t.ok(Array.isArray(callsite.pre_context))
           t.equal(callsite.pre_context.length, 2)
@@ -517,7 +518,7 @@ test('#parseError()', function (t) {
       t.error(err)
       t.ok(parsed.exception.stacktrace.length > 0)
       parsed.exception.stacktrace.forEach(function (callsite) {
-        var nodeCore = !/\//.test(callsite.abs_path)
+        var nodeCore = callsite.abs_path.indexOf(path.sep) === -1
         if (nodeCore) {
           t.notOk('pre_context' in callsite)
           t.notOk('context_line' in callsite)

--- a/test/request.js
+++ b/test/request.js
@@ -210,7 +210,10 @@ function assertRoot (t, payload) {
   t.equal(payload.app.pid, process.pid)
   t.ok(payload.app.pid > 0)
   t.ok(payload.app.process_title)
-  t.ok(/(\/usr\/local\/bin\/)?node/.test(payload.app.process_title))
+  t.ok(
+    /(npm|node)/.test(payload.app.process_title),
+    `app.process_title should contain expected value (was: "${payload.app.process_title}")`
+  )
   t.deepEqual(payload.app.argv, process.argv)
   t.ok(payload.app.argv.length >= 2)
   t.deepEqual(payload.app.runtime, {name: 'node', version: process.version})

--- a/test/script/appveyor/install-elasticsearch.ps1
+++ b/test/script/appveyor/install-elasticsearch.ps1
@@ -1,0 +1,24 @@
+Write-Host "Preparing to download and install Elasticsearch..." -ForegroundColor Cyan
+$esVersion = "6.1.2"
+$downloadUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($esVersion).zip"
+$zipPath = "$($env:USERPROFILE)\elasticsearch-$esVersion.zip"
+$extractRoot = "$env:SYSTEMDRIVE\Elasticsearch"
+$esRoot = "$extractRoot\elasticsearch-$esVersion"
+
+Write-Host "Downloading Elasticsearch..."
+(New-Object Net.WebClient).DownloadFile($downloadUrl, $zipPath)
+7z x $zipPath -y -o"$extractRoot" | Out-Null
+del $zipPath
+
+Write-Host "Installing Elasticsearch as a Windows service..."
+& "$esRoot\bin\elasticsearch-service.bat" install
+
+Write-Host "Starting Elasticsearch service..."
+& "$esRoot\bin\elasticsearch-service.bat" start
+
+do {
+  Write-Host "Waiting for Elasticsearch service to bootstrap..."
+  sleep 1
+} until(Test-NetConnection localhost -Port 9200 | ? { $_.TcpTestSucceeded } )
+
+Write-Host "Elasticsearch installed" -ForegroundColor Green

--- a/test/script/appveyor/install-redis.ps1
+++ b/test/script/appveyor/install-redis.ps1
@@ -1,0 +1,14 @@
+Write-Host "Downloading Redis..." -ForegroundColor Cyan
+$redisRoot = "$env:SYSTEMDRIVE\Redis"
+$zipPath = "$($env:USERPROFILE)\redis-2.8.19.zip"
+(New-Object Net.WebClient).DownloadFile('https://github.com/MSOpenTech/redis/releases/download/win-2.8.19/redis-2.8.19.zip', $zipPath)
+7z x $zipPath -y -o"$redisRoot" | Out-Null
+del $zipPath
+
+Write-Host "Installing Redis as a Windows service..."
+& "$redisRoot\redis-server.exe" --service-install
+
+Write-Host "Starting Redis service..."
+& "$redisRoot\redis-server.exe" --service-start
+
+Write-Host "Redis installed" -ForegroundColor Green

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -39,10 +39,10 @@ test('fails', function (t) {
       var error = data.errors[0]
       t.equal(error.exception.message, 'foo')
       t.equal(error.exception.type, 'Error')
-      t.equal(error.culprit, 'generateError (test/sourcemaps/fixtures/lib/error-inline-broken.js)')
+      t.equal(error.culprit, `generateError (${path.join('test', 'sourcemaps', 'fixtures', 'lib', 'error-inline-broken.js')})`)
 
       var frame = error.exception.stacktrace[0]
-      t.equal(frame.filename, 'test/sourcemaps/fixtures/lib/error-inline-broken.js')
+      t.equal(frame.filename, path.join('test', 'sourcemaps', 'fixtures', 'lib', 'error-inline-broken.js'))
       t.equal(frame.lineno, 6)
       t.equal(frame.function, 'generateError')
       t.equal(frame.in_app, __dirname.indexOf('node_modules') === -1)
@@ -58,10 +58,10 @@ test('fails', function (t) {
       var error = data.errors[0]
       t.equal(error.exception.message, 'foo')
       t.equal(error.exception.type, 'Error')
-      t.equal(error.culprit, 'generateError (test/sourcemaps/fixtures/lib/error-map-missing.js)')
+      t.equal(error.culprit, `generateError (${path.join('test', 'sourcemaps', 'fixtures', 'lib', 'error-map-missing.js')})`)
 
       var frame = error.exception.stacktrace[0]
-      t.equal(frame.filename, 'test/sourcemaps/fixtures/lib/error-map-missing.js')
+      t.equal(frame.filename, path.join('test', 'sourcemaps', 'fixtures', 'lib', 'error-map-missing.js'))
       t.equal(frame.lineno, 6)
       t.equal(frame.function, 'generateError')
       t.equal(frame.in_app, __dirname.indexOf('node_modules') === -1)
@@ -77,10 +77,10 @@ test('fails', function (t) {
       var error = data.errors[0]
       t.equal(error.exception.message, 'foo')
       t.equal(error.exception.type, 'Error')
-      t.equal(error.culprit, 'generateError (test/sourcemaps/fixtures/lib/error-broken.js)')
+      t.equal(error.culprit, `generateError (${path.join('test', 'sourcemaps', 'fixtures', 'lib', 'error-broken.js')})`)
 
       var frame = error.exception.stacktrace[0]
-      t.equal(frame.filename, 'test/sourcemaps/fixtures/lib/error-broken.js')
+      t.equal(frame.filename, path.join('test', 'sourcemaps', 'fixtures', 'lib', 'error-broken.js'))
       t.equal(frame.lineno, 6)
       t.equal(frame.function, 'generateError')
       t.equal(frame.in_app, __dirname.indexOf('node_modules') === -1)
@@ -103,10 +103,10 @@ function assertSourceFound (t, data) {
   var error = data.errors[0]
   t.equal(error.exception.message, 'foo')
   t.equal(error.exception.type, 'Error')
-  t.equal(error.culprit, 'generateError (test/sourcemaps/fixtures/src/error.js)')
+  t.equal(error.culprit, `generateError (${path.join('test', 'sourcemaps', 'fixtures', 'src', 'error.js')})`)
 
   var frame = error.exception.stacktrace[0]
-  t.equal(frame.filename, 'test/sourcemaps/fixtures/src/error.js')
+  t.equal(frame.filename, path.join('test', 'sourcemaps', 'fixtures', 'src', 'error.js'))
   t.equal(frame.lineno, 2)
   t.equal(frame.function, 'generateError')
   t.equal(frame.in_app, __dirname.indexOf('node_modules') === -1)
@@ -121,10 +121,10 @@ function assertSourceNotFound (t, data) {
   var error = data.errors[0]
   t.equal(error.exception.message, 'foo')
   t.equal(error.exception.type, 'Error')
-  t.equal(error.culprit, 'generateError (test/sourcemaps/fixtures/src/not/found.js)')
+  t.equal(error.culprit, `generateError (${path.join('test', 'sourcemaps', 'fixtures', 'src', 'not', 'found.js')})`)
 
   var frame = error.exception.stacktrace[0]
-  t.equal(frame.filename, 'test/sourcemaps/fixtures/src/not/found.js')
+  t.equal(frame.filename, path.join('test', 'sourcemaps', 'fixtures', 'src', 'not', 'found.js'))
   t.equal(frame.lineno, 2)
   t.equal(frame.function, 'generateError')
   t.equal(frame.in_app, __dirname.indexOf('node_modules') === -1)


### PR DESCRIPTION
This PR tests the latest Node.js LTS version on Windows using the AppVeyor service.

Since AppVeyor doesn't allow parallel builds without payment, I'm only running one build, as it would otherwise take so long that we might end up waiting for the Windows tests. If we wanted to run all builds, this is how the `.appvoyer.yml` file would have to be modified:

```diff
   PGUSER: "postgres"
   PGPASSWORD: "Password12!"
   MYSQL_PASSWORD: "Password12!"
+  matrix:
+    - NODEJS_VERSION: "9"
+    - NODEJS_VERSION: "8"
+    - NODEJS_VERSION: "6"
+    - NODEJS_VERSION: "4"
+    -
+      NODEJS_VERSION: "9"
+      ELASTIC_APM_ASYNC_HOOKS: "0"
+    -
+      NODEJS_VERSION: "8"
+      ELASTIC_APM_ASYNC_HOOKS: "0"

 # Install scripts runs after repo cloning
 install:
   - ps: .\test\script\appveyor\install-redis.ps1
   - ps: .\test\script\appveyor\install-elasticsearch.ps1
-  - ps: Install-Product node 8 # Latest LTS
+  - ps: Install-Product node $env:NODEJS_VERSION
   - npm install

 # Services are started after all install scripts have run
```

I've split this PR up into multiple commits in case we ever want to switch to another service than AppVeyor. That way we can easily revert only the AppVeyor commit.

Fixes #198