### PR TITLE
chore(*): only list Node versions in 'engines' field that we support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": "4 || 6 || >= 8"
+    "node": "4 || 6 || 8 || 9"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
As of now the old and the new version of this field is the same, but when 10.x is released we don't want that to be covered as well.
