### PR TITLE
docs: emphasize errors aren't ignored by ignore* config options

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -187,7 +187,7 @@ an exact match will be performed.
 If an element in the array is a `RegExp` object,
 its test function will be called with the URL being tested.
 
-Note that all errors that are captured during a request to an ignored URL are still sent to the APM Server regardles of this setting.
+Note that all errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of this setting.
 
 Example usage:
 
@@ -218,7 +218,7 @@ it's matched against the beginning of the User-Agent.
 If an element in the array is a `RegExp` object,
 its test function will be called with the User-Agent string being tested.
 
-Note that all errors that are captured during a request by an ignored user agent are still sent to the APM Server regardles of this setting.
+Note that all errors that are captured during a request by an ignored user agent are still sent to the APM Server regardless of this setting.
 
 Example usage:
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -187,6 +187,8 @@ an exact match will be performed.
 If an element in the array is a `RegExp` object,
 its test function will be called with the URL being tested.
 
+Note that all errors that are captured during a request to an ignored URL are still sent to the APM Server regardles of this setting.
+
 Example usage:
 
 [source,js]
@@ -215,6 +217,8 @@ If an element in the array is a `String`,
 it's matched against the beginning of the User-Agent.
 If an element in the array is a `RegExp` object,
 its test function will be called with the User-Agent string being tested.
+
+Note that all errors that are captured during a request by an ignored user agent are still sent to the APM Server regardles of this setting.
 
 Example usage:
 


### PR DESCRIPTION
Fixes #212