### PR TITLE
feat: allow setting of framework name and version

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -288,6 +288,32 @@ The OS hostname is automatically logged along with all errors and transactions.
 If you want to overwrite this,
 use this option.
 
+[[framework-name]]
+===== `frameworkName`
+
+* *Type:* String
+* *Env:* `ELASTIC_APM_FRAMEWORK_NAME`
+
+Set the name of the web framework used by the instrumented service / application.
+The name will be available as metadata for all errors and transactions sent to the APM Server.
+This can be useful for debugging and filtering.
+
+By default,
+the agent will set the value of this config option if the framework can be detected automatically.
+
+[[framework-version]]
+===== `frameworkVersion`
+
+* *Type:* String
+* *Env:* `ELASTIC_APM_FRAMEWORK_VERSION`
+
+Set the version of the web framework used by the instrumented service / application.
+The version will be available as metadata for all errors and transactions sent to the APM Server.
+This can be useful for debugging and filtering.
+
+By default,
+the agent will set the value of this config option if the framework can be detected automatically.
+
 [[log-level]]
 ===== `logLevel`
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -28,7 +28,6 @@ function Agent () {
 
   this._instrumentation = new Instrumentation(this)
   this._filters = new Filters()
-  this._platform = {}
 
   this._config()
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,8 @@ var ENV_TABLE = {
   active: 'ELASTIC_APM_ACTIVE',
   logLevel: 'ELASTIC_APM_LOG_LEVEL',
   hostname: 'ELASTIC_APM_HOSTNAME',
+  frameworkName: 'ELASTIC_APM_FRAMEWORK_NAME',
+  frameworkVersion: 'ELASTIC_APM_FRAMEWORK_VERSION',
   stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
   captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
   filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',

--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -5,7 +5,8 @@ var debug = require('debug')('elastic-apm')
 var shimmer = require('../shimmer')
 
 module.exports = function (express, agent, version) {
-  agent._platform.framework = { name: 'express', version: version }
+  if (!agent._conf.frameworkName) agent._conf.frameworkName = 'express'
+  if (!agent._conf.frameworkVersion) agent._conf.frameworkVersion = version
 
   if (!semver.satisfies(version, '^4.0.0')) {
     debug('express version %s not supported - aborting...', version)

--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -5,7 +5,8 @@ var debug = require('debug')('elastic-apm')
 var shimmer = require('../shimmer')
 
 module.exports = function (hapi, agent, version) {
-  agent._platform.framework = { name: 'hapi', version: version }
+  if (!agent._conf.frameworkName) agent._conf.frameworkName = 'hapi'
+  if (!agent._conf.frameworkVersion) agent._conf.frameworkVersion = version
 
   if (!semver.satisfies(version, '>=9.0.0')) {
     debug('hapi version %s not supported - aborting...', version)

--- a/lib/request.js
+++ b/lib/request.js
@@ -233,10 +233,10 @@ function envelope (agent) {
 
   if (agent._conf.serviceVersion) payload.service.version = agent._conf.serviceVersion
 
-  if (agent._platform.framework) {
+  if (agent._conf.frameworkName || agent._conf.frameworkVersion) {
     payload.service.framework = {
-      name: agent._platform.framework.name,
-      version: agent._platform.framework.version
+      name: agent._conf.frameworkName,
+      version: agent._conf.frameworkVersion
     }
   }
 

--- a/test/_apm_server.js
+++ b/test/_apm_server.js
@@ -27,6 +27,7 @@ function APMServer (agentOpts) {
 
   getPort().then(function (port) {
     self.agent.start(Object.assign(
+      {},
       defaultAgentOpts,
       {serverUrl: 'http://localhost:' + port},
       agentOpts

--- a/test/config.js
+++ b/test/config.js
@@ -15,6 +15,8 @@ var optionFixtures = [
   ['serviceVersion', 'SERVICE_VERSION'],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME', os.hostname()],
+  ['frameworkName', 'FRAMEWORK_NAME'],
+  ['frameworkVersion', 'FRAMEWORK_VERSION'],
   ['captureErrorLogStackTraces', 'CAPTURE_ERROR_LOG_STACK_TRACES', config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', 50],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -29,7 +29,6 @@ module.exports = function mockAgent (cb) {
       ignoreUserAgentRegExp: [],
       transactionSampleRate: 1.0
     },
-    _platform: {},
     _filters: new Filters(),
     _httpClient: {
       request: cb || noop

--- a/test/request.js
+++ b/test/request.js
@@ -25,6 +25,38 @@ test('#errors()', function (t) {
       })
   })
 
+  t.test('no custom framework', function (t) {
+    t.plan(15)
+    var errors = [{}]
+    APMServer()
+      .on('listening', function () {
+        request.errors(this.agent, errors)
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        assertRoot(t, body)
+        t.notOk(body.service.framework, 'should not have service.framework property')
+        t.deepEqual(body.errors, errors)
+        t.end()
+      })
+  })
+
+  t.test('custom framework', function (t) {
+    t.plan(15)
+    var errors = [{}]
+    APMServer({frameworkName: 'foo', frameworkVersion: 'bar'})
+      .on('listening', function () {
+        request.errors(this.agent, errors)
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        assertRoot(t, body)
+        t.deepEqual(body.service.framework, {name: 'foo', version: 'bar'})
+        t.deepEqual(body.errors, errors)
+        t.end()
+      })
+  })
+
   t.test('non-string log.message', function (t) {
     t.plan(14)
     var errors = [{log: {message: 1}}]
@@ -191,18 +223,52 @@ test('#errors()', function (t) {
 })
 
 test('#transactions()', function (t) {
-  t.plan(14)
-  var transactions = [{spans: []}]
-  APMServer()
-    .on('listening', function () {
-      request.transactions(this.agent, transactions)
-    })
-    .on('request', validateTransactionsRequest(t))
-    .on('body', function (body) {
-      assertRoot(t, body)
-      t.deepEqual(body.transactions, transactions)
-      t.end()
-    })
+  test('envelope', function (t) {
+    t.plan(14)
+    var transactions = [{spans: []}]
+    APMServer()
+      .on('listening', function () {
+        request.transactions(this.agent, transactions)
+      })
+      .on('request', validateTransactionsRequest(t))
+      .on('body', function (body) {
+        assertRoot(t, body)
+        t.deepEqual(body.transactions, transactions)
+        t.end()
+      })
+  })
+
+  t.test('no custom framework', function (t) {
+    t.plan(15)
+    var transactions = [{spans: []}]
+    APMServer()
+      .on('listening', function () {
+        request.transactions(this.agent, transactions)
+      })
+      .on('request', validateTransactionsRequest(t))
+      .on('body', function (body) {
+        assertRoot(t, body)
+        t.notOk(body.service.framework, 'should not have service.framework property')
+        t.deepEqual(body.transactions, transactions)
+        t.end()
+      })
+  })
+
+  t.test('custom framework', function (t) {
+    t.plan(15)
+    var transactions = [{spans: []}]
+    APMServer({frameworkName: 'foo', frameworkVersion: 'bar'})
+      .on('listening', function () {
+        request.transactions(this.agent, transactions)
+      })
+      .on('request', validateTransactionsRequest(t))
+      .on('body', function (body) {
+        assertRoot(t, body)
+        t.deepEqual(body.service.framework, {name: 'foo', version: 'bar'})
+        t.deepEqual(body.transactions, transactions)
+        t.end()
+      })
+  })
 })
 
 function assertRoot (t, payload) {


### PR DESCRIPTION
Add `frameworkName` and `frameworkVersion` config options.

Allow overwrite of autodetected framework name and version or to set these values in case they cannot be detected automatically.

Closes #209