### PR TITLE
fix: don't collect source code for in-app span frames by default

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -433,13 +433,10 @@ Use the following two config options to change how many lines of source code to 
 *`sourceLinesSpanAppFrames`*
 
 * *Type:* Number
-* *Default:* `5`
+* *Default:* `0`
 * *Env:* `ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES`
 
-The default value `5` means that 5 lines of source code will be collected for in-app span frames.
-2 lines above the stack frame line + 2 below + the stack frame line it self.
-
-Setting this config option to `0` means that no source code will be collected for in-app span frames.
+The default value `0` means that no source code will be collected for in-app span frames.
 
 [[source-context-span-library-frames]]
 *`sourceLinesSpanLibraryFrames`*

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,7 @@ var DEFAULTS = {
   asyncHooks: true,
   sourceLinesErrorAppFrames: 5,
   sourceLinesErrorLibraryFrames: 5,
-  sourceLinesSpanAppFrames: 5,
+  sourceLinesSpanAppFrames: 0,
   sourceLinesSpanLibraryFrames: 0,
   flushInterval: 10,
   transactionMaxSpans: Infinity,

--- a/test/config.js
+++ b/test/config.js
@@ -22,7 +22,7 @@ var optionFixtures = [
   ['asyncHooks', 'ASYNC_HOOKS', true],
   ['sourceLinesErrorAppFrames', 'SOURCE_LINES_ERROR_APP_FRAMES', 5],
   ['sourceLinesErrorLibraryFrames', 'SOURCE_LINES_ERROR_LIBRARY_FRAMES', 5],
-  ['sourceLinesSpanAppFrames', 'SOURCE_LINES_SPAN_APP_FRAMES', 5],
+  ['sourceLinesSpanAppFrames', 'SOURCE_LINES_SPAN_APP_FRAMES', 0],
   ['sourceLinesSpanLibraryFrames', 'SOURCE_LINES_SPAN_LIBRARY_FRAMES', 0]
 ]
 


### PR DESCRIPTION
This is to align with the defaults found in the Python agent.

See elastic/apm-server#622 for details.