### PR TITLE
fix: don't add req/res to unsampled transactions

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -127,7 +127,9 @@ Transaction.prototype._encode = function (cb) {
       duration: self.duration(),
       timestamp: new Date(self._timer.start).toISOString(),
       result: String(self.result),
-      sampled: self.sampled
+      sampled: self.sampled,
+      context: null,
+      spans: null
     }
 
     if (self.sampled) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -127,9 +127,7 @@ Transaction.prototype._encode = function (cb) {
       duration: self.duration(),
       timestamp: new Date(self._timer.start).toISOString(),
       result: String(self.result),
-      sampled: self.sampled,
-      context: null,
-      spans: null
+      sampled: self.sampled
     }
 
     if (self.sampled) {
@@ -143,24 +141,24 @@ Transaction.prototype._encode = function (cb) {
         tags: self._tags || {},
         custom: self._custom || {}
       }
-    }
 
-    // Only include dropped count when spans have been dropped.
-    if (self._droppedSpans > 0) {
-      payload.span_count = {
-        dropped: {
-          total: self._droppedSpans
+      // Only include dropped count when spans have been dropped.
+      if (self._droppedSpans > 0) {
+        payload.span_count = {
+          dropped: {
+            total: self._droppedSpans
+          }
         }
       }
-    }
 
-    if (self.req) {
-      var config = self._agent._conf.captureBody
-      var captureBody = config === 'transactions' || config === 'all'
-      payload.context.request = parsers.getContextFromRequest(self.req, captureBody)
-    }
-    if (self.res) {
-      payload.context.response = parsers.getContextFromResponse(self.res)
+      if (self.req) {
+        var config = self._agent._conf.captureBody
+        var captureBody = config === 'transactions' || config === 'all'
+        payload.context.request = parsers.getContextFromRequest(self.req, captureBody)
+      }
+      if (self.res) {
+        payload.context.response = parsers.getContextFromResponse(self.res)
+      }
     }
 
     cb(null, payload)

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -243,7 +243,7 @@ test('#_encode() - ended', function (t) {
   trans.end()
   trans._encode(function (err, payload) {
     t.error(err)
-    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'spans', 'context'])
+    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'context', 'spans'])
     t.equal(typeof payload.id, 'string')
     t.equal(payload.id, trans.id)
     t.equal(payload.name, 'unnamed')
@@ -267,7 +267,7 @@ test('#_encode() - with meta data, no spans', function (t) {
   trans.end()
   trans._encode(function (err, payload) {
     t.error(err)
-    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'spans', 'context'])
+    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'context', 'spans'])
     t.equal(typeof payload.id, 'string')
     t.equal(payload.id, trans.id)
     t.equal(payload.name, 'foo')
@@ -288,7 +288,7 @@ test('#_encode() - spans', function (t) {
   trans.end()
   trans._encode(function (err, payload) {
     t.error(err)
-    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'spans', 'context'])
+    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'context', 'spans'])
     t.equal(typeof payload.id, 'string')
     t.equal(payload.id, trans.id)
     t.equal(payload.name, 'unnamed')
@@ -327,7 +327,7 @@ test('#_encode() - http request meta data', function (t) {
   trans.end()
   trans._encode(function (err, payload) {
     t.error(err)
-    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'spans', 'context'])
+    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'context', 'spans'])
     t.equal(typeof payload.id, 'string')
     t.equal(payload.id, trans.id)
     t.equal(payload.name, 'POST unknown route')
@@ -380,7 +380,7 @@ test('#_encode() - disable stack spans', function (t) {
   trans.end()
   trans._encode(function (err, payload) {
     t.error(err)
-    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'spans', 'context'])
+    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'context', 'spans'])
     t.equal(payload.spans.length, 1)
     t.deepEqual(Object.keys(payload.spans[0]), ['name', 'type', 'start', 'duration'])
     t.end()
@@ -399,7 +399,7 @@ test('#_encode() - truncated spans', function (t) {
   trans.end()
   trans._encode(function (err, payload) {
     t.error(err)
-    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'spans', 'context'])
+    t.deepEqual(Object.keys(payload), ['id', 'name', 'type', 'duration', 'timestamp', 'result', 'sampled', 'context', 'spans'])
     t.equal(payload.spans.length, 2)
     t.equal(payload.spans[0].name, 'foo')
     t.equal(payload.spans[0].type, 'custom')


### PR DESCRIPTION
If a transaction isn't sampled, it will not have a `context` property. The code tried to set properties on the `context` property if a request or response had been associated with the transaction. That would result in errors like this:

    TypeError: Cannot set property 'request' of null

This commit ensures that we only try to parse the associated `trans.req` and `trans.res` if the transaction is sampled.

Fixes #235