### PR TITLE
refactor(mongodb): don't build spans that are not needed

### DIFF
--- a/lib/instrumentation/modules/mongodb-core.js
+++ b/lib/instrumentation/modules/mongodb-core.js
@@ -29,15 +29,18 @@ module.exports = function (mongodb, agent, version) {
 
   function wrapCommand (orig) {
     return function wrappedFunction (ns, cmd) {
-      var span = agent.buildSpan()
-      var id = span && span.transaction.id
+      var trans = agent._instrumentation.currentTransaction
+      var id = trans && trans.id
+      var span
 
       debug('intercepted call to mongodb-core.Server.prototype.command %o', { id: id, ns: ns })
 
-      if (span && arguments.length > 0) {
+      if (trans && arguments.length > 0) {
         var index = arguments.length - 1
         var cb = arguments[index]
         if (typeof cb === 'function') {
+          span = agent.buildSpan()
+
           var type
           if (cmd.findAndModify) type = 'findAndModify'
           else if (cmd.createIndexes) type = 'createIndexes'
@@ -62,15 +65,17 @@ module.exports = function (mongodb, agent, version) {
 
   function wrapQuery (orig, name) {
     return function wrappedFunction (ns) {
-      var span = agent.buildSpan()
-      var id = span && span.transaction.id
+      var trans = agent._instrumentation.currentTransaction
+      var id = trans && trans.id
+      var span
 
       debug('intercepted call to mongodb-core.Server.prototype.%s %o', name, { id: id, ns: ns })
 
-      if (span && arguments.length > 0) {
+      if (trans && arguments.length > 0) {
         var index = arguments.length - 1
         var cb = arguments[index]
         if (typeof cb === 'function') {
+          span = agent.buildSpan()
           arguments[index] = wrappedCallback
           span.start(ns + '.' + name, 'db.mongodb.query')
         }
@@ -88,14 +93,16 @@ module.exports = function (mongodb, agent, version) {
 
   function wrapCursor (orig, name) {
     return function wrappedFunction () {
-      var span = agent.buildSpan()
-      var id = span && span.transaction.id
+      var trans = agent._instrumentation.currentTransaction
+      var id = trans && trans.id
+      var span
 
       debug('intercepted call to mongodb-core.Cursor.prototype.%s %o', name, { id: id })
 
-      if (span && arguments.length > 0) {
+      if (trans && arguments.length > 0) {
         var cb = arguments[0]
         if (typeof cb === 'function') {
+          span = agent.buildSpan()
           arguments[0] = wrappedCallback
           span.start(this.ns + '.' + (this.cmd.find ? 'find' : name), 'db.mongodb.query')
         }


### PR DESCRIPTION
In case a callback isn't provided when making a MongoDB query, we shouldn't try to create a span as we have no way of ending it.
