### PR TITLE
feat(debug): output more debug info on start

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var path = require('path')
 var IncomingMessage = require('http').IncomingMessage
 var ServerResponse = require('http').ServerResponse
 var parseUrl = require('url').parse
@@ -7,6 +8,7 @@ var uuid = require('uuid')
 var ElasticAPMHttpClient = require('elastic-apm-http-client')
 var afterAll = require('after-all-results')
 var isError = require('core-util-is').isError
+var ancestors = require('require-ancestors')
 var debug = require('debug')('elastic-apm')
 var config = require('./config')
 var sym = require('./symbols')
@@ -77,8 +79,29 @@ Agent.prototype.start = function (opts) {
     logger.error('Elastic APM isn\'t correctly configured: serviceName "%s" contains invalid characters! (allowed: a-z, A-Z, 0-9, _, -, <space>)', this._conf.serviceName)
     this._conf.active = false
     return this
-  } else {
-    debug('agent configured correctly %o', { node: process.version, agent: version, service: this._conf.serviceName, instrument: this._conf.instrument })
+  } else if (process.env.DEBUG) {
+    var _ancestors = ancestors(module)
+    var basedir = path.dirname(_ancestors[_ancestors.length - 1])
+    var stackObj = {}
+    Error.captureStackTrace(stackObj)
+
+    try {
+      var pkg = require(path.join(basedir, 'package.json'))
+    } catch (e) {}
+
+    debug('agent configured correctly %o', {
+      pid: process.pid,
+      ppid: process.ppid,
+      arch: process.arch,
+      platform: process.platform,
+      node: process.version,
+      agent: version,
+      requireAncestors: _ancestors,
+      startTrace: stackObj.stack.split(/\n */).slice(1),
+      main: pkg && pkg.main,
+      dependencies: pkg && pkg.dependencies,
+      conf: this._conf
+    })
   }
 
   this._instrumentation.start()

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "normalize-bool": "^1.0.0",
     "original-url": "^1.2.0",
     "redact-secrets": "^1.0.0",
+    "require-ancestors": "^1.0.0",
     "require-in-the-middle": "^2.1.2",
     "semver": "^5.3.0",
     "sql-summary": "^1.0.0",


### PR DESCRIPTION
To help us with debugging issues in user applications in the future, I've been working on adding more details to the initial debug output that we print when running with `DEBUG=elastic-apm-node`.

Please let me what you think and if there's something more that should be added to the output 😄 

Here's an example of the new output:

![image](https://user-images.githubusercontent.com/10602/36421246-0daa35c6-1638-11e8-8f27-925a408b6059.png)

Here the object is formatted a little nicer:

```js
 { pid: 76707,
  ppid: 8601,
  arch: 'x64',
  platform: 'darwin',
  node: 'v9.4.0',
  agent: '1.0.3',
  requireAncestors:
   [ '/Users/watson/code/node_modules/elastic-apm-node/index.js',
     '/Users/watson/code/foo.js' ],
  startTrace:
   [ 'at Agent.start (/Users/watson/code/node_modules/elastic-apm-node/lib/agent.js:73:11)',
     'at Object.<anonymous> (/Users/watson/code/foo.js:1:91)',
     'at Module._compile (module.js:660:30)',
     'at Object.Module._extensions..js (module.js:671:10)',
     'at Module.load (module.js:573:32)',
     'at tryModuleLoad (module.js:513:12)',
     'at Function.Module._load (module.js:505:3)',
     'at Function.Module.runMain (module.js:701:10)',
     'at startup (bootstrap_node.js:193:16)',
     'at bootstrap_node.js:617:3' ],
  main: 'index.js',
  dependencies:
   { 'after-all-results': '^2.0.0',
     'async-cache': '^1.1.0',
     debug: '^2.2.0',
     'error-callsites': '^1.0.1',
     'load-source-map': '^1.0.0',
     'path-is-absolute': '^1.0.1' },
  conf:
   { verifyServerCert: true,
     active: true,
     logLevel: 'info',
     hostname: 'watson.local',
     stackTraceLimit: 50,
     captureExceptions: true,
     filterHttpHeaders: true,
     captureErrorLogStackTraces: 'messages',
     captureSpanStackTraces: true,
     captureBody: 'off',
     errorOnAbortedRequests: false,
     abortedErrorThreshold: 25000,
     instrument: true,
     asyncHooks: true,
     sourceLinesErrorAppFrames: 5,
     sourceLinesErrorLibraryFrames: 5,
     sourceLinesSpanAppFrames: 0,
     sourceLinesSpanLibraryFrames: 0,
     flushInterval: 10,
     transactionMaxSpans: Infinity,
     transactionSampleRate: 1,
     ignoreUrlStr: [],
     ignoreUrlRegExp: [],
     ignoreUserAgentStr: [],
     ignoreUserAgentRegExp: [],
     serverHost: 'localhost' } }
```
