### PR TITLE
feat: add agent.startSpan() function

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -929,8 +929,37 @@ the transaction name will default to `METHOD unknown route` (e.g. `POST unknown 
 
 Read more about naming routes manually in the <<custom-stack-route-naming,Get started with a custom Node.js stack>> article.
 
+[[apm-start-span]]
+==== `apm.startSpan([name][, type])`
+
+[source,js]
+----
+var span = apm.startSpan('My custom span')
+----
+
+Start and return a new custom span associated with the current active transaction.
+
+Arguments:
+
+* `name` - The name of the span (string).
+You can alternatively set this via <<span-name,`span.name`>>.
+Defaults to `unnamed`
+
+* `type` - The type of span (string).
+You can alternatively set this via <<span-type,`span.type`>>.
+Defaults to `custom.code`
+
+When a span is started it will measure the time until <<span-end,`span.end()`>> or <<span-truncate,`span.truncate()`>> is called.
+
+See <<span-api,Span API>> docs for details on how to use custom spans.
+
+NOTE: If there's no active transaction available,
+`null` will be returned.
+
 [[apm-build-span]]
 ==== `apm.buildSpan()`
+
+deprecated[1.1.0,Replaced by <<apm-start-span,apm.startSpan()>>]
 
 [source,js]
 ----

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -17,7 +17,7 @@ The `Agent` is a singleton and the instance is usually referred by the variable 
 An instance of the `Transaction` object is acquired by calling `apm.startTransaction()`
 
 * <<span-api,The `Span` API>> - All functions and properties on the `Span` object.
-An instance of the `Span` object is acquired by calling `apm.buildSpan()`
+An instance of the `Span` object is acquired by calling `apm.startSpan()`
 
 include::./agent-api.asciidoc[Agent API documentation]
 

--- a/docs/custom-spans.asciidoc
+++ b/docs/custom-spans.asciidoc
@@ -30,13 +30,9 @@ app.use(function (req, res, next) {
     return next()
   }
 
-  // `buildSpan` will only return a span if there's an
+  // `startSpan` will only return a span if there's an
   // active transaction
-  var span = apm.buildSpan()
-
-  // start the span to measure the time it takes to receive
-  // the body of the HTTP request
-  if (span) span.start('receiving body')
+  var span = apm.startSpan('receiving body')
 
   var buffers = []
   req.on('data', function (chunk) {
@@ -59,11 +55,9 @@ app.use(function (req, res, next) {
     return next()
   }
 
-  var span = apm.buildSpan()
-
-  // start the span to measure the time it takes to parse
+  // start a span to measure the time it takes to parse
   // the JSON
-  if (span) span.start('parse json')
+  var span = apm.startSpan('parse json')
 
   try {
     req.json = JSON.parse(req.body)

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -10,7 +10,7 @@ endif::[]
 A span measures the duration of a single event.
 
 To get a `Span` object,
-you need to call <<apm-build-span,`apm.buildSpan()`>>.
+you need to call <<apm-start-span,`apm.startSpan()`>>.
 
 To see an example of using custom spans,
 see the <<custom-spans,Custom Spans in Node.js>> article.
@@ -53,6 +53,8 @@ the following are standardized across all Elastic APM agents:
 
 [[span-start]]
 ==== `span.start()`
+
+deprecated[1.1.0,Span started automatically by <<apm-start-span,apm.startSpan()>>]
 
 [source,js]
 ----

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -45,6 +45,12 @@ Agent.prototype.setTransactionName = function () {
   return this._instrumentation.setTransactionName.apply(this._instrumentation, arguments)
 }
 
+Agent.prototype.startSpan = function (name, type) {
+  var span = this._instrumentation.buildSpan.apply(this._instrumentation)
+  if (span) span.start(name, type)
+  return span
+}
+
 Agent.prototype.buildSpan = function () {
   return this._instrumentation.buildSpan.apply(this._instrumentation, arguments)
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -8,6 +8,26 @@ var Agent = require('./_agent')
 var APMServer = require('./_apm_server')
 var config = require('../lib/config')
 
+test('#startSpan()', function (t) {
+  t.test('no active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    t.equal(agent.startSpan(), null)
+    t.end()
+  })
+
+  t.test('active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    agent.startTransaction()
+    var span = agent.startSpan('span-name', 'span-type')
+    t.ok(span, 'should return a span')
+    t.equal(span.name, 'span-name')
+    t.equal(span.type, 'span-type')
+    t.end()
+  })
+})
+
 test('#setUserContext()', function (t) {
   t.test('no active transaction', function (t) {
     var agent = Agent()


### PR DESCRIPTION
For now `agent.startSpan()` is just a convenience function that first calls `agent.buildSpan()` followed by `span.start()`.

This is step one in fixing #255.

The docs are updated to list the old `buildSpan` function as deprecated, but calling that function still works as before, so this is not a breaking change. This is how the deprecation warning looks:

![image](https://user-images.githubusercontent.com/10602/36752641-7ca33d6c-1bb8-11e8-87cb-854ad1515325.png)

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
