### PR TITLE
fix(mongodb): don't throw if span cannot be built

### DIFF
--- a/lib/instrumentation/modules/mongodb-core.js
+++ b/lib/instrumentation/modules/mongodb-core.js
@@ -38,9 +38,7 @@ module.exports = function (mongodb, agent, version) {
       if (trans && arguments.length > 0) {
         var index = arguments.length - 1
         var cb = arguments[index]
-        if (typeof cb === 'function') {
-          span = agent.buildSpan()
-
+        if (typeof cb === 'function' && (span = agent.buildSpan())) {
           var type
           if (cmd.findAndModify) type = 'findAndModify'
           else if (cmd.createIndexes) type = 'createIndexes'
@@ -74,8 +72,7 @@ module.exports = function (mongodb, agent, version) {
       if (trans && arguments.length > 0) {
         var index = arguments.length - 1
         var cb = arguments[index]
-        if (typeof cb === 'function') {
-          span = agent.buildSpan()
+        if (typeof cb === 'function' && (span = agent.buildSpan())) {
           arguments[index] = wrappedCallback
           span.start(ns + '.' + name, 'db.mongodb.query')
         }
@@ -101,8 +98,7 @@ module.exports = function (mongodb, agent, version) {
 
       if (trans && arguments.length > 0) {
         var cb = arguments[0]
-        if (typeof cb === 'function') {
-          span = agent.buildSpan()
+        if (typeof cb === 'function' && (span = agent.buildSpan())) {
           arguments[0] = wrappedCallback
           span.start(this.ns + '.' + (this.cmd.find ? 'find' : name), 'db.mongodb.query')
         }


### PR DESCRIPTION
This would happen if sampling is enabled and the current transaction isn't sampled, or if the current transaction is ended, or if the current span is dropped.