### PR TITLE
fix(config): set default maxQueueSize to 100

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -538,7 +538,7 @@ This all helps to ensure that multiple servers started at the same time will not
 ===== `maxQueueSize`
 
 * *Type:* Number
-* *Default:* `-1`
+* *Default:* `100`
 * *Env:* `ELASTIC_APM_MAX_QUEUE_SIZE`
 
 The agent maintains an in-memory queue to which recorded transactions are added when they end.

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,7 +44,8 @@ var DEFAULTS = {
   sourceLinesSpanLibraryFrames: 0,
   flushInterval: 10,
   transactionMaxSpans: Infinity,
-  transactionSampleRate: 1.0
+  transactionSampleRate: 1.0,
+  maxQueueSize: 100
 }
 
 var ENV_TABLE = {


### PR DESCRIPTION
This will prevent overflowing the queue in high-traffic environments that have not been configured to sample requests.