### PR TITLE
 refactor: don't stringify and truncate core values

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -211,8 +211,8 @@ function envelope (agent) {
     service: {
       name: agent._conf.serviceName,
       runtime: {
-        name: trunc(String(process.release.name), config.INTAKE_STRING_MAX_SIZE),
-        version: trunc(String(process.version), config.INTAKE_STRING_MAX_SIZE)
+        name: process.release.name,
+        version: process.version
       },
       language: {
         name: 'javascript'
@@ -230,8 +230,8 @@ function envelope (agent) {
     },
     system: {
       hostname: agent._conf.hostname,
-      architecture: trunc(String(process.arch), config.INTAKE_STRING_MAX_SIZE),
-      platform: trunc(String(process.platform), config.INTAKE_STRING_MAX_SIZE)
+      architecture: process.arch,
+      platform: process.platform
     }
   }
 


### PR DESCRIPTION
Depends on #281.

We should be able to safely assume that these properties will always be strings and that they will never be longer than 1024 bytes.