### PR TITLE
refactor: don't use promises in the queue

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -2,6 +2,8 @@
 
 var fs = require('fs')
 var path = require('path')
+var afterAll = require('after-all-results')
+var AsyncValuePromise = require('async-value-promise')
 var semver = require('semver')
 var hook = require('require-in-the-middle')
 var Transaction = require('./transaction')
@@ -32,11 +34,17 @@ Instrumentation.prototype.start = function () {
     maxQueueSize: this._agent._conf.maxQueueSize
   }
   this._queue = new Queue(qopts, function onFlush (transactions, done) {
-    Promise.all(transactions).then(function (transactions) {
+    var next = afterAll(function (_, transactions) {
       if (self._agent._conf.active && transactions.length > 0) {
         request.transactions(self._agent, transactions, done)
       }
-    }, done)
+    })
+    transactions.forEach(function (trans) {
+      var done = next()
+      trans.then(function (trans) {
+        done(null, trans)
+      })
+    })
   })
 
   if (this._agent._conf.asyncHooks && semver.gte(process.version, '8.2.0')) {
@@ -69,19 +77,25 @@ Instrumentation.prototype.start = function () {
 Instrumentation.prototype.addEndedTransaction = function (transaction) {
   if (this._started) {
     var queue = this._queue
+
     debug('adding transaction to queue %o', {id: transaction.id})
+
+    var payload = new AsyncValuePromise()
+
+    payload.then(null, function (err) {
+      logger.error('error encoding transaction %s: %s', transaction.id, err.message)
+    })
+
     // encode the transaction as early as possible in an attempt to free up
     // objects for garbage collection
-    queue.add(new Promise(function (resolve, reject) {
-      transaction._encode(function (err, payload) {
-        // As of writing this comment, _encode swallows all errors. So the
-        // following error handling logic shouldn't actually be needed
-        if (err) reject(err)
-        else resolve(payload)
-      })
-    }).catch(function (err) {
-      logger.error('error encoding transaction %s: %s', transaction.id, err.message)
-    }))
+    transaction._encode(function (err, _payload) {
+      // As of writing this comment, _encode swallows all errors. So the
+      // following error handling logic shouldn't actually be needed
+      if (err) payload.reject(err)
+      else payload.resolve(_payload)
+    })
+
+    queue.add(payload)
   } else {
     debug('ignoring transaction %o', {id: transaction.id})
   }

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs')
 var path = require('path')
-var afterAll = require('after-all-results')
 var AsyncValuePromise = require('async-value-promise')
 var semver = require('semver')
 var hook = require('require-in-the-middle')
@@ -34,17 +33,11 @@ Instrumentation.prototype.start = function () {
     maxQueueSize: this._agent._conf.maxQueueSize
   }
   this._queue = new Queue(qopts, function onFlush (transactions, done) {
-    var next = afterAll(function (_, transactions) {
+    AsyncValuePromise.all(transactions).then(function (transactions) {
       if (self._agent._conf.active && transactions.length > 0) {
         request.transactions(self._agent, transactions, done)
       }
-    })
-    transactions.forEach(function (trans) {
-      var done = next()
-      trans.then(function (trans) {
-        done(null, trans)
-      })
-    })
+    }, done)
   })
 
   if (this._agent._conf.asyncHooks && semver.gte(process.version, '8.2.0')) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
   "dependencies": {
     "after-all-results": "^2.0.0",
-    "async-value-promise": "^1.0.0",
+    "async-value-promise": "^1.1.0",
     "console-log-level": "^1.4.0",
     "cookie": "^0.3.1",
     "core-util-is": "^1.0.2",


### PR DESCRIPTION
The overhead of using the Promise API is too great. This reduces memory allocations and is easier on GC.

I took a stab at using your new module @Qard 😄 

As it doesn't have an `.all` function, I've implemented that manually. But it might make sense to build that into the async-value-promise module instead. If so I'll just update this PR.