### PR TITLE
fix(doc): lambda getting started had old argument

### DIFF
--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -45,11 +45,9 @@ var apm = require('elastic-apm-node').start({
   serverUrl: '',
 })
 
-function handler (payload, context, callback) {
+exports.handler = apm.lambda(function handler (payload, context, callback) {
   callback(null, `Hello, ${payload.name}!`)
-}
-
-exports.handler = apm.lambda('hello.handler', handler)
+})
 ----
 
 The agent will now monitor the performance of your lambda function.


### PR DESCRIPTION
There's a minor bug in the "getting started with lambda" part of the docs in the latest release. This fixes it.