### PR TITLE
refactor: prepare queue to be used by errors

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -9,7 +9,7 @@ var hook = require('require-in-the-middle')
 var semver = require('semver')
 
 var logger = require('../logger')
-var Queue = require('./queue')
+var Queue = require('../queue')
 var request = require('../request')
 var Transaction = require('./transaction')
 
@@ -158,5 +158,5 @@ Instrumentation.prototype._recoverTransaction = function (trans) {
 }
 
 Instrumentation.prototype.flush = function (cb) {
-  this._queue._flush(cb)
+  this._queue.flush(cb)
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,8 +30,14 @@ function Queue (opts, onFlush) {
 
 Queue.prototype.add = function (obj) {
   this._items.push(obj)
-  if (this._maxQueueSize !== -1 && this._items.length >= this._maxQueueSize) this._flush()
+  if (this._maxQueueSize !== -1 && this._items.length >= this._maxQueueSize) this.flush()
   else if (!this._timeout) this._queueFlush()
+}
+
+Queue.prototype.flush = function (cb) {
+  debug('flushing queue')
+  this._onFlush(this._items, cb || noop)
+  this._clear()
 }
 
 Queue.prototype._queueFlush = function () {
@@ -44,16 +50,10 @@ Queue.prototype._queueFlush = function () {
 
   debug('setting timer to flush queue: %dms', ms)
   this._timeout = setTimeout(function () {
-    self._flush()
+    self.flush()
   }, ms)
   this._timeout.unref()
   boot = false
-}
-
-Queue.prototype._flush = function (cb) {
-  debug('flushing queue')
-  this._onFlush(this._items, cb || noop)
-  this._clear()
 }
 
 Queue.prototype._clear = function () {

--- a/test/queue.js
+++ b/test/queue.js
@@ -2,7 +2,7 @@
 
 var test = require('tape')
 
-var Queue = require('../../lib/instrumentation/queue')
+var Queue = require('../lib/queue')
 
 test('maxQueueSize', function (t) {
   var opts = {
@@ -40,7 +40,7 @@ test('queue flush callback success', function (t) {
   })
 
   queue.add(1)
-  queue._flush(function (err) {
+  queue.flush(function (err) {
     t.error(err)
     t.equal(flush, 1)
     t.end()
@@ -58,7 +58,7 @@ test('queue flush callback error', function (t) {
   })
 
   queue.add(1)
-  queue._flush(function (err) {
+  queue.flush(function (err) {
     t.equal(err, error)
     t.equal(flush, 1)
     t.end()


### PR DESCRIPTION
The queuing logic isn't unique to transactions. It makes more sense to put it directly in the lib folder. This also allows us to use it for errors which we might want to do in the future.