### PR TITLE
added method isStarted()

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -71,8 +71,12 @@ Agent.prototype._config = function (opts) {
   logger.init({level: this._conf.logLevel})
 }
 
+Agent.prototype.isStarted = function () {
+  return global[symbols.agentInitialized]
+}
+
 Agent.prototype.start = function (opts) {
-  if (global[symbols.agentInitialized]) throw new Error('Do not call .start() more than once')
+  if (this.isStarted()) throw new Error('Do not call .start() more than once')
   global[symbols.agentInitialized] = true
 
   this._config(opts)


### PR DESCRIPTION
Problem with integrate. Running first for apm.captureError and second for metrics, example: https://github.com/intech/moleculer-elastic-apm/blob/master/index.js#L101

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update documentation
