### PR TITLE
fix: encode spans even if their stack trace can't be captured

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -150,7 +150,9 @@ Span.prototype._encode = function (cb) {
   }
 
   function done (err, frames) {
-    if (err) return cb(err)
+    if (err) {
+      self._agent.logger.warn('could not capture stack trace for span %o', {id: self.transaction.id, name: self.name, type: self.type, err: err.message})
+    }
 
     var payload = {
       name: self.name,


### PR DESCRIPTION
Discussion: https://discuss.elastic.co/t/node-agent-could-not-capture-stack-trace-for-span/130775