### PR TITLE
test(jenkins): pin mysql docker image to v5.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - nodemongodata:/data/db
 
   mysql:
-    image: mysql 
+    image: mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     ports: 


### PR DESCRIPTION
This is only temporary. MySQL 8 was just released and our test suite doesn't seem to run on that version.

Here's an example of the failure:
https://apm-ci.elastic.co/job/elastic+apm-agent-nodejs+pull-request+multijob-run-tests/435/NODEJS_VERSION=8,label=linux/console

The issue is most like this one:
https://github.com/mysqljs/mysql/issues/1507