### PR TITLE
chore: ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 node_modules
 .nyc_output
 coverage
+.vscode


### PR DESCRIPTION
Just wanted to ignore the `.vscode` config directory so git doesn't keep telling me to add it. 😅 