### PR TITLE
perf: don't collect stack traces on short spans

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -20,6 +20,7 @@ function Span (transaction) {
   this.type = null
   this._db = null
   this._timer = null
+  this._stackFrames = null
   this._stackObj = null
   this._agent = transaction._agent
 
@@ -36,7 +37,7 @@ Span.prototype.start = function (name, type) {
   this.name = name || this.name || 'unnamed'
   this.type = type || this.type || 'custom'
 
-  if (this._agent._conf.captureSpanStackTraces && !this._stackObj) {
+  if (this._agent._conf.captureSpanStackTraces && !this._stackFrames) {
     this._recordStackTrace()
   }
 
@@ -76,6 +77,7 @@ Span.prototype.end = function () {
 
   this.ended = true
   this._agent.logger.debug('ended span %o', {id: this.transaction.id, name: this.name, type: this.type, truncated: this.truncated})
+  this._processStackTrace()
   this.transaction._recordEndedSpan(this)
 }
 
@@ -108,32 +110,41 @@ Span.prototype._recordStackTrace = function (obj) {
     Error.captureStackTrace(obj, Span.prototype.start)
   }
 
-  var self = this
+  this._stackObj = obj
 
   // NOTE: This uses a promise-like thing and not a *real* promise
   // because passing error stacks into a promise context makes it
   // uncollectable by the garbage collector.
-  var stack = new Value()
-  this._stackObj = stack
+  this._stackFrames = new Value()
+}
 
-  // TODO: This is expensive! Consider if there's a way to cache some of this
-  stackman.callsites(obj, function (err, callsites) {
-    if (err || !callsites) {
-      self._agent.logger.debug('could not capture stack trace for span %o', {id: self.transaction.id, name: self.name, type: self.type, err: err && err.message})
-      stack.reject(err)
-      return
-    }
+Span.prototype._processStackTrace = function () {
+  var self = this
 
-    if (!TEST) callsites = callsites.filter(filterCallsite)
+  if (this.duration > 5) {
+    // TODO: This is expensive! Consider if there's a way to cache some of this
+    stackman.callsites(this._stackObj, function (err, callsites) {
+      if (err || !callsites) {
+        self._agent.logger.debug('could not capture stack trace for span %o', {id: self.transaction.id, name: self.name, type: self.type, err: err && err.message})
+        self._stackFrames.reject(err)
+        return
+      }
 
-    var next = afterAll((err, res) => {
-      err ? stack.reject(err) : stack.resolve(res)
+      if (!TEST) callsites = callsites.filter(filterCallsite)
+
+      var next = afterAll((err, res) => {
+        err ? self._stackFrames.reject(err) : self._stackFrames.resolve(res)
+      })
+
+      callsites.forEach(function (callsite) {
+        parsers.parseCallsite(callsite, false, self._agent, next())
+      })
     })
+  } else {
+    this._stackFrames.resolve()
+  }
 
-    callsites.forEach(function (callsite) {
-      parsers.parseCallsite(callsite, false, self._agent, next())
-    })
-  })
+  this._stackObj = null
 }
 
 Span.prototype._encode = function (cb) {
@@ -142,8 +153,8 @@ Span.prototype._encode = function (cb) {
   if (!this.started) return cb(new Error('cannot encode un-started span'))
   if (!this.ended) return cb(new Error('cannot encode un-ended span'))
 
-  if (this._agent._conf.captureSpanStackTraces && this._stackObj) {
-    this._stackObj.then(
+  if (this._agent._conf.captureSpanStackTraces && this._stackFrames) {
+    this._stackFrames.then(
       value => done(null, value),
       error => done(error)
     )


### PR DESCRIPTION
This is identical to the Python config option [`span_frames_min_duration_ms`](https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html#config-span-frames-min-duration-ms).

The idea is that very short spans are not super useful to the user, so we shouldn't waste time collecting stack traces for them.

This is an alternative to [switching off the collection of span stack traces](https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html#capture-span-stack-traces) completely, which is recommend as well in case the app performance is affected.

The question is however if enough spans are so short that it makes sense to not collect their stack traces. If this isn't very common, then this doesn't actually improve the performance of anything.

Further possibilities for optimization:

- It holds on to the stack obj until the spans ends, where in fact it could be optimized to wait 5ms and then processes it

### Benchmark

This benchmark just shows that it's possible to remove the overhead while still collecting the stack traces as long as we don't process them (the test app only had spans falling below the limit).

Avg and Stddev are req/s and sending of data to the intake API have been disabled to not have the scaling of the APM Server influence the numbers.

| | Avg | Stddev | Note |
|------------|-----|--------|------|
| Baseline | 2777.84 | 385.75 | |
| Opbeat | 1675.67 | 217.41 | The Opbeat agent uses caching |
| Elastic APM | 821.05 | 43.02 | `master` |
| Elastic APM | 1734.29 | 225.54 | `master` with `captureSpanStackTraces: false` |
| Elastic APM | 1876.57 | 263.17 | `master` with `captureSpanStackTraces: false, asyncHooks: false` |
| Elastic APM | 1780.47 | 140.2 | This PR |
| Elastic APM | 1985.99 | 254.13 | This PR with `asyncHooks: false` |

The benchmarks was run using this [autocannon](https://github.com/mcollina/autocannon) setup:

```
autocannon -i CONTRIBUTING.md -d 60 localhost:3000
```

<details>
<summary>Test app used for benchmark</summary>

```js
'use strict'

const agent = require('./').start({
  serviceName: 'test',
  captureExceptions: false
})

const http = require('http')
const fs = require('fs')
const afterAll = require('after-all-results')

const server = http.createServer(function (req, res) {
  const buffers = []
  const span = agent.startSpan('read body')
  req.on('data', buffers.push.bind(buffers))
  req.on('end', function () {
    if (agent._conf.active) span.end()
    makeSpan('foo', function (err, data) {
      if (err) throw err
      res.write(data)
      const next = afterAll(function (err, results) {
        if (err) throw err
        for (let i = 0; i < results.length; i++) res.write(results[i])
        res.end()
      })
      makeSpan('bar1', next())
      makeSpan('bar2', next())
    })
  })
})

server.listen(3000)

function makeSpan (name, cb) {
  const span = agent.startSpan(name)
  fs.readFile(__filename, function (err, data) {
    if (err) return cb(err)
    if (agent._conf.active) span.end()
    if (cb) cb(null, data)
  })
}
```
</details>

### Checklist

- [ ] Implement code
  - [ ] Add [config option](https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html#config-span-frames-min-duration-ms) to change the currently hardcoded 5ms value
- [ ] Add tests
- [ ] Update documentation
