### PR TITLE
fix: guard against non string err.message

### DIFF
--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -31,7 +31,7 @@ module.exports = function (express, agent, version) {
       shimmer.wrap(layer, 'handle', function (orig) {
         if (orig.length !== 4) return orig
         return function (err, req, res, next) {
-          if (isError(err) && !err[reportedSymbol]) {
+          if ((isError(err) || typeof err === 'string') && !err[reportedSymbol]) {
             err[reportedSymbol] = true
             agent.captureError(err, { request: req })
           }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -41,9 +41,10 @@ exports.parseError = function (err, agent, cb) {
       agent.logger.debug('error while getting error callsites: %s', _err.message)
     }
 
+    var errorMsg = String(err.message)
     var error = {
       exception: {
-        message: String(err.message),
+        message: errorMsg,
         type: String(err.name)
       }
     }
@@ -54,7 +55,7 @@ exports.parseError = function (err, agent, cb) {
       // To provide better grouping of mysql errors that happens after the async
       // boundery, we modify to exception type to include the custom mysql error
       // type (e.g. ER_PARSE_ERROR)
-      var match = err.message.match(mysqlErrorMsg)
+      var match = errorMsg.match(mysqlErrorMsg)
       if (match) error.exception.code = match[1]
     }
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -148,6 +148,22 @@ test('#captureError()', function (t) {
       })
   })
 
+  t.test('should not fail on a non string err.message', function (t) {
+    t.plan(4)
+    APMServer()
+      .on('listening', function () {
+        var err = new Error()
+        err.message = {foo: 'bar'}
+        this.agent.captureError(err)
+      })
+      .on('request', validateErrorRequest(t))
+      .on('body', function (body) {
+        t.equal(body.errors.length, 1)
+        t.equal(body.errors[0].exception.message, '[object Object]')
+        t.end()
+      })
+  })
+
   t.test('should adhere to default stackTraceLimit', function (t) {
     t.plan(5)
     APMServer()


### PR DESCRIPTION
This PR also reverts #339

### Checklist

- [x] Implement code
- [x] Add tests
