### PR TITLE
docs: add elasticsearch-js to list of instrumented modules

### DIFF
--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -72,6 +72,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 [options="header"]
 |=======================================================================
 |Module |Version |Note
+|https://www.npmjs.com/package/elasticsearch-js[elasticsearch-js] |>=8.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/graphql[graphql] |>=0.7.0 <0.14.0 |Will instrument all queries
 |https://www.npmjs.com/package/handlebars[handlebars] |* |Will instrument compile and render calls
 |https://www.npmjs.com/package/ioredis[ioredis] |\^2.0.0 \|\| ^3.0.0 |Will instrument all queries


### PR DESCRIPTION
This module was already instrumented, but was for some reason missing from the list.