### PR TITLE
feat(config): disable instrumentation

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -596,6 +596,14 @@ Currently the following HTTP headers are anonymized by default:
 If you wish to filter or santitize other data,
 use the <<apm-add-filter,`apm.addFilter()`>> function.
 
+[[disable-instrumentations]]
+===== `disableInstrumentations`
+
+* *Type:* String
+* *Env:* `ELASTIC_APM_DISABLE_INSTRUMENTATIONS`
+
+Array or comma-separated string of modules to disable instrumentation for.
+
 [[apm-is-started]]
 ==== `apm.isStarted()`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,7 +47,8 @@ var DEFAULTS = {
   transactionMaxSpans: Infinity,
   transactionSampleRate: 1.0,
   maxQueueSize: 100,
-  serverTimeout: 30
+  serverTimeout: 30,
+  disableInstrumentation: []
 }
 
 var ENV_TABLE = {
@@ -79,7 +80,8 @@ var ENV_TABLE = {
   sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
   transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
   transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
-  serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT'
+  serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT',
+  disableInstrumentation: 'ELASTIC_APM_DISABLE_INSTRUMENTATION'
 }
 
 var BOOL_OPTS = [
@@ -104,6 +106,10 @@ var NUM_OPTS = [
   'serverTimeout'
 ]
 
+var ARRAY_OPTS = [
+  'disableInstrumentation'
+]
+
 function config (opts) {
   opts = Object.assign(
     {},
@@ -115,6 +121,7 @@ function config (opts) {
 
   normalizeIgnoreOptions(opts)
   normalizeNumbers(opts)
+  normalizeArrays(opts)
   normalizeBools(opts)
   truncateOptions(opts)
 
@@ -158,6 +165,16 @@ function normalizeIgnoreOptions (opts) {
 function normalizeNumbers (opts) {
   NUM_OPTS.forEach(function (key) {
     if (key in opts) opts[key] = Number(opts[key])
+  })
+}
+
+function maybeSplit (value) {
+  return typeof value === 'string' ? value.split(',') : value
+}
+
+function normalizeArrays (opts) {
+  ARRAY_OPTS.forEach(function (key) {
+    if (key in opts) opts[key] = maybeSplit(opts[key])
   })
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -48,7 +48,7 @@ var DEFAULTS = {
   transactionSampleRate: 1.0,
   maxQueueSize: 100,
   serverTimeout: 30,
-  disableInstrumentation: []
+  disableInstrumentations: []
 }
 
 var ENV_TABLE = {
@@ -81,7 +81,7 @@ var ENV_TABLE = {
   transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
   transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
   serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT',
-  disableInstrumentation: 'ELASTIC_APM_DISABLE_INSTRUMENTATION'
+  disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS'
 }
 
 var BOOL_OPTS = [
@@ -107,7 +107,7 @@ var NUM_OPTS = [
 ]
 
 var ARRAY_OPTS = [
-  'disableInstrumentation'
+  'disableInstrumentations'
 ]
 
 function config (opts) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -50,19 +50,11 @@ Instrumentation.prototype.start = function () {
     require('./patch-async')(this)
   }
 
-  const patches = new Set(MODULES)
+  var disabled = new Set(this._agent._conf.disableInstrumentation)
 
-  this._agent._conf.disableInstrumentation.forEach(patch => {
-    patches.delete(patch)
-  })
-
-  this._applyHooks(Array.from(patches))
-}
-
-Instrumentation.prototype._applyHooks = function (modules) {
-  var self = this
   this._agent.logger.debug('shimming Module._load function')
-  hook(modules, function (exports, name, basedir) {
+  hook(MODULES, function (exports, name, basedir) {
+    var enabled = !disabled.has(name)
     var pkg, version
 
     if (basedir) {
@@ -77,9 +69,13 @@ Instrumentation.prototype._applyHooks = function (modules) {
       version = process.versions.node
     }
 
-    self._agent.logger.debug('shimming %s@%s module', name, version)
-    return require('./modules/' + name)(exports, self._agent, version)
+    return self._patchModule(exports, name, version, enabled)
   })
+}
+
+Instrumentation.prototype._patchModule = function (exports, name, version, enabled) {
+  this._agent.logger.debug('shimming %s@%s module', name, version)
+  return require('./modules/' + name)(exports, this._agent, version, enabled)
 }
 
 Instrumentation.prototype.addEndedTransaction = function (transaction) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -50,7 +50,7 @@ Instrumentation.prototype.start = function () {
     require('./patch-async')(this)
   }
 
-  var disabled = new Set(this._agent._conf.disableInstrumentation)
+  var disabled = new Set(this._agent._conf.disableInstrumentations)
 
   this._agent.logger.debug('shimming Module._load function')
   hook(MODULES, function (exports, name, basedir) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -23,6 +23,8 @@ function Instrumentation (agent) {
   this.currentTransaction = null
 }
 
+Instrumentation.modules = Object.freeze(MODULES)
+
 Instrumentation.prototype.start = function () {
   if (!this._agent._conf.instrument) return
 
@@ -48,8 +50,19 @@ Instrumentation.prototype.start = function () {
     require('./patch-async')(this)
   }
 
+  const patches = new Set(MODULES)
+
+  this._agent._conf.disableInstrumentation.forEach(patch => {
+    patches.delete(patch)
+  })
+
+  this._applyHooks(Array.from(patches))
+}
+
+Instrumentation.prototype._applyHooks = function (modules) {
+  var self = this
   this._agent.logger.debug('shimming Module._load function')
-  hook(MODULES, function (exports, name, basedir) {
+  hook(modules, function (exports, name, basedir) {
     var pkg, version
 
     if (basedir) {

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -4,7 +4,9 @@ var shimmer = require('../shimmer')
 
 var searchRegexp = /_search$/
 
-module.exports = function (elasticsearch, agent, version) {
+module.exports = function (elasticsearch, agent, version, enabled) {
+  if (!enabled) return elasticsearch
+
   agent.logger.debug('shimming elasticsearch.Transport.prototype.request')
   shimmer.wrap(elasticsearch.Transport && elasticsearch.Transport.prototype, 'request', wrapRequest)
 

--- a/lib/instrumentation/modules/express-graphql.js
+++ b/lib/instrumentation/modules/express-graphql.js
@@ -2,7 +2,9 @@
 
 var semver = require('semver')
 
-module.exports = function (graphqlHTTP, agent, version) {
+module.exports = function (graphqlHTTP, agent, version, enabled) {
+  if (!enabled) return graphqlHTTP
+
   if (!semver.satisfies(version, '^0.6.1') || typeof graphqlHTTP !== 'function') {
     agent.logger.debug('express-graphql version %s not supported - aborting...', version)
     return graphqlHTTP

--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -8,7 +8,8 @@ var symbols = require('../../symbols')
 
 var mountStackLockedSym = Symbol('ElasticAPMExpressMountStackLocked')
 
-module.exports = function (express, agent, version) {
+module.exports = function (express, agent, version, enabled) {
+  if (!enabled) return express
   if (!agent._conf.frameworkName) agent._conf.frameworkName = 'express'
   if (!agent._conf.frameworkVersion) agent._conf.frameworkVersion = version
 

--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -4,7 +4,8 @@ var semver = require('semver')
 
 var getPathFromRequest = require('../express-utils').getPathFromRequest
 
-module.exports = function (graphql, agent, version) {
+module.exports = function (graphql, agent, version, enabled) {
+  if (!enabled) return graphql
   if (!semver.satisfies(version, '>=0.7.0 <1.0.0') ||
       !graphql.Kind ||
       typeof graphql.Source !== 'function' ||

--- a/lib/instrumentation/modules/handlebars.js
+++ b/lib/instrumentation/modules/handlebars.js
@@ -2,7 +2,8 @@
 
 var shimmer = require('../shimmer')
 
-module.exports = function (handlebars, agent, version) {
+module.exports = function (handlebars, agent, version, enabled) {
+  if (!enabled) return handlebars
   agent.logger.debug('shimming handlebars.compile')
   shimmer.wrap(handlebars, 'compile', wrapCompile)
 

--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -6,7 +6,8 @@ var shimmer = require('../shimmer')
 
 var onPreAuthSym = Symbol('ElasticAPMOnPreAuth')
 
-module.exports = function (hapi, agent, version) {
+module.exports = function (hapi, agent, version, enabled) {
+  if (!enabled) return hapi
   if (!agent._conf.frameworkName) agent._conf.frameworkName = 'hapi'
   if (!agent._conf.frameworkVersion) agent._conf.frameworkVersion = version
 

--- a/lib/instrumentation/modules/http.js
+++ b/lib/instrumentation/modules/http.js
@@ -3,7 +3,8 @@
 var httpShared = require('../http-shared')
 var shimmer = require('../shimmer')
 
-module.exports = function (http, agent) {
+module.exports = function (http, agent, version, enabled) {
+  if (!enabled) return http
   agent.logger.debug('shimming http.Server.prototype.emit function')
   shimmer.wrap(http && http.Server && http.Server.prototype, 'emit', httpShared.instrumentRequest(agent, 'http'))
 

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -7,9 +7,9 @@ var eos = require('end-of-stream')
 var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
 
-module.exports = function (http2, agent) {
+module.exports = function (http2, agent, version, enabled) {
+  if (!enabled) return http2
   var ins = agent._instrumentation
-
   agent.logger.debug('shimming http2.createServer function')
   shimmer.wrap(http2, 'createServer', wrapCreateServer)
   shimmer.wrap(http2, 'createSecureServer', wrapCreateServer)

--- a/lib/instrumentation/modules/https.js
+++ b/lib/instrumentation/modules/https.js
@@ -5,7 +5,8 @@ var semver = require('semver')
 var httpShared = require('../http-shared')
 var shimmer = require('../shimmer')
 
-module.exports = function (https, agent, version) {
+module.exports = function (https, agent, version, enabled) {
+  if (!enabled) return https
   agent.logger.debug('shimming https.Server.prototype.emit function')
   shimmer.wrap(https && https.Server && https.Server.prototype, 'emit', httpShared.instrumentRequest(agent, 'https'))
 

--- a/lib/instrumentation/modules/ioredis.js
+++ b/lib/instrumentation/modules/ioredis.js
@@ -6,7 +6,7 @@ var shimmer = require('../shimmer')
 
 var spanSym = Symbol('elasticAPMSpan')
 
-module.exports = function (ioredis, agent, version) {
+module.exports = function (ioredis, agent, version, enabled) {
   if (!semver.satisfies(version, '^2.0.0 || ^3.0.0')) {
     agent.logger.debug('ioredis version %s not supported - aborting...', version)
     return ioredis
@@ -14,6 +14,8 @@ module.exports = function (ioredis, agent, version) {
 
   agent.logger.debug('shimming ioredis.Command.prototype.initPromise')
   shimmer.wrap(ioredis.Command && ioredis.Command.prototype, 'initPromise', wrapInitPromise)
+
+  if (!enabled) return ioredis
 
   agent.logger.debug('shimming ioredis.prototype.sendCommand')
   shimmer.wrap(ioredis.prototype, 'sendCommand', wrapSendCommand)

--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -3,7 +3,8 @@
 var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
 
-module.exports = function (Knex, agent, version) {
+module.exports = function (Knex, agent, version, enabled) {
+  if (!enabled) return Knex
   if (Knex.Client && Knex.Client.prototype) {
     var QUERY_FNS = ['queryBuilder', 'raw']
     agent.logger.debug('shimming Knex.Client.prototype.runner')

--- a/lib/instrumentation/modules/koa-router.js
+++ b/lib/instrumentation/modules/koa-router.js
@@ -4,7 +4,8 @@ var semver = require('semver')
 
 var shimmer = require('../shimmer')
 
-module.exports = function (Router, agent, version) {
+module.exports = function (Router, agent, version, enabled) {
+  if (!enabled) return Router
   if (!semver.satisfies(version, '>=5.2.0 <8')) {
     agent.logger.debug('koa-router version %s not supported - aborting...', version)
     return Router

--- a/lib/instrumentation/modules/mongodb-core.js
+++ b/lib/instrumentation/modules/mongodb-core.js
@@ -7,7 +7,8 @@ var shimmer = require('../shimmer')
 var SERVER_FNS = ['insert', 'update', 'remove', 'auth']
 var CURSOR_FNS_FIRST = ['_find', '_getmore']
 
-module.exports = function (mongodb, agent, version) {
+module.exports = function (mongodb, agent, version, enabled) {
+  if (!enabled) return mongodb
   if (!semver.satisfies(version, '>=1.2.19 <4.0.0')) {
     agent.logger.debug('mongodb-core version %s not supported - aborting...', version)
     return mongodb

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -6,20 +6,22 @@ var sqlSummary = require('sql-summary')
 var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
 
-module.exports = function (mysql, agent, version) {
+module.exports = function (mysql, agent, version, enabled) {
   if (!semver.satisfies(version, '^2.0.0')) {
     agent.logger.debug('mysql version %s not supported - aborting...', version)
     return mysql
   }
-
-  agent.logger.debug('shimming mysql.createConnection')
-  shimmer.wrap(mysql, 'createConnection', wrapCreateConnection)
 
   agent.logger.debug('shimming mysql.createPool')
   shimmer.wrap(mysql, 'createPool', wrapCreatePool)
 
   agent.logger.debug('shimming mysql.createPoolCluster')
   shimmer.wrap(mysql, 'createPoolCluster', wrapCreatePoolCluster)
+
+  if (!enabled) return mysql
+
+  agent.logger.debug('shimming mysql.createConnection')
+  shimmer.wrap(mysql, 'createConnection', wrapCreateConnection)
 
   return mysql
 
@@ -70,7 +72,7 @@ module.exports = function (mysql, agent, version) {
 
       if (typeof cb === 'function') {
         arguments[0] = agent._instrumentation.bindFunction(function wrapedCallback (err, connection) { // eslint-disable-line handle-callback-err
-          if (connection) wrapQueryable(connection, 'getConnection() > connection', agent)
+          if (connection && enabled) wrapQueryable(connection, 'getConnection() > connection', agent)
           return cb.apply(this, arguments)
         })
       }

--- a/lib/instrumentation/modules/pg.js
+++ b/lib/instrumentation/modules/pg.js
@@ -6,13 +6,13 @@ var sqlSummary = require('sql-summary')
 var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
 
-module.exports = function (pg, agent, version) {
+module.exports = function (pg, agent, version, enabled) {
   if (!semver.satisfies(version, '>=4.0.0 <8.0.0')) {
     agent.logger.debug('pg version %s not supported - aborting...', version)
     return pg
   }
 
-  patchClient(pg.Client, 'pg.Client', agent)
+  patchClient(pg.Client, 'pg.Client', agent, enabled)
 
   // Trying to access the pg.native getter will trigger and log the warning
   // "Cannot find module 'pg-native'" to STDERR if the module isn't installed.
@@ -26,7 +26,7 @@ module.exports = function (pg, agent, version) {
     pg.__defineGetter__('native', function () {
       var native = getter()
       if (native && native.Client) {
-        patchClient(native.Client, 'pg.native.Client', agent)
+        patchClient(native.Client, 'pg.native.Client', agent, enabled)
       }
       return native
     })
@@ -35,10 +35,12 @@ module.exports = function (pg, agent, version) {
   return pg
 }
 
-function patchClient (Client, klass, agent) {
+function patchClient (Client, klass, agent, enabled) {
   agent.logger.debug('shimming %s.prototype.query', klass)
-  shimmer.wrap(Client.prototype, 'query', wrapQuery)
   shimmer.wrap(Client.prototype, '_pulseQueryQueue', wrapPulseQueryQueue)
+  if (!enabled) return
+
+  shimmer.wrap(Client.prototype, 'query', wrapQuery)
 
   function wrapQuery (orig, name) {
     return function wrappedFunction (sql) {

--- a/lib/instrumentation/modules/redis.js
+++ b/lib/instrumentation/modules/redis.js
@@ -4,7 +4,7 @@ var semver = require('semver')
 
 var shimmer = require('../shimmer')
 
-module.exports = function (redis, agent, version) {
+module.exports = function (redis, agent, version, enabled) {
   if (!semver.satisfies(version, '^2.0.0')) {
     agent.logger.debug('redis version %s not supported - aborting...', version)
     return redis
@@ -21,23 +21,26 @@ module.exports = function (redis, agent, version) {
 
   return redis
 
+  function makeWrappedCallback (span, cb) {
+    return agent._instrumentation.bindFunction(function wrappedCallback () {
+      if (span) span.end()
+      if (cb) {
+        return cb.apply(this, arguments)
+      }
+    })
+  }
+
   function wrapInternalSendCommand (original) {
     return function wrappedInternalSendCommand (commandObj) {
-      var span = agent.buildSpan()
+      var span = enabled && agent.buildSpan()
       var id = span && span.transaction.id
       var command = commandObj && commandObj.command
 
       agent.logger.debug('intercepted call to RedisClient.prototype.internal_send_command %o', { id: id, command: command })
 
-      if (span && commandObj) {
-        var cb = commandObj.callback
-        commandObj.callback = agent._instrumentation.bindFunction(function wrappedCallback () {
-          span.end()
-          if (cb) {
-            return cb.apply(this, arguments)
-          }
-        })
-        span.start(String(command).toUpperCase(), 'cache.redis')
+      if (commandObj) {
+        commandObj.callback = makeWrappedCallback(span, commandObj.callback)
+        if (span) span.start(String(command).toUpperCase(), 'cache.redis')
       }
 
       return original.apply(this, arguments)
@@ -46,37 +49,28 @@ module.exports = function (redis, agent, version) {
 
   function wrapSendCommand (original) {
     return function wrappedSendCommand (command) {
-      var span = agent.buildSpan()
+      var span = enabled && agent.buildSpan()
       var id = span && span.transaction.id
       var args = Array.prototype.slice.call(arguments)
 
       agent.logger.debug('intercepted call to RedisClient.prototype.internal_send_command %o', { id: id, command: command })
 
-      if (span && args.length > 0) {
+      if (args.length > 0) {
         var index = args.length - 1
         var cb = args[index]
         if (typeof cb === 'function') {
-          args[index] = agent._instrumentation.bindFunction(function wrappedCallback () {
-            span.end()
-            return cb.apply(this, arguments)
-          })
+          args[index] = makeWrappedCallback(span, cb)
         } else if (Array.isArray(cb) && typeof cb[cb.length - 1] === 'function') {
-          var cb2 = cb[cb.length - 1]
-          cb[cb.length - 1] = agent._instrumentation.bindFunction(function wrappedCallback () {
-            span.end()
-            return cb2.apply(this, arguments)
-          })
+          cb[cb.length - 1] = makeWrappedCallback(span, cb[cb.length - 1])
         } else {
-          var obCb = agent._instrumentation.bindFunction(function wrappedCallback () {
-            span.end()
-          })
+          var obCb = makeWrappedCallback(span)
           if (typeof args[index] === 'undefined') {
             args[index] = obCb
           } else {
             args.push(obCb)
           }
         }
-        span.start(String(command).toUpperCase(), 'cache.redis')
+        if (span) span.start(String(command).toUpperCase(), 'cache.redis')
       }
 
       return original.apply(this, args)

--- a/test/config.js
+++ b/test/config.js
@@ -31,7 +31,7 @@ var optionFixtures = [
   ['sourceLinesSpanAppFrames', 'SOURCE_LINES_SPAN_APP_FRAMES', 0],
   ['sourceLinesSpanLibraryFrames', 'SOURCE_LINES_SPAN_LIBRARY_FRAMES', 0],
   ['serverTimeout', 'SERVER_TIMEOUT', 30],
-  ['disableInstrumentation', 'DISABLE_INSTRUMENTATION', []]
+  ['disableInstrumentations', 'DISABLE_INSTRUMENTATIONS', []]
 ]
 
 var falsyValues = [false, 0, '', '0', 'false', 'no', 'off', 'disabled']
@@ -237,7 +237,7 @@ captureBodyTests.forEach(function (captureBodyTest) {
   })
 })
 
-test('disableInstrumentation', function (t) {
+test('disableInstrumentations', function (t) {
   var hapiVersion = require('hapi/package.json').version
 
   var modules = new Set(Instrumentation.modules)
@@ -256,7 +256,7 @@ test('disableInstrumentation', function (t) {
       var agent = Agent()
       agent.start({
         serviceName: 'service',
-        disableInstrumentation: selection
+        disableInstrumentations: selection
       })
 
       var found = new Set()

--- a/test/config.js
+++ b/test/config.js
@@ -10,8 +10,8 @@ var isRegExp = require('core-util-is').isRegExp
 
 var Agent = require('./_agent')
 var config = require('../lib/config')
-var request = require('../lib/request')
 var Instrumentation = require('../lib/instrumentation')
+var request = require('../lib/request')
 
 var optionFixtures = [
   ['serviceName', 'SERVICE_NAME'],

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -26,7 +26,7 @@ module.exports = function mockAgent (cb) {
       ignoreUserAgentStr: [],
       ignoreUserAgentRegExp: [],
       transactionSampleRate: 1.0,
-      disableInstrumentation: []
+      disableInstrumentations: []
     },
     _filters: new Filters(),
     _httpClient: {

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -25,7 +25,8 @@ module.exports = function mockAgent (cb) {
       ignoreUrlRegExp: [],
       ignoreUserAgentStr: [],
       ignoreUserAgentRegExp: [],
-      transactionSampleRate: 1.0
+      transactionSampleRate: 1.0,
+      disableInstrumentation: []
     },
     _filters: new Filters(),
     _httpClient: {


### PR DESCRIPTION
Here's a basic implementation for disabling instrumentation. It still needs docs and such.

@watson Does this approach seem okay?

Fixes elastic/apm-agent-nodejs#273 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update documentation
