### PR TITLE
test(http2): fix broken tests on new Node v8.11.2 release

### DIFF
--- a/test/instrumentation/modules/http2.js
+++ b/test/instrumentation/modules/http2.js
@@ -234,7 +234,7 @@ isSecure.forEach(secure => {
       }
 
       stream.pushStream({ ':path': '/pushed' }, t.shouldCall(
-        semver.lt(process.version, '9.0.0')
+        semver.lt(process.version, '8.11.2')
           ? onPushStream
           : (err, pushStream, headers) => {
             t.error(err)


### PR DESCRIPTION
The tests broke due to a breaking change being backported from 9.x to 8.x. See https://github.com/nodejs/node/issues/20773 for details.