### PR TITLE
test: allow test suite to run against Node.js release candidates

### DIFF
--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -14,7 +14,7 @@ var semver = require('semver')
 if (semver.lt(process.version, '8.9.0') && semver.gte(pkg.version, '17.0.0')) process.exit()
 
 // hapi does not work on Node.js 10 because of https://github.com/nodejs/node/issues/20516
-if (semver.gte(process.version, '10.0.0')) process.exit()
+if (semver.gte(process.version, '10.0.0-rc')) process.exit()
 
 var http = require('http')
 

--- a/test/instrumentation/modules/http2.js
+++ b/test/instrumentation/modules/http2.js
@@ -234,7 +234,7 @@ isSecure.forEach(secure => {
       }
 
       stream.pushStream({ ':path': '/pushed' }, t.shouldCall(
-        semver.lt(process.version, '8.11.2')
+        semver.lt(process.version, '8.11.2-rc')
           ? onPushStream
           : (err, pushStream, headers) => {
             t.error(err)


### PR DESCRIPTION
This is a prerequisite for solving #316

The reason that I can't include this in the same commit that solves #316, is that I'm exploring the darker sides of Travis CI where I'm actually checking out master as part of the Travis `install` step and running the RC tests on that. So if this isn't in master the tests will fail.