### PR TITLE
test(ci): use conditional stages to quicker skip builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,92 +71,112 @@ jobs:
     # Node.js 10
     - stage: dependencies
       node_js: '10'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=generic-pool,mysql,redis,koa-router,handlebars,mongodb-core
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '10'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=ioredis,pg
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '10'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=bluebird
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '10'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
 
     # Node.js 9
     - stage: dependencies
       node_js: '9'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=generic-pool,mysql,redis,koa-router,handlebars,mongodb-core
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '9'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=ioredis,pg
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '9'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=bluebird
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '9'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
 
     # Node.js 8
     -
       node_js: '8'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=generic-pool,mysql,redis,koa-router,handlebars,mongodb-core
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '8'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=ioredis,pg
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '8'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=bluebird
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '8'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
 
     # Node.js 6
     -
       node_js: '6'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=generic-pool,mysql,redis,koa-router,handlebars,mongodb-core
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '6'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=ioredis,pg
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '6'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=bluebird
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '6'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
 
     # Node.js 4
     -
       node_js: '4'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=generic-pool,mysql,redis,koa-router,handlebars,mongodb-core
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '4'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=ioredis,pg
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '4'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=bluebird
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
     -
       node_js: '4'
+      if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
       env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express
-      script: 'if [[ "$TRAVIS_EVENT_TYPE" == "cron" || ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$TRAVIS_BRANCH" != greenkeeper/*) ]]; then tav --quiet; fi'
+      script: tav --quiet
 
 addons:
   apt:


### PR DESCRIPTION
This means that builds that would normally start up just to stop again when the if statement didn't trigger, now are not included in the job at all