### PR TITLE
chore: don't use "anonymous" functions

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -15,7 +15,7 @@ exports.errors = sendErrors
 exports.transactions = sendTransactions
 exports._envelope = envelope // Expose for testing only
 
-var request = function (agent, endpoint, payload, cb) {
+function request (agent, endpoint, payload, cb) {
   if (!agent._conf.active) return cb()
 
   if (process.env.DEBUG_PAYLOAD) capturePayload(endpoint, payload)


### PR DESCRIPTION
In this instance the function actually isn't anonymous in modern versions of V8 as the function will be given the name of the variable. But we prefer this style over the variable assignment style.