### PR TITLE
fix: get remoteAddress before req close event

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -176,10 +176,10 @@ Transaction.prototype._encode = function (cb) {
 
   if (!this.ended) return cb(new Error('cannot encode un-ended transaction'))
 
+  var payload = this.toJSON()
   var next = afterAll(function (err, spans) {
     if (err) return cb(err)
 
-    var payload = self.toJSON()
     if (self.sampled) {
       payload.spans = spans
     }


### PR DESCRIPTION
When serializing the transaction payload, we need the `remoteAddress` for the socket. This needs to happen before the socket is closed so we're sure that we still have access to the socket object. In HTTP/1.1 this didn't seem to be an issue, but in HTTP/2 the socket was set to `undefined` when the close event was emitted.