### PR TITLE
chore: don't let greenkeeper ignore get-port and restify

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,9 +132,7 @@
   },
   "greenkeeper": {
     "ignore": [
-      "get-port",
-      "inquirer",
-      "restify"
+      "inquirer"
     ]
   },
   "standard": {


### PR DESCRIPTION
We were previously stuck with old versions of these two modules, but now they are up to date.