### PR TITLE
feat: truncate very long error messages

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -489,6 +489,23 @@ The default value `0` means that no source code will be collected for in-app spa
 
 The default value `0` means that no source code will be collected for span library frames.
 
+[[error-message-max-length]]
+===== `errorMessageMaxLength`
+
+* *Type:* Number
+* *Default:* `2048`
+* *Env:* `ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH`
+
+The maximum length allowed for error messages in bytes.
+Messages above this length will be truncated before being sent to the APM Server.
+
+Set to `-1` do disable truncation.
+
+This applies to the following properties:
+
+- `error.exception.message`
+- `error.log.message`
+
 [[stack-trace-limit]]
 ===== `stackTraceLimit`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,7 @@ var DEFAULTS = {
   sourceLinesErrorLibraryFrames: 5,
   sourceLinesSpanAppFrames: 0,
   sourceLinesSpanLibraryFrames: 0,
+  errorMessageMaxLength: 2048,
   flushInterval: 10,
   transactionMaxSpans: Infinity,
   transactionSampleRate: 1.0,
@@ -78,6 +79,7 @@ var ENV_TABLE = {
   sourceLinesErrorLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES',
   sourceLinesSpanAppFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
   sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
+  errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
   transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
   transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
   serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT',
@@ -102,6 +104,7 @@ var NUM_OPTS = [
   'sourceLinesErrorLibraryFrames',
   'sourceLinesSpanAppFrames',
   'sourceLinesSpanLibraryFrames',
+  'errorMessageMaxLength',
   'transactionSampleRate',
   'serverTimeout'
 ]

--- a/lib/request.js
+++ b/lib/request.js
@@ -58,7 +58,7 @@ function sendErrors (agent, errors, cb) {
     return
   }
 
-  truncErrorsPayload(payload)
+  truncErrorsPayload(payload, agent._conf)
 
   request(agent, 'errors', payload, cb)
 }
@@ -80,7 +80,7 @@ function sendTransactions (agent, transactions, cb) {
   request(agent, 'transactions', payload, cb)
 }
 
-function truncErrorsPayload (payload) {
+function truncErrorsPayload (payload, conf) {
   payload.errors.forEach(function (error) {
     if (error.log) {
       if (error.log.level) {
@@ -88,6 +88,9 @@ function truncErrorsPayload (payload) {
       }
       if (error.log.logger_name) {
         error.log.logger_name = truncate(String(error.log.logger_name), config.INTAKE_STRING_MAX_SIZE)
+      }
+      if (error.log.message && conf.errorMessageMaxLength >= 0) {
+        error.log.message = truncate(String(error.log.message), conf.errorMessageMaxLength)
       }
       if (error.log.param_message) {
         error.log.param_message = truncate(String(error.log.param_message), config.INTAKE_STRING_MAX_SIZE)
@@ -98,6 +101,9 @@ function truncErrorsPayload (payload) {
     }
 
     if (error.exception) {
+      if (error.exception.message && conf.errorMessageMaxLength >= 0) {
+        error.exception.message = truncate(String(error.exception.message), conf.errorMessageMaxLength)
+      }
       if (error.exception.type) {
         error.exception.type = truncate(String(error.exception.type), config.INTAKE_STRING_MAX_SIZE)
       }

--- a/test/config.js
+++ b/test/config.js
@@ -30,6 +30,7 @@ var optionFixtures = [
   ['sourceLinesErrorLibraryFrames', 'SOURCE_LINES_ERROR_LIBRARY_FRAMES', 5],
   ['sourceLinesSpanAppFrames', 'SOURCE_LINES_SPAN_APP_FRAMES', 0],
   ['sourceLinesSpanLibraryFrames', 'SOURCE_LINES_SPAN_LIBRARY_FRAMES', 0],
+  ['errorMessageMaxLength', 'ERROR_MESSAGE_MAX_LENGTH', 2048],
   ['serverTimeout', 'SERVER_TIMEOUT', 30],
   ['disableInstrumentations', 'DISABLE_INSTRUMENTATIONS', []]
 ]


### PR DESCRIPTION
Will truncate error messages to max 2048 bytes by default. This length can be configured using the new `errorMessageMaxLength` config option. If set to `-1` no truncation will occur.

Fixes #390

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
