### PR TITLE
docs: add into about the npm pacakge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ This is the official Node.js agent for [Elastic APM](https://www.elastic.co/solu
 If you have any feedback or questions,
 please post them on the [Discuss forum](https://discuss.elastic.co/c/apm).
 
+[![npm](https://nodei.co/npm/elastic-apm-node.png)](https://www.npmjs.com/package/elastic-apm-node)
+
 [![Build status](https://travis-ci.org/elastic/apm-agent-nodejs.svg?branch=1.x)](https://travis-ci.org/elastic/apm-agent-nodejs)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/standard/standard)
+
+## Installation
+
+```
+npm install elastic-apm-node --save
+```
 
 ## Quick start
 


### PR DESCRIPTION
I just found my self having forgotten if our npm package was called `elastic-apm-node` or `elastic-apm-nodejs`. And since our repo name doesn't match the package name, I thought it would be a nice gesture to make is easier to see without having to leave the README file.