### PR TITLE
test: make schema integration tests more resilient

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -2,6 +2,22 @@
 
 set -x
 
+download_schema()
+{
+  from=$1
+  to=$2
+
+  for run in {1..5}
+  do
+    curl -sf --compressed ${from} > ${to}
+    result=$?
+    if [ $result -eq 0 ]; then break; fi
+    sleep 1
+  done
+
+  if [ $result -ne 0 ]; then exit $result; fi
+}
+
 schemadir="${1:-.schemacache}"
 
 FILES=( \
@@ -24,7 +40,6 @@ FILES=( \
 mkdir -p ${schemadir}/errors ${schemadir}/transactions ${schemadir}/sourcemaps
 
 for i in "${FILES[@]}"; do
-  output="${schemadir}/${i}"
-  curl -sf --compressed https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} > ${output} || exit $?
+  download_schema https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} ${schemadir}/${i}
 done
 echo "Done."


### PR DESCRIPTION
Some times curl fails when trying to download a schema from GitHub. This is usually just a temporary error and will succeed if retried.

This commit retries downloads up to 5 times before failing permanently.