### PR TITLE
test: don't test knex on unsupported Node versions

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -34,7 +34,7 @@ bluebird:
     - node test/instrumentation/modules/bluebird/bluebird.js
     - node test/instrumentation/modules/bluebird/cancel.js
 knex:
-  versions: ^0.14.0 || ^0.13.0 || ^0.12.5 || <0.12.4 >0.11.6 || <0.11.6 >0.9.0
+  versions: ^0.15.0 || ^0.14.0 || ^0.13.0 || ^0.12.5 || <0.12.4 >0.11.6 || <0.11.6 >0.9.0
   commands: node test/instrumentation/modules/pg/knex.js
 ws:
   versions: '>=1 <6'

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ioredis": "^3.0.0",
     "is-my-json-valid": "^2.17.2",
     "json-schema-ref-parser": "^5.0.3",
-    "knex": "^0.14.2",
+    "knex": "^0.15.0",
     "koa": "^2.2.0",
     "koa-router": "^7.1.1",
     "mimic-response": "^1.0.0",

--- a/test/instrumentation/modules/pg/knex.js
+++ b/test/instrumentation/modules/pg/knex.js
@@ -14,6 +14,8 @@ var semver = require('semver')
 
 // pg@7+ doesn't support Node.js pre 4.5.0
 if (semver.lt(process.version, '4.5.0') && semver.gte(pgVersion, '7.0.0')) process.exit()
+// knex@0.15+ doesn't support Node.js pre 6.0.0
+if (semver.lt(process.version, '6.0.0') && semver.gte(knexVersion, '0.15.0')) process.exit()
 
 var Knex = require('knex')
 var test = require('tape')


### PR DESCRIPTION
Newly released Knex v0.15.0 dropped support for Node.js 4+5