### PR TITLE
fix: ensure correct streaming when using mimic-response

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,6 +1,9 @@
 generic-pool:
   versions: ^2.0.0 || ^3.1.0
   commands: node test/instrumentation/modules/generic-pool.js
+mimic-response:
+  versions: ^1.0.0
+  commands: node test/instrumentation/modules/mimic-response.js
 mysql:
   versions: ^2.0.0
   commands:

--- a/.tav.yml
+++ b/.tav.yml
@@ -5,7 +5,7 @@ mimic-response:
   versions: ^1.0.0
   commands: node test/instrumentation/modules/mimic-response.js
 got:
-  versions: >=4.0.0
+  versions: '>=4.0.0'
   commands: node test/instrumentation/modules/http/github-423.js
 mysql:
   versions: ^2.0.0

--- a/.tav.yml
+++ b/.tav.yml
@@ -6,6 +6,7 @@ mimic-response:
   commands: node test/instrumentation/modules/mimic-response.js
 got:
   versions: '>=4.0.0'
+  node: '>=5'
   commands: node test/instrumentation/modules/http/github-423.js
 mysql:
   versions: ^2.0.0

--- a/.tav.yml
+++ b/.tav.yml
@@ -4,6 +4,9 @@ generic-pool:
 mimic-response:
   versions: ^1.0.0
   commands: node test/instrumentation/modules/mimic-response.js
+got:
+  versions: >=4.0.0
+  commands: node test/instrumentation/modules/http/github-423.js
 mysql:
   versions: ^2.0.0
   commands:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
     -
       node_js: '10'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,bluebird
+      env: TAV=mimic-response,got,bluebird
       script: tav --quiet
     -
       node_js: '10'
@@ -104,7 +104,7 @@ jobs:
     -
       node_js: '9'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,bluebird
+      env: TAV=mimic-response,got,bluebird
       script: tav --quiet
     -
       node_js: '9'
@@ -126,7 +126,7 @@ jobs:
     -
       node_js: '8'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,bluebird
+      env: TAV=mimic-response,got,bluebird
       script: tav --quiet
     -
       node_js: '8'
@@ -148,7 +148,7 @@ jobs:
     -
       node_js: '6'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,bluebird
+      env: TAV=mimic-response,got,bluebird
       script: tav --quiet
     -
       node_js: '6'
@@ -170,7 +170,7 @@ jobs:
     -
       node_js: '4'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,bluebird
+      env: TAV=mimic-response,got,bluebird
       script: tav --quiet
     -
       node_js: '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
     -
       node_js: '10'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=bluebird
+      env: TAV=mimic-response,bluebird
       script: tav --quiet
     -
       node_js: '10'
@@ -104,7 +104,7 @@ jobs:
     -
       node_js: '9'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=bluebird
+      env: TAV=mimic-response,bluebird
       script: tav --quiet
     -
       node_js: '9'
@@ -126,7 +126,7 @@ jobs:
     -
       node_js: '8'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=bluebird
+      env: TAV=mimic-response,bluebird
       script: tav --quiet
     -
       node_js: '8'
@@ -148,7 +148,7 @@ jobs:
     -
       node_js: '6'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=bluebird
+      env: TAV=mimic-response,bluebird
       script: tav --quiet
     -
       node_js: '6'
@@ -170,7 +170,7 @@ jobs:
     -
       node_js: '4'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=bluebird
+      env: TAV=mimic-response,bluebird
       script: tav --quiet
     -
       node_js: '4'

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -12,7 +12,7 @@ var request = require('../request')
 var Transaction = require('./transaction')
 var shimmer = require('./shimmer')
 
-var MODULES = ['http', 'https', 'http2', 'generic-pool', 'mongodb-core', 'pg', 'mysql', 'mysql2', 'express', 'express-queue', 'hapi', 'redis', 'ioredis', 'bluebird', 'knex', 'koa-router', 'ws', 'graphql', 'express-graphql', 'elasticsearch', 'handlebars']
+var MODULES = ['http', 'https', 'http2', 'generic-pool', 'mongodb-core', 'pg', 'mysql', 'mysql2', 'express', 'express-queue', 'hapi', 'redis', 'ioredis', 'bluebird', 'knex', 'koa-router', 'ws', 'graphql', 'express-graphql', 'elasticsearch', 'handlebars', 'mimic-response']
 
 module.exports = Instrumentation
 

--- a/lib/instrumentation/modules/mimic-response.js
+++ b/lib/instrumentation/modules/mimic-response.js
@@ -1,0 +1,22 @@
+'use strict'
+
+var shimmer = require('../shimmer')
+
+module.exports = function (mimicResponse, agent, version, enabled) {
+  if (!enabled) return mimicResponse
+
+  var ins = agent._instrumentation
+
+  return function wrappedMimicResponse (fromStream, toStream) {
+    // If we bound the `fromStream` emitter, but not the `toStream` emitter, we
+    // need to do so as else the `on`, `addListener`, and `prependListener`
+    // functions of the `fromStream` will be copied over to the `toStream` but
+    // run in the context of the `fromStream`.
+    if (fromStream && toStream &&
+        shimmer.isWrapped(fromStream.on) &&
+        !shimmer.isWrapped(toStream.on)) {
+      ins.bindEmitter(toStream)
+    }
+    return mimicResponse.apply(null, arguments)
+  }
+}

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -22,6 +22,7 @@ var isWrappedSym = Symbol('elasticAPMIsWrapped')
 exports.wrap = wrap
 exports.massWrap = massWrap
 exports.unwrap = unwrap
+exports.isWrapped = isWrapped
 
 // Do not load agent until used to avoid circular dependency issues.
 var _agent
@@ -105,4 +106,8 @@ function unwrap (nodule, name) {
   } else {
     return nodule[name][symbols.unwrap]()
   }
+}
+
+function isWrapped (wrapped) {
+  return wrapped && wrapped[isWrappedSym]
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "express-queue": "0.0.12",
     "generic-pool": "^3.1.5",
     "get-port": "^3.2.0",
+    "got": "^8.3.1",
     "graphql": "^0.13.2",
     "handlebars": "^4.0.11",
     "hapi": "^17.2.2",

--- a/test/.jenkins_tav.yml
+++ b/test/.jenkins_tav.yml
@@ -1,5 +1,5 @@
 TAV:
   - generic-pool+mysql+mysql2+redis+koa-router+handlebars+mongodb-core
   - ioredis+pg
-  - bluebird
+  - mimic-response+bluebird
   - knex+ws+graphql+express-graphql+elasticsearch+hapi+express+express-queue

--- a/test/.jenkins_tav.yml
+++ b/test/.jenkins_tav.yml
@@ -1,5 +1,5 @@
 TAV:
   - generic-pool+mysql+mysql2+redis+koa-router+handlebars+mongodb-core
   - ioredis+pg
-  - mimic-response+bluebird
+  - mimic-response+got+bluebird
   - knex+ws+graphql+express-graphql+elasticsearch+hapi+express+express-queue

--- a/test/instrumentation/modules/http/github-423.js
+++ b/test/instrumentation/modules/http/github-423.js
@@ -11,6 +11,8 @@ var fs = require('fs')
 var got = require('got')
 var test = require('tape')
 
+var fileSize = fs.readFileSync(__filename, 'utf8').length
+
 test('https://github.com/elastic/apm-agent-nodejs/issues/423', function (t) {
   // Start dummy remote server to fetch gzip'ed data from
   var remote = http.createServer(function (req, res) {
@@ -25,7 +27,8 @@ test('https://github.com/elastic/apm-agent-nodejs/issues/423', function (t) {
     // Start simple server that performs got-request on every request
     var server = http.createServer(function (req, res) {
       got(url).then(function (response) {
-        t.equal(response.body[0], '\'', 'body should be uncompressed')
+        t.equal(response.body.length, fileSize, 'body should be expected size')
+        t.equal(response.body.slice(0, 12), '\'use strict\'', 'body should be uncompressed')
         res.end()
       })
     })

--- a/test/instrumentation/modules/http/github-423.js
+++ b/test/instrumentation/modules/http/github-423.js
@@ -1,0 +1,45 @@
+'use strict'
+
+require('../../../..').start({
+  serviceName: 'test',
+  captureExceptions: false
+})
+
+var http = require('http')
+var zlib = require('zlib')
+var fs = require('fs')
+var got = require('got')
+var test = require('tape')
+
+test('https://github.com/elastic/apm-agent-nodejs/issues/423', function (t) {
+  // Start dummy remote server to fetch gzip'ed data from
+  var remote = http.createServer(function (req, res) {
+    res.setHeader('Content-Encoding', 'gzip')
+    fs.createReadStream(__filename).pipe(zlib.createGzip()).pipe(res)
+  })
+
+  remote.listen(function () {
+    var port = remote.address().port
+    var url = 'http://localhost:' + port
+
+    // Start simple server that performs got-request on every request
+    var server = http.createServer(function (req, res) {
+      got(url).then(function (response) {
+        t.equal(response.body[0], '\'', 'body should be uncompressed')
+        res.end()
+      })
+    })
+
+    server.listen(function () {
+      var port = server.address().port
+      var url = 'http://localhost:' + port
+
+      http.get(url, function (res) {
+        res.resume()
+        server.close()
+        remote.close()
+        t.end()
+      })
+    })
+  })
+})

--- a/test/instrumentation/modules/mimic-response.js
+++ b/test/instrumentation/modules/mimic-response.js
@@ -1,0 +1,82 @@
+'use strict'
+
+var agent = require('../../..').start({
+  serviceName: 'test',
+  captureExceptions: false
+})
+
+var PassThrough = require('stream').PassThrough
+var mimicResponse = require('mimic-response')
+var test = require('tape')
+
+test('none bound', function (t) {
+  const source = new PassThrough()
+  const target = new PassThrough()
+
+  mimicResponse(source, target)
+
+  target.on('data', function (chunk) {
+    t.ok(this === target, 'target -> onData should be bound to target stream')
+    t.equal(chunk.toString(), 'hello world')
+    t.end()
+  })
+
+  source.pipe(target)
+
+  source.end('hello world')
+})
+
+test('source bound', function (t) {
+  const source = new PassThrough()
+  const target = new PassThrough()
+
+  agent._instrumentation.bindEmitter(source)
+  mimicResponse(source, target)
+
+  target.on('data', function (chunk) {
+    t.ok(this === target, 'target -> onData should be bound to target stream')
+    t.equal(chunk.toString(), 'hello world')
+    t.end()
+  })
+
+  source.pipe(target)
+
+  source.end('hello world')
+})
+
+test('target bound', function (t) {
+  const source = new PassThrough()
+  const target = new PassThrough()
+
+  agent._instrumentation.bindEmitter(target)
+  mimicResponse(source, target)
+
+  target.on('data', function (chunk) {
+    t.ok(this === target, 'target -> onData should be bound to target stream')
+    t.equal(chunk.toString(), 'hello world')
+    t.end()
+  })
+
+  source.pipe(target)
+
+  source.end('hello world')
+})
+
+test('both bound', function (t) {
+  const source = new PassThrough()
+  const target = new PassThrough()
+
+  agent._instrumentation.bindEmitter(source)
+  agent._instrumentation.bindEmitter(target)
+  mimicResponse(source, target)
+
+  target.on('data', function (chunk) {
+    t.ok(this === target, 'target -> onData should be bound to target stream')
+    t.equal(chunk.toString(), 'hello world')
+    t.end()
+  })
+
+  source.pipe(target)
+
+  source.end('hello world')
+})


### PR DESCRIPTION
The `mimic-response` module exposes a single function with the following API:

```js
mimicResponse(fromStream, toStream)
```

If someone is calling `mimicResponse` where the `fromStream` have had its emitter functions bound using `bindEmitter(fromStream)`, the `toStream` will wrongly bind all its event listeners to the `fromStream`.

This becomes especially problematic in case the data is transformed either in the `toStream` or in between `fromStream` and `toStream`, eg:

```js
fromStream.pipe(zlib.createGunzip()).pipe(toStream)
```

In those cases, the data emitted by `toStream` will actually be the un-transformed data coming from the `fromStream`.

This commit patches `mimic-response` so that the event emitters of `toStream` runs in the expected context.

Fixes #423