### PR TITLE
test: don't patch Module.prototype.require more than once

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -53,7 +53,9 @@ Instrumentation.prototype.start = function () {
   var disabled = new Set(this._agent._conf.disableInstrumentations)
 
   this._agent.logger.debug('shimming Module._load function')
-  hook(MODULES, function (exports, name, basedir) {
+
+  // this._hook is only exposed for testing purposes
+  this._hook = hook(MODULES, function (exports, name, basedir) {
     var enabled = !disabled.has(name)
     var pkg, version
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "original-url": "^1.2.1",
     "redact-secrets": "^1.0.0",
     "require-ancestors": "^1.0.0",
-    "require-in-the-middle": "^3.0.0",
+    "require-in-the-middle": "^3.1.0",
     "semver": "^5.5.0",
     "sql-summary": "^1.0.0",
     "stackman": "^3.0.2",

--- a/test/_agent.js
+++ b/test/_agent.js
@@ -19,5 +19,10 @@ function setup () {
 function clean () {
   global[symbols.agentInitialized] = null
   process._events.uncaughtException = uncaughtExceptionListeners
-  if (agent) agent._filters = []
+  if (agent) {
+    agent._filters = []
+    if (agent._instrumentation && agent._instrumentation._hook) {
+      agent._instrumentation._hook.unhook()
+    }
+  }
 }


### PR DESCRIPTION
Ever since require-in-the-middle allowed multiple hooks to be added in the same app, the `Module.prototype.require` function was patched multiple times if the agent was initialized more than once in the same test file.

This resulted in a lot over overhead every time `require()` was called by any module. This was especially visible in the `disableInstrumentations` tests that would take about a minute to complete because of this.

With this commit, the `disableInstrumentations` tests only take a few seconds.