### PR TITLE
chore: change npm badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This is the official Node.js agent for [Elastic APM](https://www.elastic.co/solu
 If you have any feedback or questions,
 please post them on the [Discuss forum](https://discuss.elastic.co/c/apm).
 
-[![npm](https://nodei.co/npm/elastic-apm-node.png)](https://www.npmjs.com/package/elastic-apm-node)
-
+[![npm](https://img.shields.io/npm/v/elastic-apm-node.svg)](https://www.npmjs.com/package/elastic-apm-node)
 [![Build status](https://travis-ci.org/elastic/apm-agent-nodejs.svg?branch=1.x)](https://travis-ci.org/elastic/apm-agent-nodejs)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/standard/standard)
 


### PR DESCRIPTION
The old badge didn't show the correct dependency numbers, so let's just use a simpler one. As long as it links to the npm page then it's good 😄 

This is how it will look:

![image](https://user-images.githubusercontent.com/10602/42245085-c67205f0-7f17-11e8-8988-5f7a0c7d82af.png)
