### PR TITLE
perf: don't patch newer versions of mimic-response

### DIFF
--- a/lib/instrumentation/modules/mimic-response.js
+++ b/lib/instrumentation/modules/mimic-response.js
@@ -1,9 +1,16 @@
 'use strict'
 
+var semver = require('semver')
+
 var shimmer = require('../shimmer')
 
 module.exports = function (mimicResponse, agent, version, enabled) {
   if (!enabled) return mimicResponse
+
+  if (semver.gte(version, '1.0.1')) {
+    agent.logger.debug('mimic-response version %s doesn\'t need to be patched - ignoring...', version)
+    return mimicResponse
+  }
 
   var ins = agent._instrumentation
 


### PR DESCRIPTION
Version 1.0.1 of mimic-response have just been released with the following fix:

https://github.com/sindresorhus/mimic-response/pull/1

This fix makes our own patch redundant, so it's no longer necessary for us to patch this or newer versions. We should still continue to patch version 1.0.0 however.