### PR TITLE
docs: remove reference to Node 10 incompatibility

### DIFF
--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -15,7 +15,6 @@ image::https://raw.githubusercontent.com/nodejs/Release/master/schedule.png[]
 Some versions of Node.js contain bugs or issues that limit our ability to instrument them correctly.
 The following versions of Node.js are known to not be fully instrumented:
 
-- v10.x - Async/Await in Node.js 10 is currently buggy and can therefore not be supported (https://github.com/nodejs/node/issues/20516:[nodejs/node#20516])
 - v8.1.x - Recommended solution: Upgrade to v8.2.0 or higher to get full support
 - v8.0.x - Recommended solution: Upgrade to v8.2.0 or higher to get full support
 

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -13,8 +13,8 @@ var semver = require('semver')
 // hapi 17+ requires Node.js 8.9.0 or higher
 if (semver.lt(process.version, '8.9.0') && semver.gte(pkg.version, '17.0.0')) process.exit()
 
-// hapi does not work on early versions of Node.js 10 because of https://github.com/nodejs/node/issues/20516
-if (semver.satisfies(process.version, '>=10.0.0-rc <10.4.0')) process.exit()
+// hapi does not work on Node.js 10 because of https://github.com/nodejs/node/issues/20516
+if (semver.gte(process.version, '10.0.0-rc')) process.exit()
 
 var http = require('http')
 

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -13,9 +13,6 @@ var semver = require('semver')
 // hapi 17+ requires Node.js 8.9.0 or higher
 if (semver.lt(process.version, '8.9.0') && semver.gte(pkg.version, '17.0.0')) process.exit()
 
-// hapi does not work on Node.js 10 because of https://github.com/nodejs/node/issues/20516
-if (semver.gte(process.version, '10.0.0-rc')) process.exit()
-
 var http = require('http')
 
 var Hapi = require('hapi')

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -13,6 +13,9 @@ var semver = require('semver')
 // hapi 17+ requires Node.js 8.9.0 or higher
 if (semver.lt(process.version, '8.9.0') && semver.gte(pkg.version, '17.0.0')) process.exit()
 
+// hapi does not work on early versions of Node.js 10 because of https://github.com/nodejs/node/issues/20516
+if (semver.satisfies(process.version, '>=10.0.0-rc <10.4.0')) process.exit()
+
 var http = require('http')
 
 var Hapi = require('hapi')


### PR DESCRIPTION
The bug in V8 that meant we couldn't instrument Node 10 was fixed and Node 10.4.0 shipped with a newer version of V8.

This is the original bug report in Node: https://github.com/nodejs/node/issues/20516
This is the PR that fixed it in Node: https://github.com/nodejs/node/pull/19989

Closes #448