### PR TITLE
test: use custom Travis CI job names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,16 +48,19 @@ jobs:
     # Docs
     -
       script: npm run docs
+      name: "Build Docs"
       perl: '5.26'
 
     # Commit Messages
     -
       node_js: 'lts/*'
+      name: "Lint Commit Messages"
       script: commitlint-travis
 
     # Coverage
     -
       node_js: 'lts/*'
+      name: "Code Coverage"
       script:
         - npm run coverage
         - ./node_modules/.bin/nyc report --reporter=lcov > coverage.lcov
@@ -185,46 +188,55 @@ jobs:
     # Nightlies
     - stage: Node.js pre-releases
       node_js: '11'
+      name: "Node.js: 11-nightly"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '10'
+      name: "Node.js: 10-nightly"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '9'
+      name: "Node.js: 9-nightly"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '8'
+      name: "Node.js: 8-nightly"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '6'
+      name: "Node.js: 6-nightly"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
 
     # Nightlies - No async hooks
     - stage: Node.js pre-releases
       node_js: '11'
+      name: "Node.js: 11-nightly (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '10'
+      name: "Node.js: 10-nightly (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '9'
+      name: "Node.js: 9-nightly (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
       node_js: '8'
+      name: "Node.js: 8-nightly (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0
@@ -233,36 +245,43 @@ jobs:
     # Release Candidates
     -
       node_js: '10'
+      name: "Node.js: 10-rc"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
     -
       node_js: '9'
+      name: "Node.js: 9-rc"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
     -
       node_js: '8'
+      name: "Node.js: 8-rc"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
     -
       node_js: '6'
+      name: "Node.js: 6-rc"
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
 
     # Release Candidates - No async hooks
     -
       node_js: '10'
+      name: "Node.js: 10-rc (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
     -
       node_js: '9'
+      name: "Node.js: 9-rc (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
     -
       node_js: '8'
+      name: "Node.js: 8-rc (no async hooks)"
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0


### PR DESCRIPTION
Travis CI just announced that we can now [customize the job names](https://docs.travis-ci.com/user/build-stages#Naming-your-Jobs-within-Build-Stages) 🎉 

This makes it easier to know what each job does:

![image](https://user-images.githubusercontent.com/10602/42935967-3c20982c-8b4b-11e8-8c14-67ebef60a394.png)

I've just run a test build of this PR with all the different stages activated to see how it looks for each job:

https://travis-ci.org/elastic/apm-agent-nodejs/builds/405734487