### PR TITLE
test: remove Node 9 nightly/rc jobs from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,10 +192,6 @@ jobs:
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
-      node_js: '9'
-      if: type = cron
-      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
-    -
       node_js: '8'
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
@@ -218,12 +214,6 @@ jobs:
         - ELASTIC_APM_ASYNC_HOOKS=0
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
     -
-      node_js: '9'
-      if: type = cron
-      env:
-        - ELASTIC_APM_ASYNC_HOOKS=0
-        - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly/
-    -
       node_js: '8'
       if: type = cron
       env:
@@ -233,10 +223,6 @@ jobs:
     # Release Candidates
     -
       node_js: '10'
-      if: type = cron
-      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
-    -
-      node_js: '9'
       if: type = cron
       env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
     -
@@ -251,12 +237,6 @@ jobs:
     # Release Candidates - No async hooks
     -
       node_js: '10'
-      if: type = cron
-      env:
-        - ELASTIC_APM_ASYNC_HOOKS=0
-        - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/rc/
-    -
-      node_js: '9'
       if: type = cron
       env:
         - ELASTIC_APM_ASYNC_HOOKS=0


### PR DESCRIPTION
As Node.js 9 is now EOL, no new nightlies or release candidates will be created for this version. It's therefore safe to remove these jobs from the Travis CI build matrix.