### PR TITLE
fix(graphql): handle execute args object

### DIFF
--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -95,7 +95,7 @@ module.exports = function (graphql, agent, version, enabled) {
   }
 
   function wrapExecute (orig) {
-    return function wrappedExecute (schema, document, rootValue, contextValue, variableValues, operationName) {
+    function wrappedExecuteImpl (schema, document, rootValue, contextValue, variableValues, operationName) {
       var trans = agent._instrumentation.currentTransaction
       var span = agent.buildSpan()
       var id = span && span.transaction.id
@@ -134,6 +134,26 @@ module.exports = function (graphql, agent, version, enabled) {
         span.end()
       }
       return p
+    }
+
+    return function wrappedExecute (argsOrSchema, document, rootValue, contextValue, variableValues, operationName) {
+      return arguments.length === 1
+        ? wrappedExecuteImpl(
+          argsOrSchema.schema,
+          argsOrSchema.document,
+          argsOrSchema.rootValue,
+          argsOrSchema.contextValue,
+          argsOrSchema.variableValues,
+          argsOrSchema.operationName
+        )
+        : wrappedExecuteImpl(
+          argsOrSchema,
+          document,
+          rootValue,
+          contextValue,
+          variableValues,
+          operationName
+        )
     }
   }
 

--- a/test/instrumentation/modules/graphql.js
+++ b/test/instrumentation/modules/graphql.js
@@ -49,6 +49,31 @@ test('graphql.execute', function (t) {
   })
 })
 
+test('graphql.execute args object', function (t) {
+  resetAgent(done(t))
+
+  var schema = graphql.buildSchema('type Query { hello: String }')
+  var root = {hello () {
+    return Promise.resolve('Hello world!')
+  }}
+  var query = '{ hello }'
+  var source = new graphql.Source(query)
+  var documentAST = graphql.parse(source)
+  var args = {
+    schema: schema,
+    document: documentAST,
+    rootValue: root
+  }
+
+  agent.startTransaction('foo')
+
+  graphql.execute(args).then(function (response) {
+    agent.endTransaction()
+    t.deepEqual(response, {data: {hello: 'Hello world!'}})
+    agent.flush()
+  })
+})
+
 if (semver.satisfies(pkg.version, '>=0.12')) {
   test('graphql.execute sync', function (t) {
     resetAgent(done(t))


### PR DESCRIPTION
This PR fixes handling of arguments passed to the graphql execute function by adding support for passing the arguments as an object. This is [how the latest version of apollo does it](https://github.com/apollographql/apollo-server/blob/e77701c77253db007171a2437fe361c5bb2c2312/packages/apollo-server-core/src/runQuery.ts#L232) and the implementation is based on [how this is handled in the graphql module itself](https://github.com/graphql/graphql-js/blob/3124fa32dc77c5844bf74ebc07e38239ad78e856/src/execution/execute.js#L164-L183).

### Checklist

- [x] Implement code
- [x] Add tests
