### PR TITLE
test(appveyor): fix Cassandra download url

### DIFF
--- a/test/script/appveyor/install-cassandra.ps1
+++ b/test/script/appveyor/install-cassandra.ps1
@@ -1,5 +1,5 @@
-$cassandraVersion = "3.11.2"
-$downloadUrl = "http://mirrors.dotsrc.org/apache/cassandra/$cassandraVersion/apache-cassandra-$cassandraVersion-bin.tar.gz"
+$cassandraVersion = "3.11.3"
+$downloadUrl = "http://archive.apache.org/dist/cassandra/$cassandraVersion/apache-cassandra-$cassandraVersion-bin.tar.gz"
 $extractRoot = "$env:USERPROFILE"
 $tgzPath = "$extractRoot\cassandra.tar.gz"
 $tarPath = "$extractRoot\cassandra.tar"


### PR DESCRIPTION
The old url stopped working when a new patch was released. The new url will continue to work even if a new version is released.