### PR TITLE
test(api-schema): fix to support paths with spaces

### DIFF
--- a/test/instrumentation/modules/http/_echo_server_util.js
+++ b/test/instrumentation/modules/http/_echo_server_util.js
@@ -7,7 +7,8 @@ exports.echoServer = echoServer
 
 function echoServer (type, cb) {
   if (typeof type === 'function') return echoServer('http', type)
-  var cp = exec('node ' + path.join(__dirname, '/_echo_server.js ' + type))
+  var script = path.join(__dirname, '_echo_server.js')
+  var cp = exec(`node "${script}" ${type}`)
   cp.stderr.pipe(process.stderr)
   cp.stdout.once('data', function (chunk) {
     var port = chunk.trim().split('\n')[0]

--- a/test/integration/api-schema/_utils.js
+++ b/test/integration/api-schema/_utils.js
@@ -10,7 +10,8 @@ const thunky = require('thunky')
 
 const schemaDir = thunky(function (cb) {
   const dir = join(tmpdir(), '.schemacache')
-  const cmd = join(__dirname, 'download-json-schemas.sh') + ' ' + dir
+  const script = join(__dirname, 'download-json-schemas.sh')
+  const cmd = `"${script}" "${dir}"`
   console.log('downloading schemas from GitHub to %s...', dir)
   exec(cmd, function (err) {
     if (err) return cb(err)


### PR DESCRIPTION
The api-schema tests break if the path to the repo contains a directory with a space in the name.