### PR TITLE
perf: improve request body parsing speed

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -108,7 +108,9 @@ exports.getContextFromRequest = function (req, captureBody) {
 
   if (haveBody) {
     if (captureBody) {
-      var bodyStr = typeof body === 'string' ? body : stringify(body)
+      var bodyStr = typeof body === 'string'
+        ? body
+        : (tryJsonStringify(body) || stringify(body))
       if (bodyStr.length > exports._MAX_HTTP_BODY_CHARS) {
         body = truncate(bodyStr, exports._MAX_HTTP_BODY_CHARS)
       }
@@ -223,4 +225,10 @@ function getModule (frames) {
   var match = frame.filename.match(/node_modules\/([^/]*)/)
   if (!match) return
   return match[1]
+}
+
+function tryJsonStringify (obj) {
+  try {
+    return JSON.stringify(obj)
+  } catch (e) {}
 }

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -236,6 +236,16 @@ test('#getContextFromRequest()', function (t) {
     t.end()
   })
 
+  t.test('body is object, but not safe to stringify', function (t) {
+    var req = getMockReq()
+    req.body = {foo: 42}
+    req.body.bar = req.body
+    req.headers['transfer-encoding'] = 'chunked'
+    var parsed = parsers.getContextFromRequest(req, true)
+    t.deepEqual(parsed.body, req.body)
+    t.end()
+  })
+
   function getMockReq () {
     return {
       httpVersion: '1.1',


### PR DESCRIPTION
Use JSON.stringify by default but fall back to the slower fast-safe-stringify if it throws. This will be faster on larger more deeply nested bodies.

For details see:
https://github.com/davidmarkclements/fast-safe-stringify#protip