### PR TITLE
docs: fix 404 link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ but we recommend that you take a moment and read our [contribution guide](https:
 To ease development,
 set the environment variable `DEBUG_PAYLOAD=1` to have the agent dump the JSON payload sent to the APM Server to a temporary file on your local harddrive.
 
-Please see the [testing section](CONTRIBUTING.MD#testing) in CONTRIBUTING.md for testing instructions.
+Please see [TESTING.md](TESTING.md) for instructions on how to run the test suite.
 
 ## License
 


### PR DESCRIPTION
The uppercase `.MD` made the link go 404. Though the testing section still exists in the CONTRIBUTING.md document, it just instructs the reader to go to the TESTING.md file, so I thought we might as well update the link to point directly to that as well