### PR TITLE
test: fix agent lambda tests when run with nyc

### DIFF
--- a/test/agent.js
+++ b/test/agent.js
@@ -557,6 +557,8 @@ test('#lambda()', function (t) {
   }
 
   t.test('success - basic callback', function (t) {
+    t.plan(2 + assertTransaction.asserts + assertContext.asserts)
+
     var name = 'greet.hello'
     var input = { name: 'world' }
     var output = 'Hello, world!'
@@ -571,7 +573,6 @@ test('#lambda()', function (t) {
         lambda.invoke(name, input, (err, result) => {
           t.error(err)
           t.equal(result, output)
-          t.end()
         })
       })
       .on('data-transaction', function (data) {
@@ -581,6 +582,8 @@ test('#lambda()', function (t) {
   })
 
   t.test('success - context.succeed', function (t) {
+    t.plan(2 + assertTransaction.asserts + assertContext.asserts)
+
     var name = 'greet.hello'
     var input = { name: 'world' }
     var output = 'Hello, world!'
@@ -595,7 +598,6 @@ test('#lambda()', function (t) {
         lambda.invoke(name, input, (err, result) => {
           t.error(err)
           t.equal(result, output)
-          t.end()
         })
       })
       .on('data-transaction', function (data) {
@@ -605,6 +607,8 @@ test('#lambda()', function (t) {
   })
 
   t.test('success - context.done', function (t) {
+    t.plan(2 + assertTransaction.asserts + assertContext.asserts)
+
     var name = 'greet.hello'
     var input = { name: 'world' }
     var output = 'Hello, world!'
@@ -619,7 +623,6 @@ test('#lambda()', function (t) {
         lambda.invoke(name, input, (err, result) => {
           t.error(err)
           t.equal(result, output)
-          t.end()
         })
       })
       .on('data-transaction', function (data) {


### PR DESCRIPTION
This is a race condition. The tests would call t.end() before all their assertions had finished. This would not be an issue when running the tests normally, but when running via nyc it would fail.