### PR TITLE
Fixes #509

### DIFF
--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -25,15 +25,24 @@ module.exports = function (express, agent, version, enabled) {
 
   var layerPatchedSymbol = Symbol('layer-patched')
   var reportedSymbol = Symbol('reported')
+
+  function shouldReport (err) {
+    if (typeof err === 'string') return true
+    if (isError(err) && !err[reportedSymbol]) {
+      err[reportedSymbol] = true
+      return true
+    }
+    return false
+  }
+
   function patchLayer (layer) {
     if (!layer[layerPatchedSymbol]) {
       layer[layerPatchedSymbol] = true
       agent.logger.debug('shimming express.Router.Layer.handle function')
       shimmer.wrap(layer, 'handle', function (orig) {
-        if (orig.length !== 4) return orig
+        if (!agent._conf.captureExceptions || orig.length !== 4) return orig
         return function (err, req, res, next) {
-          if ((isError(err) || typeof err === 'string') && !err[reportedSymbol]) {
-            err[reportedSymbol] = true
+          if (shouldReport(err)) {
             agent.captureError(err, { request: req })
           }
           return orig.apply(this, arguments)

--- a/test/instrumentation/modules/express.js
+++ b/test/instrumentation/modules/express.js
@@ -3,7 +3,7 @@
 var agent = require('../../..').start({
   serviceName: 'test',
   secretToken: 'test',
-  captureExceptions: false
+  captureExceptions: true
 })
 
 var http = require('http')


### PR DESCRIPTION
In strict mode you cannot set a property on a string, this causes a fatal error on my side. This proposed change does still report the error, but does not set the reported symbol, furthermore it prints out a warning that a string in strict mode cannot be correctly tracked.
Besides this it allows to disable the error handler at all (we are using redis/sentry for this anyway), and do not need this error reporting feature. 
Let me know what you think.