### PR TITLE
fix(express): don't set property on error if it's a string

### DIFF
--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -32,8 +32,9 @@ module.exports = function (express, agent, version, enabled) {
       shimmer.wrap(layer, 'handle', function (orig) {
         if (orig.length !== 4) return orig
         return function (err, req, res, next) {
-          if ((isError(err) || typeof err === 'string') && !err[reportedSymbol]) {
-            err[reportedSymbol] = true
+          const isStr = typeof err === 'string'
+          if ((isError(err) && !err[reportedSymbol]) || isStr) {
+            if (!isStr) err[reportedSymbol] = true
             agent.captureError(err, { request: req })
           }
           return orig.apply(this, arguments)


### PR DESCRIPTION
Fixes #509 