### PR TITLE
chore: update debug message to match reality

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -77,7 +77,7 @@ Instrumentation.prototype.start = function () {
 
   var disabled = new Set(this._agent._conf.disableInstrumentations)
 
-  this._agent.logger.debug('shimming Module._load function')
+  this._agent.logger.debug('adding hook to Node.js module loader')
 
   // this._hook is only exposed for testing purposes
   this._hook = hook(MODULES, function (exports, name, basedir) {


### PR DESCRIPTION
The require-in-the-middle module no longer patches the Module._load function. Let's change the debug message so it's not implementation specific to avoid this problem in the future.