### PR TITLE
test: don't swallow errors in Restify tests

### DIFF
--- a/test/instrumentation/modules/restify.js
+++ b/test/instrumentation/modules/restify.js
@@ -3,7 +3,7 @@
 const agent = require('../../..').start({
   serviceName: 'test',
   secretToken: 'test',
-  captureExceptions: true
+  captureExceptions: false
 })
 
 const http = require('http')


### PR DESCRIPTION
If an error would occur during the tests, the agent would try to send it to https://localhost:8200 which would fail. In that case the user would not be shown the stack trace of the actual error, but instead only see the error message from the agent.

Normally I wouldn't make a PR like this just in case there might be an error, but this actually occurred to me when modifying the Restify tests to work with API v2, so thought I'd better fix it 😅 Here's what it looks like:

```
$ node test/instrumentation/modules/restify.js
TAP version 13
# transaction name
Sending error b9c573e3-213e-4312-9df0-992ce50c82e9 to Elastic APM
An error occrued while communicating with the APM Server: connect ECONNREFUSED 127.0.0.1:8200
```