### PR TITLE
test: do not capture exceptions in disableInstrumentations test

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -353,7 +353,8 @@ test('disableInstrumentations', function (t) {
       var agent = Agent()
       agent.start({
         serviceName: 'service',
-        disableInstrumentations: selection
+        disableInstrumentations: selection,
+        captureExceptions: false
       })
 
       var found = new Set()


### PR DESCRIPTION
This should make the `disableInstrumentations` test stop failing due to the agent being unable to connect to apm-server.