### PR TITLE
perf: declare instance properties in constructor

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -33,6 +33,10 @@ function Agent () {
   this._instrumentation = new Instrumentation(this)
   this._filters = new Filters()
 
+  this._conf = null
+  this._httpClient = null
+  this._uncaughtExceptionListener = null
+
   this._config()
 }
 

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -45,6 +45,7 @@ module.exports = Instrumentation
 function Instrumentation (agent) {
   this._agent = agent
   this._queue = null
+  this._hook = null // this._hook is only exposed for testing purposes
   this._started = false
   this.currentTransaction = null
 }
@@ -80,7 +81,6 @@ Instrumentation.prototype.start = function () {
 
   this._agent.logger.debug('adding hook to Node.js module loader')
 
-  // this._hook is only exposed for testing purposes
   this._hook = hook(MODULES, function (exports, name, basedir) {
     var enabled = !disabled.has(name)
     var pkg, version


### PR DESCRIPTION
Probably this isn't going to change much as the code path is cold. I also looked over `Transaction` and `Span` as those are much hotter, but they all conformed to best practices.