### PR TITLE
fix: always call agent.flush() callback

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -66,6 +66,8 @@ Instrumentation.prototype.start = function () {
     AsyncValuePromise.all(transactions).then(function (transactions) {
       if (self._agent._conf.active && transactions.length > 0) {
         request.transactions(self._agent, transactions, done)
+      } else {
+        done()
       }
     }, done)
   })
@@ -219,5 +221,9 @@ Instrumentation.prototype._recoverTransaction = function (trans) {
 }
 
 Instrumentation.prototype.flush = function (cb) {
-  this._queue.flush(cb)
+  if (this._queue) {
+    this._queue.flush(cb)
+  } else {
+    process.nextTick(cb)
+  }
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -209,6 +209,55 @@ test('#addFilter() - invalid argument', function (t) {
     })
 })
 
+test('#flush()', function (t) {
+  t.test('start not called', function (t) {
+    t.plan(2)
+    var agent = Agent()
+    agent.flush(function (err) {
+      t.error(err)
+      t.pass('should call flush callback even if agent.start() wasn\'t called')
+    })
+  })
+
+  t.test('start called, but agent inactive', function (t) {
+    t.plan(2)
+    var agent = Agent()
+    agent.start({active: false})
+    agent.flush(function (err) {
+      t.error(err)
+      t.pass('should call flush callback even if agent is inactive')
+    })
+  })
+
+  t.test('agent started, but no data in the queue', function (t) {
+    t.plan(2)
+    var agent = Agent()
+    agent.start()
+    agent.flush(function (err) {
+      t.error(err)
+      t.pass('should call flush callback even if there\'s nothing to flush')
+    })
+  })
+
+  t.test('agent started, but no data in the queue', function (t) {
+    t.plan(5)
+    APMServer()
+      .on('listening', function () {
+        this.agent.startTransaction('foo')
+        this.agent.endTransaction()
+        this.agent.flush(function (err) {
+          t.error(err)
+          t.pass('should call flush callback after flushing the queue')
+          t.end()
+        })
+      })
+      .on('request', validateTransactionsRequest(t))
+      .on('body', function (body) {
+        t.deepEqual(body.transactions[0].name, 'foo')
+      })
+  })
+})
+
 test('#captureError()', function (t) {
   t.test('with callback', function (t) {
     t.plan(5)


### PR DESCRIPTION
If there wasn't any transactions in the queue, the flush callback would never be called