### PR TITLE
test: fix flaky disableInstrumentations test

### DIFF
--- a/test/_agent.js
+++ b/test/_agent.js
@@ -20,7 +20,7 @@ function clean () {
   global[symbols.agentInitialized] = null
   process._events.uncaughtException = uncaughtExceptionListeners
   if (agent) {
-    agent._filters = []
+    agent._filters._filters = []
     if (agent._instrumentation && agent._instrumentation._hook) {
       agent._instrumentation._hook.unhook()
     }


### PR DESCRIPTION
The agent has a Filters instance at `agent._filters`, which has an array at `filter._filters`. Therefore, the correct code here would be `agent._filters._filters = []`.

Fixes #535