### PR TITLE
test: fix flaky `disableInstrumentations` tests

### DIFF
--- a/test/_agent.js
+++ b/test/_agent.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var Agent = require('../lib/agent')
+var Filters = require('../lib/filters')
 var symbols = require('../lib/symbols')
 
 var uncaughtExceptionListeners = process._events.uncaughtException
@@ -20,7 +21,7 @@ function clean () {
   global[symbols.agentInitialized] = null
   process._events.uncaughtException = uncaughtExceptionListeners
   if (agent) {
-    agent._filters = []
+    agent._filters = new Filters()
     if (agent._instrumentation && agent._instrumentation._hook) {
       agent._instrumentation._hook.unhook()
     }

--- a/test/config.js
+++ b/test/config.js
@@ -298,9 +298,14 @@ captureBodyTests.forEach(function (captureBodyTest) {
     t.plan(5)
 
     var errors = request.errors
+    var transactions = request.transactions
     request.errors = function (agent, list, cb) {
       request.errors = errors
-      return cb(list, agent)
+      return cb(list)
+    }
+    request.transactions = function (agent, list, cb) {
+      request.transactions = transactions
+      return cb()
     }
     var agent = Agent()
     agent.start({ captureBody: captureBodyTest.value })


### PR DESCRIPTION
Sometimes the `test/config.js` tests would run long enough for one of the agents created during the tests to flush its queue. The agent had its filters mocked and wasn't expected to actualy send data anywhere, so this would result in an uncaught exception.

This fix does away with mocking of the filters as there was really no reason for it. It also patches the test that wrongly added a transaction to the queue. So now the queue should never be flushed no matter how long the tests run.

Fixes #535