### PR TITLE
docs: update code snippet for overriding serviceName

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -62,7 +62,8 @@ Example usage configuring the agent to only be active in production:
 ----
 // Add this to the VERY top of the first file loaded in your app
 require('elastic-apm-node').start({
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -47,7 +47,8 @@ Here's a simple example of how Elastic APM is normally required and started:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -37,7 +37,8 @@ Here's a simple Express example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -37,7 +37,8 @@ Here's a simple hapi example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -45,7 +45,8 @@ Here's a simple Koa example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -35,8 +35,9 @@ Here's a simple lambda example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required app name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
-  appName: '',
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
+  serviceName: '',
 
   // Use if APM Server requires a token
   secretToken: '',

--- a/docs/restify.asciidoc
+++ b/docs/restify.asciidoc
@@ -37,7 +37,8 @@ Here's a simple Restify example with the Elastic APM agent installed:
 ----
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -75,7 +75,8 @@ to the <<apm-start,`start`>> function, e.g:
 [source,js]
 ----
 module.exports = {
-  // Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)
+  // Overwrite service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 
   // Use if APM Server requires a token


### PR DESCRIPTION
This also fixes a bug in the lambda docs wrongly showing the old `appName` config option.