### PR TITLE
chore: un-pin wait-on devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "thunky": "^1.0.2",
     "untildify": "^3.0.2",
     "util.promisify": "^1.0.0",
-    "wait-on": "2.1.0",
+    "wait-on": "^2.1.2",
     "ws": "^6.0.0"
   },
   "greenkeeper": {


### PR DESCRIPTION
The upstream issue that required us to pin the wait-on package have now been fixed: https://github.com/jeffbski/wait-on/issues/28