### PR TITLE
chore(package): pin dependency-check to 2.x version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "bluebird": "^3.4.6",
     "cassandra-driver": "^3.5.0",
     "connect": "^3.6.3",
-    "dependency-check": "^3.2.0",
+    "dependency-check": "^2.10.1",
     "elasticsearch": "^15.0.0",
     "express": "^4.14.0",
     "express-graphql": "^0.6.12",


### PR DESCRIPTION
Version 3.2.1 was just released which no longer works on Node.js 4. Version 3.x never officially supported Node.js 4, but did run fine until now.

This commit and be reverted once the following PR is released:
https://github.com/maxogden/dependency-check/pull/99