### PR TITLE
test: update intake API endpoint path

### DIFF
--- a/test/_apm_server.js
+++ b/test/_apm_server.js
@@ -54,7 +54,7 @@ function APMServer (agentOpts, mockOpts) {
 
     var server = self.server = http.createServer(function (req, res) {
       assert.strictEqual(req.method, 'POST', `Unexpected HTTP method: ${req.method}`)
-      assert.strictEqual(req.url, '/v2/intake', `Unexpected HTTP url: ${req.url}`)
+      assert.strictEqual(req.url, '/intake//v2/events', `Unexpected HTTP url: ${req.url}`)
 
       self.emit('request', req, res)
       var expect = requests.shift()

--- a/test/_apm_server.js
+++ b/test/_apm_server.js
@@ -54,7 +54,7 @@ function APMServer (agentOpts, mockOpts) {
 
     var server = self.server = http.createServer(function (req, res) {
       assert.strictEqual(req.method, 'POST', `Unexpected HTTP method: ${req.method}`)
-      assert.strictEqual(req.url, '/intake//v2/events', `Unexpected HTTP url: ${req.url}`)
+      assert.strictEqual(req.url, '/intake/v2/events', `Unexpected HTTP url: ${req.url}`)
 
       self.emit('request', req, res)
       var expect = requests.shift()

--- a/test/agent.js
+++ b/test/agent.js
@@ -814,7 +814,7 @@ assertStackTrace.asserts = 4
 function validateRequest (t) {
   return function (req) {
     t.equal(req.method, 'POST', 'should be a POST request')
-    t.equal(req.url, '/v2/intake', 'should be sent to the intake endpoint')
+    t.equal(req.url, '/intake/v2/events', 'should be sent to the intake endpoint')
   }
 }
 validateRequest.asserts = 2

--- a/test/integration/server-url-path.js
+++ b/test/integration/server-url-path.js
@@ -15,7 +15,7 @@ getPort().then(function (port) {
 
   test('should allow path in serverUrl', function (t) {
     var server = http.createServer(function (req, res) {
-      t.equal(req.url, '/sub/v2/intake')
+      t.equal(req.url, '/sub/intake/v2/events')
       res.end()
       t.end()
       server.close()


### PR DESCRIPTION
After I merged the update to the HTTP client these tests have started to fail as we haven't pinned the new API v2 HTTP client to any particular commit/version yet.