### PR TITLE
Added initial type definitions for usage in Typescript

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -105,3 +105,30 @@ import apm from 'elastic-apm-node/start'
 
 Then either configure the agent using the environment variables associated with each <<apm-start,config option>>,
 or use the optional <<agent-configuration-file,agent configuration file>>.
+
+[float]
+[[typescript]]
+=== Typescript support
+
+If you are using Typescript, type definitions are provided. Importing the `elastic-apm-node` module:
+
+[source,js]
+----
+import * as apm from 'elastic-apm-node';
+const agent: apm.Agent = apm.start({
+  // add configuration options here -- comes with type safety
+  });
+let started: boolean = agent.isStarted(); //Will return true!
+----
+
+Or if using Babel / ES Modules and the agent needs to be started before other imports use the `elastic-apm-node/start` module: 
+
+[source,js]
+----
+import * as apm from 'elastic-apm-node/start';
+let started: boolean = apm.isStarted(); //Will return true!
+----
+
+
+Then either configure the agent using the environment variables associated with each <<apm-start,config option>>,
+or use the optional <<agent-configuration-file,agent configuration file>>.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,78 @@
+// Type definitions for Elastic APM Node.js Agent 1.x
+// Project: https://www.elastic.co/solutions/apm
+// Definitions by: Shahaed Hasan <https://github.com/shahaed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+export = a;
+
+declare const a: a.Agent;
+
+declare namespace a {
+
+    interface Agent {
+
+        currentTransaction: any;
+        logger: any;
+
+        start(opts?: AgentOptions): Agent;
+        isStarted(): boolean;
+        addFilter(filter: (payload: any) => any): void;
+        setUserContext(context: Context): boolean;
+        setCustomContext(context: any): boolean;
+        setTag(name: string, value: string): any;
+        addTags(tags: any): any;
+        captureError(error: Error | string | object, options?: object, callback?: (err?: any) => any): void;
+        startTransaction(name?: string, type?: string): any;
+        endTransaction(result?: any): any;
+        setTransactionName(name: string): any;
+        startSpan(name?: string, type?: any): any;
+        handleUncaughtExceptions(callback?: (err: Error) => any): any;
+        flush(callback?: any): any;
+        lambda(handler: any): any;
+        lambda(type: any, handler: any): any;
+    }
+
+    interface AgentOptions {
+        serviceName?: string;
+        secretToken?: string;
+        serverUrl?: string;
+        verifyServerCert?: boolean;
+        serviceVersion?: string;
+        active?: boolean;
+        instrument?: boolean;
+        asyncHooks?: boolean;
+        ignoreUrls?: (RegExp | string)[];
+        ignoreUserAgents?: (RegExp | string)[];
+        captureBody?: string;
+        errorOnAbortedRequests?: boolean;
+        abortedErrorThreshold?: number;
+        transactionSampleRate?: number;
+        hostname?: string;
+        frameworkName?: string;
+        frameworkVersion?: string;
+        logLevel?: string;
+        logger?: any;
+        captureExceptions?: boolean;
+        captureErrorLogStackTraces?: string;
+        captureSpanStackTraces?: boolean;
+        sourceLinesErrorAppFrames?: number;
+        sourceLinesErrorLibraryFrames?: number;
+        sourceLinesSpanAppFrames?: number;
+        sourceLinesSpanLibraryFrames?: number;
+        errorMessageMaxLength?: number;
+        stackTraceLimit?: number;
+        transactionMaxSpans?: number;
+        flushInterval?: number;
+        serverTimeout?: number;
+        maxQueueSize?: number;
+        filterHttpHeaders?: boolean;
+        disableInstrumentations?: string;
+    }
+
+    interface Context {
+        id?: string;
+        username?: string;
+        email?: string;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.12.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "docs": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
     "lint": "standard",

--- a/start.d.ts
+++ b/start.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for Babel / ES Modules support
+// Documentation: https://www.elastic.co/guide/en/apm/agent/nodejs/1.x/advanced-setup.html#es-modules
+// Usage: `import * as apm from 'elastic-apm-node/start'`
+import * as agent from './';
+export = agent;


### PR DESCRIPTION
Resolves elastic/apm-agent-nodejs#586 

Adding initial type declarations for typescript and updating documentation. Not everything is perfectly typed (there are a decent amount of `any`). More explicit typing suggestions are welcome!

### Checklist

- [x] Implement code
- [x] Update documentation
