### PR TITLE
test(mongodb): ensure spans are sorted by start time

### DIFF
--- a/test/instrumentation/modules/mongodb-core.js
+++ b/test/instrumentation/modules/mongodb-core.js
@@ -28,6 +28,11 @@ test('instrument simple command', function (t) {
     t.equal(trans.type, 'bar')
     t.equal(trans.result, 'success')
 
+    // Ensure spans are sorted by start time
+    data.spans = data.spans.sort((a, b) => {
+      return a.start - b.start
+    })
+
     if (semver.lt(version, '2.0.0')) {
       // mongodb-core v1.x will sometimes perform two `ismaster` queries
       // towards the admin and/or the system database. This doesn't always


### PR DESCRIPTION
This should (hopefully) solve the mongodb tav issues we've been having.