### PR TITLE
test: fix api schema integration tests

### DIFF
--- a/test/integration/api-schema/basic.js
+++ b/test/integration/api-schema/basic.js
@@ -38,9 +38,9 @@ const next = afterAll(function (err, validators) {
     t.deepEqual(validateTransaction.errors, [
       { field: 'data.duration', message: 'is required', value: {}, type: 'object', schemaPath: [ 'allOf', 0 ] },
       { field: 'data.type', message: 'is required', value: {}, type: 'object', schemaPath: [ 'allOf', 0 ] },
-      { field: 'data.id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 1 ] },
-      { field: 'data.trace_id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 1 ] },
-      { field: 'data.span_count', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 1 ] }
+      { field: 'data.id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] },
+      { field: 'data.trace_id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] },
+      { field: 'data.span_count', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] }
     ])
     t.end()
   })
@@ -48,10 +48,14 @@ const next = afterAll(function (err, validators) {
   test('span schema failure', function (t) {
     t.equal(validateSpan({}), false)
     t.deepEqual(validateSpan.errors, [
-      { field: 'data.duration', message: 'is required', value: {}, type: 'object', schemaPath: [] },
-      { field: 'data.name', message: 'is required', value: {}, type: 'object', schemaPath: [] },
-      { field: 'data.start', message: 'is required', value: {}, type: 'object', schemaPath: [] },
-      { field: 'data.type', message: 'is required', value: {}, type: 'object', schemaPath: [] }
+      { field: 'data.duration', message: 'is required', value: {}, type: 'object', schemaPath: [ 'allOf', 0 ] },
+      { field: 'data.name', message: 'is required', value: {}, type: 'object', schemaPath: [ 'allOf', 0 ] },
+      { field: 'data.type', message: 'is required', value: {}, type: 'object', schemaPath: [ 'allOf', 0 ] },
+      { field: 'data.id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] },
+      { field: 'data.transaction_id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] },
+      { field: 'data.trace_id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] },
+      { field: 'data.parent_id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2 ] },
+      { field: 'data', message: 'no schemas match', value: {}, type: undefined, schemaPath: [ 'allOf', 3 ] }
     ])
     t.end()
   })
@@ -60,7 +64,7 @@ const next = afterAll(function (err, validators) {
     t.equal(validateError({}), false)
     t.deepEqual(validateError.errors, [
       { field: 'data', message: 'no schemas match', value: {}, type: 'object', schemaPath: [ 'allOf', 0 ] },
-      { field: 'data.id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 1, 'allOf', 0 ] }
+      { field: 'data.id', message: 'is required', value: {}, type: undefined, schemaPath: [ 'allOf', 2, 'allOf', 0 ] }
     ])
     t.equal(validateError({ id: 'foo', exception: {} }), false)
     t.deepEqual(validateError.errors, [

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -23,9 +23,10 @@ schemadir="${1:-.schemacache}"
 FILES=( \
   "errors/common_error.json" \
   "errors/v2_error.json" \
-  "metricsets/metricset.json" \
+  "metricsets/common_metricset.json" \
   "metricsets/payload.json" \
   "metricsets/sample.json" \
+  "metricsets/v2_metricset.json" \
   "sourcemaps/payload.json" \
   "spans/common_span.json" \
   "spans/v2_span.json" \
@@ -40,6 +41,8 @@ FILES=( \
   "stacktrace_frame.json" \
   "system.json" \
   "tags.json" \
+  "timestamp_epoch.json" \
+  "timestamp_rfc3339.json" \
   "user.json" \
 )
 
@@ -51,6 +54,6 @@ mkdir -p \
   ${schemadir}/sourcemaps
 
 for i in "${FILES[@]}"; do
-  download_schema https://raw.githubusercontent.com/elastic/apm-server/v2/docs/spec/${i} ${schemadir}/${i}
+  download_schema https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} ${schemadir}/${i}
 done
 echo "Done."


### PR DESCRIPTION
This PR technically depends on elastic/apm-server#1447 and on another PR (that I'll make in a sec) that refactors the agent to use the new microsecond timestamps. But we can't all land it in the same PR, so even though this PR will not pass CI, it's cleaner to land it alone as the current state of the api-v2 branch is broken because of this anyway.