### PR TITLE
test: remove unnecessary download of JSON schema

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -42,7 +42,6 @@ FILES=( \
   "system.json" \
   "tags.json" \
   "timestamp_epoch.json" \
-  "timestamp_rfc3339.json" \
   "user.json" \
 )
 


### PR DESCRIPTION
This file is only used in v1_*.json schemas.