### PR TITLE
chore(package): upgrade read-pkg-up to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "is-native": "^1.0.1",
     "normalize-bool": "^1.0.0",
     "original-url": "^1.2.1",
-    "read-pkg-up": "^3.0.0",
+    "read-pkg-up": "^4.0.0",
     "redact-secrets": "^1.0.0",
     "relative-microtime": "^2.0.0",
     "require-ancestors": "^1.0.0",


### PR DESCRIPTION
v4.x requires Node.js 6+, so this goes into api-v2