### PR TITLE
fix: use correct default value for apiRequestSize

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -569,7 +569,7 @@ Use the <<api-request-size,`apiRequestSize`>> config option to control the byte 
 ===== `apiRequestSize`
 
 * *Type:* String
-* *Default:* `1mb`
+* *Default:* `750kb`
 * *Env:* `ELASTIC_APM_API_REQUEST_SIZE`
 
 The agent maintains an open HTTP request to the APM Server that is used to transmit the collected transactions,

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,8 +33,8 @@ var DEFAULTS = {
   verifyServerCert: true,
   active: true,
   logLevel: 'info',
-  apiRequestSize: '1mb', // TODO: Is this the right default
-  apiRequestTime: '10s', // TODO: Is this the right default. Should this be ms?
+  apiRequestSize: '750kb',
+  apiRequestTime: '10s',
   stackTraceLimit: 50,
   captureExceptions: true,
   filterHttpHeaders: true,

--- a/test/config.js
+++ b/test/config.js
@@ -28,7 +28,7 @@ var optionFixtures = [
   ['active', 'ACTIVE', true],
   ['logLevel', 'LOG_LEVEL', 'info'],
   ['hostname', 'HOSTNAME'],
-  ['apiRequestSize', 'API_REQUEST_SIZE', 1024 * 1024],
+  ['apiRequestSize', 'API_REQUEST_SIZE', 750 * 1024],
   ['apiRequestTime', 'API_REQUEST_TIME', 10],
   ['frameworkName', 'FRAMEWORK_NAME'],
   ['frameworkVersion', 'FRAMEWORK_VERSION'],


### PR DESCRIPTION
### Checklist

- [x] Implement code
- [x] Update documentation
