### PR TITLE
feat(shimmer): safely handle property descriptors

### DIFF
--- a/lib/instrumentation/patch-async.js
+++ b/lib/instrumentation/patch-async.js
@@ -28,6 +28,7 @@ var massWrap = shimmer.massWrap
 
 var v6plus = semver.gte(process.version, '6.0.0')
 var v7plus = semver.gte(process.version, '7.0.0')
+var v11plus = semver.gte(process.version, '11.0.0')
 
 var wrapperSym = Symbol('elasticAPMWrapper')
 
@@ -321,13 +322,11 @@ module.exports = function (ins) {
   var crypto
   try { crypto = require('crypto') } catch (err) { }
   if (crypto) {
+    var cryptoFunctions = ['pbkdf2', 'randomBytes']
+    if (!v11plus) cryptoFunctions.push('pseudoRandomBytes')
     massWrap(
       crypto,
-      [
-        'pbkdf2',
-        'randomBytes',
-        'pseudoRandomBytes'
-      ],
+      cryptoFunctions,
       activator
     )
   }

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -57,6 +57,12 @@ function wrap (nodule, name, wrapper) {
     return
   }
 
+  var desc = Object.getOwnPropertyDescriptor(nodule, name)
+  if (desc && !desc.writable) {
+    logger().debug('function %s is not writable', name)
+    return
+  }
+
   var original = nodule[name]
   var wrapped = wrapper(original, name)
 


### PR DESCRIPTION
The current error in #632 happens because several functions in the crypto module became property descriptors. This change ensures we don't accidentally try to patch a property that is not writable.