### PR TITLE
Fix documentation spelling and grammatical errors

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -165,7 +165,7 @@ Note that both `active` and `instrument` needs to be `true` for instrumentation 
 * *Env:* `ELASTIC_APM_ASYNC_HOOKS`
 
 A boolean specifying if the agent should use the experimental https://nodejs.org/api/async_hooks.html[Async Hooks] API found in Node.js version 8.2.0 and above.
-This setting have no effect when running a Node.js version older than 8.2.0.
+This setting has no effect when running a Node.js version older than 8.2.0.
 
 If you experience any issues related to using Async Hooks,
 please https://github.com/elastic/apm-agent-nodejs/issues[open an issue].

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -568,7 +568,7 @@ the next flush isn't scheduled until a transaction have ended.
 This is done to introduce variance and also ensures that empty queues are not scheduled for flushing.
 
 On top of that,
-the actual interval is ajusted by +/- 5% between each flush.
+the actual interval is adjusted by +/- 5% between each flush.
 
 This all helps to ensure that multiple servers started at the same time will not establish connections to the APM Server simultaneously.
 ====
@@ -618,7 +618,7 @@ Currently the following HTTP headers are anonymized by default:
 * `Cookie` - The cookies inside the `Cookie` header are analyzed and their values redacted if they appear sensitive (like a session cookie).
   See the https://github.com/watson/is-secret[is-secret] module for details about which patterns are considered sensitive.
 
-If you wish to filter or santitize other data,
+If you wish to filter or sanitize other data,
 use the <<apm-add-filter,`apm.addFilter()`>> function.
 
 [[disable-instrumentations]]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -11,7 +11,7 @@ The API reference documentation is divided into three parts:
 
 * <<agent-api,The `Agent` API>> - All functions and properties on the `Agent` object.
 An instance of the `Agent` object is acquired by requiring/importing the Node.js APM Agent module.
-The `Agent` is a singleton and the instance is usually referred by the variable `apm` in this documentation
+The `Agent` is a singleton and the instance is usually referred to by the variable `apm` in this documentation
 
 * <<transaction-api,The `Transaction` API>> - All functions and properties on the `Transaction` object.
 An instance of the `Transaction` object is acquired by calling `apm.startTransaction()`

--- a/docs/custom-spans.asciidoc
+++ b/docs/custom-spans.asciidoc
@@ -7,14 +7,14 @@ endif::[]
 
 == Custom Spans
 
-If you want to track and time a custom event that happens in your application during a transaction,
-you can add a new span to an existing transaction.
-
 This is an example of how to use custom spans.
 For general information about the Elastic APM Node.js Span API,
 see the <<span-api,Span API documentation>>.
 
-In the example below we create an Express app that times how long it takes to:
+If you want to track and time a custom event that happens in your application during a transaction,
+you can add a new span to an existing transaction.
+
+In the example below, we create an Express app that times how long it takes to:
 
 1. Receive the body of an HTTP POST or PUT request
 2. Parse JSON sent by the client

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -219,7 +219,7 @@ the agent error handler should be the first in the chain to ensure that it will 
 [source,js]
 ----
 var apm = require('elastic-apm-node').start()
-var conncet = require('connect')
+var connect = require('connect')
 
 var app = connect()
 

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -19,8 +19,8 @@ we recommend that you read these articles instead:
 * <<restify,Get started with Restify>>
 * <<lambda,Get started with Lambda>>
 
-For a custom Node.js app,
-follow the guide below and refer to the <<api,API documentation>> for all the advanced stuff.
+For a custom Node.js app, follow the guide below to get started.
+For more advanced topics, check out the <<api,API Reference>>.
 
 [float]
 [[custom-stack-installation]]

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -103,7 +103,7 @@ It records spans for database queries,
 external HTTP requests,
 and other slow operations that happen during requests to your app.
 
-By default the agent will instrument <<compatibility,the most common modules>>.
+By default, the agent will instrument <<compatibility,the most common modules>>.
 To instrument other events,
 you can use custom spans.
 For information about custom spans,
@@ -120,7 +120,7 @@ See the <<custom-transactions,Custom Transactions section>> for details.
 The Node.js agent tracks incoming HTTP requests to your application in what are called "transactions".
 All transactions with the same name are grouped together automatically.
 
-In a normal web application you want to name transactions based on the route that matches the incoming HTTP request.
+In a normal web application, you want to name transactions based on the route that matches the incoming HTTP request.
 So say you have a route to display posts on a blog identified by `GET /posts/{id}`.
 You want requests `GET /posts/12`, `GET /posts/42` etc to be grouped together under a transaction named `GET /posts/{id}`.
 
@@ -241,7 +241,7 @@ app.use(function (err, req, res, next) {
 [[custom-stack-filter-sensitive-information]]
 === Filter sensitive information
 
-By default the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
+By default, the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
 
 It's possible for you to tweak these defaults or remove any information you don't want to send to Elastic APM:
 

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -9,7 +9,8 @@ endif::[]
 
 Getting Elastic APM set up for your Express app is easy,
 and there are various ways you can tweak it to fit your needs.
-Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
+Follow the guide below to get started, and for more advanced topics,
+check out the <<api,API Reference>>.
 
 [float]
 [[express-installation]]

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -9,8 +9,7 @@ endif::[]
 
 Getting Elastic APM set up for your Express app is easy,
 and there are various ways you can tweak it to fit your needs.
-
-Follow the guide below and refer to the <<api,API documentation>> for all the advanced stuff.
+Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
 
 [float]
 [[express-installation]]
@@ -101,7 +100,7 @@ It records spans for database queries,
 external HTTP requests,
 and other slow operations that happen during requests to your Express app.
 
-By default the agent will instrument <<compatibility,the most common modules>>.
+By default, the agent will instrument <<compatibility,the most common modules>>.
 To instrument other events,
 you can use custom spans.
 For information about custom spans,
@@ -153,14 +152,14 @@ see <<apm-capture-error,the API documentation>>.
 [[express-filter-sensitive-information]]
 === Filter sensitive information
 
-By default the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
+By default, the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
 
 It's possible for you to tweak these defaults or remove any information you don't want to send to Elastic APM:
 
-* By default the Node.js agent will not log the body of HTTP requests.
+* By default, the Node.js agent will not log the body of HTTP requests.
 To enable this,
 use the <<capture-body,`captureBody`>> config option
-* By default the Node.js agent will filter certain HTTP headers known to contain sensitive information.
+* By default, the Node.js agent will filter certain HTTP headers known to contain sensitive information.
 To disable this,
 use the <<filter-http-headers,`filterHttpHeaders`>> config option
 * To apply custom filters,

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -9,7 +9,8 @@ endif::[]
 
 Getting Elastic APM set up for your hapi app is easy,
 and there are various ways you can tweak it to fit your needs.
-Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
+Follow the guide below to get started, and for more advanced topics,
+check out the <<api,API Reference>>.
 
 [float]
 [[hapi-installation]]

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -9,8 +9,7 @@ endif::[]
 
 Getting Elastic APM set up for your hapi app is easy,
 and there are various ways you can tweak it to fit your needs.
-
-Follow the guide below and refer to the <<api,API documentation>> for all the advanced stuff.
+Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
 
 [float]
 [[hapi-installation]]
@@ -112,7 +111,7 @@ It records spans for database queries,
 external HTTP requests,
 and other slow operations that happen during requests to your hapi app.
 
-By default the agent will instrument <<compatibility,the most common modules>>.
+By default, the agent will instrument <<compatibility,the most common modules>>.
 To instrument other events,
 you can use custom spans.
 For information about custom spans,
@@ -141,8 +140,8 @@ please follow the <<troubleshooting,Troubleshooting Guide>>.
 [[hapi-error-logging]]
 === Error logging
 
-By default the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
-But in most cases errors are not thrown but returned via a callback,
+By default, the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
+But in most cases, errors are not thrown but returned via a callback,
 caught by a promise,
 or simply manually created.
 Those errors will not automatically be sent to Elastic APM.
@@ -164,14 +163,14 @@ see <<apm-capture-error,the API documentation>>.
 [[hapi-filter-sensitive-information]]
 === Filter sensitive information
 
-By default the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
+By default, the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
 
 It's possible for you to tweak these defaults or remove any information you don't want to send to Elastic APM:
 
-* By default the Node.js agent will not log the body of HTTP requests.
+* By default, the Node.js agent will not log the body of HTTP requests.
 To enable this,
 use the <<capture-body,`captureBody`>> config option
-* By default the Node.js agent will filter certain HTTP headers known to contain sensitive information.
+* By default, the Node.js agent will filter certain HTTP headers known to contain sensitive information.
 To disable this,
 use the <<filter-http-headers,`filterHttpHeaders`>> config option
 * To apply custom filters,

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -12,8 +12,8 @@ Welcome to the APM Node.js Agent documentation.
 The Elastic APM Node.js Agent sends performance metrics and errors to the APM Server.
 It has built-in support for the most popular frameworks and routers,
 as well as a simple API which allows you to instrument any application.
-The agent is only one of multiple components you need to get started with APM.
-Please also have a look at the documentation for
+The agent is only one of the multiple components you need to get started with APM.
+Please also have a look at the documentation for:
 
 * {apm-server-ref}/index.html[APM Server]
 * {ref}/index.html[Elasticsearch]
@@ -29,12 +29,12 @@ To get you off the ground, we've prepared guides for the most popular web framew
 * <<koa,Get started with Koa>>
 * <<restify,Get started with Restify>>
 
-Alternatively you should check out our guide for <<custom-stack,getting started with a custom Node.js stack>>.
-To get an overview over which components of your application we instrument automatically,
+Alternatively, you should check out our guide for <<custom-stack,getting started with a custom Node.js stack>>.
+To get an overview of which components of your application we instrument automatically,
 use the <<compatibility,Compatibility Overview>> page.
 
-Other useful documentation include:
+Other useful documentation includes:
 
 - <<advanced-setup,Advanced Setup and Configuration>>
-- <<api,API reference>>
+- <<api,API Reference>>
 - <<troubleshooting,Troubleshooting>>

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -9,7 +9,8 @@ endif::[]
 
 Getting Elastic APM set up for your Koa app is easy,
 and there are various ways you can tweak it to fit your needs.
-Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
+Follow the guide below to get started, and for more advanced topics,
+check out the <<api,API Reference>>.
 
 Koa doesn't have a built-in router,
 so we can't support Koa directly since we rely on router information for full support.

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -9,16 +9,15 @@ endif::[]
 
 Getting Elastic APM set up for your Koa app is easy,
 and there are various ways you can tweak it to fit your needs.
+Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
 
-Follow the guide below and refer to the <<api,API documentation>> for all the advanced stuff.
-
-Koa doesn't have a built in router,
+Koa doesn't have a built-in router,
 so we can't support Koa directly since we rely on router information for full support.
 We currently support the most popular Koa router called https://github.com/alexmingoia/koa-router[koa-router].
 
 If you use another router with your Koa application,
 please https://github.com/elastic/apm-agent-nodejs/issues[open an issue] so we can make sure to support your stack.
-In the mean time you can <<custom-stack,configure Elastic APM to work with any stack>>.
+In the meantime, you can <<custom-stack,configure Elastic APM to work with any stack>>.
 
 [float]
 [[koa-installation]]
@@ -114,7 +113,7 @@ It records spans for database queries,
 external HTTP requests,
 and other slow operations that happen during requests to your Koa app.
 
-By default the agent will instrument <<compatibility,the most common modules>>.
+By default, the agent will instrument <<compatibility,the most common modules>>.
 To instrument other events,
 you can use custom spans.
 For information about custom spans,
@@ -143,8 +142,8 @@ please follow the <<troubleshooting,Troubleshooting Guide>>.
 [[koa-error-logging]]
 === Error logging
 
-By default the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
-But in most cases errors are not thrown but returned via a callback,
+By default, the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
+But in most cases, errors are not thrown but returned via a callback,
 caught by a promise,
 or simply manually created.
 Those errors will not automatically be sent to Elastic APM.
@@ -166,14 +165,14 @@ see <<apm-capture-error,the API documentation>>.
 [[koa-filter-sensitive-information]]
 === Filter sensitive information
 
-By default the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
+By default, the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
 
 It's possible for you to tweak these defaults or remove any information you don't want to send to Elastic APM:
 
-* By default the Node.js agent will not log the body of HTTP requests.
+* By default, the Node.js agent will not log the body of HTTP requests.
 To enable this,
 use the <<capture-body,`captureBody`>> config option
-* By default the Node.js agent will filter certain HTTP headers known to contain sensitive information.
+* By default, the Node.js agent will filter certain HTTP headers known to contain sensitive information.
 To disable this,
 use the <<filter-http-headers,`filterHttpHeaders`>> config option
 * To apply custom filters,

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -9,8 +9,7 @@ endif::[]
 
 Getting Elastic APM set up for your lambda functions is easy,
 and there are various ways you can tweak it to fit your needs.
-
-Follow the guide below and refer to the <<api,API documentation>> for all the advanced stuff.
+Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
 
 [float]
 [[lambda-installation]]
@@ -69,7 +68,7 @@ It records traces for database queries,
 external HTTP requests,
 and other slow operations that happen during execution.
 
-By default the agent will trace <<compatibility,the most common modules>>.
+By default, the agent will trace <<compatibility,the most common modules>>.
 To trace other events,
 you can use custom traces.
 For information about custom traces,
@@ -79,8 +78,8 @@ see the <<custom-spans,Custom Spans section>>.
 [[lambda-error-logging]]
 === Error logging
 
-By default the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
-But in most cases errors are not thrown but returned via a callback,
+By default, the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
+But in most cases, errors are not thrown but returned via a callback,
 caught by a promise,
 or simply manually created.
 Those errors will not automatically be sent to Elastic APM.
@@ -102,14 +101,14 @@ see <<apm-capture-error,the API documentation>>.
 [[lambda-filter-sensitive-information]]
 === Filter sensitive information
 
-By default the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
+By default, the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
 
 It's possible for you to tweak these defaults or remove any information you don't want to send to Elastic APM:
 
-* By default the Node.js agent will not log the body of HTTP requests.
+* By default, the Node.js agent will not log the body of HTTP requests.
 To enable this,
 use the <<capture-body,`logBody`>> config option
-* By default the Node.js agent will filter certain HTTP headers known to contain sensitive information.
+* By default, the Node.js agent will filter certain HTTP headers known to contain sensitive information.
 To disable this,
 use the <<filter-http-headers,`filterHttpHeaders`>> config option
 * To apply custom filters,

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -9,7 +9,8 @@ endif::[]
 
 Getting Elastic APM set up for your lambda functions is easy,
 and there are various ways you can tweak it to fit your needs.
-Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
+Follow the guide below to get started, and for more advanced topics,
+check out the <<api,API Reference>>.
 
 [float]
 [[lambda-installation]]

--- a/docs/performance-tuning.asciidoc
+++ b/docs/performance-tuning.asciidoc
@@ -157,5 +157,5 @@ The <<transaction-max-spans,`transactionMaxSpans`>> setting limits the number of
 Spans may include many things such as a stack trace and context data.
 Limiting the number of spans that may be recorded will reduce memory usage.
 
-Reducing max spans could result in loss of useful data about what occured within a request,
+Reducing max spans could result in loss of useful data about what occurred within a request,
 if it is set too low.

--- a/docs/performance-tuning.asciidoc
+++ b/docs/performance-tuning.asciidoc
@@ -26,7 +26,7 @@ meaning _all_ requests are traced.
 The sample rate will impact all four performance categories,
 so simply turning down the sample rate is an easy way to improve performance.
 
-Example setting the sample rate to 20%:
+Here's an example of setting the sample rate to 20%:
 
 [source,js]
 ----
@@ -53,7 +53,7 @@ To prevent items from staying in the queue for a long time during low activity,
 the <<flush-interval,`flushInterval`>> setting is used to ensure the queue empties if anything in it is too old.
 
 Lowering the flush interval will ensure transactions are sent to the APM Server faster,
-but may also result in increased HTTP traffic and cpu usage.
+but may also result in increased HTTP traffic and CPU usage.
 
 [float]
 [[performance-max-queue-size]]
@@ -92,7 +92,7 @@ set <<capture-span-stack-traces,`captureSpanStackTraces`>> to `false`.
 
 This will mainly impact memory usage,
 but may also have a noticeable impact on speed too.
-The cpu time required to capture and convert a stack frame to something JavaScript can understand is not insignificant.
+The CPU time required to capture and convert a stack frame to something JavaScript can understand is not insignificant.
 
 [float]
 [[performance-source-lines]]
@@ -132,7 +132,7 @@ The <<stack-trace-limit,`stackTraceLimit`>> controls how many stack frames shoul
 
 This will mainly impact memory usage,
 but may also have a noticeable impact on speed too.
-The cpu time required to capture and convert a stack frame to something JavaScript can understand is not insignificant.
+The CPU time required to capture and convert a stack frame to something JavaScript can understand is not insignificant.
 
 [float]
 [[performance-error-log-stack-traces]]

--- a/docs/restify.asciidoc
+++ b/docs/restify.asciidoc
@@ -9,8 +9,7 @@ endif::[]
 
 Getting Elastic APM set up for your Restify app is easy,
 and there are various ways you can tweak it to fit your needs.
-
-Follow the guide below and refer to the <<api,API documentation>> for all the advanced stuff.
+Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
 
 [float]
 [[restify-installation]]
@@ -104,7 +103,7 @@ It records spans for database queries,
 external HTTP requests,
 and other slow operations that happen during requests to your Restify app.
 
-By default the agent will instrument <<compatibility,the most common modules>>.
+By default, the agent will instrument <<compatibility,the most common modules>>.
 To instrument other events,
 you can use custom spans.
 For information about custom spans,
@@ -133,8 +132,8 @@ please follow the <<troubleshooting,Troubleshooting Guide>>.
 [[restify-error-logging]]
 === Error logging
 
-By default the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
-But in most cases errors are not thrown but returned via a callback,
+By default, the Node.js agent will watch for uncaught exceptions and send them to Elastic APM automatically.
+But in most cases, errors are not thrown but returned via a callback,
 caught by a promise,
 or simply manually created.
 Those errors will not automatically be sent to Elastic APM.
@@ -156,14 +155,14 @@ see <<apm-capture-error,the API documentation>>.
 [[restify-filter-sensitive-information]]
 === Filter sensitive information
 
-By default the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
+By default, the Node.js agent will filter common sensitive information before sending errors and metrics to the Elastic APM server.
 
 It's possible for you to tweak these defaults or remove any information you don't want to send to Elastic APM:
 
-* By default the Node.js agent will not log the body of HTTP requests.
+* By default, the Node.js agent will not log the body of HTTP requests.
 To enable this,
 use the <<capture-body,`captureBody`>> config option
-* By default the Node.js agent will filter certain HTTP headers known to contain sensitive information.
+* By default, the Node.js agent will filter certain HTTP headers known to contain sensitive information.
 To disable this,
 use the <<filter-http-headers,`filterHttpHeaders`>> config option
 * To apply custom filters,

--- a/docs/restify.asciidoc
+++ b/docs/restify.asciidoc
@@ -9,7 +9,8 @@ endif::[]
 
 Getting Elastic APM set up for your Restify app is easy,
 and there are various ways you can tweak it to fit your needs.
-Follow the guide below to get started, then view the <<api,API Reference>> for the more advanced stuff.
+Follow the guide below to get started, and for more advanced topics,
+check out the <<api,API Reference>>.
 
 [float]
 [[restify-installation]]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -70,7 +70,7 @@ ELASTIC_APM_CONFIG_FILE=/path/to/elastic-apm-node.js
 ----
 
 The configuration file is expected to export an object following the same conventions as the `options` object given as the first argument
-to the <<apm-start,`start`>> function, e.g:
+to the <<apm-start,`start`>> function, e.g.:
 
 [source,js]
 ----
@@ -94,8 +94,8 @@ module.exports = {
 If you are using ES Modules,
 for instance with the help of Babel,
 all import statements are evaluated prior to calling any functions.
-In that case you can't configure the agent by passing a configuration object to the `start` function,
-as this call will happen after all the modules have been loaded.
+In this case, you can't configure the agent by passing a configuration object to the `start` function,
+as this call will happen after all of the modules have been loaded.
 Instead you need to import the `elastic-apm-node/start` module:
 
 [source,js]
@@ -103,5 +103,5 @@ Instead you need to import the `elastic-apm-node/start` module:
 import apm from 'elastic-apm-node/start'
 ----
 
-Then either configure the agent using the environment variables associated with each <<apm-start,config option>>,
+Now, you can either configure the agent using the environment variables associated with each <<apm-start,config option>>,
 or use the optional <<agent-configuration-file,agent configuration file>>.

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -22,7 +22,7 @@ see the <<custom-spans,Custom Spans in Node.js>> article.
 
 A reference to the parent transaction object.
 
-All spans belongs to a transaction.
+All spans belong to a transaction.
 
 [[span-name]]
 ==== `span.name`
@@ -46,7 +46,7 @@ The type is a hierarchical string used to group similar spans together.
 For instance,
 all spans of MySQL queries are given the type `db.mysql.query`.
 
-In the above example `db` is considered the type prefix.
+In the above example, `db` is considered the type prefix.
 Though there are no naming restrictions for this prefix,
 the following are standardized across all Elastic APM agents:
 `app`, `db`, `cache`, `template`, and `ext`.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -11,7 +11,7 @@ endif::[]
 [[no-data-sent]]
 === No data is sent to the APM Server
 
-If neither errors or performance metrics are being sent to the APM Server,
+If neither errors nor performance metrics are being sent to the APM Server,
 it's a good idea to first check your log file and look for output just as the app starts.
 
 [float]
@@ -39,7 +39,7 @@ See the API documentation about <<active,`active`>> for details.
 Elastic APM isn't correctly configured: Missing serviceName
 ----
 
-Ensure that the agent is correctly configured with an `serviceName` config option either by passing it to the `start()` function,
+Ensure that the agent is correctly configured with a `serviceName` config option either by passing it to the `start()` function,
 by specifying it in the optional configuration file,
 or by using environment variables.
 
@@ -54,7 +54,7 @@ Elastic APM isn't correctly configured: serviceName "..." contains invalid chara
 ----
 
 The `serviceName` you provided contained invalid characters.
-You can only use the the letters a-z (both upper and lowercase), numbers, underscore (`_`), hyphen (`-`), and space (` `).
+You can only use the letters a-z (both upper and lowercase), numbers, underscore (`_`), hyphen (`-`), and space (` `).
 
 See the API documentation on <<service-name,`serviceName`>> for details.
 
@@ -62,10 +62,10 @@ See the API documentation on <<service-name,`serviceName`>> for details.
 [[missing-performance-metrics]]
 === No performance metrics sent to APM Server
 
-Errors gets tracked just fine,
+Errors get tracked just fine,
 but you don't see any performance metrics.
 
-First make sure you have https://www.npmjs.com/package/elastic-apm-node[the latest version] of the Elastic APM Node.js agent.
+First, make sure you have https://www.npmjs.com/package/elastic-apm-node[the latest version] of the Elastic APM Node.js agent.
 Issues are fixed and support for new metrics are added all the time,
 so make sure you keep your dependency up to date.
 
@@ -80,7 +80,7 @@ make sure you have read about the <<es-modules,Babel / ES Module support>>.
 
 If this is not the issue,
 your app dependencies might be incompatible with the agent.
-Please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM discuss forum] and try to include as much information as possible, e.g:
+Please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM discuss forum] and try to include as much information as possible, such as:
 
 * The dependencies in you `package.json` file
 * Your app's main js file showing how the agent is initialized (usually the `index.js`, `server.js` or `app.js` file)

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 
 == Upgrading
 
-The following upgrading guides are available:
+The following upgrade guides are available:
 
 * <<upgrade-to-v1,Upgrade to v1.x>> - Follow this guide to upgrade from version 0.x to version 1.x of the Elastic APM Node.js agent
 


### PR DESCRIPTION
Cleaned up some spelling and grammar issues I found in the docs. No content changes, so probably only needs to be reviewed by one of you?