### PR TITLE
feat: simplified spans

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -504,6 +504,9 @@ var span = apm.startSpan('My custom span')
 ----
 
 Start and return a new custom span associated with the current active transaction.
+This is the same as getting the current transaction with `apm.currentTransaction` and,
+if a transaction was found,
+calling `transaction.startSpan(name, type)` on it.
 
 Arguments:
 
@@ -516,23 +519,6 @@ You can alternatively set this via <<span-type,`span.type`>>.
 Defaults to `custom.code`
 
 When a span is started it will measure the time until <<span-end,`span.end()`>> is called.
-
-See <<span-api,Span API>> docs for details on how to use custom spans.
-
-NOTE: If there's no active transaction available,
-`null` will be returned.
-
-[[apm-build-span]]
-==== `apm.buildSpan()`
-
-deprecated[1.1.0,Replaced by <<apm-start-span,apm.startSpan()>>]
-
-[source,js]
-----
-var span = apm.buildSpan()
-----
-
-Prepare and return a new custom span associated with the current active transaction.
 
 See <<span-api,Span API>> docs for details on how to use custom spans.
 

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -8,6 +8,7 @@ endif::[]
 === `Span` API
 
 A span measures the duration of a single event.
+When a span is created it will measure the time until <<span-end,`span.end()`>> is called.
 
 To get a `Span` object,
 you need to call <<apm-start-span,`apm.startSpan()`>>.
@@ -50,30 +51,6 @@ In the above example, `db` is considered the type prefix.
 Though there are no naming restrictions for this prefix,
 the following are standardized across all Elastic APM agents:
 `app`, `db`, `cache`, `template`, and `ext`.
-
-[[span-start]]
-==== `span.start()`
-
-deprecated[1.1.0,Span started automatically by <<apm-start-span,apm.startSpan()>>]
-
-[source,js]
-----
-span.start([name][, type])
-----
-
-Start a span.
-
-Arguments:
-
-* `name` - The name of the span (string).
-You can alternatively set this via <<span-name,`span.name`>>.
-Defaults to `unnamed`
-
-* `type` - The type of span (string).
-You can alternatively set this via <<span-type,`span.type`>>.
-Defaults to `custom.code`
-
-When a span is started it will measure the time until <<span-end,`span.end()`>> is called.
 
 [[span-end]]
 ==== `span.end()`

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -49,6 +49,30 @@ The transaction result.
 
 Think of the transaction result as equivalent to the status code of an HTTP response.
 
+[[transaction-start-span]]
+==== `transaction.startSpan([name][, type])`
+
+[source,js]
+----
+var span = transaction.startSpan('My custom span')
+----
+
+Start and return a new custom span associated with this transaction.
+
+Arguments:
+
+* `name` - The name of the span (string).
+You can alternatively set this via <<span-name,`span.name`>>.
+Defaults to `unnamed`
+
+* `type` - The type of span (string).
+You can alternatively set this via <<span-type,`span.type`>>.
+Defaults to `custom`
+
+When a span is started it will measure the time until <<span-end,`span.end()`>> is called.
+
+See <<span-api,Span API>> docs for details on how to use custom spans.
+
 [[transaction-end]]
 ==== `transaction.end([result])`
 

--- a/docs/upgrade-to-v1.asciidoc
+++ b/docs/upgrade-to-v1.asciidoc
@@ -55,5 +55,5 @@ The following functions have been renamed between version 0.x and 1.x:
 
 |=======================================================================
 |Old name |New name| Note
-|`buildTrace()` |<<apm-build-span,`buildSpan()`>> |Renamed to align with new naming conventions
+|`buildTrace()` |`buildSpan()` |Renamed to align with new naming conventions
 |=======================================================================

--- a/docs/upgrade-to-v2.asciidoc
+++ b/docs/upgrade-to-v2.asciidoc
@@ -92,3 +92,8 @@ and spans respectively.
 ====
 
 The previously undocumented method `span.offsetTime()` has been removed in 2.0.0.
+
+The previously undocumented `transaction.buildSpan()` method has been replaced with <<transaction-start-span,`transaction.startSpan(name, type)`>> in 2.0.0.
+
+The `agent.buildSpan(name, type)` and `span.start(name, type)` methods have been removed in 2.0.0.
+They have been replaced by <<apm-start-span,`agent.startSpan(name, type)`>>.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -75,13 +75,7 @@ Agent.prototype.setTransactionName = function () {
 }
 
 Agent.prototype.startSpan = function (name, type) {
-  var span = this._instrumentation.buildSpan.apply(this._instrumentation)
-  if (span) span.start(name, type)
-  return span
-}
-
-Agent.prototype.buildSpan = function () {
-  return this._instrumentation.buildSpan.apply(this._instrumentation, arguments)
+  return this._instrumentation.startSpan.apply(this._instrumentation, arguments)
 }
 
 Agent.prototype._config = function (opts) {

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -95,7 +95,7 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
 
   return function (orig) {
     return function (...args) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan(null, spanType)
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to %s.request %o', moduleName, { id: id })
@@ -135,8 +135,7 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
 
       ins.bindEmitter(req)
 
-      var name = req.method + ' ' + req._headers.host + url.parse(req.path).pathname
-      span.start(name, spanType)
+      span.name = req.method + ' ' + req._headers.host + url.parse(req.path).pathname
       req.on('response', onresponse)
 
       return req

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -172,13 +172,13 @@ Instrumentation.prototype.setTransactionName = function (name) {
   trans.name = name
 }
 
-Instrumentation.prototype.buildSpan = function () {
+Instrumentation.prototype.startSpan = function (name, type) {
   if (!this.currentTransaction) {
     this._agent.logger.debug('no active transaction found - cannot build new span')
     return null
   }
 
-  return this.currentTransaction.buildSpan()
+  return this.currentTransaction.startSpan(name, type)
 }
 
 Instrumentation.prototype.bindFunction = function (original) {

--- a/lib/instrumentation/modules/cassandra-driver.js
+++ b/lib/instrumentation/modules/cassandra-driver.js
@@ -23,12 +23,10 @@ module.exports = function (cassandra, agent, version, enabled) {
 
   function wrapConnect (original) {
     return function wrappedConnect (callback) {
-      const span = agent.buildSpan()
+      const span = agent.startSpan('Cassandra: Connect', 'db.cassandra.connect')
       if (!span) {
         return original.apply(this, arguments)
       }
-
-      span.start('Cassandra: Connect', 'db.cassandra.connect')
 
       function resolve () {
         span.end()
@@ -63,7 +61,7 @@ module.exports = function (cassandra, agent, version, enabled) {
 
   function wrapBatch (original) {
     return function wrappedBatch (queries, options, callback) {
-      const span = agent.buildSpan()
+      const span = agent.startSpan('Cassandra: Batch query', 'db.cassandra.query')
       if (!span) {
         return original.apply(this, arguments)
       }
@@ -71,8 +69,10 @@ module.exports = function (cassandra, agent, version, enabled) {
       const queryStrings = queries.map(toQueryString)
       const query = queryStrings.join(';\n')
 
-      span.setDbContext({ statement: query, type: 'cassandra' })
-      span.start('Cassandra: Batch query', 'db.cassandra.query')
+      span.setDbContext({
+        statement: query,
+        type: 'cassandra'
+      })
 
       function resolve () {
         span.end()
@@ -105,15 +105,13 @@ module.exports = function (cassandra, agent, version, enabled) {
 
   function wrapExecute (original) {
     return function wrappedExecute (query, params, options, callback) {
-      const span = agent.buildSpan()
+      const span = agent.startSpan(null, 'db.cassandra.query')
       if (!span) {
         return original.apply(this, arguments)
       }
 
-      span.type = 'db.cassandra.query'
       span.setDbContext({ statement: query, type: 'cassandra' })
       span.name = sqlSummary(query)
-      span.start()
 
       function resolve () {
         span.end()
@@ -146,15 +144,13 @@ module.exports = function (cassandra, agent, version, enabled) {
 
   function wrapEachRow (original) {
     return function wrappedEachRow (query, params, options, rowCallback, callback) {
-      const span = agent.buildSpan()
+      const span = agent.startSpan(null, 'db.cassandra.query')
       if (!span) {
         return original.apply(this, arguments)
       }
 
-      span.type = 'db.cassandra.query'
       span.setDbContext({ statement: query, type: 'cassandra' })
       span.name = sqlSummary(query)
-      span.start()
 
       // Wrap the callback
       const index = arguments.length - 1

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -14,7 +14,7 @@ module.exports = function (elasticsearch, agent, version, enabled) {
 
   function wrapRequest (original) {
     return function wrappedRequest (params, cb) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan(null, 'db.elasticsearch.request')
       var id = span && span.transaction.id
       var method = params && params.method
       var path = params && params.path
@@ -23,7 +23,7 @@ module.exports = function (elasticsearch, agent, version, enabled) {
       agent.logger.debug('intercepted call to elasticsearch.Transport.prototype.request %o', { id: id, method: method, path: path })
 
       if (span && method && path) {
-        span.start('Elasticsearch: ' + method + ' ' + path, 'db.elasticsearch.request')
+        span.name = `Elasticsearch: ${method} ${path}`
 
         if (query && searchRegexp.test(path)) {
           span.setDbContext({

--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -56,9 +56,8 @@ module.exports = function (graphql, agent, version, enabled) {
   function wrapGraphql (orig) {
     return function wrappedGraphql (schema, requestString, rootValue, contextValue, variableValues, operationName) {
       var trans = agent._instrumentation.currentTransaction
-      var span = agent.buildSpan()
+      var span = agent.startSpan('GraphQL: Unkown Query', 'db.graphql.execute')
       var id = span && span.transaction.id
-      var spanName = 'GraphQL: Unkown Query'
       agent.logger.debug('intercepted call to graphql.graphql %o', { id: id })
 
       // As of now, the only reason why there might be a transaction but no
@@ -76,7 +75,7 @@ module.exports = function (graphql, agent, version, enabled) {
           var validationErrors = graphql.validate(schema, documentAST)
           if (validationErrors && validationErrors.length === 0) {
             var queries = extractDetails(documentAST, operationName).queries
-            if (queries.length > 0) spanName = 'GraphQL: ' + queries.join(', ')
+            if (queries.length > 0) span.name = 'GraphQL: ' + queries.join(', ')
           }
         } else {
           agent.logger.debug('graphql.parse(source) failed - skipping graphql query extraction')
@@ -85,7 +84,6 @@ module.exports = function (graphql, agent, version, enabled) {
         agent.logger.debug('graphql.Source(query) failed - skipping graphql query extraction')
       }
 
-      span.start(spanName, 'db.graphql.execute')
       var p = orig.apply(this, arguments)
       p.then(function () {
         span.end()
@@ -97,9 +95,8 @@ module.exports = function (graphql, agent, version, enabled) {
   function wrapExecute (orig) {
     function wrappedExecuteImpl (schema, document, rootValue, contextValue, variableValues, operationName) {
       var trans = agent._instrumentation.currentTransaction
-      var span = agent.buildSpan()
+      var span = agent.startSpan('GraphQL: Unkown Query', 'db.graphql.execute')
       var id = span && span.transaction.id
-      var spanName = 'GraphQL: Unkown Query'
       agent.logger.debug('intercepted call to graphql.execute %o', { id: id })
 
       // As of now, the only reason why there might be a transaction but no
@@ -113,7 +110,7 @@ module.exports = function (graphql, agent, version, enabled) {
       var details = extractDetails(document, operationName)
       var queries = details.queries
       operationName = operationName || (details.operation && details.operation.name && details.operation.name.value)
-      if (queries.length > 0) spanName = 'GraphQL: ' + (operationName ? operationName + ' ' : '') + queries.join(', ')
+      if (queries.length > 0) span.name = 'GraphQL: ' + (operationName ? operationName + ' ' : '') + queries.join(', ')
 
       if (trans._graphqlRoute) {
         var name = queries.length > 0 ? queries.join(', ') : 'Unknown GraphQL query'
@@ -124,7 +121,6 @@ module.exports = function (graphql, agent, version, enabled) {
         trans.setDefaultName(defaultName)
       }
 
-      span.start(spanName, 'db.graphql.execute')
       var p = orig.apply(this, arguments)
       if (typeof p.then === 'function') {
         p.then(function () {

--- a/lib/instrumentation/modules/handlebars.js
+++ b/lib/instrumentation/modules/handlebars.js
@@ -11,7 +11,7 @@ module.exports = function (handlebars, agent, version, enabled) {
 
   function wrapTemplate (original) {
     return function wrappedTemplate (data) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan('handlebars', 'template.handlebars.render')
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to handlebars render %o', {
@@ -19,7 +19,6 @@ module.exports = function (handlebars, agent, version, enabled) {
         data: data
       })
 
-      if (span) span.start('handlebars', 'template.handlebars.render')
       var ret = original.apply(this, arguments)
       if (span) span.end()
 
@@ -29,7 +28,7 @@ module.exports = function (handlebars, agent, version, enabled) {
 
   function wrapCompile (original) {
     return function wrappedCompile (input) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan('handlebars', 'template.handlebars.compile')
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to handlebars compile %o', {
@@ -37,7 +36,6 @@ module.exports = function (handlebars, agent, version, enabled) {
         input: input
       })
 
-      if (span) span.start('handlebars', 'template.handlebars.compile')
       var ret = original.apply(this, arguments)
       if (span) span.end()
 

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -145,7 +145,7 @@ module.exports = function (http2, agent, version, enabled) {
 
   function wrapRequest (orig, host) {
     return function (headers) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan(null, 'ext.http2')
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to http2.request %o', { id })
@@ -156,8 +156,7 @@ module.exports = function (http2, agent, version, enabled) {
       ins.bindEmitter(req)
 
       var path = url.parse(headers[':path']).pathname
-      var name = headers[':method'] + ' ' + host + path
-      span.start(name, 'ext.http2')
+      span.name = headers[':method'] + ' ' + host + path
 
       req.on('end', () => {
         agent.logger.debug('intercepted http2 client end event %o', { id })

--- a/lib/instrumentation/modules/ioredis.js
+++ b/lib/instrumentation/modules/ioredis.js
@@ -48,7 +48,7 @@ module.exports = function (ioredis, agent, version, enabled) {
 
   function wrapSendCommand (original) {
     return function wrappedSendCommand (command) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan(null, 'cache.redis')
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to ioredis.prototype.sendCommand %o', { id: id, command: command && command.name })
@@ -76,7 +76,7 @@ module.exports = function (ioredis, agent, version, enabled) {
           }
         }
 
-        span.start(String(command.name).toUpperCase(), 'cache.redis')
+        span.name = String(command.name).toUpperCase()
       }
 
       return original.apply(this, arguments)

--- a/lib/instrumentation/modules/mongodb-core.js
+++ b/lib/instrumentation/modules/mongodb-core.js
@@ -39,7 +39,7 @@ module.exports = function (mongodb, agent, version, enabled) {
       if (trans && arguments.length > 0) {
         var index = arguments.length - 1
         var cb = arguments[index]
-        if (typeof cb === 'function' && (span = agent.buildSpan())) {
+        if (typeof cb === 'function') {
           var type
           if (cmd.findAndModify) type = 'findAndModify'
           else if (cmd.createIndexes) type = 'createIndexes'
@@ -47,8 +47,10 @@ module.exports = function (mongodb, agent, version, enabled) {
           else if (cmd.count) type = 'count'
           else type = 'command'
 
-          arguments[index] = wrappedCallback
-          span.start(ns + '.' + type, 'db.mongodb.query')
+          span = agent.startSpan(ns + '.' + type, 'db.mongodb.query')
+          if (span) {
+            arguments[index] = wrappedCallback
+          }
         }
       }
 
@@ -73,9 +75,11 @@ module.exports = function (mongodb, agent, version, enabled) {
       if (trans && arguments.length > 0) {
         var index = arguments.length - 1
         var cb = arguments[index]
-        if (typeof cb === 'function' && (span = agent.buildSpan())) {
-          arguments[index] = wrappedCallback
-          span.start(ns + '.' + name, 'db.mongodb.query')
+        if (typeof cb === 'function') {
+          span = agent.startSpan(ns + '.' + name, 'db.mongodb.query')
+          if (span) {
+            arguments[index] = wrappedCallback
+          }
         }
       }
 
@@ -99,9 +103,12 @@ module.exports = function (mongodb, agent, version, enabled) {
 
       if (trans && arguments.length > 0) {
         var cb = arguments[0]
-        if (typeof cb === 'function' && (span = agent.buildSpan())) {
-          arguments[0] = wrappedCallback
-          span.start(this.ns + '.' + (this.cmd.find ? 'find' : name), 'db.mongodb.query')
+        if (typeof cb === 'function') {
+          var spanName = `${this.ns}.${this.cmd.find ? 'find' : name}`
+          span = agent.startSpan(spanName, 'db.mongodb.query')
+          if (span) {
+            arguments[0] = wrappedCallback
+          }
         }
       }
 

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -88,7 +88,7 @@ function wrapQueryable (obj, objType, agent) {
 
   function wrapQuery (original) {
     return function wrappedQuery (sql, values, cb) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan(null, 'db.mysql.query')
       var id = span && span.transaction.id
       var hasCallback = false
       var sqlStr
@@ -96,8 +96,6 @@ function wrapQueryable (obj, objType, agent) {
       agent.logger.debug('intercepted call to mysql %s.query %o', objType, { id: id })
 
       if (span) {
-        span.type = 'db.mysql.query'
-
         if (this[symbols.knexStackObj]) {
           span.customStackTrace(this[symbols.knexStackObj])
           this[symbols.knexStackObj] = null
@@ -136,7 +134,6 @@ function wrapQueryable (obj, objType, agent) {
       if (span && result && !hasCallback) {
         shimmer.wrap(result, 'emit', function (original) {
           return function (event) {
-            span.start()
             switch (event) {
               case 'error':
               case 'end':
@@ -151,7 +148,6 @@ function wrapQueryable (obj, objType, agent) {
 
       function wrapCallback (cb) {
         hasCallback = true
-        span.start()
         return function wrappedCallback () {
           span.end()
           return cb.apply(this, arguments)

--- a/lib/instrumentation/modules/mysql2.js
+++ b/lib/instrumentation/modules/mysql2.js
@@ -20,14 +20,12 @@ module.exports = function (mysql2, agent, version, enabled) {
 
   function wrapQuery (original) {
     return function wrappedQuery (sql, values, cb) {
-      var span = enabled && agent.buildSpan()
+      var span = enabled && agent.startSpan(null, 'db.mysql.query')
       var id = span && span.transaction.id
       var hasCallback = false
       var sqlStr
 
       if (span) {
-        span.type = 'db.mysql.query'
-
         if (this[symbols.knexStackObj]) {
           span.customStackTrace(this[symbols.knexStackObj])
           this[symbols.knexStackObj] = null
@@ -65,13 +63,8 @@ module.exports = function (mysql2, agent, version, enabled) {
       if (result && !hasCallback) {
         ins.bindEmitter(result)
         if (span) {
-          var started = false
           shimmer.wrap(result, 'emit', function (original) {
             return function (event) {
-              if (!started) {
-                started = true
-                span.start()
-              }
               switch (event) {
                 case 'error':
                 case 'close':
@@ -88,7 +81,6 @@ module.exports = function (mysql2, agent, version, enabled) {
 
       function wrapCallback (cb) {
         hasCallback = true
-        if (span) span.start()
         return agent._instrumentation.bindFunction(span ? wrappedCallback : cb)
         function wrappedCallback () {
           span.end()

--- a/lib/instrumentation/modules/pg.js
+++ b/lib/instrumentation/modules/pg.js
@@ -44,7 +44,7 @@ function patchClient (Client, klass, agent, enabled) {
 
   function wrapQuery (orig, name) {
     return function wrappedFunction (sql) {
-      var span = agent.buildSpan()
+      var span = agent.startSpan('SQL', 'db.postgresql.query')
       var id = span && span.transaction.id
 
       if (sql && typeof sql.text === 'string') sql = sql.text
@@ -68,10 +68,9 @@ function patchClient (Client, klass, agent, enabled) {
 
         if (typeof sql === 'string') {
           span.setDbContext({ statement: sql, type: 'sql' })
-          span.start(sqlSummary(sql), 'db.postgresql.query')
+          span.name = sqlSummary(sql)
         } else {
           agent.logger.debug('unable to parse sql form pg module (type: %s)', typeof sql)
-          span.start('SQL', 'db.postgresql.query')
         }
 
         if (typeof cb === 'function') {

--- a/lib/instrumentation/modules/redis.js
+++ b/lib/instrumentation/modules/redis.js
@@ -32,7 +32,7 @@ module.exports = function (redis, agent, version, enabled) {
 
   function wrapInternalSendCommand (original) {
     return function wrappedInternalSendCommand (commandObj) {
-      var span = enabled && agent.buildSpan()
+      var span = enabled && agent.startSpan(null, 'cache.redis')
       var id = span && span.transaction.id
       var command = commandObj && commandObj.command
 
@@ -40,7 +40,7 @@ module.exports = function (redis, agent, version, enabled) {
 
       if (commandObj) {
         commandObj.callback = makeWrappedCallback(span, commandObj.callback)
-        if (span) span.start(String(command).toUpperCase(), 'cache.redis')
+        if (span) span.name = String(command).toUpperCase()
       }
 
       return original.apply(this, arguments)
@@ -49,7 +49,7 @@ module.exports = function (redis, agent, version, enabled) {
 
   function wrapSendCommand (original) {
     return function wrappedSendCommand (command) {
-      var span = enabled && agent.buildSpan()
+      var span = enabled && agent.startSpan(null, 'cache.redis')
       var id = span && span.transaction.id
       var args = Array.prototype.slice.call(arguments)
 
@@ -70,7 +70,7 @@ module.exports = function (redis, agent, version, enabled) {
             args.push(obCb)
           }
         }
-        if (span) span.start(String(command).toUpperCase(), 'cache.redis')
+        if (span) span.name = String(command).toUpperCase()
       }
 
       return original.apply(this, args)

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -39,7 +39,7 @@ module.exports = function (tedious, agent, version, enabled) {
 
     const originalMakeRequest = OriginalConnection.prototype.makeRequest
     Connection.prototype.makeRequest = function makeRequest (request) {
-      const span = agent.buildSpan()
+      const span = agent.startSpan(null, 'db.mssql.query')
       if (!span) {
         return originalMakeRequest.apply(this, arguments)
       }
@@ -47,9 +47,8 @@ module.exports = function (tedious, agent, version, enabled) {
       const preparing = request.sqlTextOrProcedure === 'sp_prepare'
       const params = request.parametersByName
       const sql = (params.statement || params.stmt || {}).value
-      const name = sqlSummary(sql) + (preparing ? ' (prepare)' : '')
+      span.name = sqlSummary(sql) + (preparing ? ' (prepare)' : '')
       span.setDbContext({ statement: sql, type: 'sql' })
-      span.start(name, 'db.mssql.query')
 
       request.userCallback = wrapCallback(request.userCallback)
 

--- a/lib/instrumentation/modules/ws.js
+++ b/lib/instrumentation/modules/ws.js
@@ -18,7 +18,7 @@ module.exports = function (ws, agent, version, enabled) {
 
   function wrapSend (orig) {
     return function wrappedSend () {
-      var span = agent.buildSpan()
+      var span = agent.startSpan('Send WebSocket Message', 'websocket.send')
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to ws.prototype.send %o', { id: id })
@@ -33,8 +33,6 @@ module.exports = function (ws, agent, version, enabled) {
         cb = null
         args.push(done)
       }
-
-      span.start('Send WebSocket Message', 'websocket.send')
 
       return orig.apply(this, args)
 

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -11,43 +11,22 @@ const TEST = process.env.ELASTIC_APM_TEST
 
 module.exports = Span
 
-function Span (transaction) {
+function Span (transaction, name, type) {
   this.transaction = transaction
-  this.started = false
   this.ended = false
-  this.name = null
-  this.type = null
-  this.timestamp = null
   this._db = null
-  this._timer = null
   this._stackObj = null
   this._agent = transaction._agent
 
   var current = this._agent._instrumentation.activeSpan || transaction
   this.context = current.context.child()
 
-  this._agent.logger.debug('init span %o', { id: this.transaction.id })
-}
-
-Object.defineProperty(Span.prototype, 'id', {
-  get () {
-    return this.context.id
-  }
-})
-
-Span.prototype.start = function (name, type) {
-  if (this.started) {
-    this._agent.logger.debug('tried to call span.start() on already started span %o', { id: this.transaction.id, name: this.name, type: this.type })
-    return
-  }
-
-  this.started = true
-  this.name = name || this.name || 'unnamed'
-  this.type = type || this.type || 'custom'
+  this.name = name || 'unnamed'
+  this.type = type || 'custom'
 
   this._agent._instrumentation.bindingSpan = this
 
-  if (this._agent._conf.captureSpanStackTraces && !this._stackObj) {
+  if (this._agent._conf.captureSpanStackTraces) {
     this._recordStackTrace()
   }
 
@@ -57,16 +36,19 @@ Span.prototype.start = function (name, type) {
   this._agent.logger.debug('start span %o', { id: this.transaction.id, name: name, type: type })
 }
 
+Object.defineProperty(Span.prototype, 'id', {
+  get () {
+    return this.context.id
+  }
+})
+
 Span.prototype.customStackTrace = function (stackObj) {
   this._agent.logger.debug('applying custom stack trace to span %o', { id: this.transaction.id })
   this._recordStackTrace(stackObj)
 }
 
 Span.prototype.end = function () {
-  if (!this.started) {
-    this._agent.logger.debug('tried to call span.end() on un-started span %o', { id: this.transaction.id, name: this.name, type: this.type })
-    return
-  } else if (this.ended) {
+  if (this.ended) {
     this._agent.logger.debug('tried to call span.end() on already ended span %o', { id: this.transaction.id, name: this.name, type: this.type })
     return
   }
@@ -96,7 +78,7 @@ Span.prototype.setDbContext = function (context) {
 Span.prototype._recordStackTrace = function (obj) {
   if (!obj) {
     obj = {}
-    Error.captureStackTrace(obj, Span.prototype.start)
+    Error.captureStackTrace(obj, Span)
   }
 
   var self = this
@@ -130,7 +112,6 @@ Span.prototype._recordStackTrace = function (obj) {
 Span.prototype._encode = function (cb) {
   var self = this
 
-  if (!this.started) return cb(new Error('cannot encode un-started span'))
   if (!this.ended) return cb(new Error('cannot encode un-ended span'))
 
   if (this._agent._conf.captureSpanStackTraces && this._stackObj) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -133,7 +133,7 @@ Transaction.prototype.addTags = function (tags) {
   return true
 }
 
-Transaction.prototype.buildSpan = function () {
+Transaction.prototype.startSpan = function (name, type) {
   if (!this.sampled) {
     return null
   }
@@ -148,7 +148,7 @@ Transaction.prototype.buildSpan = function () {
   }
   this._builtSpans++
 
-  return new Span(this)
+  return new Span(this, name, type)
 }
 
 Transaction.prototype.toJSON = function () {

--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -51,7 +51,7 @@ module.exports = function mockAgent (expected, cb) {
     agent.startTransaction = sharedInstrumentation.startTransaction.bind(sharedInstrumentation)
     agent.endTransaction = sharedInstrumentation.endTransaction.bind(sharedInstrumentation)
     agent.setTransactionName = sharedInstrumentation.setTransactionName.bind(sharedInstrumentation)
-    agent.buildSpan = sharedInstrumentation.buildSpan.bind(sharedInstrumentation)
+    agent.startSpan = sharedInstrumentation.startSpan.bind(sharedInstrumentation)
     agent._instrumentation.start()
   } else {
     sharedInstrumentation._agent = agent
@@ -60,7 +60,7 @@ module.exports = function mockAgent (expected, cb) {
     agent.startTransaction = sharedInstrumentation.startTransaction.bind(sharedInstrumentation)
     agent.endTransaction = sharedInstrumentation.endTransaction.bind(sharedInstrumentation)
     agent.setTransactionName = sharedInstrumentation.setTransactionName.bind(sharedInstrumentation)
-    agent.buildSpan = sharedInstrumentation.buildSpan.bind(sharedInstrumentation)
+    agent.startSpan = sharedInstrumentation.startSpan.bind(sharedInstrumentation)
   }
 
   return agent

--- a/test/instrumentation/github-issue-75.js
+++ b/test/instrumentation/github-issue-75.js
@@ -34,8 +34,7 @@ times(5, function (n, done) {
     })
 
     var server = http.createServer(function (req, res) {
-      var span = agent.buildSpan()
-      span.start(agent._instrumentation.currentTransaction.id)
+      var span = agent.startSpan(agent._instrumentation.currentTransaction.id)
       setTimeout(function () {
         span.end()
         send(req, __filename).pipe(res)

--- a/test/instrumentation/index.js
+++ b/test/instrumentation/index.js
@@ -66,11 +66,11 @@ test('basic', function (t) {
   function generateTransaction (id, cb) {
     var trans = ins.startTransaction('foo' + id, 'bar' + id)
     trans.result = 'baz' + id
-    var span = startSpan(ins, 't' + id + '0', 'type')
+    var span = ins.startSpan('t' + id + '0', 'type')
 
     process.nextTick(function () {
       span.end()
-      span = startSpan(ins, 't' + id + '1', 'type')
+      span = ins.startSpan('t' + id + '1', 'type')
       process.nextTick(function () {
         span.end()
         trans.end()
@@ -96,8 +96,8 @@ test('same tick', function (t) {
   var ins = agent._instrumentation
 
   var trans = ins.startTransaction('foo')
-  var t0 = startSpan(ins, 't0')
-  var t1 = startSpan(ins, 't1')
+  var t0 = ins.startSpan('t0')
+  var t1 = ins.startSpan('t1')
   t1.end()
   t0.end()
   trans.end()
@@ -119,10 +119,10 @@ test('serial - no parents', function (t) {
   var ins = agent._instrumentation
 
   var trans = ins.startTransaction('foo')
-  var t0 = startSpan(ins, 't0')
+  var t0 = ins.startSpan('t0')
   process.nextTick(function () {
     t0.end()
-    var t1 = startSpan(ins, 't1')
+    var t1 = ins.startSpan('t1')
     process.nextTick(function () {
       t1.end()
       trans.end()
@@ -146,9 +146,9 @@ test('serial - with parents', function (t) {
   var ins = agent._instrumentation
 
   var trans = ins.startTransaction('foo')
-  var t0 = startSpan(ins, 't0')
+  var t0 = ins.startSpan('t0')
   process.nextTick(function () {
-    var t1 = startSpan(ins, 't1')
+    var t1 = ins.startSpan('t1')
     process.nextTick(function () {
       t1.end()
       t0.end()
@@ -173,8 +173,8 @@ test('stack branching - no parents', function (t) {
   var ins = agent._instrumentation
 
   var trans = ins.startTransaction('foo')
-  var t0 = startSpan(ins, 't0') // 1
-  var t1 = startSpan(ins, 't1') // 2
+  var t0 = ins.startSpan('t0') // 1
+  var t1 = ins.startSpan('t1') // 2
   setTimeout(function () {
     t0.end() // 3
   }, 25)
@@ -200,7 +200,7 @@ test('currentTransaction missing - recoverable', function (t) {
 
   var trans = ins.startTransaction('foo')
   setImmediate(function () {
-    t0 = startSpan(ins, 't0')
+    t0 = ins.startSpan('t0')
     ins.currentTransaction = undefined
     setImmediate(function () {
       t0.end()
@@ -228,11 +228,11 @@ test('currentTransaction missing - not recoverable - last span failed', function
 
   var trans = ins.startTransaction('foo')
   setImmediate(function () {
-    t0 = startSpan(ins, 't0')
+    t0 = ins.startSpan('t0')
     setImmediate(function () {
       t0.end()
       ins.currentTransaction = undefined
-      t1 = startSpan(ins, 't1')
+      t1 = ins.startSpan('t1')
       t.equal(t1, null)
       setImmediate(function () {
         ins.currentTransaction = trans
@@ -260,14 +260,14 @@ test('currentTransaction missing - not recoverable - middle span failed', functi
 
   var trans = ins.startTransaction('foo')
   setImmediate(function () {
-    t0 = startSpan(ins, 't0')
+    t0 = ins.startSpan('t0')
     setImmediate(function () {
       ins.currentTransaction = undefined
-      t1 = startSpan(ins, 't1')
+      t1 = ins.startSpan('t1')
       t.equal(t1, null)
       setImmediate(function () {
         t0.end()
-        t2 = startSpan(ins, 't2')
+        t2 = ins.startSpan('t2')
         setImmediate(function () {
           t2.end()
           setImmediate(function () {
@@ -390,10 +390,10 @@ test('unsampled transactions do not include spans', function (t) {
   var ins = agent._instrumentation
 
   var trans = ins.startTransaction()
-  var span = startSpan(ins, 'span 0', 'type')
+  var span = ins.startSpan('span 0', 'type')
   process.nextTick(function () {
     if (span) span.end()
-    span = startSpan(ins, 'span 1', 'type')
+    span = ins.startSpan('span 1', 'type')
     process.nextTick(function () {
       if (span) span.end()
       trans.end()
@@ -444,7 +444,7 @@ test('bind', function (t) {
     var trans = ins.startTransaction('foo')
 
     function fn () {
-      var t0 = startSpan(ins, 't0')
+      var t0 = ins.startSpan('t0')
       if (t0) t0.end()
       trans.end()
     }
@@ -465,7 +465,7 @@ test('bind', function (t) {
     var trans = ins.startTransaction('foo')
 
     var fn = ins.bindFunction(function () {
-      var t0 = startSpan(ins, 't0')
+      var t0 = ins.startSpan('t0')
       if (t0) t0.end()
       trans.end()
     })
@@ -497,7 +497,7 @@ test('bind', function (t) {
       var emitter = new EventEmitter()
 
       emitter[method]('foo', function () {
-        var t0 = startSpan(ins, 't0')
+        var t0 = ins.startSpan('t0')
         if (t0) t0.end()
         trans.end()
       })
@@ -523,7 +523,7 @@ test('bind', function (t) {
       ins.bindEmitter(emitter)
 
       emitter[method]('foo', function () {
-        var t0 = startSpan(ins, 't0')
+        var t0 = ins.startSpan('t0')
         if (t0) t0.end()
         trans.end()
       })
@@ -582,10 +582,10 @@ test('nested spans', function (t) {
     }
   }
 
-  var s0 = startSpan(ins, 's0')
+  var s0 = ins.startSpan('s0')
   process.nextTick(function () {
     process.nextTick(function () {
-      var s01 = startSpan(ins, 's01')
+      var s01 = ins.startSpan('s01')
       process.nextTick(function () {
         s01.end()
         done()
@@ -594,9 +594,9 @@ test('nested spans', function (t) {
     s0.end()
   })
 
-  var s1 = startSpan(ins, 's1')
+  var s1 = ins.startSpan('s1')
   process.nextTick(function () {
-    var s11 = startSpan(ins, 's11')
+    var s11 = ins.startSpan('s11')
     process.nextTick(function () {
       s11.end()
       done()
@@ -606,7 +606,7 @@ test('nested spans', function (t) {
   // Will adopt the t1 span as its parent,
   // because no new span has been created.
   process.nextTick(function () {
-    var s12 = startSpan(ins, 's12')
+    var s12 = ins.startSpan('s12')
     process.nextTick(function () {
       s12.end()
       done()
@@ -644,20 +644,14 @@ test('nested transactions', function (t) {
   var ins = agent._instrumentation
 
   var t0 = ins.startTransaction('t0')
-  var s0 = startSpan(ins, 's0')
+  var s0 = ins.startSpan('s0')
   var t1 = ins.startTransaction('t1', null, t0.context.toString())
-  var s1 = startSpan(ins, 's1')
+  var s1 = ins.startSpan('s1')
   s1.end()
   t1.end()
   s0.end()
   t0.end()
 })
-
-function startSpan (ins, name, type) {
-  var span = ins.buildSpan()
-  if (span) span.start(name, type)
-  return span
-}
 
 function resetAgent (expected, cb) {
   agent._instrumentation.currentTransaction = null

--- a/test/instrumentation/modules/http/sse.js
+++ b/test/instrumentation/modules/http/sse.js
@@ -15,8 +15,7 @@ test('normal response', function (t) {
   })
 
   var server = http.createServer(function (req, res) {
-    var span = agent.buildSpan()
-    if (span) span.start('foo', 'bar')
+    var span = agent.startSpan('foo', 'bar')
     setTimeout(function () {
       if (span) span.end()
       res.end()
@@ -34,8 +33,7 @@ test('SSE response with explicit headers', function (t) {
 
   var server = http.createServer(function (req, res) {
     res.writeHead(200, { 'Content-Type': 'text/event-stream' })
-    var span = agent.buildSpan()
-    if (span) span.start('foo', 'bar')
+    var span = agent.startSpan('foo', 'bar')
     setTimeout(function () {
       if (span) span.end()
       res.end()
@@ -54,8 +52,7 @@ test('SSE response with implicit headers', function (t) {
   var server = http.createServer(function (req, res) {
     res.setHeader('Content-type', 'text/event-stream; foo')
     res.write('data: hello world\n\n')
-    var span = agent.buildSpan()
-    if (span) span.start('foo', 'bar')
+    var span = agent.startSpan('foo', 'bar')
     setTimeout(function () {
       if (span) span.end()
       res.end()

--- a/test/instrumentation/span.js
+++ b/test/instrumentation/span.js
@@ -14,8 +14,7 @@ var agent = mockAgent()
 
 test('properties', function (t) {
   var trans = new Transaction(agent)
-  var span = new Span(trans)
-  span.start('sig', 'type')
+  var span = new Span(trans, 'sig', 'type')
   t.ok(/^[\da-f]{16}$/.test(span.id))
   t.equal(span.transaction, trans)
   t.equal(span.name, 'sig')
@@ -26,8 +25,7 @@ test('properties', function (t) {
 
 test('#end()', function (t) {
   var trans = new Transaction(agent)
-  var span = new Span(trans)
-  span.start('sig', 'type')
+  var span = new Span(trans, 'sig', 'type')
   t.equal(span.ended, false)
   span.end()
   t.equal(span.ended, true)
@@ -37,7 +35,6 @@ test('#end()', function (t) {
 test('#duration()', function (t) {
   var trans = new Transaction(agent)
   var span = new Span(trans)
-  span.start()
   setTimeout(function () {
     span.end()
     t.ok(span.duration() > 49, span.duration() + ' should be larger than 49')
@@ -48,24 +45,13 @@ test('#duration()', function (t) {
 test('#duration() - return null if not ended', function (t) {
   var trans = new Transaction(agent)
   var span = new Span(trans)
-  span.start()
   t.equal(span.duration(), null)
   t.end()
-})
-
-test('#_encode() - un-started', function (t) {
-  var trans = new Transaction(agent)
-  var span = new Span(trans)
-  span._encode(function (err, payload) {
-    t.equal(err.message, 'cannot encode un-started span')
-    t.end()
-  })
 })
 
 test('#_encode() - un-ended', function (t) {
   var trans = new Transaction(agent)
   var span = new Span(trans)
-  span.start()
   span._encode(function (err, payload) {
     t.equal(err.message, 'cannot encode un-ended span')
     t.end()
@@ -75,7 +61,6 @@ test('#_encode() - un-ended', function (t) {
 test('#_encode() - ended unnamed', function myTest1 (t) {
   var trans = new Transaction(agent)
   var span = new Span(trans)
-  span.start()
   span.end()
   span._encode(function (err, payload) {
     t.error(err)
@@ -98,8 +83,7 @@ test('#_encode() - ended unnamed', function myTest1 (t) {
 
 test('#_encode() - ended named', function myTest2 (t) {
   var trans = new Transaction(agent)
-  var span = new Span(trans)
-  span.start('foo', 'bar')
+  var span = new Span(trans, 'foo', 'bar')
   span.end()
   span._encode(function (err, payload) {
     t.error(err)
@@ -125,7 +109,6 @@ test('#_encode() - disabled stack traces', function (t) {
   ins._agent._conf.captureSpanStackTraces = false
   var trans = new Transaction(ins._agent)
   var span = new Span(trans)
-  span.start()
   span.end()
   span._encode(function (err, payload) {
     t.error(err)

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -344,8 +344,7 @@ test('#_encode() - with spans', function (t) {
 
   var trans = new Transaction(ins._agent, 'single-name', 'type')
   trans.result = 'result'
-  var span = trans.buildSpan()
-  span.start('span')
+  var span = trans.startSpan('span')
   span.end()
   trans.end()
 
@@ -378,11 +377,9 @@ test('#_encode() - dropped spans', function (t) {
 
   var trans = new Transaction(ins._agent, 'single-name', 'type')
   trans.result = 'result'
-  var span0 = trans.buildSpan()
-  span0.start('s0', 'type0')
-  var span1 = trans.buildSpan()
-  span1.start('s1', 'type1')
-  var span2 = trans.buildSpan()
+  var span0 = trans.startSpan('s0', 'type0')
+  trans.startSpan('s1', 'type1')
+  var span2 = trans.startSpan()
   if (span2) {
     t.fail('should have dropped the span')
   }
@@ -421,7 +418,7 @@ test('#_encode() - not sampled', function (t) {
   trans.result = 'result'
   trans.req = mockRequest()
   trans.res = mockResponse()
-  var span = trans.buildSpan()
+  var span = trans.startSpan()
   t.notOk(span)
   trans.end()
 

--- a/test/script/cli.js
+++ b/test/script/cli.js
@@ -237,17 +237,13 @@ var transactionTest = function () {
 
     var type = Math.random() > 0.5 ? 'request' : 'my-custom-type'
     var trans = agent.startTransaction('foo', type)
-    var t1 = agent.buildSpan()
-    t1.start('sig1', 'foo.bar.baz1')
-    var t2 = agent.buildSpan()
-    t2.start('sig2', 'foo.bar.baz1')
+    var t1 = agent.startSpan('sig1', 'foo.bar.baz1')
+    var t2 = agent.startSpan('sig2', 'foo.bar.baz1')
 
     setTimeout(function () {
-      var t3 = agent.buildSpan()
-      t3.start('sig3', 'foo.bar.baz2')
+      var t3 = agent.startSpan('sig3', 'foo.bar.baz2')
       setTimeout(function () {
-        var t4 = agent.buildSpan()
-        t4.start('sig4', 'foo.bar.baz3')
+        var t4 = agent.startSpan('sig4', 'foo.bar.baz3')
         setTimeout(function () {
           t3.end()
           t4.end()
@@ -257,11 +253,9 @@ var transactionTest = function () {
     }, Math.random() * 100 + 25)
 
     setTimeout(function () {
-      var t5 = agent.buildSpan()
-      t5.start('sig5', 'foo.bar.baz2')
+      var t5 = agent.startSpan('sig5', 'foo.bar.baz2')
       setTimeout(function () {
-        var t6 = agent.buildSpan()
-        t6.start('sig6', 'foo.bar.baz4')
+        var t6 = agent.startSpan('sig6', 'foo.bar.baz4')
         setTimeout(function () {
           t6.end()
           t5.end()


### PR DESCRIPTION
This removes `agent.buildSpan`, `transaction.buildSpan`, and `span.start`. In there place is `agent.startSpan` and now `transaction.startSpan`. All the prior starting logic from `span.start` is now part of the `Span` constructor.

This is an alternative to #600.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
