### PR TITLE
test(express-graphql): update test and patch ranges to match

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -98,22 +98,38 @@ express-graphql-0.6.11_11:
 express-graphql-0.6.12_10:
   name: express-graphql
   peerDependencies: graphql@^0.10.0
-  versions: '>=0.6.12'
+  versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_11:
   name: express-graphql
   peerDependencies: graphql@^0.11.0
-  versions: '>=0.6.12'
+  versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_12:
   name: express-graphql
   peerDependencies: graphql@^0.12.0
-  versions: '>=0.6.12'
+  versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_13:
   name: express-graphql
   peerDependencies: graphql@^0.13.0
-  versions: '>=0.6.12'
+  versions: '^0.6.12'
+  commands: node test/instrumentation/modules/express-graphql.js
+
+express-graphql-0.7,1_12:
+  name: express-graphql
+  peerDependencies: graphql@^0.12.0
+  versions: '^0.7.1'
+  commands: node test/instrumentation/modules/express-graphql.js
+express-graphql-0.7.1_13:
+  name: express-graphql
+  peerDependencies: graphql@^0.13.0
+  versions: '^0.7.1'
+  commands: node test/instrumentation/modules/express-graphql.js
+express-graphql-0.7.1_14:
+  name: express-graphql
+  peerDependencies: graphql@^14.0.0
+  versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-queue:

--- a/lib/instrumentation/modules/express-graphql.js
+++ b/lib/instrumentation/modules/express-graphql.js
@@ -5,7 +5,7 @@ var semver = require('semver')
 module.exports = function (graphqlHTTP, agent, version, enabled) {
   if (!enabled) return graphqlHTTP
 
-  if (!semver.satisfies(version, '^0.6.1') || typeof graphqlHTTP !== 'function') {
+  if (!semver.satisfies(version, '>=0.6.1 <0.8') || typeof graphqlHTTP !== 'function') {
     agent.logger.debug('express-graphql version %s not supported - aborting...', version)
     return graphqlHTTP
   }


### PR DESCRIPTION
CI is failing right now because express-graphql 0.7.x was released and, while the tav ranges tried to test against them, the patch range did not apply the patch, resulting in test failures.