### PR TITLE
feat(apollo-server-express): add support for apollo-server-express

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -59,7 +59,7 @@ ws:
   versions: '>=1 <7'
   commands: node test/instrumentation/modules/ws.js
 graphql:
-  preinstall: rm -fr node_modules/express-graphql
+  preinstall: npm uninstall express-graphql
   versions: '>=0.7.0 <0.11.0 || >=0.11.1 <15.0.0 || ^14.0.0-rc'
   commands: node test/instrumentation/modules/graphql.js
 express:
@@ -68,99 +68,99 @@ express:
 
 express-graphql-1:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.8.2
   versions: '0.6.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-2:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.9.0
   versions: '>=0.6.2 <0.6.6'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-3:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.10.0
   versions: '>=0.6.6 <0.6.8'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.6.11_10:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.10.0
   versions: '0.6.11'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.11_11:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.11.0
   versions: '0.6.11'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.6.12_10:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.10.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_11:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.11.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_12:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.12.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_13:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.13.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.7,1_12:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.12.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.7.1_13:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^0.13.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.7.1_14:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: npm uninstall apollo-server-express
   peerDependencies: graphql@^14.0.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
 apollo-server-express-2_12:
   name: apollo-server-express
-  preinstall: rm -fr node_modules/express-graphql # express-graphql peer dependencies conflict with apollo-server-express
+  preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.12.0
   versions: '>=2.0.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_13:
   name: apollo-server-express
-  preinstall: rm -fr node_modules/express-graphql # express-graphql peer dependencies conflict with apollo-server-express
+  preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.13.0
   versions: '>=2.0.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_14:
   name: apollo-server-express
-  preinstall: rm -fr node_modules/express-graphql # express-graphql peer dependencies conflict with apollo-server-express
+  preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
   versions: '>=2.0.2'
   node: '>=6'

--- a/.tav.yml
+++ b/.tav.yml
@@ -68,87 +68,99 @@ express:
 
 express-graphql-1:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.8.2
   versions: '0.6.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-2:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.9.0
   versions: '>=0.6.2 <0.6.6'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-3:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.10.0
   versions: '>=0.6.6 <0.6.8'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.6.11_10:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.10.0
   versions: '0.6.11'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.11_11:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.11.0
   versions: '0.6.11'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.6.12_10:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.10.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_11:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.11.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_12:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.12.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_13:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.13.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.7,1_12:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.12.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.7.1_13:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.13.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.7.1_14:
   name: express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^14.0.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
 apollo-server-express-2_12:
   name: apollo-server-express
-  preinstall: rm -fr node_modules/express-graphql
+  preinstall: rm -fr node_modules/express-graphql # express-graphql peer dependencies conflict with apollo-server-express
   peerDependencies: graphql@^0.12.0
   versions: '>=2.0.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_13:
   name: apollo-server-express
-  preinstall: rm -fr node_modules/express-graphql
+  preinstall: rm -fr node_modules/express-graphql # express-graphql peer dependencies conflict with apollo-server-express
   peerDependencies: graphql@^0.13.0
   versions: '>=2.0.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_14:
   name: apollo-server-express
-  preinstall: rm -fr node_modules/express-graphql
+  preinstall: rm -fr node_modules/express-graphql # express-graphql peer dependencies conflict with apollo-server-express
   peerDependencies: graphql@^14.0.0
   versions: '>=2.0.2'
   node: '>=6'

--- a/.tav.yml
+++ b/.tav.yml
@@ -132,6 +132,25 @@ express-graphql-0.7.1_14:
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
+apollo-server-express-2_12:
+  name: apollo-server-express
+  peerDependencies: graphql@^0.12.0
+  versions: '>=2.0.2'
+  node: '>=6'
+  commands: node test/instrumentation/modules/apollo-server-express.js
+apollo-server-express-2_13:
+  name: apollo-server-express
+  peerDependencies: graphql@^0.13.0
+  versions: '>=2.0.2'
+  node: '>=6'
+  commands: node test/instrumentation/modules/apollo-server-express.js
+apollo-server-express-2_14:
+  name: apollo-server-express
+  peerDependencies: graphql@^14.0.0
+  versions: '>=2.0.2'
+  node: '>=6'
+  commands: node test/instrumentation/modules/apollo-server-express.js
+
 express-queue:
   versions: '>=0.0.11'
   commands: node test/instrumentation/modules/express-queue.js

--- a/.tav.yml
+++ b/.tav.yml
@@ -134,18 +134,21 @@ express-graphql-0.7.1_14:
 
 apollo-server-express-2_12:
   name: apollo-server-express
+  preinstall: rm -fr node_modules/express-graphql
   peerDependencies: graphql@^0.12.0
   versions: '>=2.0.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_13:
   name: apollo-server-express
+  preinstall: rm -fr node_modules/express-graphql
   peerDependencies: graphql@^0.13.0
   versions: '>=2.0.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_14:
   name: apollo-server-express
+  preinstall: rm -fr node_modules/express-graphql
   peerDependencies: graphql@^14.0.0
   versions: '>=2.0.2'
   node: '>=6'

--- a/.tav.yml
+++ b/.tav.yml
@@ -68,78 +68,78 @@ express:
 
 express-graphql-1:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.8.2
   versions: '0.6.1'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-2:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.9.0
   versions: '>=0.6.2 <0.6.6'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-3:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.10.0
   versions: '>=0.6.6 <0.6.8'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.6.11_10:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.10.0
   versions: '0.6.11'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.11_11:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.11.0
   versions: '0.6.11'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.6.12_10:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.10.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_11:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.11.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_12:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.12.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.6.12_13:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.13.0
   versions: '^0.6.12'
   commands: node test/instrumentation/modules/express-graphql.js
 
 express-graphql-0.7,1_12:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.12.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.7.1_13:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^0.13.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js
 express-graphql-0.7.1_14:
   name: express-graphql
-  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* # apollo-server-express peer dependencies conflict with express-graphql
+  preinstall: rm -fr node_modules/apollo-* node_modules/graphql-* node_modules/@apollographql* # apollo-server-express peer dependencies conflict with express-graphql
   peerDependencies: graphql@^14.0.0
   versions: '^0.7.1'
   commands: node test/instrumentation/modules/express-graphql.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
     -
       node_js: '10'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
       script: tav --quiet
 
     # Node.js 9
@@ -116,7 +116,7 @@ jobs:
     -
       node_js: '9'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
       script: tav --quiet
 
     # Node.js 8
@@ -138,7 +138,7 @@ jobs:
     -
       node_js: '8'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
       script: tav --quiet
 
     # Node.js 6
@@ -160,7 +160,7 @@ jobs:
     -
       node_js: '6'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
       script: tav --quiet
 
     # Node.js 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,12 +89,12 @@ jobs:
     -
       node_js: '10'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,got,bluebird
+      env: TAV=mimic-response,got,bluebird,apollo-server-express
       script: tav --quiet
     -
       node_js: '10'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
       script: tav --quiet
 
     # Node.js 9
@@ -111,12 +111,12 @@ jobs:
     -
       node_js: '9'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,got,bluebird
+      env: TAV=mimic-response,got,bluebird,apollo-server-express
       script: tav --quiet
     -
       node_js: '9'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
       script: tav --quiet
 
     # Node.js 8
@@ -133,12 +133,12 @@ jobs:
     -
       node_js: '8'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,got,bluebird
+      env: TAV=mimic-response,got,bluebird,apollo-server-express
       script: tav --quiet
     -
       node_js: '8'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
       script: tav --quiet
 
     # Node.js 6
@@ -155,12 +155,12 @@ jobs:
     -
       node_js: '6'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=mimic-response,got,bluebird
+      env: TAV=mimic-response,got,bluebird,apollo-server-express
       script: tav --quiet
     -
       node_js: '6'
       if: type IN (cron, pull_request) AND NOT branch =~ ^greenkeeper/.*
-      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue,apollo-server-express
+      env: TAV=knex,ws,graphql,express-graphql,elasticsearch,hapi,express,express-queue
       script: tav --quiet
 
     # Node.js 4

--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -61,6 +61,7 @@ These modules override that behavior to give better insights into specialized HT
 |=======================================================================
 |Module |Version |Note
 |https://www.npmjs.com/package/express-graphql[express-graphql] |^0.6.1 |Will name all transactions by the GraphQL query name
+|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |^2.0.2 |Will name all transactions by the GraphQL query name
 |=======================================================================
 
 [float]

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -13,6 +13,7 @@ var Transaction = require('./transaction')
 var shimmer = require('./shimmer')
 
 var MODULES = [
+  'apollo-server-core',
   'bluebird',
   'cassandra-driver',
   'elasticsearch',

--- a/lib/instrumentation/modules/apollo-server-core.js
+++ b/lib/instrumentation/modules/apollo-server-core.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const semver = require('semver')
+const shimmer = require('../shimmer')
+
+module.exports = function (apolloServerCore, agent, version, enabled) {
+  if (!enabled) return apolloServerCore
+
+  if (!semver.satisfies(version, '^2.0.0')) {
+    agent.logger.debug('apollo-server-core version %s not supported - aborting...', version)
+    return apolloServerCore
+  }
+
+  shimmer.wrap(apolloServerCore, 'runHttpQuery', function (runHttpQuery) {
+    return function wrappedRunHttpQuery () {
+      var trans = agent._instrumentation.currentTransaction
+      if (trans) trans._graphqlRoute = true
+      return runHttpQuery.apply(this, arguments)
+    }
+  })
+
+  return apolloServerCore
+}

--- a/lib/instrumentation/modules/apollo-server-core.js
+++ b/lib/instrumentation/modules/apollo-server-core.js
@@ -6,7 +6,7 @@ const shimmer = require('../shimmer')
 module.exports = function (apolloServerCore, agent, version, enabled) {
   if (!enabled) return apolloServerCore
 
-  if (!semver.satisfies(version, '^2.0.0')) {
+  if (!semver.satisfies(version, '^2.0.2')) {
     agent.logger.debug('apollo-server-core version %s not supported - aborting...', version)
     return apolloServerCore
   }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.1",
     "@commitlint/travis-cli": "^7.0.0",
+    "apollo-server-express": "^2.0.2",
     "bluebird": "^3.4.6",
     "cassandra-driver": "^3.5.0",
     "connect": "^3.6.3",

--- a/test/.jenkins_tav.yml
+++ b/test/.jenkins_tav.yml
@@ -1,5 +1,5 @@
 TAV:
   - generic-pool+mysql+mysql2+redis+koa-router+handlebars+mongodb-core
   - ioredis+pg+cassandra-driver+tedious+restify
-  - mimic-response+got+bluebird
-  - knex+ws+graphql+express-graphql+elasticsearch+hapi+express+express-queue+apollo-server-express
+  - mimic-response+got+bluebird+apollo-server-express
+  - knex+ws+graphql+express-graphql+elasticsearch+hapi+express+express-queue

--- a/test/.jenkins_tav.yml
+++ b/test/.jenkins_tav.yml
@@ -2,4 +2,4 @@ TAV:
   - generic-pool+mysql+mysql2+redis+koa-router+handlebars+mongodb-core
   - ioredis+pg+cassandra-driver+tedious+restify
   - mimic-response+got+bluebird
-  - knex+ws+graphql+express-graphql+elasticsearch+hapi+express+express-queue
+  - knex+ws+graphql+express-graphql+elasticsearch+hapi+express+express-queue+apollo-server-express

--- a/test/config.js
+++ b/test/config.js
@@ -376,6 +376,7 @@ test('disableInstrumentations', function (t) {
   }
   if (semver.lt(process.version, '6.0.0')) {
     modules.delete('express-queue')
+    modules.delete('apollo-server-core')
   }
 
   function testSlice (t, name, selector) {

--- a/test/instrumentation/modules/apollo-server-express.js
+++ b/test/instrumentation/modules/apollo-server-express.js
@@ -1,0 +1,219 @@
+'use strict'
+
+var agent = require('../../..').start({
+  serviceName: 'test',
+  secretToken: 'test',
+  captureExceptions: false
+})
+
+var semver = require('semver')
+if (semver.lt(process.version, '6.0.0')) process.exit()
+
+var test = require('tape')
+
+var http = require('http')
+var express = require('express')
+var querystring = require('querystring')
+
+var ApolloServer = require('apollo-server-express').ApolloServer
+var gql = require('apollo-server-express').gql
+
+test('POST /graphql', function (t) {
+  resetAgent(done(t, 'hello'))
+
+  var typeDefs = gql`
+    type Query {
+      hello: String
+    }
+  `
+  var resolvers = {
+    Query: {
+      hello () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 'Hello world!'
+      }
+    }
+  }
+  var query = '{"query":"{ hello }"}'
+
+  var app = express()
+  var apollo = new ApolloServer({ typeDefs, resolvers })
+  apollo.applyMiddleware({ app })
+  var server = app.listen(function () {
+    var port = server.address().port
+    var opts = {
+      method: 'POST',
+      port: port,
+      path: '/graphql',
+      headers: { 'Content-Type': 'application/json' }
+    }
+    var req = http.request(opts, function (res) {
+      var chunks = []
+      res.on('data', chunks.push.bind(chunks))
+      res.on('end', function () {
+        server.close()
+        var result = Buffer.concat(chunks).toString()
+        t.equal(result, '{"data":{"hello":"Hello world!"}}\n')
+        agent.flush()
+      })
+    })
+    req.end(query)
+  })
+})
+
+test('GET /graphql', function (t) {
+  resetAgent(done(t, 'hello'))
+
+  var typeDefs = gql`
+    type Query {
+      hello: String
+    }
+  `
+  var resolvers = {
+    Query: {
+      hello () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 'Hello world!'
+      }
+    }
+  }
+  var query = querystring.stringify({ query: '{ hello }' })
+
+  var app = express()
+  var apollo = new ApolloServer({ typeDefs, resolvers })
+  apollo.applyMiddleware({ app })
+  var server = app.listen(function () {
+    var port = server.address().port
+    var opts = {
+      method: 'GET',
+      port: port,
+      path: '/graphql?' + query
+    }
+    var req = http.request(opts, function (res) {
+      var chunks = []
+      res.on('data', chunks.push.bind(chunks))
+      res.on('end', function () {
+        server.close()
+        var result = Buffer.concat(chunks).toString()
+        t.equal(result, '{"data":{"hello":"Hello world!"}}\n')
+        agent.flush()
+      })
+    })
+    req.end()
+  })
+})
+
+test('POST /graphql - named query', function (t) {
+  resetAgent(done(t, 'HelloQuery hello'))
+
+  var typeDefs = gql`
+    type Query {
+      hello: String
+    }
+  `
+  var resolvers = {
+    Query: {
+      hello () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 'Hello world!'
+      }
+    }
+  }
+  var query = '{"query":"query HelloQuery { hello }"}'
+
+  var app = express()
+  var apollo = new ApolloServer({ typeDefs, resolvers })
+  apollo.applyMiddleware({ app })
+  var server = app.listen(function () {
+    var port = server.address().port
+    var opts = {
+      method: 'POST',
+      port: port,
+      path: '/graphql',
+      headers: { 'Content-Type': 'application/json' }
+    }
+    var req = http.request(opts, function (res) {
+      var chunks = []
+      res.on('data', chunks.push.bind(chunks))
+      res.on('end', function () {
+        server.close()
+        var result = Buffer.concat(chunks).toString()
+        t.equal(result, '{"data":{"hello":"Hello world!"}}\n')
+        agent.flush()
+      })
+    })
+    req.end(query)
+  })
+})
+
+test('POST /graphql - sort multiple queries', function (t) {
+  resetAgent(done(t, 'hello, life'))
+
+  var typeDefs = gql`
+    type Query {
+      hello: String
+      life: Int
+    }
+  `
+  var resolvers = {
+    Query: {
+      hello () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 'Hello world!'
+      },
+      life () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 42
+      }
+    }
+  }
+  var query = '{"query":"{ life, hello }"}'
+
+  var app = express()
+  var apollo = new ApolloServer({ typeDefs, resolvers })
+  apollo.applyMiddleware({ app })
+  var server = app.listen(function () {
+    var port = server.address().port
+    var opts = {
+      method: 'POST',
+      port: port,
+      path: '/graphql',
+      headers: { 'Content-Type': 'application/json' }
+    }
+    var req = http.request(opts, function (res) {
+      var chunks = []
+      res.on('data', chunks.push.bind(chunks))
+      res.on('end', function () {
+        server.close()
+        var result = Buffer.concat(chunks).toString()
+        t.equal(result, '{"data":{"life":42,"hello":"Hello world!"}}\n')
+        agent.flush()
+      })
+    })
+    req.end(query)
+  })
+})
+
+function done (t, query) {
+  return function (endpoint, headers, data, cb) {
+    t.equal(data.transactions.length, 1)
+
+    var trans = data.transactions[0]
+
+    t.equal(trans.name, query + ' (/graphql)')
+    t.equal(trans.type, 'request')
+    t.equal(trans.spans.length, 1)
+    t.equal(trans.spans[0].name, 'GraphQL: ' + query)
+    t.equal(trans.spans[0].type, 'db.graphql.execute')
+    t.ok(trans.spans[0].start + trans.spans[0].duration < trans.duration)
+
+    t.end()
+  }
+}
+
+function resetAgent (cb) {
+  agent._instrumentation._queue._clear()
+  agent._instrumentation.currentTransaction = null
+  agent._httpClient = { request: cb || function () {} }
+  agent.captureError = function (err) { throw err }
+}


### PR DESCRIPTION
Added instrumentation for apollo-server-express. As the actual instrumentation happens in apollo-server-core it might also work with all other apollo-server-*, but hasn't been tested yet.

Fixes #641 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
