### PR TITLE
feat: replace double-quotes with underscores

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -114,7 +114,7 @@ Transaction.prototype.setCustomContext = function (context) {
 Transaction.prototype.setTag = function (key, value) {
   if (!key) return false
   if (!this._tags) this._tags = {}
-  var skey = key.replace(/[.*]/g, '_')
+  var skey = key.replace(/[.*"]/g, '_')
   if (key !== skey) {
     this._agent.logger.warn('Illegal characters used in tag key: %s', key)
   }

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -64,22 +64,43 @@ test('#setCustomContext', function (t) {
 })
 
 test('#setTag', function (t) {
-  var ins = mockInstrumentation(function (added) {
-    t.equal(added.ended, true)
-    t.equal(added, trans)
+  t.test('valid', function (t) {
+    var ins = mockInstrumentation(function (added) {
+      t.equal(added.ended, true)
+      t.equal(added, trans)
+      t.end()
+    })
+    var trans = new Transaction(ins._agent)
+    t.equal(trans._tags, null)
+    t.equal(trans.setTag(), false)
+    t.equal(trans._tags, null)
+    trans.setTag('foo', 1)
+    t.deepEqual(trans._tags, { foo: '1' })
+    trans.setTag('bar', { baz: 2 })
+    t.deepEqual(trans._tags, { foo: '1', bar: '[object Object]' })
+    trans.setTag('foo', 3)
+    t.deepEqual(trans._tags, { foo: '3', bar: '[object Object]' })
     t.end()
   })
-  var trans = new Transaction(ins._agent)
-  t.equal(trans._tags, null)
-  t.equal(trans.setTag(), false)
-  t.equal(trans._tags, null)
-  trans.setTag('foo', 1)
-  t.deepEqual(trans._tags, { foo: '1' })
-  trans.setTag('bar', { baz: 2 })
-  t.deepEqual(trans._tags, { foo: '1', bar: '[object Object]' })
-  trans.setTag('foo', 3)
-  t.deepEqual(trans._tags, { foo: '3', bar: '[object Object]' })
-  t.end()
+
+  t.test('invalid', function (t) {
+    var ins = mockInstrumentation(function (added) {
+      t.equal(added.ended, true)
+      t.equal(added, trans)
+      t.end()
+    })
+    var trans = new Transaction(ins._agent)
+    t.equal(trans._tags, null)
+    t.equal(trans.setTag(), false)
+    t.equal(trans._tags, null)
+    trans.setTag('invalid*', 1)
+    t.deepEqual(trans._tags, { invalid_: '1' })
+    trans.setTag('invalid.', 2)
+    t.deepEqual(trans._tags, { invalid_: '2' })
+    trans.setTag('invalid"', 3)
+    t.deepEqual(trans._tags, { invalid_: '3' })
+    t.end()
+  })
 })
 
 test('#addTags', function (t) {


### PR DESCRIPTION
We previously replaced . and * with _ characters, however, the " character is also invalid so that should be converted too.

Fixes #659

### Checklist

- [x] Implement code
- [x] Add tests
