### PR TITLE
fix: output APM Server error messages

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -195,7 +195,29 @@ function config (opts) {
       })
 
       transport.on('error', err => {
-        agent.logger.error('An error occrued while communicating with the APM Server:', err.message)
+        const haveAccepted = Number.isFinite(err.accepted)
+        const haveErrors = Array.isArray(err.errors)
+        let msg
+
+        if (err.code) {
+          msg = `APM Server transport error (${err.code}): ${err.message}`
+        } else {
+          msg = `APM Server transport error: ${err.message}`
+        }
+
+        if (haveAccepted || haveErrors) {
+          if (haveAccepted) msg += `\nAPM Server accepted ${err.accepted} events in the last request`
+          if (haveErrors) {
+            err.errors.forEach(error => {
+              msg += `\nError: ${error.message}`
+              if (error.document) msg += `\n  Document: ${error.document}`
+            })
+          }
+        } else if (err.response) {
+          msg += `\n${err.response}`
+        }
+
+        agent.logger.error(msg)
       })
 
       return transport


### PR DESCRIPTION
We need to output the errors returned from the APM Server in some way.

This is a first attempt and might not be optimal. Hardcoding this in the general transport might not be a good idea either. But it's a good way to get the discussion started.