### PR TITLE
fix(async_hooks): more reliable cleanup

### DIFF
--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -1,10 +1,26 @@
 'use strict'
 
 const asyncHooks = require('async_hooks')
+const shimmer = require('./shimmer')
 
 module.exports = function (ins) {
   const asyncHook = asyncHooks.createHook({ init, destroy })
   const transactions = new Map()
+  const contexts = new WeakMap()
+
+  shimmer.wrap(ins, 'addEndedTransaction', function (addEndedTransaction) {
+    return function wrappedAddEndedTransaction (transaction) {
+      if (contexts.has(transaction)) {
+        for (let asyncId of contexts.get(transaction)) {
+          if (transactions.has(asyncId)) {
+            transactions.delete(asyncId)
+          }
+        }
+        contexts.delete(transaction)
+      }
+      return addEndedTransaction.call(this, transaction)
+    }
+  })
 
   Object.defineProperty(ins, 'currentTransaction', {
     get () {
@@ -25,11 +41,29 @@ module.exports = function (ins) {
     // type, which will init for each scheduled timer.
     if (type === 'TIMERWRAP') return
 
-    transactions.set(asyncId, ins.currentTransaction)
+    var transaction = ins.currentTransaction
+    if (!transaction) return
+
+    transactions.set(asyncId, transaction)
+
+    // Track the context by the transaction
+    if (!contexts.has(transaction)) {
+      contexts.set(transaction, [])
+    }
+    contexts.get(transaction).push(asyncId)
   }
 
   function destroy (asyncId) {
     if (!transactions.has(asyncId)) return // in case type === TIMERWRAP
+
+    var transaction = transactions.get(asyncId)
+
+    if (contexts.get(transaction)) {
+      var list = contexts.get(transaction)
+      var index = list.indexOf(asyncId)
+      list.splice(index, 1)
+    }
+
     transactions.delete(asyncId)
   }
 }


### PR DESCRIPTION
This is an attempt to improve the reliability of the map cleanup with `async_hooks`. This will cleanup _all_ contexts related to a transaction when the transaction is sent. This _does_ mean it would no longer be possible to continue creating spans within a transaction after the transaction itself is ended, but we don't currently really support that officially anyway.