### PR TITLE
chore(package): bump elastic-apm-http-client to ^6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "console-log-level": "^1.4.0",
     "cookie": "^0.3.1",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "^6.0.0",
+    "elastic-apm-http-client": "^6.0.1",
     "end-of-stream": "^1.4.1",
     "fast-safe-stringify": "^2.0.6",
     "http-headers": "^3.0.2",


### PR DESCRIPTION
~~This fixed the issue with correctly counting the size of the sent data so it now counts compressed data instead of uncompressed.~~

Edit: Eh no, too many releases 😅 This fixes the bug with aborting the outgoing request as soon as the server responds