### PR TITLE
test: fix possible race condition

### DIFF
--- a/test/agent.js
+++ b/test/agent.js
@@ -861,8 +861,6 @@ test('#captureError()', function (t) {
     let span = null
     const expect = [
       'metadata',
-      'transaction',
-      'span',
       'error'
     ]
 
@@ -873,8 +871,6 @@ test('#captureError()', function (t) {
         this.agent.captureError(new Error('with callback'), function () {
           t.pass('called callback')
         })
-        span.end()
-        trans.end()
       })
       .on('data-error', function (data) {
         t.equal(data.exception.message, 'with callback')


### PR DESCRIPTION
Sometimes the error would arrive before the span and the tests would fail.

Since we don't actually care about the arrival of the span or the transaction, we can just not end those and the test will not have a race condition anymore.