### PR TITLE
perf: improve Async Hooks implementation

### DIFF
--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -10,14 +10,14 @@ module.exports = function (ins) {
 
   shimmer.wrap(ins, 'addEndedTransaction', function (addEndedTransaction) {
     return function wrappedAddEndedTransaction (transaction) {
-      if (contexts.has(transaction)) {
-        for (const asyncId of contexts.get(transaction)) {
-          if (transactions.has(asyncId)) {
-            transactions.delete(asyncId)
-          }
+      const asyncIds = contexts.get(transaction)
+      if (asyncIds) {
+        for (const asyncId of asyncIds) {
+          transactions.delete(asyncId)
         }
         contexts.delete(transaction)
       }
+
       return addEndedTransaction.call(this, transaction)
     }
   })
@@ -25,7 +25,7 @@ module.exports = function (ins) {
   Object.defineProperty(ins, 'currentTransaction', {
     get () {
       const asyncId = asyncHooks.executionAsyncId()
-      return transactions.has(asyncId) ? transactions.get(asyncId) : null
+      return transactions.get(asyncId) || null
     },
     set (trans) {
       const asyncId = asyncHooks.executionAsyncId()
@@ -51,21 +51,23 @@ module.exports = function (ins) {
     transactions.set(asyncId, transaction)
 
     // Track the context by the transaction
-    if (!contexts.has(transaction)) {
-      contexts.set(transaction, [])
+    let asyncIds = contexts.get(transaction)
+    if (!asyncIds) {
+      asyncIds = []
+      contexts.set(transaction, asyncIds)
     }
-    contexts.get(transaction).push(asyncId)
+    asyncIds.push(asyncId)
   }
 
   function destroy (asyncId) {
-    if (!transactions.has(asyncId)) return // in case type === TIMERWRAP
-
     const transaction = transactions.get(asyncId)
-    const list = contexts.get(transaction)
 
-    if (list) {
-      const index = list.indexOf(asyncId)
-      list.splice(index, 1)
+    if (!transaction) return
+
+    const asyncIds = contexts.get(transaction)
+    if (asyncIds) {
+      const index = asyncIds.indexOf(asyncId)
+      asyncIds.splice(index, 1)
     }
 
     transactions.delete(asyncId)

--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -11,7 +11,7 @@ module.exports = function (ins) {
   shimmer.wrap(ins, 'addEndedTransaction', function (addEndedTransaction) {
     return function wrappedAddEndedTransaction (transaction) {
       if (contexts.has(transaction)) {
-        for (let asyncId of contexts.get(transaction)) {
+        for (const asyncId of contexts.get(transaction)) {
           if (transactions.has(asyncId)) {
             transactions.delete(asyncId)
           }
@@ -29,7 +29,11 @@ module.exports = function (ins) {
     },
     set (trans) {
       const asyncId = asyncHooks.executionAsyncId()
-      transactions.set(asyncId, trans)
+      if (trans) {
+        transactions.set(asyncId, trans)
+      } else {
+        transactions.delete(asyncId)
+      }
     }
   })
 
@@ -41,7 +45,7 @@ module.exports = function (ins) {
     // type, which will init for each scheduled timer.
     if (type === 'TIMERWRAP') return
 
-    var transaction = ins.currentTransaction
+    const transaction = ins.currentTransaction
     if (!transaction) return
 
     transactions.set(asyncId, transaction)
@@ -56,11 +60,11 @@ module.exports = function (ins) {
   function destroy (asyncId) {
     if (!transactions.has(asyncId)) return // in case type === TIMERWRAP
 
-    var transaction = transactions.get(asyncId)
+    const transaction = transactions.get(asyncId)
+    const list = contexts.get(transaction)
 
-    if (contexts.get(transaction)) {
-      var list = contexts.get(transaction)
-      var index = list.indexOf(asyncId)
+    if (list) {
+      const index = list.indexOf(asyncId)
       list.splice(index, 1)
     }
 


### PR DESCRIPTION
The biggest change here is not setting the keys in the `transactions` map to `null` but deleting them when the current transaction is being set to `null`.

Besides reducing the size of the of the map, this makes the check for `transactions.has(asyncId)` correct, and though means less overhead trying to access a transaction that is actually just `null`.