### PR TITLE
docs: fix APM Server links to 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ npm install elastic-apm-node --save
 
 1. To run Elastic APM for your own applications,
    make sure you have the prerequisites in place first.
-   This agent is compatible with [APM Server](https://github.com/elastic/apm-server) v6.2 and above.
+   Version 1.x of this agent is compatible with [APM Server](https://github.com/elastic/apm-server) v6.2 to v6.4.
+   For support for newer releases of the APM Server,
+   use a newer version of the agent.
    For details see [Getting Started with Elastic APM](https://www.elastic.co/guide/en/apm/get-started)
 
 1. Now follow the documentation links below relevant to your framework or stack to get set up

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -686,7 +686,7 @@ and will receive a `payload` object as the only argument,
 containing the data about to be sent to the APM Server.
 
 For details on the format of the payload,
-see the {apm-server-ref}/intake-api.html[APM Server intake API documentation].
+see the {apm-server-ref-64}/intake-api.html[APM Server intake API documentation].
 
 The filter function is synchronous and should return the manipulated payload object.
 If a filter function doesn't return any value or returns a falsy value,

--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -28,7 +28,9 @@ that not all core Node.js API's can be instrumented without the use of Async Hoo
 [[elastic-stack-compatibility]]
 === Elastic Stack Compatibility
 
-This agent is compatible with {apm-server-ref}[APM Server] v6.2 and above.
+Version 1.x of the agent is compatible with {apm-server-ref-64}[APM Server] v6.2 to v6.4.
+For support for APM Server v6.5 and above,
+use version 2.0.0 or higher of the Node.js agent.
 
 [float]
 [[compatibility-frameworks]]

--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -30,7 +30,7 @@ that not all core Node.js API's can be instrumented without the use of Async Hoo
 
 Version 1.x of the agent is compatible with {apm-server-ref-64}[APM Server] v6.2 to v6.4.
 For support for APM Server v6.5 and above,
-use version 2.0.0 or higher of the Node.js agent.
+use {apm-node-ref-index}[version 2.0.0 or higher] of the Node.js agent.
 
 [float]
 [[compatibility-frameworks]]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -15,7 +15,7 @@ as well as a simple API which allows you to instrument any application.
 The agent is only one of the multiple components you need to get started with APM.
 Please also have a look at the documentation for:
 
-* {apm-server-ref}/index.html[APM Server]
+* {apm-server-ref-64}/index.html[APM Server]
 * {ref}/index.html[Elasticsearch]
 
 [float]


### PR DESCRIPTION
These changes are not critical as none of the links are technically broken, but it would just be nicer if the links to the APM Server for version 1.x of the agent pointed to version 6.4 of the APM Server.

@Qard This is the first time we do a PR into an old branch, but I guess this is how we would do it right?