### PR TITLE
fix: log APM Server API errors correctly

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -195,6 +195,10 @@ function config (opts) {
       })
 
       transport.on('error', err => {
+        agent.logger.error('APM Server transport error:', err.stack)
+      })
+
+      transport.on('request-error', err => {
         const haveAccepted = Number.isFinite(err.accepted)
         const haveErrors = Array.isArray(err.errors)
         let msg


### PR DESCRIPTION
APM Server API errors are emitted by the HTTP client as 'request-error' events.

In case of more serious errors, the 'error' event is still used, but indicates that the client could not recover from the error.

The `request-error` event is emitted here: https://github.com/elastic/apm-nodejs-http-client/blob/5d364e1fe9150bde74b6fde8732187f1e2c00e48/index.js#L59