### PR TITLE
docs: add redirects file

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -39,3 +39,5 @@ include::./supported-technologies.asciidoc[]
 include::./upgrading.asciidoc[]
 
 include::./troubleshooting.asciidoc[]
+
+include::./redirects.asciidoc[]

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -1,0 +1,9 @@
+["appendix",role="exclude",id="redirects"]
+= Deleted pages
+
+The following pages have moved or been deleted.
+
+[role="exclude",id="compatibility"]
+=== Compatibility
+
+This page has moved. Please see <<supported-technologies>>.


### PR DESCRIPTION
Add hidden `redirects.asciidoc` file to handle "redirect" on current (as we're not supposed to redirect current). Should also backport to 2.x. Will set up website redirect for 2.x as well.