### PR TITLE
fix(hapi): ignore internal events channel

### DIFF
--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -84,7 +84,9 @@ module.exports = function (hapi, agent, version, enabled) {
   }
 
   function captureError (type, req, event, tags) {
-    if (!event || !tags.error) return
+    if (!event || !tags.error || event.channel === 'internal') {
+      return
+    }
 
     // TODO: Find better location to put this than custom
     var payload = {

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -378,6 +378,7 @@ test('request error logging with Error does not affect event tags', function (t)
 
   var emitter = server.events || server
   emitter.on('request', function (req, event, tags) {
+    if (event.channel === 'internal') return
     t.deepEqual(event.tags, ['elastic-apm', 'error'])
   })
 
@@ -385,6 +386,7 @@ test('request error logging with Error does not affect event tags', function (t)
     t.error(err, 'start error')
 
     emitter.on('request', function (req, event, tags) {
+      if (event.channel === 'internal') return
       t.deepEqual(event.tags, ['elastic-apm', 'error'])
     })
 
@@ -491,7 +493,7 @@ test('request error logging with Object', function (t) {
 })
 
 test('error handling', function (t) {
-  t.plan(semver.satisfies(pkg.version, '>=17') ? 12 : 10)
+  t.plan(10)
 
   resetAgent(1, function (data) {
     assert(t, data, { status: 'HTTP 5xx', name: 'GET /error' })


### PR DESCRIPTION
In certain cases, hapi will tag internal events as "errors" when they are not really errors from a user-facing point of view. This didn't surface until Node.js 11 started to emit them consistently.

This will fix the hapi-related issues in #632.
