### PR TITLE
docs: fix cross document links (master)

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -83,7 +83,7 @@ containing the data about to be sent to the APM Server.
 
 The format of the payload depends on the event type being sent.
 For details about the different formats,
-see the {apm-server-ref}/intake-api.html[APM Server intake API documentation].
+see the {apm-server-ref-v}/intake-api.html[APM Server intake API documentation].
 
 The filter function is synchronous and should return the manipulated payload object.
 If a filter function doesn't return any value or returns a falsy value,
@@ -310,7 +310,7 @@ To ease debugging it's possible to send some extra data with each error you send
 The APM Server intake API supports a lot of different metadata fields,
 most of which are automatically managed by the Elastic APM Node.js Agent.
 But if you wish you can supply some extra details using `user` or `custom`.
-For more details on the properties accepted by the events intake API see the {apm-server-ref}/events-api.html[events intake API docs].
+For more details on the properties accepted by the events intake API see the {apm-server-ref-v}/events-api.html[events intake API docs].
 
 To supply any of these extra fields,
 use the optional options argument when calling `apm.captureError()`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-:node-branch: 2.x
+:node-branch: master
 :server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,5 @@
-:branch: current
+:node-branch: 2.x
+:server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -18,7 +18,8 @@ as well as a simple API which allows you to instrument any application.
 === Additional Components
 
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server],
-{ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+{ref}/index.html[Elasticsearch],
+and {kibana-ref}/index.html[Kibana].
 Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
 
 [float]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -17,8 +17,9 @@ as well as a simple API which allows you to instrument any application.
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together. 
+APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server],
+{ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
 
 [float]
 [[get-started]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -28,7 +28,7 @@ that not all core Node.js API's can be instrumented without the use of Async Hoo
 [[elastic-stack-compatibility]]
 === Elastic Stack Compatibility
 
-This agent is compatible with {apm-server-ref}[APM Server] v6.5 and above.
+This agent is compatible with {apm-server-ref-v}[APM Server] v6.5 and above.
 For support for previous releases of the APM Server,
 use version {apm-node-ref-1x}[1.x] of the agent.
 


### PR DESCRIPTION
Versions master links to APM Server and APM Overview v6.5 per elastic/apm/issues/19.

Needs to be backported to 2.x (but with `:node-branch: 2.x` instead of `master`) - is it easier if I just create a new PR in 2.x?