### PR TITLE
docs: fix cross document links (1.x)

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -686,7 +686,7 @@ and will receive a `payload` object as the only argument,
 containing the data about to be sent to the APM Server.
 
 For details on the format of the payload,
-see the {apm-server-ref-64}/intake-api.html[APM Server intake API documentation].
+see the {apm-server-ref-v}/intake-api.html[APM Server intake API documentation].
 
 The filter function is synchronous and should return the manipulated payload object.
 If a filter function doesn't return any value or returns a falsy value,
@@ -887,7 +887,7 @@ To ease debugging it's possible to send some extra data with each error you send
 The APM Server intake API supports a lot of different metadata fields,
 most of which are automatically managed by the Elastic APM Node.js Agent.
 But if you wish you can supply some extra details using `user` or `custom`.
-For more details on the properties accepted by the error intake API see the {apm-server-ref}/error-api.html[intake error API docs].
+For more details on the properties accepted by the error intake API see the {apm-server-ref-v}/error-api.html[intake error API docs].
 
 To supply any of these extra fields,
 use the optional options argument when calling `apm.captureError()`.

--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -28,7 +28,7 @@ that not all core Node.js API's can be instrumented without the use of Async Hoo
 [[elastic-stack-compatibility]]
 === Elastic Stack Compatibility
 
-Version 1.x of the agent is compatible with {apm-server-ref-64}[APM Server] v6.2 to v6.4.
+Version 1.x of the agent is compatible with {apm-server-ref-v}[APM Server] v6.2 to v6.4.
 For support for APM Server v6.5 and above,
 use {apm-node-ref-index}[version 2.0.0 or higher] of the Node.js agent.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,5 @@
-:branch: current
+:node-branch: 1.x
+:server-branch: 6.4
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -15,7 +15,7 @@ as well as a simple API which allows you to instrument any application.
 The agent is only one of the multiple components you need to get started with APM.
 Please also have a look at the documentation for:
 
-* {apm-server-ref-64}/index.html[APM Server]
+* {apm-server-ref-v}/index.html[APM Server]
 * {ref}/index.html[Elasticsearch]
 
 [float]


### PR DESCRIPTION
Versions 1.x links to APM Server and APM Overview v6.4 per elastic/apm/issues/19.