### PR TITLE
docs: version fix

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-:node-branch: master
+:branch: current
 :server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
Fixes issue discussed in #703. `node-branch` is not needed. `branch` is needed for Elasticsearch and Kibana links.