### PR TITLE
docs: version fix

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,5 @@
-:node-branch: 1.x
-:server-branch: 6.4
+:branch: 6.4
+:server-branch: {branch}
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]


### PR DESCRIPTION
Fixes issue discussed in #703. `node-branch` is not needed. `branch` is needed for Elasticsearch and Kibana links.