### PR TITLE
fix: don't throw on older versions of Node.js 6

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -83,8 +83,12 @@ function isRequestBlacklisted (agent, req) {
 // NOTE: This will also stringify and parse URL instances
 // to a format which can be mixed into the options object.
 function ensureUrl (v) {
-  if (typeof v === 'string' || v instanceof url.URL) {
-    return url.parse(String(v))
+  if (typeof v === 'string') {
+    return url.parse(v)
+  } else if (v instanceof url.Url) {
+    return v
+  } else if (url.URL && v instanceof url.URL) { // check for url.URL because it wasn't added until Node.js 6.13.0
+    return url.parse(v.toString())
   } else {
     return v
   }


### PR DESCRIPTION
The `url.URL` object was added in Node.js v6.13.0. If you tried to perform a `foo instanceof url.URL` on earlier versions, the code would throw the following exception:

```
TypeError: Expecting a function in instanceof check, but got undefined
```

This is a prerequisite for #705 but might also solve #710 - We'll see when it's merged into master.