### PR TITLE
[1.x] fix(hapi): ignore internal events channel (#700)

### DIFF
--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -84,7 +84,9 @@ module.exports = function (hapi, agent, version, enabled) {
   }
 
   function captureError (type, req, event, tags) {
-    if (!event || !tags.error) return
+    if (!event || !tags.error || event.channel === 'internal') {
+      return
+    }
 
     // TODO: Find better location to put this than custom
     var payload = {

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -374,6 +374,7 @@ test('request error logging with Error does not affect event tags', function (t)
 
   var emitter = server.events || server
   emitter.on('request', function (req, event, tags) {
+    if (event.channel === 'internal') return
     t.deepEqual(event.tags, ['elastic-apm', 'error'])
   })
 
@@ -381,6 +382,7 @@ test('request error logging with Error does not affect event tags', function (t)
     t.error(err, 'start error')
 
     emitter.on('request', function (req, event, tags) {
+      if (event.channel === 'internal') return
       t.deepEqual(event.tags, ['elastic-apm', 'error'])
     })
 
@@ -487,7 +489,7 @@ test('request error logging with Object', function (t) {
 })
 
 test('error handling', function (t) {
-  t.plan(semver.satisfies(pkg.version, '>=17') ? 13 : 11)
+  t.plan(10)
 
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 5xx', name: 'GET /error' })

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -489,7 +489,7 @@ test('request error logging with Object', function (t) {
 })
 
 test('error handling', function (t) {
-  t.plan(10)
+  t.plan(11)
 
   resetAgent(function (endpoint, headers, data, cb) {
     assert(t, data, { status: 'HTTP 5xx', name: 'GET /error' })


### PR DESCRIPTION
Backports the following commits to 1.x:
 - fix(hapi): ignore internal events channel  (#700)