### PR TITLE
chore(package): bump random-poly-fill to ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "http-headers": "^3.0.2",
     "is-native": "^1.0.1",
     "original-url": "^1.2.2",
-    "random-poly-fill": "^1.0.0",
+    "random-poly-fill": "^1.0.1",
     "read-pkg-up": "^4.0.0",
     "redact-secrets": "^1.0.0",
     "relative-microtime": "^2.0.0",


### PR DESCRIPTION
The previous version accidentally included devDependencies as regular dependencies which made the footprint of this package much larger than necessary.