### PR TITLE
chore: update engines field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": "4 || 6 || 8 || 9 || 10"
+    "node": "6 || 8 || 9 || 10 || 11"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
It wrongly stated support for Node.js 4 which was dropped in v2.0.0 and it also didn't include version 11.