### PR TITLE
test(ci): remove forced upgrade of npm to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   - for i in {1..3}; do travis_wait 5 npm install && break; rm -rf node_modules; done
 
 before_script:
-  - npm install -g npm@latest
   - wait-on tcp:9200
 
 node_js:


### PR DESCRIPTION
This was added in elastic/apm-agent-nodejs#557 to fix a TAV test failure. But the issue requiring us to upgrade have since been fixed.