### PR TITLE
Fix graphql error handling (#1)

### DIFF
--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -70,15 +70,20 @@ module.exports = function (graphql, agent, version, enabled) {
 
       var source = new graphql.Source(requestString || '', 'GraphQL request')
       if (source) {
-        var documentAST = graphql.parse(source)
+        var documentAST
+
+        try {
+          documentAST = graphql.parse(source)
+        } catch (syntaxError) {
+          agent.logger.debug('graphql.parse(source) failed - skipping graphql query extraction')
+        }
+
         if (documentAST) {
           var validationErrors = graphql.validate(schema, documentAST)
           if (validationErrors && validationErrors.length === 0) {
             var queries = extractDetails(documentAST, operationName).queries
             if (queries.length > 0) span.name = 'GraphQL: ' + queries.join(', ')
           }
-        } else {
-          agent.logger.debug('graphql.parse(source) failed - skipping graphql query extraction')
         }
       } else {
         agent.logger.debug('graphql.Source(query) failed - skipping graphql query extraction')

--- a/test/instrumentation/modules/graphql.js
+++ b/test/instrumentation/modules/graphql.js
@@ -44,9 +44,9 @@ test('graphql.graphql - invalid query', function (t) {
 
   graphql.graphql(schema, query, root).then(function (response) {
     agent.endTransaction()
-    t.deepEqual(response, { errors: [
-      { message: 'Syntax Error: Expected Name, found <EOF>', locations: [ { line: 1, column: 8 } ] }
-    ] })
+    t.deepEqual(Object.keys(response), ['errors'])
+    t.equal(response.errors.length, 1, 'should have one error')
+    t.ok(response.errors[0].message.indexOf('Syntax Error') !== -1, 'should return a sytax error')
     agent.flush()
   })
 })

--- a/test/instrumentation/modules/graphql.js
+++ b/test/instrumentation/modules/graphql.js
@@ -31,6 +31,26 @@ test('graphql.graphql', function (t) {
   })
 })
 
+test('graphql.graphql - invalid query', function (t) {
+  resetAgent(done(t, 'Unkown Query'))
+
+  var schema = graphql.buildSchema('type Query { hello: String }')
+  var root = { hello () {
+    return 'Hello world!'
+  } }
+  var query = '{ hello'
+
+  agent.startTransaction('foo')
+
+  graphql.graphql(schema, query, root).then(function (response) {
+    agent.endTransaction()
+    t.deepEqual(response, { errors: [
+      { message: 'Syntax Error: Expected Name, found <EOF>', locations: [ { line: 1, column: 8 } ] }
+    ] })
+    agent.flush()
+  })
+})
+
 test('graphql.execute', function (t) {
   resetAgent(done(t))
 
@@ -98,7 +118,9 @@ if (semver.satisfies(pkg.version, '>=0.12')) {
   })
 }
 
-function done (t) {
+function done (t, spanNameSuffix) {
+  spanNameSuffix = spanNameSuffix || 'hello'
+
   return function (data, cb) {
     t.equal(data.transactions.length, 1)
     t.equal(data.spans.length, 1)
@@ -108,7 +130,7 @@ function done (t) {
 
     t.equal(trans.name, 'foo')
     t.equal(trans.type, 'custom')
-    t.equal(span.name, 'GraphQL: hello')
+    t.equal(span.name, 'GraphQL: ' + spanNameSuffix)
     t.equal(span.type, 'db.graphql.execute')
 
     var offset = span.timestamp - trans.timestamp


### PR DESCRIPTION
Fixes module graphqls error handling with syntax errors in queries

On our project we ran into the problem, that elastic-apm-node would break the working integration of graphql in our app.
Instead of returning a Promise.resolve() with an error object graphql() will throw an error when used with elastic-apm-node.

The pr will fix this behavior by adding a try/catch around the query parsing.


I hope i didn't miss any steps required for this PR.
- testing was done via `npm test all 10 graphql ` and returned "OK"

elastic/apm-agent-nodejs#746