### PR TITLE
[1.x] fix(graphql): don't throw on invalid query (#747)

### DIFF
--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -71,15 +71,20 @@ module.exports = function (graphql, agent, version, enabled) {
 
       var source = new graphql.Source(requestString || '', 'GraphQL request')
       if (source) {
-        var documentAST = graphql.parse(source)
+        var documentAST
+
+        try {
+          documentAST = graphql.parse(source)
+        } catch (syntaxError) {
+          agent.logger.debug('graphql.parse(source) failed - skipping graphql query extraction')
+        }
+
         if (documentAST) {
           var validationErrors = graphql.validate(schema, documentAST)
           if (validationErrors && validationErrors.length === 0) {
             var queries = extractDetails(documentAST, operationName).queries
             if (queries.length > 0) spanName = 'GraphQL: ' + queries.join(', ')
           }
-        } else {
-          agent.logger.debug('graphql.parse(source) failed - skipping graphql query extraction')
         }
       } else {
         agent.logger.debug('graphql.Source(query) failed - skipping graphql query extraction')


### PR DESCRIPTION
Backports the following commits to 1.x:
 - fix(graphql): don't throw on invalid query  (#747)