### PR TITLE
refactor: improve span payload encoding

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -122,10 +122,9 @@ Span.prototype._encode = function (cb) {
       timestamp: self.timestamp,
       duration: self.duration(),
       context: undefined,
-      stacktrace: undefined
+      stacktrace: frames
     }
 
-    if (frames) payload.stacktrace = frames
     if (self._db || self._tags) {
       payload.context = {
         db: self._db || undefined,


### PR DESCRIPTION
Just a tiny nit that I found. Would normally have done this as part of the refactor in the span tags PR, but I missed it.