### PR TITLE
test: ensure squashed commit messages doesn't exceed limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "apollo-server-express": "^2.1.0",
     "bluebird": "^3.5.2",
     "cassandra-driver": "^4.0.0",
+    "commitlint-config-squash-pr": "^1.0.0",
     "connect": "^3.6.6",
     "dependency-check": "^3.2.1",
     "elasticsearch": "^15.1.1",
@@ -161,6 +162,7 @@
   },
   "commitlint": {
     "extends": [
+      "squash-pr",
       "@commitlint/config-conventional"
     ]
   },


### PR DESCRIPTION
See [commitlint-config-squash-pr](https://github.com/watson/commitlint-config-squash-pr) for details of what extra commit lint rules this PR adds.

The maximum allowed length of a commit message is normally 72 chars. Currently our PR id's have a length of 3 (`764` in the case of this PR). That means that the commit message shouldn't be longer than 65 chars to accommodate the ` (#764)` suffix (72-4-3=65). I've on purpose made the length of this commit message 66 to test that it works. When merging the trailing ` xxxxxxx` should be removed.
