### PR TITLE
test(schema): improve reliability

### DIFF
--- a/test/integration/api-schema/_utils.js
+++ b/test/integration/api-schema/_utils.js
@@ -36,15 +36,15 @@ exports.metadataValidator = thunky(function (cb) {
 })
 
 exports.transactionValidator = thunky(function (cb) {
-  loadSchema(join('transactions', 'v2_transaction.json'), cb)
+  loadSchema(join('transactions', 'transaction.json'), cb)
 })
 
 exports.spanValidator = thunky(function (cb) {
-  loadSchema(join('spans', 'v2_span.json'), cb)
+  loadSchema(join('spans', 'span.json'), cb)
 })
 
 exports.errorValidator = thunky(function (cb) {
-  loadSchema(join('errors', 'v2_error.json'), cb)
+  loadSchema(join('errors', 'error.json'), cb)
 })
 
 function loadSchema (relativePath, cb) {

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -21,18 +21,13 @@ download_schema()
 schemadir="${1:-.schemacache}"
 
 FILES=( \
-  "errors/common_error.json" \
-  "errors/v2_error.json" \
-  "metricsets/common_metricset.json" \
-  "metricsets/payload.json" \
+  "errors/error.json" \
   "metricsets/sample.json" \
-  "metricsets/v2_metricset.json" \
+  "metricsets/metricset.json" \
   "sourcemaps/payload.json" \
-  "spans/common_span.json" \
-  "spans/v2_span.json" \
-  "transactions/common_transaction.json" \
+  "spans/span.json" \
   "transactions/mark.json" \
-  "transactions/v2_transaction.json" \
+  "transactions/transaction.json" \
   "context.json" \
   "metadata.json" \
   "process.json" \


### PR DESCRIPTION
This fixes the latest schema change issues, but should also make the tests more reliable. As far as I'm aware, the rest of the object structure doesn't really matter, but I can restore that, if you think it's important.