### PR TITLE
[docs] Restructure configuration

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -7,10 +7,7 @@ endif::[]
 
 == API Reference
 
-The API reference documentation is divided into four parts:
-
-* <<configuration,Configuration>> - Configuration options can be provided via the `apm.start()` method,
-via a config file or via environment variables.
+The API reference documentation is divided into three parts:
 
 * <<agent-api,The `Agent` API>> - All functions and properties on the `Agent` object.
 An instance of the `Agent` object is acquired by requiring/importing the Node.js APM Agent module.
@@ -21,8 +18,6 @@ An instance of the `Transaction` object is acquired by calling `apm.startTransac
 
 * <<span-api,The `Span` API>> - All functions and properties on the `Span` object.
 An instance of the `Span` object is acquired by calling `apm.startSpan()`
-
-include::./configuration.asciidoc[Agent configuration documentation]
 
 include::./agent-api.asciidoc[Agent API documentation]
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -9,12 +9,12 @@ endif::[]
 
 The API reference documentation is divided into four parts:
 
+* <<configuration,Configuration>> - Configuration options can be provided via the `apm.start()` method,
+via a config file or via environment variables.
+
 * <<agent-api,The `Agent` API>> - All functions and properties on the `Agent` object.
 An instance of the `Agent` object is acquired by requiring/importing the Node.js APM Agent module.
 The `Agent` is a singleton and the instance is usually referred to by the variable `apm` in this documentation
-
-* <<configuration,Configuration>> - Configuration options can be provided via the `apm.start()` method,
-via a config file or via environment variables.
 
 * <<transaction-api,The `Transaction` API>> - All functions and properties on the `Transaction` object.
 An instance of the `Transaction` object is acquired by calling `apm.startTransaction()`
@@ -22,9 +22,9 @@ An instance of the `Transaction` object is acquired by calling `apm.startTransac
 * <<span-api,The `Span` API>> - All functions and properties on the `Span` object.
 An instance of the `Span` object is acquired by calling `apm.startSpan()`
 
-include::./agent-api.asciidoc[Agent API documentation]
-
 include::./configuration.asciidoc[Agent configuration documentation]
+
+include::./agent-api.asciidoc[Agent API documentation]
 
 include::./transaction-api.asciidoc[Transaction API documentation]
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -5,46 +5,18 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html[elastic.co]
 endif::[]
 
-=== Configuration
+=== Configuration options
 
-The available configuration options are listed below.
+The available configuration options and equivalent environment variable names are listed below.
 Most configuration options can be set in one of three ways:
 
-1. In the optional `options` object
-2. By using environment variables
+1. By using environment variables
+
+2. In the optional <<agent-configuration-object,`options`>> object
+
 3. Via the <<agent-configuration-file,agent configuration file>>.
 
-Environment variables will always take precedence over properties of the `options` object.
-On this page, the equivalent environment variable name is listed together with each option.
-
-To use the optional `options` argument, simply pass it into the `apm.start()` method:
-
-[source,js]
-----
-apm.start([options])
-----
-
-Here's an example usage configuring the agent to only be active in production:
-
-[source,js]
-----
-// Add this to the VERY top of the first file loaded in your app
-require('elastic-apm-node').start({
-
-  // Override service name from package.json
-  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
-  serviceName: '',
-
-  // Use if APM Server requires a token
-  secretToken: '',
-
-  // Set custom APM Server URL (default: http://localhost:8200)
-  serverUrl: '',
-
-  // Only activate the agent if it's running in production
-  active: process.env.NODE_ENV === 'production'
-})
-----
+For more information on setting configuration options, see <<configuring-the-agent, configuring the agent>>.
 
 TIP: The only required parameter is <<service-name,`serviceName`>>.
 However,

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -8,23 +8,29 @@ endif::[]
 === Configuration
 
 The available configuration options are listed below.
-Most configuration options can be set either in the optional `options` object,
-by using environment variables,
-or via the <<agent-configuration-file,agent configuration file>>.
-Their equivalent environment variable name is listed together with each option.
+Most configuration options can be set in one of three ways:
+
+1. In the optional `options` object
+2. By using environment variables
+3. Via the <<agent-configuration-file,agent configuration file>>.
 
 Environment variables will always take precedence over properties of the `options` object.
+On this page, the equivalent environment variable name is listed together with each option.
 
-The only required parameter is <<service-name,`serviceName`>>.
-However,
-the agent will use the `name` from `package.json` by default if available.
+To use the optional `options` argument, simply pass it into the `apm.start()` method:
 
-Example usage configuring the agent to only be active in production:
+[source,js]
+----
+apm.start([options])
+----
+
+Here's an example usage configuring the agent to only be active in production:
 
 [source,js]
 ----
 // Add this to the VERY top of the first file loaded in your app
 require('elastic-apm-node').start({
+
   // Override service name from package.json
   // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
@@ -39,6 +45,10 @@ require('elastic-apm-node').start({
   active: process.env.NODE_ENV === 'production'
 })
 ----
+
+TIP: The only required parameter is <<service-name,`serviceName`>>.
+However,
+the agent will use the `name` from `package.json` by default if available.
 
 [[service-name]]
 ==== `serviceName`

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -11,8 +11,8 @@ The following pages will help you set up and configure your APM Agent.
 
 * <<starting-the-agent>>
 * <<configuring-the-agent>>
-* <<agent-configuration-object>>
-* <<agent-configuration-file>>
+** <<agent-configuration-object>>
+** <<agent-configuration-file>>
 * <<es-modules>>
 * <<configuration>>
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -7,6 +7,13 @@ endif::[]
 
 == Advanced Setup and Configuration
 
+* <<starting-the-agent>>
+* <<configuring-the-agent>>
+* <<agent-configuration-object>>
+* <<agent-configuration-file>>
+* <<es-modules>>
+* <<configuration>>
+
 [float]
 [[starting-the-agent]]
 === Starting the agent
@@ -42,20 +49,51 @@ NOTE: If you are using Babel, you need to use the `elastic-apm-node/start` appro
 [[configuring-the-agent]]
 === Configuring the agent
 
-There are three ways to configure the Node.js agent:
+There are three ways to configure the Node.js agent. In order of precedence, they are:
 
-1. If calling the <<apm-start,`start`>> function,
-you can supply a configurations object as the first argument.
-The option parameters given here will take precedence over config options provided by other means
+1. Environment variables.
 
-2. If a given config option is not provided in the call to the <<apm-start,`start`>> function (or if requiring the `elastic-apm-node/start` script),
-the agent will look for the config option in the optional <<agent-configuration-file,agent configuration file>>
+2. If calling the `apm.start()` function,
+you can supply a <<agent-configuration-object,configurations object>> as the first argument.
 
-3. If a config option is not provided in any of the above means,
-the agent will look for its associated environment variable.
-You can see the expected names of these environment variables in the documentation for the <<apm-start,`start`>> options below
+3. Via the <<agent-configuration-file,agent configuration file>>.
 
-For information on the available configuration properties, see the <<apm-start,API reference>>.
+For information on the available configuration properties, and the expected names of environment variables, see the <<configuration,Configuration options>> documentation.
+
+[float]
+[[agent-configuration-object]]
+==== Agent configuration object
+
+To use the optional `options` argument, simply pass it into the `apm.start()` method:
+
+[source,js]
+----
+var apm = require('elastic-apm-node').start({
+  // add configuration options here
+})
+----
+
+Here's an example usage configuring the agent to only be active in production:
+
+[source,js]
+----
+// Add this to the VERY top of the first file loaded in your app
+require('elastic-apm-node').start({
+
+  // Override service name from package.json
+  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
+  serviceName: '',
+
+  // Use if APM Server requires a token
+  secretToken: '',
+
+  // Set custom APM Server URL (default: http://localhost:8200)
+  serverUrl: '',
+
+  // Only activate the agent if it's running in production
+  active: process.env.NODE_ENV === 'production'
+})
+----
 
 [float]
 [[agent-configuration-file]]
@@ -103,5 +141,7 @@ Instead you need to import the `elastic-apm-node/start` module:
 import apm from 'elastic-apm-node/start'
 ----
 
-Now, you can either configure the agent using the environment variables associated with each <<apm-start,config option>>,
+Now, you can either configure the agent using the environment variables associated with each <<configuration,configuration option>>,
 or use the optional <<agent-configuration-file,agent configuration file>>.
+
+include::./configuration.asciidoc[Agent configuration documentation]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -5,7 +5,9 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs/current/advanced-setup.html[elastic.co]
 endif::[]
 
-== Advanced Setup and Configuration
+== Setup and Configuration
+
+The following pages will help you set up and configure your APM Agent.
 
 * <<starting-the-agent>>
 * <<configuring-the-agent>>
@@ -14,7 +16,6 @@ endif::[]
 * <<es-modules>>
 * <<configuration>>
 
-[float]
 [[starting-the-agent]]
 === Starting the agent
 
@@ -45,7 +46,6 @@ but instead have to rely on <<configuring-the-agent,one of the other methods of 
 NOTE: If you are using Babel, you need to use the `elastic-apm-node/start` approach.
 <<es-modules,Read more>>.
 
-[float]
 [[configuring-the-agent]]
 === Configuring the agent
 
@@ -125,7 +125,6 @@ module.exports = {
 }
 ----
 
-[float]
 [[es-modules]]
 === Babel / ES Modules support
 
@@ -144,4 +143,4 @@ import apm from 'elastic-apm-node/start'
 Now, you can either configure the agent using the environment variables associated with each <<configuration,configuration option>>,
 or use the optional <<agent-configuration-file,agent configuration file>>.
 
-include::./configuration.asciidoc[Agent configuration documentation]
+include::./configuration.asciidoc[]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -49,7 +49,7 @@ NOTE: If you are using Babel, you need to use the `elastic-apm-node/start` appro
 [[configuring-the-agent]]
 === Configuring the agent
 
-There are three ways to configure the Node.js agent. In order of precedence, they are:
+There are three ways to configure the Node.js agent. In order of precedence (higher overwrites lower):
 
 1. Environment variables.
 


### PR DESCRIPTION
Fixes #758, fixes configuration precedence, updates some links from `agent-api` to `configuration`. 

After looking at this a little deeper, it doesn't make sense to nest the `configuration` options within the `Agent API` - it's simply too big.

I'm wondering what you think of this solution. 

In this PR, I've moved the configuration options out of the API reference and into the `Advanced Setup and Configuration` section. Alternatively, I could move the config out of Advanced setup and into the API reference. Either way, the content was being duplicated and it'd be best if it only lived in one place.