### PR TITLE
fix(tedious): don't fail on newest tedious v4.1.3

### DIFF
--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -1,7 +1,5 @@
 'use strict'
 
-var inherits = require('util').inherits
-
 var semver = require('semver')
 var sqlSummary = require('sql-summary')
 
@@ -22,42 +20,44 @@ module.exports = function (tedious, agent, version, enabled) {
   return tedious
 
   function wrapRequest (OriginalRequest) {
-    function Request () {
-      OriginalRequest.apply(this, arguments)
-      ins.bindEmitter(this)
+    class Request extends OriginalRequest {
+      constructor () {
+        super(...arguments)
+        ins.bindEmitter(this)
+      }
     }
-    inherits(Request, OriginalRequest)
+
     return Request
   }
 
   function wrapConnection (OriginalConnection) {
-    function Connection () {
-      OriginalConnection.apply(this, arguments)
-      ins.bindEmitter(this)
-    }
-    inherits(Connection, OriginalConnection)
-
-    const originalMakeRequest = OriginalConnection.prototype.makeRequest
-    Connection.prototype.makeRequest = function makeRequest (request) {
-      const span = agent.startSpan(null, 'db.mssql.query')
-      if (!span) {
-        return originalMakeRequest.apply(this, arguments)
+    class Connection extends OriginalConnection {
+      constructor () {
+        super(...arguments)
+        ins.bindEmitter(this)
       }
 
-      const preparing = request.sqlTextOrProcedure === 'sp_prepare'
-      const params = request.parametersByName
-      const sql = (params.statement || params.stmt || {}).value
-      span.name = sqlSummary(sql) + (preparing ? ' (prepare)' : '')
-      span.setDbContext({ statement: sql, type: 'sql' })
+      makeRequest (request) {
+        const span = agent.startSpan(null, 'db.mssql.query')
+        if (!span) {
+          return super.makeRequest(...arguments)
+        }
 
-      request.userCallback = wrapCallback(request.userCallback)
+        const preparing = request.sqlTextOrProcedure === 'sp_prepare'
+        const params = request.parametersByName
+        const sql = (params.statement || params.stmt || {}).value
+        span.name = sqlSummary(sql) + (preparing ? ' (prepare)' : '')
+        span.setDbContext({ statement: sql, type: 'sql' })
 
-      return originalMakeRequest.apply(this, arguments)
+        request.userCallback = wrapCallback(request.userCallback)
 
-      function wrapCallback (cb) {
-        return function () {
-          span.end()
-          return cb && cb.apply(this, arguments)
+        return super.makeRequest(...arguments)
+
+        function wrapCallback (cb) {
+          return function () {
+            span.end()
+            return cb && cb.apply(this, arguments)
+          }
         }
       }
     }


### PR DESCRIPTION
I ran TAV on all versions locally after this change and all passed ✅ 

Fixes:

```
running: test\instrumentation\modules\tedious.js
TAP version 13
# execSql
not ok 1 no error
  ---
    operator: error
    expected: |-
      undefined
    actual: |-
      [TypeError: Class constructor Connection cannot be invoked without 'new']
    at: withConnection.then (C:\projects\apm-agent-nodejs\test\instrumentation\modules\tedious.js:74:7)
    stack: |-
      TypeError: Class constructor Connection cannot be invoked without 'new'
          at new Connection (C:\projects\apm-agent-nodejs\lib\instrumentation\modules\tedious.js:35:26)
          at Promise (C:\projects\apm-agent-nodejs\test\instrumentation\modules\tedious.js:38:18)
          at new Promise (<anonymous>)
          at withConnection (C:\projects\apm-agent-nodejs\test\instrumentation\modules\tedious.js:37:10)
          at Test.test (C:\projects\apm-agent-nodejs\test\instrumentation\modules\tedious.js:59:3)
          at Test.bound [as _cb] (C:\projects\apm-agent-nodejs\node_modules\tape\lib\test.js:76:32)
          at Test.run (C:\projects\apm-agent-nodejs\node_modules\tape\lib\test.js:95:10)
          at Test.bound [as run] (C:\projects\apm-agent-nodejs\node_modules\tape\lib\test.js:76:32)
          at Immediate.next [as _onImmediate] (C:\projects\apm-agent-nodejs\node_modules\tape\lib\results.js:71:15)
          at runCallback (timers.js:810:20)
          at tryOnImmediate (timers.js:768:5)
          at processImmediate [as _immediateCallback] (timers.js:745:5)
  ...
```