### PR TITLE
feat: ignore internal errors

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -205,6 +205,11 @@ Agent.prototype.addSpanFilter = function (fn) {
   this._spanFilters.add(fn)
 }
 
+const internalFrameRegex = /^node_modules\/elastic-apm/
+function isInternalFrame (frame) {
+  return internalFrameRegex.test(frame.filename)
+}
+
 Agent.prototype.captureError = function (err, opts, cb) {
   if (typeof opts === 'function') return this.captureError(err, null, opts)
 
@@ -233,6 +238,11 @@ Agent.prototype.captureError = function (err, opts, cb) {
     prepareError(parsers.parseMessage(err))
   } else {
     parsers.parseError(err, agent, function (_, error) {
+      const hasInternal = error.exception.stacktrace
+        .some(isInternalFrame)
+
+      if (hasInternal) return
+
       // As of now, parseError suppresses errors internally, but even if they
       // were passed on, we would want to suppress them here anyway
       prepareError(error)


### PR DESCRIPTION
This should prevent internal errors from being reported, prevent infinite error reporting loops.

Fixes elastic/apm-agent-nodejs#31

### Checklist

- [x] Implement code
- [ ] Add tests
- [ ] Update documentation
