### PR TITLE
[1.x] fix: we don't support mongodb-core v3.1.10+ (#792)

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -53,7 +53,7 @@ pg:
     - node test/instrumentation/modules/pg/pg.js
     - node test/instrumentation/modules/pg/knex.js
 mongodb-core:
-  versions: '>=1.2.19 <4'
+  versions: '>=1.2.19 <3.1.10'
   commands: node test/instrumentation/modules/mongodb-core.js
 bluebird:
   versions: '>=2 <4'

--- a/docs/compatibility.asciidoc
+++ b/docs/compatibility.asciidoc
@@ -80,7 +80,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 |https://www.npmjs.com/package/graphql[graphql] |>=0.7.0 <15.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/handlebars[handlebars] |* |Will instrument compile and render calls
 |https://www.npmjs.com/package/ioredis[ioredis] |>=2.0.0 <5.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/mongodb-core[mongodb-core] |>=1.2.19 <4.0.0 |Will instrument all queries.
+|https://www.npmjs.com/package/mongodb-core[mongodb-core] |>=1.2.19 <3.1.10 |Will instrument all queries.
 A lot of higher level MongoDB modules use mongodb-core,
 so those should be supported as well
 |https://www.npmjs.com/package/mongodb[mongodb] |>=2.0.0 |Supported via mongodb-core

--- a/lib/instrumentation/modules/mongodb-core.js
+++ b/lib/instrumentation/modules/mongodb-core.js
@@ -9,7 +9,7 @@ var CURSOR_FNS_FIRST = ['_find', '_getmore']
 
 module.exports = function (mongodb, agent, version, enabled) {
   if (!enabled) return mongodb
-  if (!semver.satisfies(version, '>=1.2.19 <4.0.0')) {
+  if (!semver.satisfies(version, '>=1.2.19 <3.1.10')) {
     agent.logger.debug('mongodb-core version %s not supported - aborting...', version)
     return mongodb
   }

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "koa-router": "^7.1.1",
     "mimic-response": "^1.0.0",
     "mkdirp": "^0.5.0",
-    "mongodb-core": "^3.0.2",
+    "mongodb-core": "3.1.9",
     "mysql": "^2.14.1",
     "mysql2": "^1.6.3",
     "nyc": "^12.0.2",


### PR DESCRIPTION
Backports the following commits to 1.x:
 - fix: we don't support mongodb-core v3.1.10+  (#792)