### PR TITLE
fix: ensure request.url.port is a string on transactions

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -133,6 +133,11 @@ Transaction.prototype.toJSON = function () {
       var config = this._agent._conf.captureBody
       var captureBody = config === 'transactions' || config === 'all'
       payload.context.request = parsers.getContextFromRequest(this.req, captureBody)
+
+      // TODO: Tempoary fix for https://github.com/elastic/apm-agent-nodejs/issues/813
+      if (payload.context.request && payload.context.request.url && payload.context.request.url.port) {
+        payload.context.request.url.port = String(payload.context.request.url.port)
+      }
     }
     if (this.res) {
       payload.context.response = parsers.getContextFromResponse(this.res)


### PR DESCRIPTION
This was introduced by elastic/apm-nodejs-http-client#36 and should ideally be fixed in that repo. For now we fix it here.

Fixes #813