### PR TITLE
fix(parsers): move port fix into parser

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -132,11 +132,6 @@ Transaction.prototype.toJSON = function () {
     var conf = this._agent._conf
     if (this.req) {
       payload.context.request = parsers.getContextFromRequest(this.req, conf, 'transactions')
-
-      // TODO: Tempoary fix for https://github.com/elastic/apm-agent-nodejs/issues/813
-      if (payload.context.request && payload.context.request.url && payload.context.request.url.port) {
-        payload.context.request.url.port = String(payload.context.request.url.port)
-      }
     }
     if (this.res) {
       payload.context.response = parsers.getContextFromResponse(this.res, conf)

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -126,6 +126,11 @@ exports.getContextFromRequest = function (req, conf, type) {
     }
   }
 
+  // TODO: Tempoary fix for https://github.com/elastic/apm-agent-nodejs/issues/813
+  if (context.url && context.url.port) {
+    context.url.port = String(context.url.port)
+  }
+
   return context
 }
 

--- a/test/instrumentation/modules/hapi.js
+++ b/test/instrumentation/modules/hapi.js
@@ -41,7 +41,7 @@ test('extract URL from request', function (t) {
     t.equal(request.url.search, '?foo=bar')
     t.equal(request.url.raw, '/captureError?foo=bar')
     t.equal(request.url.hostname, 'localhost')
-    t.equal(request.url.port, server.info.port)
+    t.equal(request.url.port, String(server.info.port))
     t.equal(request.socket.encrypted, false)
     server.stop(noop)
     t.end()

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -155,7 +155,7 @@ test('#getContextFromRequest()', function (t) {
       search: '?key=value',
       protocol: 'https:',
       hostname: 'www.example.com',
-      port: 8080,
+      port: '8080',
       full: 'https://www.example.com:8080/some/path?key=value',
       raw: 'https://www.example.com:8080/some/path?key=value'
     })
@@ -168,7 +168,7 @@ test('#getContextFromRequest()', function (t) {
     var parsed = parsers.getContextFromRequest(req, {})
     t.deepEqual(parsed.url, {
       hostname: 'example.com',
-      port: 8080,
+      port: '8080',
       pathname: '/some/path',
       search: '?key=value',
       protocol: 'http:',


### PR DESCRIPTION
The request context parser is actually used in multiple places, so the port fix should be applied centrally.

Fixes #819
