### PR TITLE
refactor: remove sampled property alias from trace context

### DIFF
--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -45,7 +45,7 @@ Object.defineProperty(GenericSpan.prototype, 'parentId', {
 Object.defineProperty(GenericSpan.prototype, 'sampled', {
   enumerable: true,
   get () {
-    return this._context.sampled
+    return this._context.recorded
   }
 })
 

--- a/lib/instrumentation/trace-context.js
+++ b/lib/instrumentation/trace-context.js
@@ -94,7 +94,6 @@ function start (sampled = false) {
   // Generate new ids
   randomFillSync(buffer, OFFSETS.traceId, SIZES.ids)
 
-  // Apply reported and requested flags
   if (sampled) {
     buffer[OFFSETS.flags] |= FLAGS.recorded
   }
@@ -107,23 +106,16 @@ const bufferSymbol = Symbol('trace-context-buffer')
 class TraceContext {
   constructor (buffer) {
     this[bufferSymbol] = buffer
+    Object.defineProperty(this, 'recorded', {
+      value: !!(buffer[OFFSETS.flags] & FLAGS.recorded),
+      enumerable: true
+    })
+
     defineLazyProp(this, 'version', hexSliceFn(buffer, OFFSETS.version, OFFSETS.traceId))
     defineLazyProp(this, 'traceId', hexSliceFn(buffer, OFFSETS.traceId, OFFSETS.id))
     defineLazyProp(this, 'id', hexSliceFn(buffer, OFFSETS.id, OFFSETS.flags))
     defineLazyProp(this, 'flags', hexSliceFn(buffer, OFFSETS.flags, OFFSETS.parentId))
     defineLazyProp(this, 'parentId', maybeHexSliceFn(buffer, OFFSETS.parentId))
-
-    const recorded = !!(this[bufferSymbol][OFFSETS.flags] & FLAGS.recorded)
-    Object.defineProperties(this, {
-      recorded: {
-        enumerable: true,
-        value: recorded
-      },
-      sampled: {
-        enumerable: true,
-        value: recorded
-      }
-    })
   }
 
   static startOrResume (traceparent, conf) {

--- a/test/instrumentation/trace-context.js
+++ b/test/instrumentation/trace-context.js
@@ -54,8 +54,7 @@ test('toJSON', t => {
     traceId,
     id,
     flags,
-    recorded: true,
-    sampled: true
+    recorded: true
   }, 'trace context serializes fields to hex strings, in JSON form')
 
   t.end()
@@ -83,7 +82,7 @@ test('startOrResume', t => {
     t.equal(context.version, version, 'version matches')
     t.notEqual(context.traceId, traceId, 'has new traceId')
     t.notEqual(context.id, id, 'has new id')
-    t.equal(context.sampled, true, 'is sampled')
+    t.equal(context.recorded, true, 'is sampled')
 
     t.end()
   })
@@ -97,7 +96,7 @@ test('startOrResume', t => {
     t.equal(context.version, version, 'version matches')
     t.notEqual(context.traceId, traceId, 'has new traceId')
     t.notEqual(context.id, id, 'has new id')
-    t.equal(context.sampled, false, 'is sampled')
+    t.equal(context.recorded, false, 'is sampled')
 
     t.end()
   })


### PR DESCRIPTION
This just makes the code less complex.