### PR TITLE
fix: don't ignore custom trace context on spans

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -23,7 +23,7 @@ function Span (transaction, name, type, opts) {
     }
   } else {
     opts.timer = transaction._timer
-    if (!opts.traceparent) {
+    if (!opts.traceparent && !opts.traceContext) {
       opts.traceContext = (transaction._agent._instrumentation.activeSpan || transaction)._context
     }
   }


### PR DESCRIPTION
This becomes important if we want to support OpenTracing as that makes use of this option.