### PR TITLE
refactor: simplify API for resuming traces

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -459,7 +459,7 @@ Sub-millisecond precision can be achieved using decimals.
 If not provided,
 the current time will be used
 
-** `traceparent` - The traceparent header received from a remote service (string)
+** `childOf` - The traceparent header received from a remote service (string)
 
 Use this function to create a custom transaction.
 Note that the agent will do this for you automatically whenever your application receives an incoming HTTP request.

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -10,9 +10,7 @@ module.exports = GenericSpan
 
 function GenericSpan (agent, type, opts) {
   this._timer = new Timer(opts.timer, opts.startTime)
-  this._context = opts.traceContext
-    ? opts.traceContext.child()
-    : TraceContext.startOrResume(opts.traceparent, agent._conf)
+  this._context = TraceContext.startOrResume(opts.childOf, agent._conf)
   this._agent = agent
   this._tags = null
 

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -144,9 +144,8 @@ Instrumentation.prototype.addEndedSpan = function (span) {
 }
 
 Instrumentation.prototype.startTransaction = function (name, type, opts) {
-  // To be backwards compatible with the old API, we also accept the
-  // traceparent as a string
-  if (typeof opts === 'string') opts = { traceparent: opts }
+  // To be backwards compatible with the old API, we also accept a `traceparent` string
+  if (typeof opts === 'string') opts = { childOf: opts }
 
   return new Transaction(this._agent, name, type, opts)
 }

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -19,12 +19,12 @@ function Span (transaction, name, type, opts) {
   if (!opts) {
     opts = {
       timer: transaction._timer,
-      traceContext: (transaction._agent._instrumentation.activeSpan || transaction)._context
+      childOf: transaction._agent._instrumentation.activeSpan || transaction
     }
   } else {
     opts.timer = transaction._timer
-    if (!opts.traceparent && !opts.traceContext) {
-      opts.traceContext = (transaction._agent._instrumentation.activeSpan || transaction)._context
+    if (!opts.childOf) {
+      opts.childOf = transaction._agent._instrumentation.activeSpan || transaction
     }
   }
 

--- a/lib/instrumentation/trace-context.js
+++ b/lib/instrumentation/trace-context.js
@@ -2,12 +2,6 @@
 
 const { randomFillSync } = require('random-poly-fill') // TODO: Remove when Node.js 6 is no longer supported
 
-// Avoid circular require dependency
-let GenericSpan = {}
-process.nextTick(function () {
-  GenericSpan = require('./generic-span')
-})
-
 const SIZES = {
   version: 1,
   traceId: 16,
@@ -134,7 +128,7 @@ class TraceContext {
 
   static startOrResume (childOf, conf) {
     if (childOf instanceof TraceContext) return childOf.child()
-    if (childOf instanceof GenericSpan) return childOf._context.child()
+    if (childOf && childOf._context instanceof TraceContext) return childOf._context.child()
 
     return isValidHeader(childOf)
       ? resume(childOf)

--- a/lib/instrumentation/trace-context.js
+++ b/lib/instrumentation/trace-context.js
@@ -2,6 +2,12 @@
 
 const { randomFillSync } = require('random-poly-fill') // TODO: Remove when Node.js 6 is no longer supported
 
+// Avoid circular require dependency
+let GenericSpan = {}
+process.nextTick(function () {
+  GenericSpan = require('./generic-span')
+})
+
 const SIZES = {
   version: 1,
   traceId: 16,
@@ -126,9 +132,12 @@ class TraceContext {
     })
   }
 
-  static startOrResume (traceparent, conf) {
-    return isValidHeader(traceparent)
-      ? resume(traceparent)
+  static startOrResume (childOf, conf) {
+    if (childOf instanceof TraceContext) return childOf.child()
+    if (childOf instanceof GenericSpan) return childOf._context.child()
+
+    return isValidHeader(childOf)
+      ? resume(childOf)
       : start(Math.random() <= conf.transactionSampleRate)
   }
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -93,9 +93,8 @@ Transaction.prototype.startSpan = function (name, type, opts) {
   }
   this._builtSpans++
 
-  // To be backwards compatible with the old API, we also accept the
-  // traceparent as a string
-  if (typeof opts === 'string') opts = { traceparent: opts }
+  // To be backwards compatible with the old API, we also accept a `traceparent` string
+  if (typeof opts === 'string') opts = { childOf: opts }
 
   return new Span(this, name, type, opts)
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -36,11 +36,11 @@ test('#startTransaction()', function (t) {
     t.end()
   })
 
-  t.test('options.traceparent', function (t) {
+  t.test('options.childOf', function (t) {
     var agent = Agent()
     agent.start()
-    var traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-    var trans = agent.startTransaction('foo', 'bar', { traceparent })
+    var childOf = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    var trans = agent.startTransaction('foo', 'bar', { childOf })
     t.equal(trans._context.version, '00')
     t.equal(trans._context.traceId, '4bf92f3577b34da6a3ce929d0e0e4736')
     t.notEqual(trans._context.id, '00f067aa0ba902b7')
@@ -208,12 +208,12 @@ test('#startSpan()', function (t) {
     t.end()
   })
 
-  t.test('options.traceparent', function (t) {
+  t.test('options.childOf', function (t) {
     var agent = Agent()
     agent.start()
     agent.startTransaction()
-    var traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-    var span = agent.startSpan(null, null, { traceparent })
+    var childOf = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    var span = agent.startSpan(null, null, { childOf })
     t.equal(span._context.version, '00')
     t.equal(span._context.traceId, '4bf92f3577b34da6a3ce929d0e0e4736')
     t.notEqual(span._context.id, '00f067aa0ba902b7')

--- a/test/instrumentation/span.js
+++ b/test/instrumentation/span.js
@@ -24,10 +24,10 @@ test('init', function (t) {
     t.end()
   })
 
-  t.test('options.traceparent', function (t) {
-    var traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+  t.test('options.childOf', function (t) {
+    var childOf = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
     var trans = new Transaction(agent)
-    var span = new Span(trans, 'sig', 'type', { traceparent })
+    var span = new Span(trans, 'sig', 'type', { childOf })
     t.equal(span._context.version, '00')
     t.equal(span._context.traceId, '4bf92f3577b34da6a3ce929d0e0e4736')
     t.notEqual(span._context.id, '00f067aa0ba902b7')
@@ -65,9 +65,8 @@ test('#duration() - return null if not ended', function (t) {
 
 test('custom start time', function (t) {
   var trans = new Transaction(agent)
-  var traceparent = trans._context.toString()
   var startTime = Date.now() - 1000
-  var span = new Span(trans, 'sig', 'type', { traceparent, startTime })
+  var span = new Span(trans, 'sig', 'type', { childOf: trans, startTime })
   span.end()
   var duration = span.duration()
   t.ok(duration > 999, `duration should be circa more than 1s (was: ${duration})`) // we've seen 999.9 in the wild
@@ -77,10 +76,9 @@ test('custom start time', function (t) {
 
 test('#end(time)', function (t) {
   var trans = new Transaction(agent)
-  var traceparent = trans._context.toString()
   var startTime = Date.now() - 1000
   var endTime = startTime + 2000.123
-  var span = new Span(trans, 'sig', 'type', { traceparent, startTime })
+  var span = new Span(trans, 'sig', 'type', { childOf: trans, startTime })
   span.end(endTime)
   t.equal(span.duration(), 2000.123)
   t.end()

--- a/test/instrumentation/trace-context.js
+++ b/test/instrumentation/trace-context.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto')
 const test = require('tape')
 
+const agent = require('./_agent')()
 const TraceContext = require('../../lib/instrumentation/trace-context')
 
 const version = Buffer.alloc(1).toString('hex')
@@ -64,6 +65,47 @@ test('toJSON', t => {
 test('startOrResume', t => {
   t.test('resume from header', t => {
     const context = TraceContext.startOrResume(header)
+
+    isValid(t, context)
+    t.equal(context.version, version, 'version matches')
+    t.equal(context.traceId, traceId, 'traceId matches')
+    t.notEqual(context.id, id, 'has new id')
+    t.equal(context.flags, flags, 'flags matches')
+
+    t.end()
+  })
+
+  t.test('resume from TraceContext', t => {
+    const context = TraceContext.startOrResume(
+      TraceContext.fromString(header)
+    )
+
+    isValid(t, context)
+    t.equal(context.version, version, 'version matches')
+    t.equal(context.traceId, traceId, 'traceId matches')
+    t.notEqual(context.id, id, 'has new id')
+    t.equal(context.flags, flags, 'flags matches')
+
+    t.end()
+  })
+
+  t.test('resume from Transaction', t => {
+    const trans = agent.startTransaction(null, null, { childOf: header })
+    const context = TraceContext.startOrResume(trans)
+
+    isValid(t, context)
+    t.equal(context.version, version, 'version matches')
+    t.equal(context.traceId, traceId, 'traceId matches')
+    t.notEqual(context.id, id, 'has new id')
+    t.equal(context.flags, flags, 'flags matches')
+
+    t.end()
+  })
+
+  t.test('resume from Span', t => {
+    const trans = agent.startTransaction(null, null, { childOf: header })
+    const span = trans.startSpan()
+    const context = TraceContext.startOrResume(span)
 
     isValid(t, context)
     t.equal(context.version, version, 'version matches')

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -22,9 +22,9 @@ test('init', function (t) {
     t.end()
   })
 
-  t.test('options.traceparent', function (t) {
-    var traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-    var trans = new Transaction(agent, 'name', 'type', { traceparent })
+  t.test('options.childOf', function (t) {
+    var childOf = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    var trans = new Transaction(agent, 'name', 'type', { childOf })
     t.equal(trans._context.version, '00')
     t.equal(trans._context.traceId, '4bf92f3577b34da6a3ce929d0e0e4736')
     t.notEqual(trans._context.id, '00f067aa0ba902b7')
@@ -150,10 +150,10 @@ test('#startSpan()', function (t) {
     t.end()
   })
 
-  t.test('options.traceparent', function (t) {
+  t.test('options.childOf', function (t) {
     var trans = new Transaction(agent)
-    var traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
-    var span = trans.startSpan(null, null, { traceparent })
+    var childOf = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    var span = trans.startSpan(null, null, { childOf })
     t.equal(span._context.version, '00')
     t.equal(span._context.traceId, '4bf92f3577b34da6a3ce929d0e0e4736')
     t.notEqual(span._context.id, '00f067aa0ba902b7')


### PR DESCRIPTION
Simplify the API for marking a span or transaction as a child of another span or transaction, either local to the process or across processes via the `traceparent` header.

A parent can now be provided either as a Transaction, Span, or TraceContext object, or as a `traceparent` string. And no matter which format the parent is provided in, the parameter name is `childOf`.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation