### PR TITLE
test(mock): add sendMetricSet to http client mock

### DIFF
--- a/test/_mock_http_client.js
+++ b/test/_mock_http_client.js
@@ -36,6 +36,9 @@ module.exports = function (expected, done) {
     sendError (error, cb) {
       this._write({ error }, cb)
     },
+    sendMetricSet (error, cb) {
+      this._write({ error }, cb)
+    },
     flush (cb) {
       if (cb) process.nextTick(cb)
     }


### PR DESCRIPTION
This part of the mock was not actually used in the test suite, so it never failed any tests, but it resulted in some test output log spam.