### PR TITLE
test(apollo-server-express): exclude range broken by core-js

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -156,21 +156,21 @@ apollo-server-express-2_12:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.12.0
-  versions: '>=2.0.2'
+  versions: '>=2.0.2 <2.2 || >= 2.3.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_13:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.13.0
-  versions: '>=2.0.2'
+  versions: '>=2.0.2 <2.2 || >= 2.3.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_14:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
-  versions: '>=2.0.2'
+  versions: '>=2.0.2 <2.2 || >= 2.3.2'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 


### PR DESCRIPTION
The previously passing range of apollo-server-express versions is now failing due to a breaking change in an in-range version of core-js, which it depends on. This excludes that range.

See: https://github.com/apollographql/apollo-tooling/issues/962
