### PR TITLE
ci: fix agent mock metricsInterval

### DIFF
--- a/test/instrumentation/_agent.js
+++ b/test/instrumentation/_agent.js
@@ -28,7 +28,8 @@ module.exports = function mockAgent (expected, cb) {
       ignoreUserAgentRegExp: [],
       transactionSampleRate: 1.0,
       disableInstrumentations: [],
-      captureHeaders: true
+      captureHeaders: true,
+      metricsInterval: 0
     },
     _errorFilters: new Filters(),
     _transactionFilters: new Filters(),


### PR DESCRIPTION
Tests using the agent mock were not exiting properly due to the metrics reporter not being disabled.