### PR TITLE
ci: pin tape as 4.10 breaks test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "rimraf": "^2.6.2",
     "send": "^0.16.2",
     "standard": "^12.0.1",
-    "tape": "^4.9.1",
+    "tape": "4.9.x",
     "tedious": "^2.6.1",
     "test-all-versions": "^4.0.0",
     "thunky": "^1.0.3",


### PR DESCRIPTION
Prior to 4.10, it was possible to create nested tests without needing to call `t.end()`. This was considered a bug and the capability was removed in 4.10, however our test suite is currently heavily dependent on this behaviour.

Fixes #845 
Fixes #846 
Fixes #847 

Related substack/tape#459