### PR TITLE
Improve koa transaction name

### DIFF
--- a/lib/instrumentation/modules/koa.js
+++ b/lib/instrumentation/modules/koa.js
@@ -1,10 +1,43 @@
 'use strict'
 
+var semver = require('semver')
+
+var shimmer = require('../shimmer')
+
 module.exports = function (koa, agent, version, enabled) {
   if (!enabled) return koa
 
   if (!agent._conf.frameworkName) agent._conf.frameworkName = 'koa'
   if (!agent._conf.frameworkVersion) agent._conf.frameworkVersion = version
 
+  if (!semver.satisfies(version, '>=0.1.0')) {
+    agent.logger.debug('koa version %s not supported - aborting...', version)
+    return koa
+  }
+
+  agent.logger.debug('shimming koa prototype.createContext function')
+  shimmer.wrap(koa.prototype, 'createContext', function (orig) {
+    return function (req, res) {
+      var context = orig.apply(this, arguments)
+
+      var method = context.method
+      var path = context.path
+
+      if (typeof method !== 'string') {
+        agent.logger.debug('unexpected method type in koa prototype.createContext: %s', typeof method)
+        return context
+      }
+
+      if (typeof path !== 'string') {
+        agent.logger.debug('unexpected path type in koa prototype.createContext: %s', typeof path)
+        return context
+      }
+
+      var name = method + ' ' + path
+      agent._instrumentation.setDefaultTransactionName(name)
+
+      return context
+    }
+  })
   return koa
 }


### PR DESCRIPTION
In `koa` application, the transaction name is `${method} unknown route` if the request respond before reaching `koa-router` middleware.

With this change, the transaction name will be set properly. This change doesn't affect to `koa-router`'s instrumentation because it happens before `koa-router`'s instrumentation. The transaction name will be overwrited by `koa-router` if the request reached to `koa-router` middleware.

This change needs `koa` version `>=0.1.0` because of `createContext` method. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update documentation
