### PR TITLE
[APM-CI] some exceptions are not convert to String when you call error step error step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ def generateStep(version, tav = ''){
           }
         }
       } catch(e){
-        error(e)
+        error(e.toString())
       } finally {
         junit(allowEmptyResults: true,
           keepLongStdio: true,


### PR DESCRIPTION
* Convert the exception always to string before to call error

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [NA] Add tests
- [NA] Update documentation
