### PR TITLE
fix(metrics): prevent 0ms timers from being created

### DIFF
--- a/lib/metrics/registry.js
+++ b/lib/metrics/registry.js
@@ -21,7 +21,8 @@ class MetricsRegistry extends SelfReportingMetricsRegistry {
     const options = Object.assign({}, defaultReporterOptions, reporterOptions)
     const reporter = new MetricsReporter(transport, options)
     super(reporter, registryOptions)
-    createSystemMetrics(this, options.defaultReportingIntervalInSeconds)
+    const interval = options.defaultReportingIntervalInSeconds
+    if (interval) createSystemMetrics(this, interval)
   }
 
   shutdown () {


### PR DESCRIPTION
Apparently timers with a duration of 0 do not always unref correctly on Node 6. This PR prevents the linux platform stats collector from starting a timer if the given duration is zero.

This was the cause of Jenkins hanging sometimes on Node 6.x.