### PR TITLE
feat: Accept parent transaction in lambda wrapper

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -89,7 +89,13 @@ module.exports = function elasticApmAwsLambda (agent) {
     }
 
     return function wrappedLambda (payload, context, callback) {
-      const trans = agent.startTransaction(context.functionName, type)
+      let parentId
+      if (payload.headers !== undefined) {
+        parentId = payload.headers['elastic-apm-traceparent']
+      }
+      const trans = agent.startTransaction(context.functionName, type, {
+        childOf: parentId
+      })
 
       // Wrap context and callback to finish and send transaction
       context = wrapContext(trans, payload, context)

--- a/test/lambda/mock/agent.js
+++ b/test/lambda/mock/agent.js
@@ -7,8 +7,8 @@ module.exports = class AgentMock {
     this.errors = []
   }
 
-  startTransaction (name, type) {
-    const trans = new TransactionMock(name, type)
+  startTransaction (name, type, opts) {
+    const trans = new TransactionMock(name, type, opts)
     this.transactions.push(trans)
     return trans
   }

--- a/test/lambda/mock/transaction.js
+++ b/test/lambda/mock/transaction.js
@@ -1,9 +1,10 @@
 module.exports = class TransactionMock {
-  constructor (name, type) {
+  constructor (name, type, opts) {
     this.name = name
     this.type = type
     this.ended = false
     this.customContext = {}
+    this.opts = opts
   }
 
   setCustomContext (custom) {

--- a/test/lambda/promises.js
+++ b/test/lambda/promises.js
@@ -46,6 +46,49 @@ test('resolve', function (t) {
   })
 })
 
+test('resolve with parent id header present', function (t) {
+  const name = 'greet.hello'
+  const input = {
+    name: 'world',
+    headers: {
+      'elastic-apm-traceparent': 'test'
+    }
+  }
+  const output = 'Hello, world!'
+  let context
+
+  const agent = new AgentMock()
+  const wrap = lambda(agent)
+
+  lambdaLocal.execute({
+    event: input,
+    lambdaFunc: {
+      [name]: wrap((payload, _context) => {
+        context = _context
+        return Promise.resolve(`Hello, ${payload.name}!`)
+      })
+    },
+    lambdaHandler: name,
+    timeoutMs: 3000,
+    verboseLevel: 0,
+    callback: function (err, result) {
+      t.error(err)
+      t.equal(result, output)
+
+      t.ok(agent.flushed)
+
+      t.equal(agent.errors.length, 0)
+
+      t.equal(agent.transactions.length, 1)
+      assertTransaction(t, agent.transactions[0], name, context, input, output)
+
+      t.equal(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
+
+      t.end()
+    }
+  })
+})
+
 test('reject', function (t) {
   const name = 'fn.fail'
   const input = {}


### PR DESCRIPTION
Looks for the `elastic-apm-traceparent` header in the lambda event, using it as the parent transaction ID if it is found.

### Checklist

- [x] Implement code
- [x] Add tests
