### PR TITLE
chore(package): bump elastic-apm-http-client to ^7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "console-log-level": "^1.4.0",
     "cookie": "^0.3.1",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "^7.1.0",
+    "elastic-apm-http-client": "^7.1.1",
     "end-of-stream": "^1.4.1",
     "fast-safe-stringify": "^2.0.6",
     "http-headers": "^3.0.2",


### PR DESCRIPTION
This version includes a fix that ensures that all reported http headers
are always strings or array of strings.

Fixes #888