### PR TITLE
feat(config): add usePathAsTransactionName config option

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -382,6 +382,15 @@ A capture location stack trace is never generated for uncaught exceptions.
 
 Set this option to `false` to disable capture of stack traces for measured spans during instrumentation.
 
+[[use-path-as-transaction-name]]
+==== `usePathAsTransactionName`
+
+* *Type:* Boolean
+* *Default:* `false`
+* *Env:* `ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME`
+
+Set this option to `true` to use the URL path as the transaction name if no other route could be determined. If the agent do not support your router, you can set this option to `true` to use specific URL path as the transaction name instead of `GET unknown route`.
+
 [[source-context-error]]
 ==== `sourceLinesErrorAppFrames` + `sourceLinesErrorLibraryFrames`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,6 +65,7 @@ var DEFAULTS = {
   kubernetesPodUID: undefined,
   captureHeaders: true,
   metricsInterval: '30s',
+  usePathAsTransactionName: false,
   addPatch: undefined
 }
 
@@ -108,6 +109,7 @@ var ENV_TABLE = {
   kubernetesPodUID: 'ELASTIC_APM_KUBERNETES_POD_UID',
   captureHeaders: 'ELASTIC_APM_CAPTURE_HEADERS',
   metricsInterval: 'ELASTIC_APM_METRICS_INTERVAL',
+  usePathAsTransactionName: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
   addPatch: 'ELASTIC_APM_ADD_PATCH'
 }
 
@@ -120,7 +122,8 @@ var BOOL_OPTS = [
   'errorOnAbortedRequests',
   'instrument',
   'asyncHooks',
-  'captureHeaders'
+  'captureHeaders',
+  'usePathAsTransactionName'
 ]
 
 var NUM_OPTS = [

--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -1,5 +1,11 @@
 'use strict'
 
+var parseUrl
+try {
+  parseUrl = require('parseurl')
+} catch (e) {
+  parseUrl = require('url').parse
+}
 var symbols = require('../symbols')
 
 function ensureSlash (value) {
@@ -28,7 +34,7 @@ function getStackPath (req) {
 
 // This function is also able to extract the path from a Restify request as
 // it's storing the route name on req.route.path as well
-function getPathFromRequest (req, useBase) {
+function getPathFromRequest (req, useBase, usePathAsTransactionName) {
   // Static serving route
   if (req[symbols.staticFile]) {
     return 'static file'
@@ -43,6 +49,12 @@ function getPathFromRequest (req, useBase) {
 
   if (useBase) {
     return path
+  }
+
+  // Enable usePathAsTransactionName config
+  if (usePathAsTransactionName) {
+    const parsed = parseUrl(req)
+    return parsed && parsed.pathname
   }
 }
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -160,7 +160,7 @@ Transaction.prototype.setDefaultName = function (name) {
 
 Transaction.prototype.setDefaultNameFromRequest = function () {
   var req = this.req
-  var path = getPathFromRequest(req)
+  var path = getPathFromRequest(req, false, this._agent._conf.usePathAsTransactionName)
 
   if (!path) {
     this._agent.logger.debug('could not extract route name from request %o', {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coverage:report": "nyc report --reporter=lcov",
     "test": "./test/script/run_tests.sh",
     "test:cli": "node test/script/cli.js",
-    "test:deps": "dependency-check . -i async_hooks && dependency-check . --unused --no-dev --entry lib/instrumentation/modules/*",
+    "test:deps": "dependency-check . -i async_hooks -i parseurl && dependency-check . --unused --no-dev --entry lib/instrumentation/modules/*",
     "test:tav": "tav --quiet",
     "test:docs": "./test/script/docker/run_docs.sh",
     "test:types": "tsc --project test/types/tsconfig.json && tsc --project test/types/transpile/tsconfig.json && node test/types/transpile/index.js",


### PR DESCRIPTION
Closes elastic/apm-agent-nodejs#904 
Add usePathAsTransactionName config option.
elastic/apm-agent-nodejs#903 
elastic/apm-agent-nodejs#850 


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
