### PR TITLE
chore: make Agent method signatures more explicit

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -67,19 +67,19 @@ Agent.prototype.destroy = function () {
   if (this._transport) this._transport.destroy()
 }
 
-Agent.prototype.startTransaction = function () {
+Agent.prototype.startTransaction = function (name, type, { startTime, childOf } = {}) {
   return this._instrumentation.startTransaction.apply(this._instrumentation, arguments)
 }
 
-Agent.prototype.endTransaction = function () {
+Agent.prototype.endTransaction = function (result, endTime) {
   return this._instrumentation.endTransaction.apply(this._instrumentation, arguments)
 }
 
-Agent.prototype.setTransactionName = function () {
+Agent.prototype.setTransactionName = function (name) {
   return this._instrumentation.setTransactionName.apply(this._instrumentation, arguments)
 }
 
-Agent.prototype.startSpan = function () {
+Agent.prototype.startSpan = function (name, type, { childOf } = {}) {
   return this._instrumentation.startSpan.apply(this._instrumentation, arguments)
 }
 


### PR DESCRIPTION
This should improve autocompletion and hints in editors like VS Code.

Here are some example screenshots of how this changes the experience in VS Code:

![image](https://user-images.githubusercontent.com/10602/54205510-ca588600-44d6-11e9-81af-6a92de758044.png)

![image](https://user-images.githubusercontent.com/10602/54205545-dcd2bf80-44d6-11e9-809b-8aefae0bfe2f.png)

Gotcha: Because there already exist TypeScript definitions on DefinitelyTyped, those will actually overwrite any in-code hints like these, so if the users editor is set up to download type definitions from DefinitelyTyped, this will not have any effect (related: #917).