### PR TITLE
fix: bind the agent.flush callback

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -347,7 +347,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
     if (agent._transport) {
       agent.logger.info(`Sending error to Elastic APM`, { id: error.id })
       agent._transport.sendError(error, function () {
-        agent._transport.flush(function (err) {
+        agent.flush(function (err) {
           if (cb) cb(err, error.id)
         })
       })
@@ -381,7 +381,8 @@ Agent.prototype.handleUncaughtExceptions = function (cb) {
 
 Agent.prototype.flush = function (cb) {
   if (this._transport) {
-    this._transport.flush(cb)
+    // TODO: Only bind the callback if the transport can't use AsyncResource from async hooks
+    this._transport.flush(this._instrumentation.bindFunction(cb))
   } else {
     this.logger.warn(new Error('cannot flush agent before it is started'))
     process.nextTick(cb)


### PR DESCRIPTION
Before this, we might have lost context in case the callback was queued internally in the http client (which would often happen).

There's another issue to use AsyncResource in the http client: https://github.com/elastic/apm-nodejs-http-client/issues/48