### PR TITLE
chore(package): update measured-reporting to 1.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "fast-safe-stringify": "^2.0.6",
     "http-headers": "^3.0.2",
     "is-native": "^1.0.1",
-    "measured-reporting": "^1.39.1",
+    "measured-reporting": "^1.41.0",
     "object-filter-sequence": "^1.0.0",
     "original-url": "^1.2.2",
     "read-pkg-up": "^4.0.0",


### PR DESCRIPTION
This release replaces the bunyan reporter with console-log-level. The reason for this is because bunyan has an optional dependency on the dtrace-provider native module. While optional dependencies are generally fine to fail installing, it's problematic with a native module because it may fail to install on Windows due to not having Python installed, which actually fails the entire install process, not just the optional dependency install.

Fixes #900