### PR TITLE
fix(agent): allow flush callback to be undefined

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -382,10 +382,10 @@ Agent.prototype.handleUncaughtExceptions = function (cb) {
 Agent.prototype.flush = function (cb) {
   if (this._transport) {
     // TODO: Only bind the callback if the transport can't use AsyncResource from async hooks
-    this._transport.flush(this._instrumentation.bindFunction(cb))
+    this._transport.flush(cb && this._instrumentation.bindFunction(cb))
   } else {
     this.logger.warn(new Error('cannot flush agent before it is started'))
-    process.nextTick(cb)
+    if (cb) process.nextTick(cb)
   }
 }
 


### PR DESCRIPTION
It has always been specified as optional in the docs, but the code didn't allow it.