### PR TITLE
fix(transaction): don't set transaction result of it's null

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -190,7 +190,7 @@ Transaction.prototype.end = function (result, endTime) {
     return
   }
 
-  if (result !== undefined) {
+  if (result !== undefined && result !== null) {
     this.result = result
   }
 


### PR DESCRIPTION
I found this when I was implementing the TypeScript `.d.ts` file