### PR TITLE
chore(npm): add missing files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,11 @@
 # Files to ignore
+.DS_Store
 .appveyor.yml
 .backportrc.json
 .codecov.yml
 .tav.yml
 .travis.yml
+.vscode
 CONTRIBUTING.md
 CODE_OF_CONDUCT.md
 TESTING.md


### PR DESCRIPTION
These two files had been added to `.gitignore` previously, so we should also add them here.

Together with #941, this should clean up our npm build