### PR TITLE
fix(package): bump elastic-apm-http-client to ^7.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "console-log-level": "^1.4.0",
     "cookie": "^0.3.1",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "^7.1.1",
+    "elastic-apm-http-client": "^7.1.2",
     "end-of-stream": "^1.4.1",
     "fast-safe-stringify": "^2.0.6",
     "http-headers": "^3.0.2",


### PR DESCRIPTION
This version includes fixes for AWS Lambda context mutation issues when using the `agent.lambda()` API.