### PR TITLE
fix: don't add traceparent header to S3 requests

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -4,6 +4,8 @@ var url = require('url')
 
 var endOfStream = require('end-of-stream')
 
+const s3Host = /\.s3\.amazonaws\.com$/
+
 const transactionForResponse = new WeakMap()
 exports.transactionForResponse = transactionForResponse
 
@@ -123,7 +125,7 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
       // to indicate requested services should not be sampled.
       // Use the transaction context as the parent, in this case.
       var parent = span || agent.currentTransaction
-      if (parent && parent._context) {
+      if (parent && parent._context && shouldPropagateTraceContext(options.host)) {
         options.headers['elastic-apm-traceparent'] = parent._context.toString()
       }
 
@@ -174,4 +176,8 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
       }
     }
   }
+}
+
+function shouldPropagateTraceContext (host) {
+  return !s3Host.test(host)
 }


### PR DESCRIPTION
This would make the request fail by invalidating the request signature and return this error:

    SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.

Brought to my attention by this post: https://discuss.elastic.co/t/aws-s3-getobject-failure-signature-mismatch-while-updating-apm-to-2-x/173275/3