### PR TITLE
fix: instrument http/https.get requests

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -94,7 +94,7 @@ function ensureUrl (v) {
   }
 }
 
-exports.traceOutgoingRequest = function (agent, moduleName) {
+exports.traceOutgoingRequest = function (agent, moduleName, method) {
   var spanType = 'ext.' + moduleName + '.http'
   var ins = agent._instrumentation
 
@@ -103,7 +103,7 @@ exports.traceOutgoingRequest = function (agent, moduleName) {
       var span = agent.startSpan(null, spanType)
       var id = span && span.transaction.id
 
-      agent.logger.debug('intercepted call to %s.request %o', moduleName, { id: id })
+      agent.logger.debug('intercepted call to %s.%s %o', moduleName, method, { id: id })
 
       var options = {}
       var newArgs = [ options ]

--- a/lib/instrumentation/modules/http.js
+++ b/lib/instrumentation/modules/http.js
@@ -11,11 +11,11 @@ module.exports = function (http, agent, { enabled }) {
   shimmer.wrap(http && http.Server && http.Server.prototype, 'emit', httpShared.instrumentRequest(agent, 'http'))
 
   agent.logger.debug('shimming http.request function')
-  shimmer.wrap(http, 'request', httpShared.traceOutgoingRequest(agent, 'http'))
+  shimmer.wrap(http, 'request', httpShared.traceOutgoingRequest(agent, 'http', 'request'))
 
   if (semver.gte(process.version, '8.0.0')) {
     agent.logger.debug('shimming http.get function')
-    shimmer.wrap(http, 'get', httpShared.traceOutgoingRequest(agent, 'http'))
+    shimmer.wrap(http, 'get', httpShared.traceOutgoingRequest(agent, 'http', 'get'))
   }
 
   agent.logger.debug('shimming http.ServerResponse.prototype.writeHead function')

--- a/lib/instrumentation/modules/http.js
+++ b/lib/instrumentation/modules/http.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var semver = require('semver')
+
 var httpShared = require('../http-shared')
 var shimmer = require('../shimmer')
 
@@ -10,6 +12,11 @@ module.exports = function (http, agent, { enabled }) {
 
   agent.logger.debug('shimming http.request function')
   shimmer.wrap(http, 'request', httpShared.traceOutgoingRequest(agent, 'http'))
+
+  if (semver.gte(process.version, '8.0.0')) {
+    agent.logger.debug('shimming http.get function')
+    shimmer.wrap(http, 'get', httpShared.traceOutgoingRequest(agent, 'http'))
+  }
 
   agent.logger.debug('shimming http.ServerResponse.prototype.writeHead function')
   shimmer.wrap(http && http.ServerResponse && http.ServerResponse.prototype, 'writeHead', wrapWriteHead)

--- a/lib/instrumentation/modules/https.js
+++ b/lib/instrumentation/modules/https.js
@@ -19,10 +19,10 @@ module.exports = function (https, agent, { version, enabled }) {
   // https://github.com/nodejs/node/commit/5118f3146643dc55e7e7bd3082d1de4d0e7d5426
   if (semver.gte(version, '9.0.0')) {
     agent.logger.debug('shimming https.request function')
-    shimmer.wrap(https, 'request', httpShared.traceOutgoingRequest(agent, 'https'))
+    shimmer.wrap(https, 'request', httpShared.traceOutgoingRequest(agent, 'https', 'request'))
 
     agent.logger.debug('shimming https.get function')
-    shimmer.wrap(https, 'get', httpShared.traceOutgoingRequest(agent, 'https'))
+    shimmer.wrap(https, 'get', httpShared.traceOutgoingRequest(agent, 'https', 'get'))
   }
 
   return https

--- a/lib/instrumentation/modules/https.js
+++ b/lib/instrumentation/modules/https.js
@@ -20,6 +20,9 @@ module.exports = function (https, agent, { version, enabled }) {
   if (semver.gte(version, '9.0.0')) {
     agent.logger.debug('shimming https.request function')
     shimmer.wrap(https, 'request', httpShared.traceOutgoingRequest(agent, 'https'))
+
+    agent.logger.debug('shimming https.get function')
+    shimmer.wrap(https, 'get', httpShared.traceOutgoingRequest(agent, 'https'))
   }
 
   return https

--- a/test/instrumentation/modules/http/aborted-requests-enabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-enabled.js
@@ -45,7 +45,7 @@ test('client-side abort below error threshold - call end', function (t) {
 
   server.listen(function () {
     var port = server.address().port
-    clientReq = http.get('http://localhost:' + port, function (res) {
+    clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -88,7 +88,7 @@ test('client-side abort above error threshold - call end', function (t) {
 
   server.listen(function () {
     var port = server.address().port
-    clientReq = http.get('http://localhost:' + port, function (res) {
+    clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -127,7 +127,7 @@ test('client-side abort below error threshold - don\'t call end', function (t) {
 
   server.listen(function () {
     var port = server.address().port
-    clientReq = http.get('http://localhost:' + port, function (res) {
+    clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -165,7 +165,7 @@ test('client-side abort above error threshold - don\'t call end', function (t) {
 
   server.listen(function () {
     var port = server.address().port
-    clientReq = http.get('http://localhost:' + port, function (res) {
+    clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -206,7 +206,7 @@ test('server-side abort below error threshold and socket closed - call end', fun
 
   server.listen(function () {
     var port = server.address().port
-    var clientReq = http.get('http://localhost:' + port, function (res) {
+    var clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -249,7 +249,7 @@ test('server-side abort above error threshold and socket closed - call end', fun
 
   server.listen(function () {
     var port = server.address().port
-    var clientReq = http.get('http://localhost:' + port, function (res) {
+    var clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -289,7 +289,7 @@ test('server-side abort below error threshold and socket closed - don\'t call en
 
   server.listen(function () {
     var port = server.address().port
-    var clientReq = http.get('http://localhost:' + port, function (res) {
+    var clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -330,7 +330,7 @@ test('server-side abort above error threshold and socket closed - don\'t call en
 
   server.listen(function () {
     var port = server.address().port
-    var clientReq = http.get('http://localhost:' + port, function (res) {
+    var clientReq = get('http://localhost:' + port, function (res) {
       t.fail('should not call http.get callback')
     })
     clientReq.on('error', function (err) {
@@ -369,7 +369,7 @@ test('server-side abort below error threshold but socket not closed - call end',
 
   server.listen(function () {
     var port = server.address().port
-    http.get('http://localhost:' + port, function (res) {
+    get('http://localhost:' + port, function (res) {
       res.on('end', function () {
         t.equal(agent._transport._writes.length, 1, 'should send transactions')
       })
@@ -407,7 +407,7 @@ test('server-side abort above error threshold but socket not closed - call end',
 
   server.listen(function () {
     var port = server.address().port
-    http.get('http://localhost:' + port, function (res) {
+    get('http://localhost:' + port, function (res) {
       res.on('end', function () {
         t.equal(agent._transport._writes.length, 1, 'should send transactions')
       })
@@ -419,4 +419,9 @@ test('server-side abort above error threshold but socket not closed - call end',
 function resetAgent (cb) {
   agent._instrumentation.currentTransaction = null
   agent._transport = mockClient(1, cb)
+}
+
+function get () {
+  agent._instrumentation.currentTransaction = null
+  return http.get.apply(http, arguments)
 }


### PR DESCRIPTION
For `http.get` this was broken in Node.js 8 and up
For `https.get` this was broken in Node.js 9 and up

Fixes #953