### PR TITLE
fix(instrumentation): explicitly use `require`

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -68,7 +68,7 @@ function Instrumentation (agent) {
   this._patches = new NamedArray()
 
   for (let mod of MODULES) {
-    this.addPatch(mod, require.resolve(`./modules/${mod}`))
+    this.addPatch(mod, require(`./modules/${mod}`))
   }
 }
 


### PR DESCRIPTION
Closes the webpack issue causing https://github.com/elastic/apm-agent-nodejs/issues/955. Personally, I'd just avoid the API where people can define paths at all - it'll never work in bundlers and it just adds additional code. I'm not sure I understand the value except late requires, but that seems negligible.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update documentation