### PR TITLE
[docs] Add release notes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -47,4 +47,6 @@ include::./upgrading.asciidoc[]
 
 include::./troubleshooting.asciidoc[]
 
+include::./release-notes.asciidoc[]
+
 include::./redirects.asciidoc[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,0 +1,4 @@
+[[release-notes]]
+== Release notes
+
+Release notes are published in the https://github.com/elastic/apm-agent-nodejs/blob/master/CHANGELOG.md[changelog].


### PR DESCRIPTION
See https://github.com/elastic/apm/issues/68.

Adds a link to release notes.