### PR TITLE
fix: don't add response listener to outgoing requests

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -102,6 +102,8 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
 
   return function (orig) {
     return function (...args) {
+      // TODO: See if we can delay the creation of span until the `response`
+      // event is fired, while still having it have the correct stack trace
       var span = agent.startSpan(null, spanType)
       var id = span && span.transaction.id
 
@@ -144,6 +146,9 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
 
       span.name = req.method + ' ' + req._headers.host + url.parse(req.path).pathname
 
+      // TODO: Research if it's possible to add this to the prototype instead.
+      // Or if it's somehow preferable to listen for when a `response` listener
+      // is added instead of when `response` is emitted.
       const emit = req.emit
       req.emit = function (type, res) {
         if (type === 'response') onresponse(res)

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -143,7 +143,12 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       ins.bindEmitter(req)
 
       span.name = req.method + ' ' + req._headers.host + url.parse(req.path).pathname
-      req.on('response', onresponse)
+
+      const emit = req.emit
+      req.emit = function (type, res) {
+        if (type === 'response') onresponse(res)
+        return emit.apply(req, arguments)
+      }
 
       return req
 


### PR DESCRIPTION
The very act of adding a `response` listener to outgoing requests could trigger a memory leak in case the user didn't also attach a `response` listener.