### PR TITLE
fix(agent): set package.json

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -136,10 +136,8 @@ Agent.prototype.start = function (opts) {
     this._conf.active = false
     return this
   } else if (this._conf.logLevel === 'trace') {
-    var _ancestors = ancestors(module).filter(Boolean)
-    var userModule = process.argv[1]
-    _ancestors.push(userModule)
-    var basedir = path.dirname(_ancestors[_ancestors.length - 1])
+    var _ancestors = ancestors(module)
+    var basedir = path.dirname(process.argv[1])
     var stackObj = {}
     Error.captureStackTrace(stackObj)
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -136,7 +136,9 @@ Agent.prototype.start = function (opts) {
     this._conf.active = false
     return this
   } else if (this._conf.logLevel === 'trace') {
-    var _ancestors = ancestors(module)
+    var _ancestors = ancestors(module).filter(Boolean)
+    var userModule = process.argv[1]
+    _ancestors.push(userModule)
     var basedir = path.dirname(_ancestors[_ancestors.length - 1])
     var stackObj = {}
     Error.captureStackTrace(stackObj)


### PR DESCRIPTION
Fixes elastic/apm-agent-nodejs#960 

This fix sets the users `package.json` into the `logger.trace` object and also removes any falsy values from the array returned from the _ancestors while loop. 

I believe this also Fixes elastic/apm-agent-nodejs#973 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
