### PR TITLE
fix(ts): handleUncaughtExceptions callback is optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare class Agent implements Taggable, StartSpanFn {
   lambda (handler: AwsLambda.Handler): AwsLambda.Handler;
   lambda (type: string, handler: AwsLambda.Handler): AwsLambda.Handler;
   handleUncaughtExceptions (
-    fn: (err: Error) => void
+    fn?: (err: Error) => void
   ): void;
 
   // Errors

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -25,6 +25,7 @@ agent.clearPatches('foo')
 agent.lambda(() => {})
 agent.lambda('foo', () => {})
 
+agent.handleUncaughtExceptions()
 agent.handleUncaughtExceptions((err: Error) => {
   console.error(err.stack)
   process.exit(1)


### PR DESCRIPTION
This callback has always been optional, I just incorrectly marked it as required in the TypeScript `.d.ts` file