### PR TITLE
fix(ts): add TypeScript typings for new traceparent API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,9 @@ declare class Agent implements Taggable, StartSpanFn {
     callback?: CaptureErrorCallback
   ): void;
 
+  // Distributed Tracing
+  currentTraceparent: string | null;
+
   // Transactions
   startTransaction (
     name?: string,
@@ -75,6 +78,7 @@ declare class GenericSpan implements Taggable {
   // timestamp, ended, id, traceId, parentId, sampled, duration()
 
   type: string;
+  traceparent: string;
 
   setTag (name: string, value: TagValue): boolean;
   addTags (tags: Tags): boolean;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -65,7 +65,8 @@ Object.defineProperty(Agent.prototype, 'currentSpan', {
 
 Object.defineProperty(Agent.prototype, 'currentTraceparent', {
   get () {
-    return (this.currentSpan || this.currentTransaction || {}).traceparent
+    const current = this.currentSpan || this.currentTransaction
+    return current ? current.traceparent : null
   }
 })
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -8,6 +8,13 @@ agent.start({
 function started (bool: boolean) {}
 started(agent.isStarted())
 
+const trans = agent.currentTransaction
+if (trans) trans.end()
+const span = agent.currentSpan
+if (span) span.end()
+const traceparent = agent.currentTraceparent
+if (traceparent) traceparent.split('-')
+
 agent.setFramework({})
 agent.setFramework({ name: 'foo' })
 agent.setFramework({ name: 'foo', version: 'bar' })
@@ -108,6 +115,8 @@ agent.logger.fatal('')
 {
   const trans = agent.startTransaction()
   if (trans) {
+    trans.traceparent.split('-')
+
     trans.setTag('foo', 'bar')
     trans.setTag('foo', 42)
     trans.setTag('foo', false)
@@ -135,6 +144,8 @@ agent.logger.fatal('')
   if (trans) {
     const span = trans.startSpan()
     if (span) {
+      span.traceparent.split('-')
+
       span.setTag('foo', 'bar')
       span.setTag('foo', 42)
       span.setTag('foo', false)


### PR DESCRIPTION
The docs specify that `agent.currentTransaction` can return a string or `null`, but in reality, it could return a string or `undefined`. So this PR also updates that API to return `null` in case there's no active span or transaction.