### PR TITLE
fix(express): improve names for routes added via app.use()

### DIFF
--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -9,7 +9,7 @@ try {
 }
 var symbols = require('../symbols')
 
-function ensureSlash (value) {
+function normalizeSlash (value) {
   return value[0] === '/' ? value : '/' + value
 }
 
@@ -18,25 +18,24 @@ function excludeRoot (value) {
 }
 
 function join (parts) {
-  return parts.filter(excludeRoot).map(ensureSlash).join('')
+  if (!parts) return
+  return parts.filter(excludeRoot).map(normalizeSlash).join('') || '/'
 }
 
 // This works for both express AND restify
 function routePath (route) {
-  if (!route) return ''
-  return route.path || (route.regexp && route.regexp.source) || ''
+  if (!route) return
+  return route.path || (route.regexp && route.regexp.source)
 }
 
 function getStackPath (req) {
   var stack = req[symbols.expressMountStack]
-  var res = stack && stack.length && join(stack)
-  return res !== '.' && res
+  return join(stack)
 }
 
 // This function is also able to extract the path from a Restify request as
 // it's storing the route name on req.route.path as well
 function getPathFromRequest (req, useBase, usePathAsTransactionName) {
-  // Static serving route
   if (req[symbols.staticFile]) {
     return 'static file'
   }
@@ -45,14 +44,11 @@ function getPathFromRequest (req, useBase, usePathAsTransactionName) {
   var route = routePath(req.route)
 
   if (route) {
-    return path ? join([ path, route ]) : route
-  }
-
-  if (useBase) {
+    return path ? join([path, route]) : route
+  } else if (path && (path !== '/' || useBase)) {
     return path
   }
 
-  // Enable usePathAsTransactionName config
   if (usePathAsTransactionName) {
     const parsed = parseUrl(req)
     return parsed && parsed.pathname

--- a/test/instrumentation/modules/express-graphql.js
+++ b/test/instrumentation/modules/express-graphql.js
@@ -17,148 +17,152 @@ var test = require('tape')
 
 var mockClient = require('../../_mock_http_client')
 
-test('POST /graphql', function (t) {
-  resetAgent(done(t, 'hello'))
+const paths = ['/graphql', '/']
 
-  var schema = buildSchema('type Query { hello: String }')
-  var root = { hello () {
-    t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
-    return 'Hello world!'
-  } }
-  var query = '{"query":"{ hello }"}'
+paths.forEach(function (path) {
+  test(`POST ${path}`, function (t) {
+    resetAgent(done(t, 'hello', path))
 
-  var app = express()
-  app.use('/graphql', graphqlHTTP({ schema: schema, rootValue: root }))
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.equal(result, '{"data":{"hello":"Hello world!"}}')
-        agent.flush()
-      })
-    })
-    req.end(query)
-  })
-})
-
-test('GET /graphql', function (t) {
-  resetAgent(done(t, 'hello'))
-
-  var schema = buildSchema('type Query { hello: String }')
-  var root = { hello () {
-    t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
-    return 'Hello world!'
-  } }
-  var query = querystring.stringify({ query: '{ hello }' })
-
-  var app = express()
-  app.use('/graphql', graphqlHTTP({ schema: schema, rootValue: root }))
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'GET',
-      port: port,
-      path: '/graphql?' + query
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.equal(result, '{"data":{"hello":"Hello world!"}}')
-        agent.flush()
-      })
-    })
-    req.end()
-  })
-})
-
-test('POST /graphql - named query', function (t) {
-  resetAgent(done(t, 'HelloQuery hello'))
-
-  var schema = buildSchema('type Query { hello: String }')
-  var root = { hello () {
-    t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
-    return 'Hello world!'
-  } }
-  var query = '{"query":"query HelloQuery { hello }"}'
-
-  var app = express()
-  app.use('/graphql', graphqlHTTP({ schema: schema, rootValue: root }))
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.equal(result, '{"data":{"hello":"Hello world!"}}')
-        agent.flush()
-      })
-    })
-    req.end(query)
-  })
-})
-
-test('POST /graphql - sort multiple queries', function (t) {
-  resetAgent(done(t, 'hello, life'))
-
-  var schema = buildSchema('type Query { hello: String, life: Int }')
-  var root = {
-    hello () {
+    var schema = buildSchema('type Query { hello: String }')
+    var root = { hello () {
       t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
       return 'Hello world!'
-    },
-    life () {
-      t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
-      return 42
-    }
-  }
-  var query = '{"query":"{ life, hello }"}'
+    } }
+    var query = '{"query":"{ hello }"}'
 
-  var app = express()
-  app.use('/graphql', graphqlHTTP({ schema: schema, rootValue: root }))
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.equal(result, '{"data":{"life":42,"hello":"Hello world!"}}')
-        agent.flush()
+    var app = express()
+    app.use(path, graphqlHTTP({ schema: schema, rootValue: root }))
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path,
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.equal(result, '{"data":{"hello":"Hello world!"}}')
+          agent.flush()
+        })
       })
+      req.end(query)
     })
-    req.end(query)
+  })
+
+  test(`GET ${path}`, function (t) {
+    resetAgent(done(t, 'hello', path))
+
+    var schema = buildSchema('type Query { hello: String }')
+    var root = { hello () {
+      t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+      return 'Hello world!'
+    } }
+    var query = querystring.stringify({ query: '{ hello }' })
+
+    var app = express()
+    app.use(path, graphqlHTTP({ schema: schema, rootValue: root }))
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'GET',
+        port: port,
+        path: `${path}?${query}`
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.equal(result, '{"data":{"hello":"Hello world!"}}')
+          agent.flush()
+        })
+      })
+      req.end()
+    })
+  })
+
+  test(`POST ${path} - named query`, function (t) {
+    resetAgent(done(t, 'HelloQuery hello', path))
+
+    var schema = buildSchema('type Query { hello: String }')
+    var root = { hello () {
+      t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+      return 'Hello world!'
+    } }
+    var query = '{"query":"query HelloQuery { hello }"}'
+
+    var app = express()
+    app.use(path, graphqlHTTP({ schema: schema, rootValue: root }))
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path,
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.equal(result, '{"data":{"hello":"Hello world!"}}')
+          agent.flush()
+        })
+      })
+      req.end(query)
+    })
+  })
+
+  test(`POST ${path} - sort multiple queries`, function (t) {
+    resetAgent(done(t, 'hello, life', path))
+
+    var schema = buildSchema('type Query { hello: String, life: Int }')
+    var root = {
+      hello () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 'Hello world!'
+      },
+      life () {
+        t.ok(agent._instrumentation.currentTransaction, 'have active transaction')
+        return 42
+      }
+    }
+    var query = '{"query":"{ life, hello }"}'
+
+    var app = express()
+    app.use(path, graphqlHTTP({ schema: schema, rootValue: root }))
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path,
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.equal(result, '{"data":{"life":42,"hello":"Hello world!"}}')
+          agent.flush()
+        })
+      })
+      req.end(query)
+    })
   })
 })
 
-function done (t, query) {
+function done (t, query, path) {
   return function (data, cb) {
     t.equal(data.transactions.length, 1)
     t.equal(data.spans.length, 1)
@@ -166,7 +170,7 @@ function done (t, query) {
     var trans = data.transactions[0]
     var span = data.spans[0]
 
-    t.equal(trans.name, query + ' (/graphql)')
+    t.equal(trans.name, `${query} (${path})`)
     t.equal(trans.type, 'request')
     t.equal(span.name, 'GraphQL: ' + query)
     t.equal(span.type, 'db.graphql.execute')


### PR DESCRIPTION
Previously all `app.use()` routes would be treated as unknown routes. With this commit, only the following routes will be considered unknown:

- `app.use(fn)`
- `app.use('/', fn)`

All other routes, e.g. `app.use('/foo', fn)`, will have their transactions named accordingly. Note that the HTTP method will still be part of the transaction name, even if the route is defined using `app.use()`. I.e. `GET /foo` and `POST /foo` will be part of two different transaction groups even though they might be served by the same router function.

Fixes elastic/apm-agent-nodejs#1008