### PR TITLE
fix: don't create spans for APM Server requests

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -107,7 +107,7 @@ Agent.prototype._config = function (opts) {
 
   const url = this._conf.serverUrl
     ? parseUrl(this._conf.serverUrl)
-    : { host: 'localhost', port: '8200' }
+    : { host: 'localhost:8200', port: '8200' }
 
   this._conf.serverHost = url.host
   this._conf.serverPort = parseInt(url.port, 10)


### PR DESCRIPTION
This would happen if no serverUrl was provided and the agent defaulted to localhost:8200.

This is an implementation of a fix described in #794