### PR TITLE
chore: rename tags to labels

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -212,7 +212,7 @@ You can set multiple labels on the same transaction.
 If an error happens during the current transaction,
 it will also get tagged with the same label.
 
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 
 [[apm-add-labels]]
@@ -221,7 +221,7 @@ Tags are key/value pairs that are indexed by Elasticsearch and therefore searcha
 [small]#Added in: v1.5.0#
 [small]#Renamed from `apm.addTags()` to `apm.addLabels()`: v2.10.0#
 
-* `tags` +{type-object}+ Contains key/value pairs:
+* `labels` +{type-object}+ Contains key/value pairs:
 ** `name` +{type-string}+
 Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
 as those characters have special meaning in Elasticsearch
@@ -234,7 +234,7 @@ You can add labels multiple times.
 If an error happens during the current transaction,
 it will also get tagged with the same labels.
 
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 [[apm-capture-error]]
 ==== `apm.captureError(error[, options][, callback])`

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -198,6 +198,7 @@ and any custom context given as the 2nd argument to <<apm-capture-error,`apm.cap
 ==== `apm.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
+[small]#Renamed from `apm.setTag()` to `apm.setLabel()`: v2.10.0#
 
 * `name` +{type-string}+
 Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
@@ -218,6 +219,7 @@ Tags are key/value pairs that are indexed by Elasticsearch and therefore searcha
 ==== `apm.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#
+[small]#Renamed from `apm.addTags()` to `apm.addLabels()`: v2.10.0#
 
 * `tags` +{type-object}+ Contains key/value pairs:
 ** `name` +{type-string}+

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -194,10 +194,33 @@ If an error is captured,
 the context from the active transaction is used as context for the captured error,
 and any custom context given as the 2nd argument to <<apm-capture-error,`apm.captureError`>> takes precedence and is shallow merged on top.
 
+[[apm-set-tag]]
+==== `apm.setTag(name, value)`
+
+deprecated[2.10.0,Replaced by <<apm-set-label>>]
+
+[small]#Added in: v0.1.0#
+
+* `name` +{type-string}+
+Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+* `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+Set a tag on the current transaction.
+You can set multiple tags on the same transaction.
+If an error happens during the current transaction,
+it will also get tagged with the same tags.
+
+Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+
+
 [[apm-set-label]]
 ==== `apm.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
+
 [small]#Renamed from `apm.setTag()` to `apm.setLabel()`: v2.10.0#
 
 * `name` +{type-string}+
@@ -214,11 +237,34 @@ it will also get tagged with the same label.
 
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
+[[apm-add-tags]]
+==== `apm.addTags({ [name]: value })`
+
+deprecated[2.10.0,Replaced by <<apm-add-labels>>]
+
+[small]#Added in: v1.5.0#
+
+* `tags` +{type-object}+ Contains key/value pairs:
+** `name` +{type-string}+
+Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+** `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+Add several tags on the current transaction.
+You can add tags multiple times.
+If an error happens during the current transaction,
+it will also get tagged with the same tags.
+
+Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+
 
 [[apm-add-labels]]
 ==== `apm.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#
+
 [small]#Renamed from `apm.addTags()` to `apm.addLabels()`: v2.10.0#
 
 * `labels` +{type-object}+ Contains key/value pairs:

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -194,8 +194,8 @@ If an error is captured,
 the context from the active transaction is used as context for the captured error,
 and any custom context given as the 2nd argument to <<apm-capture-error,`apm.captureError`>> takes precedence and is shallow merged on top.
 
-[[apm-set-tag]]
-==== `apm.setTag(name, value)`
+[[apm-set-label]]
+==== `apm.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
 
@@ -214,8 +214,8 @@ it will also get tagged with the same tags.
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 
-[[apm-add-tags]]
-==== `apm.addTags({ [name]: value })`
+[[apm-add-labels]]
+==== `apm.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -207,10 +207,10 @@ as those characters have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-Set a tag on the current transaction.
-You can set multiple tags on the same transaction.
+Set a label on the current transaction.
+You can set multiple labels on the same transaction.
 If an error happens during the current transaction,
-it will also get tagged with the same tags.
+it will also get tagged with the same label.
 
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
@@ -229,10 +229,10 @@ as those characters have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-Add several tags on the current transaction.
-You can add tags multiple times.
+Add several labels on the current transaction.
+You can add labels multiple times.
 If an error happens during the current transaction,
-it will also get tagged with the same tags.
+it will also get tagged with the same labels.
 
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -269,7 +269,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[custom-stack-compatibility]]

--- a/docs/custom-stack.asciidoc
+++ b/docs/custom-stack.asciidoc
@@ -269,7 +269,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[custom-stack-compatibility]]

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -180,7 +180,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[express-compatibility]]

--- a/docs/express.asciidoc
+++ b/docs/express.asciidoc
@@ -180,7 +180,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[express-compatibility]]

--- a/docs/fastify.asciidoc
+++ b/docs/fastify.asciidoc
@@ -189,7 +189,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[fastify-compatibility]]

--- a/docs/fastify.asciidoc
+++ b/docs/fastify.asciidoc
@@ -189,7 +189,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[fastify-compatibility]]

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -191,7 +191,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[hapi-compatibility]]

--- a/docs/hapi.asciidoc
+++ b/docs/hapi.asciidoc
@@ -191,7 +191,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[hapi-compatibility]]

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -193,7 +193,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[koa-compatibility]]

--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -193,7 +193,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[koa-compatibility]]

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -129,7 +129,7 @@ use one of the two functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[lambda-troubleshooting]]

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -129,7 +129,7 @@ use one of the two functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[lambda-troubleshooting]]

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -7,3 +7,33 @@ The following pages have moved or been deleted.
 === Compatibility
 
 This page has moved. Please see <<supported-technologies>>.
+
+[role="exclude",id="apm-set-tag"]
+=== `apm.setTag(name, value)`
+
+This endpoint has moved. Please see <<apm-set-label>>.
+
+[role="exclude",id="apm-add-tags"]
+=== `apm.addTags({ [name]: value })`
+
+This endpoint has moved. Please see <<apm-add-labels>>.
+
+[role="exclude",id="span-set-tag"]
+=== `span.setTag(name, value)`
+
+This endpoint has moved. Please see <<span-set-label>>.
+
+[role="exclude",id="span-add-tags"]
+=== `span.addTags({ [name]: value })`
+
+This endpoint has moved. Please see <<span-add-labels>>.
+
+[role="exclude",id="transaction-set-tag"]
+=== `transaction.setTag(name, value)`
+
+This endpoint has moved. Please see <<transaction-set-label>>.
+
+[role="exclude",id="transaction-add-tags"]
+=== `transaction.addTags({ [name]: value })`
+
+This endpoint has moved. Please see <<transaction-add-labels>>.

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -8,32 +8,35 @@ The following pages have moved or been deleted.
 
 This page has moved. Please see <<supported-technologies>>.
 
-[role="exclude",id="apm-set-tag"]
-=== `apm.setTag(name, value)`
+// The following headings have been deprecated.
+// When they are ready to be removed they can be uncommented.
 
-This endpoint has moved. Please see <<apm-set-label>>.
+// [role="exclude",id="apm-set-tag"]
+// === `apm.setTag(name, value)`
 
-[role="exclude",id="apm-add-tags"]
-=== `apm.addTags({ [name]: value })`
+// This endpoint has moved. Please see <<apm-set-label>>.
 
-This endpoint has moved. Please see <<apm-add-labels>>.
+// [role="exclude",id="apm-add-tags"]
+// === `apm.addTags({ [name]: value })`
 
-[role="exclude",id="span-set-tag"]
-=== `span.setTag(name, value)`
+// This endpoint has moved. Please see <<apm-add-labels>>.
 
-This endpoint has moved. Please see <<span-set-label>>.
+// [role="exclude",id="span-set-tag"]
+// === `span.setTag(name, value)`
 
-[role="exclude",id="span-add-tags"]
-=== `span.addTags({ [name]: value })`
+// This endpoint has moved. Please see <<span-set-label>>.
 
-This endpoint has moved. Please see <<span-add-labels>>.
+// [role="exclude",id="span-add-tags"]
+// === `span.addTags({ [name]: value })`
 
-[role="exclude",id="transaction-set-tag"]
-=== `transaction.setTag(name, value)`
+// This endpoint has moved. Please see <<span-add-labels>>.
 
-This endpoint has moved. Please see <<transaction-set-label>>.
+// [role="exclude",id="transaction-set-tag"]
+// === `transaction.setTag(name, value)`
 
-[role="exclude",id="transaction-add-tags"]
-=== `transaction.addTags({ [name]: value })`
+// This endpoint has moved. Please see <<transaction-set-label>>.
 
-This endpoint has moved. Please see <<transaction-add-labels>>.
+// [role="exclude",id="transaction-add-tags"]
+// === `transaction.addTags({ [name]: value })`
+
+// This endpoint has moved. Please see <<transaction-add-labels>>.

--- a/docs/restify.asciidoc
+++ b/docs/restify.asciidoc
@@ -183,7 +183,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (labels are indexed in Elasticsearch)
 
 [float]
 [[restify-compatibility]]

--- a/docs/restify.asciidoc
+++ b/docs/restify.asciidoc
@@ -183,7 +183,7 @@ use one of the functions below:
 
 * <<apm-set-user-context,`apm.setUserContext()`>> - Call this to enrich collected performance data and errors with information about the user/client
 * <<apm-set-custom-context,`apm.setCustomContext()`>> - Call this to enrich collected performance data and errors with any information that you think will help you debug performance issues and errors (this data is only stored, but not indexed in Elasticsearch)
-* <<apm-set-tag,`apm.setTag()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
+* <<apm-set-label,`apm.setLabel()`>> - Call this to enrich collected performance data and errors with simple key/value strings that you think will help you debug performance issues and errors (tags are indexed in Elasticsearch)
 
 [float]
 [[restify-compatibility]]

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -64,7 +64,7 @@ the following are standardized across all Elastic APM agents:
 Get the serialized traceparent string of the span.
 
 [[span-set-tag]]
-==== `span.setTag(name, value)`
+==== `span.setLabel(name, value)`
 
 [small]#Added in: v2.1.0#
 
@@ -79,7 +79,7 @@ Set a tag on the span.
 You can set multiple tags on the same span.
 
 [[span-add-tags]]
-==== `span.addTags({ [name]: value })`
+==== `span.addLabels({ [name]: value })`
 
 [small]#Added in: v2.1.0#
 

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -63,7 +63,7 @@ the following are standardized across all Elastic APM agents:
 
 Get the serialized traceparent string of the span.
 
-[[span-set-tag]]
+[[span-set-label]]
 ==== `span.setLabel(name, value)`
 
 [small]#Added in: v2.1.0#
@@ -79,7 +79,7 @@ it's converted to a string before being sent to the APM Server
 Set a label on the span.
 You can set multiple labels on the same span.
 
-[[span-add-tags]]
+[[span-add-labels]]
 ==== `span.addLabels({ [name]: value })`
 
 [small]#Added in: v2.1.0#

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -67,6 +67,7 @@ Get the serialized traceparent string of the span.
 ==== `span.setLabel(name, value)`
 
 [small]#Added in: v2.1.0#
+[small]#Renamed from `span.setTag()` to `span.setLabel()`: v2.10.0#
 
 * `name` +{type-string}+
 Periods (`.`), asterisks (`*`), and double quotation marks (`"`) will be replaced by underscores (`_`),
@@ -82,6 +83,7 @@ You can set multiple tags on the same span.
 ==== `span.addLabels({ [name]: value })`
 
 [small]#Added in: v2.1.0#
+[small]#Renamed from `span.addTags()` to `span.addLabels()`: v2.10.0#
 
 * `tags` +{type-object}+ Contains key/value pairs:
 ** `name` +{type-string}+

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -63,10 +63,28 @@ the following are standardized across all Elastic APM agents:
 
 Get the serialized traceparent string of the span.
 
+[[span-set-tag]]
+==== `span.setTag(name, value)`
+
+deprecated[2.10.0,Replaced by <<span-set-label>>]
+
+[small]#Added in: v2.1.0#
+
+* `name` +{type-string}+
+Periods (`.`), asterisks (`*`), and double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+* `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+Set a tag on the span.
+You can set multiple tags on the same span.
+
 [[span-set-label]]
 ==== `span.setLabel(name, value)`
 
 [small]#Added in: v2.1.0#
+
 [small]#Renamed from `span.setTag()` to `span.setLabel()`: v2.10.0#
 
 * `name` +{type-string}+
@@ -79,10 +97,29 @@ it's converted to a string before being sent to the APM Server
 Set a label on the span.
 You can set multiple labels on the same span.
 
+[[span-add-tags]]
+==== `span.addTags({ [name]: value })`
+
+deprecated[2.10.0,Replaced by <<span-add-labels>>]
+
+[small]#Added in: v2.1.0#
+
+* `tags` +{type-object}+ Contains key/value pairs:
+** `name` +{type-string}+
+Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+** `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+Add several tags on the span.
+You can add tags multiple times.
+
 [[span-add-labels]]
 ==== `span.addLabels({ [name]: value })`
 
 [small]#Added in: v2.1.0#
+
 [small]#Renamed from `span.addTags()` to `span.addLabels()`: v2.10.0#
 
 * `labels` +{type-object}+ Contains key/value pairs:

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -76,8 +76,8 @@ as those characters have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-Set a tag on the span.
-You can set multiple tags on the same span.
+Set a label on the span.
+You can set multiple labels on the same span.
 
 [[span-add-tags]]
 ==== `span.addLabels({ [name]: value })`
@@ -85,7 +85,7 @@ You can set multiple tags on the same span.
 [small]#Added in: v2.1.0#
 [small]#Renamed from `span.addTags()` to `span.addLabels()`: v2.10.0#
 
-* `tags` +{type-object}+ Contains key/value pairs:
+* `labels` +{type-object}+ Contains key/value pairs:
 ** `name` +{type-string}+
 Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
 as those characters have special meaning in Elasticsearch
@@ -93,8 +93,8 @@ as those characters have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-Add several tags on the span.
-You can add tags multiple times.
+Add several labels on the span.
+You can add labels multiple times.
 
 [[span-end]]
 ==== `span.end([endTime])`

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -86,7 +86,7 @@ When a span is started it will measure the time until <<span-end,`span.end()`>> 
 See <<span-api,Span API>> docs for details on how to use custom spans.
 
 [[transaction-set-tag]]
-==== `transaction.setTag(name, value)`
+==== `transaction.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
 
@@ -105,7 +105,7 @@ it will also get tagged with the same tags.
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 [[transaction-add-tags]]
-==== `transaction.addTags({ [name]: value })`
+==== `transaction.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -98,10 +98,10 @@ as those characters have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-Set a tag on the transaction.
-You can set multiple tags on the same transaction.
+Set a label on the transaction.
+You can set multiple labels on the same transaction.
 If an error happens during the transaction,
-it will also get tagged with the same tags.
+it will also get tagged with the same labels.
 
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
@@ -111,7 +111,7 @@ Tags are key/value pairs that are indexed by Elasticsearch and therefore searcha
 [small]#Added in: v1.5.0#
 [small]#Renamed from `transaction.addTags()` to `transaction.addLabels()`: v2.10.0#
 
-* `tags` +{type-object}+ Contains key/value pairs:
+* `labels` +{type-object}+ Contains key/value pairs:
 ** `name` +{type-string}+
 Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
 as those characters have special meaning in Elasticsearch
@@ -119,12 +119,12 @@ as those characters have special meaning in Elasticsearch
 If a non-string data type is given,
 it's converted to a string before being sent to the APM Server
 
-Add several tags on the transaction.
-You can add tags multiple times.
+Add several labels on the transaction.
+You can add labels multiple times.
 If an error happens during the transaction,
-it will also get tagged with the same tags.
+it will also get tagged with the same labels.
 
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
 [[transaction-ensure-parent-id]]
 ==== `transaction.ensureParentId()`

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -89,6 +89,7 @@ See <<span-api,Span API>> docs for details on how to use custom spans.
 ==== `transaction.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
+[small]#Renamed from `transaction.setTag()` to `transaction.setLabel()`: v2.10.0#
 
 * `name` +{type-string}+
 Periods (`.`), asterisks (`*`), and double quotation marks (`"`) will be replaced by underscores (`_`),
@@ -108,6 +109,7 @@ Tags are key/value pairs that are indexed by Elasticsearch and therefore searcha
 ==== `transaction.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#
+[small]#Renamed from `transaction.addTags()` to `transaction.addLabels()`: v2.10.0#
 
 * `tags` +{type-object}+ Contains key/value pairs:
 ** `name` +{type-string}+

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -85,10 +85,33 @@ When a span is started it will measure the time until <<span-end,`span.end()`>> 
 
 See <<span-api,Span API>> docs for details on how to use custom spans.
 
+[[transaction-set-tag]]
+==== `transaction.setTag(name, value)`
+
+deprecated[2.10.0,Replaced by <<transaction-set-label>>]
+
+[small]#Added in: v0.1.0#
+
+* `name` +{type-string}+
+Periods (`.`), asterisks (`*`), and double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+* `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+Set a tag on the transaction.
+You can set multiple tags on the same transaction.
+If an error happens during the transaction,
+it will also get tagged with the same tags.
+
+Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+
+
 [[transaction-set-label]]
 ==== `transaction.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
+
 [small]#Renamed from `transaction.setTag()` to `transaction.setLabel()`: v2.10.0#
 
 * `name` +{type-string}+
@@ -105,10 +128,34 @@ it will also get tagged with the same labels.
 
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
+[[transaction-add-tags]]
+==== `transaction.addTags({ [name]: value })`
+
+deprecated[2.10.0,Replaced by <<transaction-add-labels>>]
+
+[small]#Added in: v1.5.0#
+
+* `tags` +{type-object}+ Contains key/value pairs:
+** `name` +{type-string}+
+Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+** `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+Add several tags on the transaction.
+You can add tags multiple times.
+If an error happens during the transaction,
+it will also get tagged with the same tags.
+
+Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+
+
 [[transaction-add-labels]]
 ==== `transaction.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#
+
 [small]#Renamed from `transaction.addTags()` to `transaction.addLabels()`: v2.10.0#
 
 * `labels` +{type-object}+ Contains key/value pairs:

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -85,7 +85,7 @@ When a span is started it will measure the time until <<span-end,`span.end()`>> 
 
 See <<span-api,Span API>> docs for details on how to use custom spans.
 
-[[transaction-set-tag]]
+[[transaction-set-label]]
 ==== `transaction.setLabel(name, value)`
 
 [small]#Added in: v0.1.0#
@@ -105,7 +105,7 @@ it will also get tagged with the same labels.
 
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
-[[transaction-add-tags]]
+[[transaction-add-labels]]
 ==== `transaction.addLabels({ [name]: value })`
 
 [small]#Added in: v1.5.0#

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,8 +56,10 @@ declare class Agent implements Taggable, StartSpanFn {
   currentSpan: Span | null;
 
   // Context
-  setTag (name: string, value: TagValue): boolean;
-  addTags (tags: Tags): boolean;
+  setLabel (name: string, value: LabelValue): boolean;
+  setTag (name: string, value: LabelValue): boolean; // Deprecated
+  addLabels (labels: Labels): boolean;
+  addTags (labels: Labels): boolean; // Deprecated
   setUserContext (user: UserObject): void;
   setCustomContext (custom: object): void;
 
@@ -80,8 +82,10 @@ declare class GenericSpan implements Taggable {
   type: string;
   traceparent: string;
 
-  setTag (name: string, value: TagValue): boolean;
-  addTags (tags: Tags): boolean;
+  setLabel (name: string, value: LabelValue): boolean;
+  setTag (name: string, value: LabelValue): boolean; // Deprecated
+  addLabels (labels: Labels): boolean;
+  addTags (labels: Labels): boolean; // Deprecated
 }
 
 declare class Transaction extends GenericSpan implements StartSpanFn {
@@ -157,13 +161,14 @@ interface CaptureErrorOptions {
   timestamp?: number;
   handled?: boolean;
   user?: UserObject;
-  tags?: Tags;
+  labels?: Labels;
+  tags?: Labels;
   custom?: object;
   message?: string;
 }
 
-interface Tags {
-  [key: string]: TagValue;
+interface Labels {
+  [key: string]: LabelValue;
 }
 
 interface UserObject {
@@ -208,7 +213,7 @@ type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 type CaptureErrorCallback = (err: Error | null, id: string) => void;
 type FilterFn = (payload: Payload) => Payload | boolean | void;
-type TagValue = string | number | boolean | null | undefined;
+type LabelValue = string | number | boolean | null | undefined;
 
 type Payload = { [propName: string]: any }
 
@@ -220,8 +225,10 @@ interface PatchOptions {
 }
 
 interface Taggable {
-  setTag (name: string, value: TagValue): boolean;
-  addTags (tags: Tags): boolean;
+  setLabel (name: string, value: LabelValue): boolean;
+  setTag (name: string, value: LabelValue): boolean; // Deprecated
+  addLabels (labels: Labels): boolean;
+  addTags (labels: Labels): boolean; // Deprecated
 }
 
 interface StartSpanFn {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -201,15 +201,23 @@ Agent.prototype.setCustomContext = function (context) {
 }
 
 Agent.prototype.setTag = function (key, value) {
+  return this.setLabel(key, value)
+}
+
+Agent.prototype.setLabel = function (key, value) {
   var trans = this.currentTransaction
   if (!trans) return false
-  return trans.setTag(key, value)
+  return trans.setLabel(key, value)
 }
 
 Agent.prototype.addTags = function (tags) {
+  return this.addLabels(tags)
+}
+
+Agent.prototype.addLabels = function (labels) {
   var trans = this.currentTransaction
   if (!trans) return false
-  return trans.addTags(tags)
+  return trans.addLabels(labels)
 }
 
 Agent.prototype.addFilter = function (fn) {
@@ -293,8 +301,9 @@ Agent.prototype.captureError = function (err, opts, cb) {
       ),
       tags: Object.assign(
         {},
-        trans && trans._tags,
-        opts && opts.tags
+        trans && trans._labels,
+        opts && opts.tags,
+        opts && opts.labels
       ),
       custom: Object.assign(
         {},

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -201,6 +201,7 @@ Agent.prototype.setCustomContext = function (context) {
 }
 
 Agent.prototype.setTag = function (key, value) {
+  this.logger.warn('Called deprecated method: apm.setTag(...)')
   return this.setLabel(key, value)
 }
 
@@ -211,6 +212,7 @@ Agent.prototype.setLabel = function (key, value) {
 }
 
 Agent.prototype.addTags = function (tags) {
+  this.logger.warn('Called deprecated method: apm.addTags(...)')
   return this.addLabels(tags)
 }
 

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -12,7 +12,7 @@ function GenericSpan (agent, type, opts) {
   this._timer = new Timer(opts.timer, opts.startTime)
   this._context = TraceParent.startOrResume(opts.childOf, agent._conf) // _context is used by the OT bridge, and should unfortunately therefore be considered public
   this._agent = agent
-  this._tags = null
+  this._labels = null
 
   this.timestamp = this._timer.start
   this.type = type || 'custom'
@@ -65,21 +65,29 @@ GenericSpan.prototype.duration = function () {
 }
 
 GenericSpan.prototype.setTag = function (key, value) {
+  return this.setLabel(key, value)
+}
+
+GenericSpan.prototype.setLabel = function (key, value) {
   if (!key) return false
-  if (!this._tags) this._tags = {}
+  if (!this._labels) this._labels = {}
   var skey = key.replace(/[.*"]/g, '_')
   if (key !== skey) {
     this._agent.logger.warn('Illegal characters used in tag key: %s', key)
   }
-  this._tags[skey] = truncate(String(value), config.INTAKE_STRING_MAX_SIZE)
+  this._labels[skey] = truncate(String(value), config.INTAKE_STRING_MAX_SIZE)
   return true
 }
 
 GenericSpan.prototype.addTags = function (tags) {
-  if (!tags) return false
-  var keys = Object.keys(tags)
+  return this.addLabels(tags)
+}
+
+GenericSpan.prototype.addLabels = function (labels) {
+  if (!labels) return false
+  var keys = Object.keys(labels)
   for (let key of keys) {
-    if (!this.setTag(key, tags[key])) {
+    if (!this.setLabel(key, labels[key])) {
       return false
     }
   }

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -65,6 +65,7 @@ GenericSpan.prototype.duration = function () {
 }
 
 GenericSpan.prototype.setTag = function (key, value) {
+  this.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.setTag(...)`)
   return this.setLabel(key, value)
 }
 
@@ -80,6 +81,7 @@ GenericSpan.prototype.setLabel = function (key, value) {
 }
 
 GenericSpan.prototype.addTags = function (tags) {
+  this.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.addTags(...)`)
   return this.addLabels(tags)
 }
 

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -136,10 +136,10 @@ Span.prototype._encode = function (cb) {
       sync: self.sync
     }
 
-    if (self._db || self._tags) {
+    if (self._db || self._labels) {
       payload.context = {
         db: self._db || undefined,
-        tags: self._tags || undefined
+        tags: self._labels || undefined
       }
     }
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -124,7 +124,7 @@ Transaction.prototype.toJSON = function () {
         this.req && parsers.getUserContextFromRequest(this.req),
         this._user
       ),
-      tags: this._tags || {},
+      tags: this._labels || {},
       custom: this._custom || {}
     }
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -340,40 +340,52 @@ test('#setCustomContext()', function (t) {
   })
 })
 
-test('#setTag()', function (t) {
-  t.test('no active transaction', function (t) {
-    var agent = Agent()
-    agent.start()
-    t.equal(agent.setTag('foo', 1), false)
-    t.end()
-  })
+var singleLabelTests = [
+  { name: '#setLabel()', method: 'setLabel' },
+  { name: '#setTag() - deprecated', method: 'setTag' }
+]
+singleLabelTests.forEach((labelTest) => {
+  test(labelTest.name, function (t) {
+    t.test('no active transaction', function (t) {
+      var agent = Agent()
+      agent.start()
+      t.equal(agent[labelTest.method]('foo', 1), false)
+      t.end()
+    })
 
-  t.test('active transaction', function (t) {
-    var agent = Agent()
-    agent.start()
-    var trans = agent.startTransaction()
-    t.equal(agent.setTag('foo', 1), true)
-    t.deepEqual(trans._tags, { foo: '1' })
-    t.end()
+    t.test('active transaction', function (t) {
+      var agent = Agent()
+      agent.start()
+      var trans = agent.startTransaction()
+      t.equal(agent[labelTest.method]('foo', 1), true)
+      t.deepEqual(trans._labels, { foo: '1' })
+      t.end()
+    })
   })
 })
 
-test('#addTags', function (t) {
-  t.test('no active transaction', function (t) {
-    var agent = Agent()
-    agent.start()
-    t.equal(agent.addTags({ foo: 1 }), false)
-    t.end()
-  })
+var multipleLabelTests = [
+  { name: '#addLabels()', method: 'addLabels' },
+  { name: '#addTags() - deprecated', method: 'addTags' }
+]
+multipleLabelTests.forEach((multipleTest) => {
+  test(multipleTest.name, function (t) {
+    t.test('no active transaction', function (t) {
+      var agent = Agent()
+      agent.start()
+      t.equal(agent[multipleTest.method]({ foo: 1 }), false)
+      t.end()
+    })
 
-  t.test('active transaction', function (t) {
-    var agent = Agent()
-    agent.start()
-    var trans = agent.startTransaction()
-    t.equal(agent.addTags({ foo: 1, bar: 2 }), true)
-    t.equal(agent.addTags({ foo: 3 }), true)
-    t.deepEqual(trans._tags, { foo: '3', bar: '2' })
-    t.end()
+    t.test('active transaction', function (t) {
+      var agent = Agent()
+      agent.start()
+      var trans = agent.startTransaction()
+      t.equal(agent[multipleTest.method]({ foo: 1, bar: 2 }), true)
+      t.equal(agent[multipleTest.method]({ foo: 3 }), true)
+      t.deepEqual(trans._labels, { foo: '3', bar: '2' })
+      t.end()
+    })
   })
 })
 

--- a/test/instrumentation/span.js
+++ b/test/instrumentation/span.js
@@ -87,63 +87,63 @@ test('#end(time)', function (t) {
   t.end()
 })
 
-test('#setTag', function (t) {
+test('#setLabel', function (t) {
   t.test('valid', function (t) {
     var trans = new Transaction(agent)
     var span = new Span(trans)
-    t.equal(span._tags, null)
-    t.equal(span.setTag(), false)
-    t.equal(span._tags, null)
-    span.setTag('foo', 1)
-    t.deepEqual(span._tags, { foo: '1' })
-    span.setTag('bar', { baz: 2 })
-    t.deepEqual(span._tags, { foo: '1', bar: '[object Object]' })
-    span.setTag('foo', 3)
-    t.deepEqual(span._tags, { foo: '3', bar: '[object Object]' })
+    t.equal(span._labels, null)
+    t.equal(span.setLabel(), false)
+    t.equal(span._labels, null)
+    span.setLabel('foo', 1)
+    t.deepEqual(span._labels, { foo: '1' })
+    span.setLabel('bar', { baz: 2 })
+    t.deepEqual(span._labels, { foo: '1', bar: '[object Object]' })
+    span.setLabel('foo', 3)
+    t.deepEqual(span._labels, { foo: '3', bar: '[object Object]' })
     t.end()
   })
 
   t.test('invalid', function (t) {
     var trans = new Transaction(agent)
     var span = new Span(trans)
-    t.equal(span._tags, null)
-    t.equal(span.setTag(), false)
-    t.equal(span._tags, null)
-    span.setTag('invalid*', 1)
-    t.deepEqual(span._tags, { invalid_: '1' })
-    span.setTag('invalid.', 2)
-    t.deepEqual(span._tags, { invalid_: '2' })
-    span.setTag('invalid"', 3)
-    t.deepEqual(span._tags, { invalid_: '3' })
+    t.equal(span._labels, null)
+    t.equal(span.setLabel(), false)
+    t.equal(span._labels, null)
+    span.setLabel('invalid*', 1)
+    t.deepEqual(span._labels, { invalid_: '1' })
+    span.setLabel('invalid.', 2)
+    t.deepEqual(span._labels, { invalid_: '2' })
+    span.setLabel('invalid"', 3)
+    t.deepEqual(span._labels, { invalid_: '3' })
     t.end()
   })
 })
 
-test('#addTags', function (t) {
+test('#addLabels', function (t) {
   var trans = new Transaction(agent)
   var span = new Span(trans)
-  t.equal(span._tags, null)
+  t.equal(span._labels, null)
 
-  t.equal(span.setTag(), false)
-  t.equal(span._tags, null)
+  t.equal(span.setLabel(), false)
+  t.equal(span._labels, null)
 
-  span.addTags({ foo: 1 })
-  t.deepEqual(span._tags, { foo: '1' })
+  span.addLabels({ foo: 1 })
+  t.deepEqual(span._labels, { foo: '1' })
 
-  span.addTags({ bar: { baz: 2 } })
-  t.deepEqual(span._tags, {
+  span.addLabels({ bar: { baz: 2 } })
+  t.deepEqual(span._labels, {
     foo: '1',
     bar: '[object Object]'
   })
 
-  span.addTags({ foo: 3 })
-  t.deepEqual(span._tags, {
+  span.addLabels({ foo: 3 })
+  t.deepEqual(span._labels, {
     foo: '3',
     bar: '[object Object]'
   })
 
-  span.addTags({ bux: 'bax', bix: 'bex' })
-  t.deepEqual(span._tags, {
+  span.addLabels({ bux: 'bax', bix: 'bex' })
+  t.deepEqual(span._labels, {
     foo: '3',
     bar: '[object Object]',
     bux: 'bax',
@@ -225,7 +225,7 @@ test('#_encode() - with meta data', function myTest2 (t) {
   var span = new Span(trans, 'foo', 'bar')
   span.end()
   span.setDbContext({ statement: 'foo', type: 'bar' })
-  span.setTag('baz', 1)
+  span.setLabel('baz', 1)
   span._encode(function (err, payload) {
     t.error(err)
     t.deepEqual(Object.keys(payload), ['id', 'transaction_id', 'parent_id', 'trace_id', 'name', 'type', 'timestamp', 'duration', 'context', 'stacktrace', 'sync'])

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -67,60 +67,60 @@ test('#setCustomContext', function (t) {
   t.end()
 })
 
-test('#setTag', function (t) {
+test('#setLabel', function (t) {
   t.test('valid', function (t) {
     var trans = new Transaction(agent)
-    t.equal(trans._tags, null)
-    t.equal(trans.setTag(), false)
-    t.equal(trans._tags, null)
-    trans.setTag('foo', 1)
-    t.deepEqual(trans._tags, { foo: '1' })
-    trans.setTag('bar', { baz: 2 })
-    t.deepEqual(trans._tags, { foo: '1', bar: '[object Object]' })
-    trans.setTag('foo', 3)
-    t.deepEqual(trans._tags, { foo: '3', bar: '[object Object]' })
+    t.equal(trans._labels, null)
+    t.equal(trans.setLabel(), false)
+    t.equal(trans._labels, null)
+    trans.setLabel('foo', 1)
+    t.deepEqual(trans._labels, { foo: '1' })
+    trans.setLabel('bar', { baz: 2 })
+    t.deepEqual(trans._labels, { foo: '1', bar: '[object Object]' })
+    trans.setLabel('foo', 3)
+    t.deepEqual(trans._labels, { foo: '3', bar: '[object Object]' })
     t.end()
   })
 
   t.test('invalid', function (t) {
     var trans = new Transaction(agent)
-    t.equal(trans._tags, null)
-    t.equal(trans.setTag(), false)
-    t.equal(trans._tags, null)
-    trans.setTag('invalid*', 1)
-    t.deepEqual(trans._tags, { invalid_: '1' })
-    trans.setTag('invalid.', 2)
-    t.deepEqual(trans._tags, { invalid_: '2' })
-    trans.setTag('invalid"', 3)
-    t.deepEqual(trans._tags, { invalid_: '3' })
+    t.equal(trans._labels, null)
+    t.equal(trans.setLabel(), false)
+    t.equal(trans._labels, null)
+    trans.setLabel('invalid*', 1)
+    t.deepEqual(trans._labels, { invalid_: '1' })
+    trans.setLabel('invalid.', 2)
+    t.deepEqual(trans._labels, { invalid_: '2' })
+    trans.setLabel('invalid"', 3)
+    t.deepEqual(trans._labels, { invalid_: '3' })
     t.end()
   })
 })
 
-test('#addTags', function (t) {
+test('#addLabels', function (t) {
   var trans = new Transaction(agent)
-  t.equal(trans._tags, null)
+  t.equal(trans._labels, null)
 
-  t.equal(trans.setTag(), false)
-  t.equal(trans._tags, null)
+  t.equal(trans.setLabel(), false)
+  t.equal(trans._labels, null)
 
-  trans.addTags({ foo: 1 })
-  t.deepEqual(trans._tags, { foo: '1' })
+  trans.addLabels({ foo: 1 })
+  t.deepEqual(trans._labels, { foo: '1' })
 
-  trans.addTags({ bar: { baz: 2 } })
-  t.deepEqual(trans._tags, {
+  trans.addLabels({ bar: { baz: 2 } })
+  t.deepEqual(trans._labels, {
     foo: '1',
     bar: '[object Object]'
   })
 
-  trans.addTags({ foo: 3 })
-  t.deepEqual(trans._tags, {
+  trans.addLabels({ foo: 3 })
+  t.deepEqual(trans._labels, {
     foo: '3',
     bar: '[object Object]'
   })
 
-  trans.addTags({ bux: 'bax', bix: 'bex' })
-  t.deepEqual(trans._tags, {
+  trans.addLabels({ bux: 'bax', bix: 'bex' })
+  t.deepEqual(trans._labels, {
     foo: '3',
     bar: '[object Object]',
     bux: 'bax',
@@ -335,7 +335,7 @@ test('#_encode() - with meta data', function (t) {
   var trans = new Transaction(ins._agent, 'foo', 'bar')
   trans.result = 'baz'
   trans.setUserContext({ foo: 1 })
-  trans.setTag('bar', 1)
+  trans.setLabel('bar', 1)
   trans.setCustomContext({ baz: 1 })
   trans.end()
   const payload = trans._encode()

--- a/test/integration/api-schema/basic.js
+++ b/test/integration/api-schema/basic.js
@@ -143,7 +143,7 @@ const next = afterAll(function (err, validators) {
       agent.startTransaction()
       const span = agent.startSpan('name1', 'type1')
       span.setDbContext({ statement: 'foo', type: 'bar' })
-      span.setTag('baz', 1)
+      span.setLabel('baz', 1)
       span.end()
       // Collecting the span stack trace is an async process. Wait a little before flushing
       setTimeout(function () {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -65,11 +65,11 @@ agent.startSpan('foo')
 agent.startSpan('foo', 'bar')
 agent.startSpan('foo', 'bar', { childOf: 'baz' })
 
-agent.setTag('foo', 'bar')
-agent.setTag('foo', 1)
-agent.setTag('foo', false)
+agent.setLabel('foo', 'bar')
+agent.setLabel('foo', 1)
+agent.setLabel('foo', false)
 
-agent.addTags({ s: 'bar', n: 42, b: false })
+agent.addLabels({ s: 'bar', n: 42, b: false })
 
 agent.setUserContext({
   id: 'foo',
@@ -117,11 +117,11 @@ agent.logger.fatal('')
   if (trans) {
     trans.traceparent.split('-')
 
-    trans.setTag('foo', 'bar')
-    trans.setTag('foo', 42)
-    trans.setTag('foo', false)
+    trans.setLabel('foo', 'bar')
+    trans.setLabel('foo', 42)
+    trans.setLabel('foo', false)
 
-    trans.addTags({ s: 'bar', n: 42, b: false })
+    trans.addLabels({ s: 'bar', n: 42, b: false })
 
     trans.startSpan()
     trans.startSpan('foo')
@@ -146,11 +146,11 @@ agent.logger.fatal('')
     if (span) {
       span.traceparent.split('-')
 
-      span.setTag('foo', 'bar')
-      span.setTag('foo', 42)
-      span.setTag('foo', false)
+      span.setLabel('foo', 'bar')
+      span.setLabel('foo', 42)
+      span.setLabel('foo', false)
 
-      span.addTags({ s: 'bar', n: 42, b: false })
+      span.addLabels({ s: 'bar', n: 42, b: false })
 
       span.end()
       span.end(42)


### PR DESCRIPTION
I've renamed tags to labels in the API, as suggested by [ECS](https://github.com/elastic/ecs). This includes renaming in the docs. I'm unsure if the old anchors should be left. Do we want to leave the whole sections in-tact with some sort of deprecation notice? I tried searching the docs for other deprecation warnings and didn't find anything to copy. 🤔 

Fixes #962

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
