### PR TITLE
added support for default tags

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -237,6 +237,23 @@ it will also get tagged with the same label.
 
 Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 
+[[apm-set-default-tags]]
+==== `apm.setDefaultTags({ [name]: value })`
+
+[small]#Added in: v2.10.0#
+
+* `tags` +{type-object}+ Contains key/value pairs:
+** `name` +{type-string}+
+Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
+as those characters have special meaning in Elasticsearch
+** `value` +{type-string}+
+If a non-string data type is given,
+it's converted to a string before being sent to the APM Server
+
+All transactions and spans will get tagged with those "default tags".
+
+Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
+
 [[apm-add-tags]]
 ==== `apm.addTags({ [name]: value })`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,7 @@ declare class Agent implements Taggable, StartSpanFn {
   // Context
   setLabel (name: string, value: LabelValue): boolean;
   setTag (name: string, value: LabelValue): boolean; // Deprecated
+  setDefaultTags(labels: Labels): void;
   addLabels (labels: Labels): boolean;
   addTags (labels: Labels): boolean; // Deprecated
   setUserContext (user: UserObject): void;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -86,6 +86,10 @@ Agent.prototype.clearPatches = function (name) {
   return this._instrumentation.clearPatches.apply(this._instrumentation, arguments)
 }
 
+Agent.prototype.setDefaultTags = function (tags) {
+  return this._instrumentation.setDefaultTags.apply(this._instrumentation, arguments)
+}
+
 Agent.prototype.startTransaction = function (name, type, { startTime, childOf } = {}) {
   return this._instrumentation.startTransaction.apply(this._instrumentation, arguments)
 }

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -44,6 +44,8 @@ var MODULES = [
   'ws'
 ]
 
+var defaultTags = {}
+
 module.exports = Instrumentation
 
 function Instrumentation (agent) {
@@ -72,6 +74,10 @@ function Instrumentation (agent) {
   for (let mod of MODULES) {
     this.addPatch(mod, require.resolve(`./modules/${mod}`))
   }
+}
+
+Instrumentation.prototype.setDefaultTags = function (tags) {
+  defaultTags = tags
 }
 
 Instrumentation.prototype.addPatch = function (name, handler) {
@@ -178,6 +184,12 @@ Instrumentation.prototype._patchModule = function (exports, name, version, enabl
 Instrumentation.prototype.addEndedTransaction = function (transaction) {
   var agent = this._agent
 
+  if (!transaction._tags) {
+    transaction._tags = {}
+  }
+
+  Object.assign(transaction._tags, defaultTags)
+
   if (this._started) {
     var payload = agent._transactionFilters.process(transaction._encode())
     if (!payload) return agent.logger.debug('transaction ignored by filter %o', { trans: transaction.id, trace: transaction.traceId })
@@ -190,6 +202,12 @@ Instrumentation.prototype.addEndedTransaction = function (transaction) {
 
 Instrumentation.prototype.addEndedSpan = function (span) {
   var agent = this._agent
+
+  if (!span._tags) {
+    span._tags = {}
+  }
+  
+  Object.assign(span._tags, defaultTags)
 
   if (this._started) {
     agent.logger.debug('encoding span %o', { span: span.id, parent: span.parentId, trace: span.traceId, name: span.name, type: span.type })


### PR DESCRIPTION
This pull request adds support for "defaultTags" applied to all transactions and spans. This solves an Issue according to:
- Elastic Support Case 00327560
- Thomas Watson's (wa7son) comment ["It's currently not possible to set "global" tags etc that will automatically be applied to all transactions."](https://discuss.elastic.co/t/apm-nodejs-agent-how-to-use-setusercontext-settag-setcustomcontext/158800/6)
- and is might be related with [Issue 42](https://github.com/elastic/apm/issues/42)

### Checklist

- [x] Implement code
- [ ] Add tests
- [x] Update documentation
