### PR TITLE
fix(config): do not use ELASTIC_APM_ prefix for k8s

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -641,7 +641,7 @@ it will be parsed out of the `/proc/self/cgroup` file.
 ==== `kubernetesNodeName`
 
 * *Type:* String
-* *Env:* `ELASTIC_APM_KUBERNETES_NODE_NAME`
+* *Env:* `KUBERNETES_NODE_NAME`
 
 Specify the kubernetes node name to associate with all reported events.
 
@@ -649,7 +649,7 @@ Specify the kubernetes node name to associate with all reported events.
 ==== `kubernetesNamespace`
 
 * *Type:* String
-* *Env:* `ELASTIC_APM_KUBERNETES_NAMESPACE`
+* *Env:* `KUBERNETES_NAMESPACE`
 
 Specify the kubernetes namespace to associate with all reported events.
 
@@ -657,7 +657,7 @@ Specify the kubernetes namespace to associate with all reported events.
 ==== `kubernetesPodName`
 
 * *Type:* String
-* *Env:* `ELASTIC_APM_KUBERNETES_POD_NAME`
+* *Env:* `KUBERNETES_POD_NAME`
 
 Specify the kubernetes pod name to associate with all reported events.
 If absent,
@@ -668,7 +668,7 @@ this will default to the local hostname.
 ==== `kubernetesPodUID`
 
 * *Type:* String
-* *Env:* `ELASTIC_APM_KUBERNETES_POD_UID`
+* *Env:* `KUBERNETES_POD_UID`
 
 Specify the kubernetes pod uid to associate with all reported events.
 If absent,

--- a/lib/config.js
+++ b/lib/config.js
@@ -105,10 +105,10 @@ var ENV_TABLE = {
   disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
   payloadLogFile: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
   containerId: 'ELASTIC_APM_CONTAINER_ID',
-  kubernetesNodeName: 'ELASTIC_APM_KUBERNETES_NODE_NAME',
-  kubernetesNamespace: 'ELASTIC_APM_KUBERNETES_NAMESPACE',
-  kubernetesPodName: 'ELASTIC_APM_KUBERNETES_POD_NAME',
-  kubernetesPodUID: 'ELASTIC_APM_KUBERNETES_POD_UID',
+  kubernetesNodeName: [ 'ELASTIC_APM_KUBERNETES_NODE_NAME', 'KUBERNETES_NODE_NAME' ],
+  kubernetesNamespace: [ 'ELASTIC_APM_KUBERNETES_NAMESPACE', 'KUBERNETES_NAMESPACE' ],
+  kubernetesPodName: [ 'ELASTIC_APM_KUBERNETES_POD_NAME', 'KUBERNETES_POD_NAME' ],
+  kubernetesPodUID: [ 'ELASTIC_APM_KUBERNETES_POD_UID', 'KUBERNETES_POD_UID' ],
   captureHeaders: 'ELASTIC_APM_CAPTURE_HEADERS',
   metricsInterval: 'ELASTIC_APM_METRICS_INTERVAL',
   usePathAsTransactionName: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
@@ -280,7 +280,12 @@ function readEnv () {
 
   Object.keys(ENV_TABLE).forEach(function (key) {
     var env = ENV_TABLE[key]
-    if (env in process.env) opts[key] = process.env[env]
+    if (!Array.isArray(env)) env = [ env ]
+    for (let envKey of env) {
+      if (envKey in process.env) {
+        opts[key] = process.env[envKey]
+      }
+    }
   })
 
   return opts

--- a/test/config.js
+++ b/test/config.js
@@ -313,6 +313,25 @@ keyValuePairValues.forEach(function (key) {
   })
 })
 
+var noPrefixValues = [
+  ['kubernetesNodeName', 'KUBERNETES_NODE_NAME'],
+  ['kubernetesNamespace', 'KUBERNETES_NAMESPACE'],
+  ['kubernetesPodName', 'KUBERNETES_POD_NAME'],
+  ['kubernetesPodUID', 'KUBERNETES_POD_UID']
+]
+
+noPrefixValues.forEach(function (pair) {
+  const [ key, envVar ] = pair
+  test(`maps ${envVar} to ${key}`, (t) => {
+    var agent = Agent()
+    process.env[envVar] = 'test'
+    agent.start()
+    delete process.env[envVar]
+    t.equal(agent._conf[key], 'test')
+    t.end()
+  })
+})
+
 test('should overwrite option property active by ELASTIC_APM_ACTIVE', function (t) {
   var agent = Agent()
   var opts = { serviceName: 'foo', secretToken: 'baz', active: true }


### PR DESCRIPTION
This makes kubernetes environment variables consistent with other agents while not breaking the prior behaviour. We should consider deprecating and removing the old environment variables in the next major.

Fixes #1028 

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
