### PR TITLE
fix(instrumentation): prevent handler leak in bindEmitter

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -256,6 +256,8 @@ Instrumentation.prototype.startSpan = function () {
   return this.currentTransaction.startSpan.apply(this.currentTransaction, arguments)
 }
 
+var wrapped = Symbol('elastic-apm-wrapped-function')
+
 Instrumentation.prototype.bindFunction = function (original) {
   if (typeof original !== 'function' || original.name === 'elasticAPMCallbackWrapper') return original
 
@@ -265,6 +267,8 @@ Instrumentation.prototype.bindFunction = function (original) {
   if (trans && !trans.sampled) {
     return original
   }
+
+  original[wrapped] = elasticAPMCallbackWrapper
 
   return elasticAPMCallbackWrapper
 
@@ -284,17 +288,26 @@ Instrumentation.prototype.bindFunction = function (original) {
 Instrumentation.prototype.bindEmitter = function (emitter) {
   var ins = this
 
-  var methods = [
+  var addMethods = [
     'on',
     'addListener'
   ]
 
+  var removeMethods = [
+    'off',
+    'removeListener'
+  ]
+
   if (semver.satisfies(process.versions.node, '>=6')) {
-    methods.push('prependListener')
+    addMethods.push('prependListener')
   }
 
-  shimmer.massWrap(emitter, methods, (original) => function (name, handler) {
+  shimmer.massWrap(emitter, addMethods, (original) => function (name, handler) {
     return original.call(this, name, ins.bindFunction(handler))
+  })
+
+  shimmer.massWrap(emitter, removeMethods, (original) => function (name, handler) {
+    return original.call(this, name, handler[wrapped] || handler)
   })
 }
 

--- a/test/instrumentation/index.js
+++ b/test/instrumentation/index.js
@@ -474,6 +474,32 @@ test('bind', function (t) {
     fn()
   })
 
+  t.test('removes listeners properly', function (t) {
+    resetAgent(1, function (data) {
+      t.equal(data.transactions.length, 1)
+      t.end()
+    })
+    var ins = agent._instrumentation
+    var trans = ins.startTransaction('foo')
+    var listeners
+
+    var emitter = new EventEmitter()
+    ins.bindEmitter(emitter)
+
+    function handler () { }
+
+    emitter.addListener('foo', handler)
+    listeners = emitter.listeners('foo')
+    t.equal(listeners.length, 1)
+    t.notEqual(listeners[0], handler)
+
+    emitter.removeListener('foo', handler)
+    listeners = emitter.listeners('foo')
+    t.equal(listeners.length, 0)
+
+    trans.end()
+  })
+
   var methods = [
     'on',
     'once',


### PR DESCRIPTION
I fixed the event emitter leak described in https://discuss.elastic.co/t/elastic-apm-node-memory-leak/179245 by ensuring calls to remove listeners use the wrapped function when given the unwrapped function.

### Checklist

- [x] Implement code
- [x] Add tests
