### PR TITLE
docs: document additional capture error options

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -324,13 +324,13 @@ it's possible to use this option to supply an additional message string that wil
 
 ** `custom` - See <<metadata,metadata section>> for details about this option
 
-** `request` +{type-incomingmessage}+ You can associate an error with information about the incoming request to gain additional context such as the request url, headers and cookies. 
-However in most cases the agent will detect if an error was in response to a http request and automatically add the request details for you. 
-See <<http-requests, http requests section>> for more details.
+** `request` +{type-incomingmessage}+ You can associate an error with information about the incoming request to gain additional context such as the request url, headers, and cookies.
+However, in most cases, the agent will detect if an error was in response to an http request and automatically add the request details for you.
+See <<http-requests,http requests section>> for more details.
 
-** `response` +{type-serverresponse}+ You can associate an error with information about the http response to get additional details such as status code and headers. 
-However in most cases the agent will detect if an error occured during a http request and automatically response details for you. 
-See <<http-responses, http responses section>> for more details.
+** `response` +{type-serverresponse}+ You can associate an error with information about the http response to get additional details such as status code and headers.
+However, in most cases, the agent will detect if an error occured during an http request and automatically add response details for you.
+See <<http-responses,http responses section>> for more details.
 
 ** `handled` +{type-boolean}+ Adds additional context to the exception to show whether the error is handled or uncaught.
 *Default:* `true`.

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -324,6 +324,14 @@ it's possible to use this option to supply an additional message string that wil
 
 ** `custom` - See <<metadata,metadata section>> for details about this option
 
+** `request` You can associate an error with an instance of `http.IncomingMessage` to gain additional context such as the request url, headers and cookies. However in most cases the agent will detect if an error was in response to a  http request and automatically add the request details for you. See <<http-requests, http requests section>> for more details.
+
+** `response` You can associate an error with an instance of `http.ServerResponse` to get additional details such as status code and headers. However in most cases the agent will detect if an error occured during a http request and automatically response details for you. See <<http-responses, http responses section>> for more details.
+
+** `handled` +{type-boolean}+ true by default. Adds additional context to the exception to show whether the error is handled or uncaught.
+
+** `tags` +{type-object}+ Add aditional context with tags, these tags will be merged with the tags inside the current transaction.
+
 * `callback` - Will be called after the error has been sent to the APM Server.
 It will receive an `Error` instance if the agent failed to send the error,
 and the id of the captured error

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -324,13 +324,19 @@ it's possible to use this option to supply an additional message string that wil
 
 ** `custom` - See <<metadata,metadata section>> for details about this option
 
-** `request` You can associate an error with an instance of `http.IncomingMessage` to gain additional context such as the request url, headers and cookies. However in most cases the agent will detect if an error was in response to a  http request and automatically add the request details for you. See <<http-requests, http requests section>> for more details.
+** `request` +{type-incomingmessage}+ You can associate an error with information about the incoming request to gain additional context such as the request url, headers and cookies. 
+However in most cases the agent will detect if an error was in response to a http request and automatically add the request details for you. 
+See <<http-requests, http requests section>> for more details.
 
-** `response` You can associate an error with an instance of `http.ServerResponse` to get additional details such as status code and headers. However in most cases the agent will detect if an error occured during a http request and automatically response details for you. See <<http-responses, http responses section>> for more details.
+** `response` +{type-serverresponse}+ You can associate an error with information about the http response to get additional details such as status code and headers. 
+However in most cases the agent will detect if an error occured during a http request and automatically response details for you. 
+See <<http-responses, http responses section>> for more details.
 
-** `handled` +{type-boolean}+ true by default. Adds additional context to the exception to show whether the error is handled or uncaught.
+** `handled` +{type-boolean}+ Adds additional context to the exception to show whether the error is handled or uncaught.
+*Default:* `true`.
 
-** `tags` +{type-object}+ Add aditional context with tags, these tags will be merged with the tags inside the current transaction.
+** `labels` +{type-object}+ Add additional context with labels, these labels will be added to the error along with the labels from the current transaction.
+See the <<apm-add-labels,`apm.addLabels()`>> method for details about the format.
 
 * `callback` - Will be called after the error has been sent to the APM Server.
 It will receive an `Error` instance if the agent failed to send the error,

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -9,6 +9,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :type-function: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function[<Function>]
 :type-error: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[<Error>]
 :type-undefined: https://developer.mozilla.org/en-US/docs/Glossary/Undefined[<Undefined>]
+:type-incomingmessage: https://nodejs.org/api/http.html#http_class_http_incomingmessage[<http.IncomingMessage>]
+:type-serverresponse: https://nodejs.org/api/http.html#http_class_http_serverresponse[<http.ServerResponse>]
 
 ifdef::env-github[]
 NOTE: For the best reading experience,


### PR DESCRIPTION
Fixes elastic/apm-agent-nodejs#932 

I've only just started working with this library so I may have misjudged what some of the options are doing. 