### PR TITLE
fix(instrumentation): explicitly use `require`

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -70,7 +70,13 @@ function Instrumentation (agent) {
   this._patches = new NamedArray()
 
   for (let mod of MODULES) {
-    this.addPatch(mod, require.resolve(`./modules/${mod}`))
+    this.addPatch(mod, (exports, name, version, enabled) => {
+      // Lazy require so that we don't have to use `require.resolve` which
+      // would fail in combination with Webpack. For more info see:
+      // https://github.com/elastic/apm-agent-nodejs/pull/957
+      const patch = require(`./modules/${mod}`)
+      return patch(exports, name, version, enabled)
+    })
   }
 }
 


### PR DESCRIPTION
This PR is a replacement for #957:

> Closes the webpack issue causing https://github.com/elastic/apm-agent-nodejs/issues/955. Personally, I'd just avoid the API where people can define paths at all - it'll never work in bundlers and it just adds additional code. I'm not sure I understand the value except late requires, but that seems negligible.
> 
> Fixes #1048