### PR TITLE
fix: url.parse expects req.url not req

### DIFF
--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -4,7 +4,8 @@ var parseUrl
 try {
   parseUrl = require('parseurl')
 } catch (e) {
-  parseUrl = require('url').parse
+  const url = require('url')
+  parseUrl = req => url.parse(req.url)]
 }
 var symbols = require('../symbols')
 

--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -5,7 +5,7 @@ try {
   parseUrl = require('parseurl')
 } catch (e) {
   const url = require('url')
-  parseUrl = req => url.parse(req.url)]
+  parseUrl = req => url.parse(req.url)
 }
 var symbols = require('../symbols')
 


### PR DESCRIPTION
The `parseurl` module receives a request object while `url.parse` expects to receive the url string. This should fix that. I'm not sure how to test this though, as it loads the url module as a fallback when first running the module. An alternative would maybe be to just add `parseurl` to the dependencies and _always_ use it. 🤔 

### Checklist

- [x] Implement code
- [ ] Add tests
