### PR TITLE
test(jenkins): fail test if part of pipeline fails

### DIFF
--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e # abort if any of the commands exit badly
+set -eo pipefail # abort if any of the commands exit badly
 
 number_of_started_containers () {
   echo "$(docker ps --format '{{.ID}}' | wc -l | awk '{$1=$1};1')"


### PR DESCRIPTION
This is required for Jenkins to behave correctly because the output of the tests are piped into a tap parser:

https://github.com/elastic/apm-agent-nodejs/blob/9abb4aa926fdca65e70c570735f8f91985905952/test/script/run_tests.sh#L48