### PR TITLE
[docs] update npm run docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,6 @@ jobs:
       node_js: '8'
       env: ELASTIC_APM_ASYNC_HOOKS=false
 
-    # Docs
-    -
-      script: npm run docs
-      name: "Build Docs"
-      perl: '5.26'
-
     # Commit Messages
     -
       node_js: 'lts/*'

--- a/docs/scripts/build_docs.sh
+++ b/docs/scripts/build_docs.sh
@@ -27,6 +27,6 @@ dest_dir="$html_dir/${name}"
 mkdir -p "$dest_dir"
 params="--chunk=1"
 if [ "$PREVIEW" = "1" ]; then
-  params="--chunk=1 -open chunk=1 -open"
+  params="$params --open"
 fi
-$docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+$docs_dir/build_docs --asciidoctor $params --doc "$index" --out "$dest_dir"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "docs": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
+    "docs:open": "PREVIEW=1 ./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
+    "docs:build": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "lint:commit": "test/lint-commits.sh",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "docs:open": "PREVIEW=1 ./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
+    "docs:open": "PREVIEW=1 npm run docs:build",
     "docs:build": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
     "lint": "standard",
     "lint:fix": "standard --fix",


### PR DESCRIPTION
* Fixes https://github.com/elastic/apm-agent-nodejs/issues/1072 by using docker and asciidoctor to build the docs.
* Fixes https://github.com/elastic/apm-agent-nodejs/issues/1071 by removing the docs build from travis

I was bored last night so I played around with this. I think I need your help, not sure what the best way to have a "build" and an "open" script is. In this potential solution I added a `docs:open` script that opens the documentation and a `docs:build` script that just builds it. Not sure what a best practice would be though. 