### PR TITLE
test(fastify): exclude v2.4.0 from test matrix

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -233,7 +233,7 @@ restify-new:
   commands: node test/instrumentation/modules/restify/basic.js
 
 fastify:
-  versions: '>=0.27.0 <0.29.0 || >0.29.0'
+  versions: '>=0.27.0 <0.29.0 || >0.29.0 <2.4.0 || >2.4.0'
   commands:
     - node test/instrumentation/modules/fastify/fastify.js
     - node test/instrumentation/modules/fastify/async-await.js


### PR DESCRIPTION
It's a broken release.