### PR TITLE
fix: don't add traceparent header to signed AWS requests

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -4,8 +4,6 @@ var url = require('url')
 
 var endOfStream = require('end-of-stream')
 
-const s3Host = /\.s3\.amazonaws\.com$/
-
 const transactionForResponse = new WeakMap()
 exports.transactionForResponse = transactionForResponse
 
@@ -127,7 +125,7 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       // to indicate requested services should not be sampled.
       // Use the transaction context as the parent, in this case.
       var parent = span || agent.currentTransaction
-      if (parent && parent._context && shouldPropagateTraceContext(options.host)) {
+      if (parent && parent._context && shouldPropagateTraceContext(options)) {
         options.headers['elastic-apm-traceparent'] = parent._context.toString()
       }
 
@@ -188,6 +186,11 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
   }
 }
 
-function shouldPropagateTraceContext (host) {
-  return !s3Host.test(host)
+function shouldPropagateTraceContext (opts) {
+  return !isAWSSigned(opts)
+}
+
+function isAWSSigned (opts) {
+  const auth = opts.headers && (opts.headers['Authorization'] || opts.headers['authorization'])
+  return typeof auth === 'string' ? auth.startsWith('AWS4-') : false
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@commitlint/travis-cli": "^7.2.1",
     "@types/node": "^12.0.0",
     "apollo-server-express": "^2.1.0",
+    "aws-sdk": "^2.463.0",
     "bluebird": "^3.5.2",
     "cassandra-driver": "^4.0.0",
     "commitlint-config-squash-pr": "^1.0.0",

--- a/test/instrumentation/modules/http/aws.js
+++ b/test/instrumentation/modules/http/aws.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const agent = require('../../../..').start({
+  captureExceptions: false,
+  metricsInterval: 0
+})
+
+const http = require('http')
+
+const AWS = require('aws-sdk')
+const test = require('tape')
+
+AWS.config.update({
+  accessKeyId: 'foo',
+  secretAccessKey: 'bar'
+})
+
+test('non aws-sdk request', function (t) {
+  const server = http.createServer(function (req, res) {
+    t.equal(req.headers['authorization'], undefined, 'no authorization header')
+    t.ok(req.headers['elastic-apm-traceparent'].length > 0, 'elastic-apm-traceparent header')
+    res.end()
+    server.close()
+    t.end()
+  })
+
+  server.listen(function () {
+    const port = server.address().port
+
+    agent.startTransaction()
+
+    const req = http.request({ port }, function (res) {
+      res.resume()
+    })
+    req.end()
+  })
+})
+
+test('aws-sdk request', function (t) {
+  const server = http.createServer(function (req, res) {
+    t.equal(req.headers['authorization'].substr(0, 5), 'AWS4-', 'AWS authorization header')
+    t.equal(req.headers['elastic-apm-traceparent'], undefined, 'no elastic-apm-traceparent header')
+    res.end()
+    server.close()
+    t.end()
+  })
+
+  server.listen(function () {
+    const port = server.address().port
+    const endpoint = new AWS.Endpoint('http://localhost:' + port)
+    const s3 = new AWS.S3({ endpoint })
+
+    agent.startTransaction()
+
+    s3.listBuckets(function (err, data) {
+      if (err) throw err
+    })
+  })
+})


### PR DESCRIPTION
If the outgoing HTTP request is signed with an AWS version 4 signature, this traceparent header will not be added by the agent.

Fixes #1055