### PR TITLE
fix(metrics): report correct CPU usage on Linux

### DIFF
--- a/lib/metrics/platforms/linux/index.js
+++ b/lib/metrics/platforms/linux/index.js
@@ -2,9 +2,9 @@
 
 const Stats = require('./stats')
 
-module.exports = function createSystemMetrics (registry, interval) {
+module.exports = function createSystemMetrics (registry, reportingIntervalInSeconds) {
   const stats = new Stats()
-  stats.start(interval)
+  stats.start(reportingIntervalInSeconds)
 
   const metrics = [
     'system.cpu.total.norm.pct',

--- a/lib/metrics/platforms/linux/stats.js
+++ b/lib/metrics/platforms/linux/stats.js
@@ -173,13 +173,13 @@ class Stats {
     this.inProgress = false
   }
 
-  start (interval, cb) {
+  start (reportingIntervalInSeconds, cb) {
     if (this.timer) this.stop()
 
     const timer = setInterval(() => {
       if (cb) cb(this.toJSON())
       this.reload()
-    }, interval)
+    }, reportingIntervalInSeconds * 1000)
 
     this.timer = timer
     timer.unref()

--- a/lib/metrics/registry.js
+++ b/lib/metrics/registry.js
@@ -12,7 +12,7 @@ const createSystemMetrics = process.platform === 'linux'
 const defaultReporterOptions = {
   defaultDimensions: {
     hostname: os.hostname(),
-    env: process.env.NODE_ENV || 'development'
+    env: process.env.NODE_ENV || 'development' // TODO: Use environment config option once it lands
   }
 }
 
@@ -21,8 +21,7 @@ class MetricsRegistry extends SelfReportingMetricsRegistry {
     const options = Object.assign({}, defaultReporterOptions, reporterOptions)
     const reporter = new MetricsReporter(transport, options)
     super(reporter, registryOptions)
-    const interval = options.defaultReportingIntervalInSeconds
-    if (interval) createSystemMetrics(this, interval)
+    if (options.enabled) createSystemMetrics(this, options.defaultReportingIntervalInSeconds)
   }
 
   shutdown () {


### PR DESCRIPTION
CPU usage metrics are reported to the APM Server at a set interval. Instead of looking at the time spend on CPU since the last reporting, the CPU usage metrics on Linux only looked at the last 100th fraction of that time. E.g. if reporting metrics every 10 seconds (the default), the CPU usage numbers in each reporting would only cover the last 100ms - leaving a big gap of 9900ms unreported.

In reality, the entire 10 seconds was calculated, but in chunks of 100ms. And only the calculation for the last 100ms interval was kept. So not only was the data from the 9900ms lost, it also incurred an
unnecessary calculation overhead. This overhead is now also avoided.

Fixes #1068 

(snuck in some minor unrelated cleanup as will - hope you don't mind)