### PR TITLE
test(tav): add set-framework tests to tav test matrix

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -205,12 +205,16 @@ pug:
 hapi-no-async-await:
   name: hapi
   versions: '>=9.0.1 <17.0.0'
-  commands: node test/instrumentation/modules/hapi/basic.js
+  commands:
+    - node test/instrumentation/modules/hapi/basic.js
+    - node test/instrumentation/modules/hapi/set-framework.js
 hapi-async-await:
   name: hapi
   node: '>=8.2'
   versions: '>=17.0.0'
-  commands: node test/instrumentation/modules/hapi/basic.js
+  commands:
+    - node test/instrumentation/modules/hapi/basic.js
+    - node test/instrumentation/modules/hapi/set-framework.js
 
 tedious:
   name: tedious
@@ -225,18 +229,23 @@ cassandra-driver:
 restify-old:
   name: restify
   versions: '>=5.2.0 <8.0.0'
-  commands: node test/instrumentation/modules/restify/basic.js
+  commands:
+    - node test/instrumentation/modules/restify/basic.js
+    - node test/instrumentation/modules/restify/set-framework.js
 restify-new:
   name: restify
   node: '>=8.6.0'
   versions: '>=8.0.0'
-  commands: node test/instrumentation/modules/restify/basic.js
+  commands:
+    - node test/instrumentation/modules/restify/basic.js
+    - node test/instrumentation/modules/restify/set-framework.js
 
 fastify:
   versions: '>=0.27.0 <0.29.0 || >0.29.0 <2.4.0 || >2.4.0'
   commands:
     - node test/instrumentation/modules/fastify/fastify.js
     - node test/instrumentation/modules/fastify/async-await.js
+    - node test/instrumentation/modules/fastify/set-framework.js
 
 finalhandler:
   versions: '*'


### PR DESCRIPTION
To avoid merge conflicts, this PR doesn't add set-framework tests for Express as that's taken care of in #1111