### PR TITLE
ci(jenkins): don't pollute package.json with tap-junit

### DIFF
--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -44,9 +44,9 @@ run_test_suite () {
   
   if [ -n "${JUNIT}" ]
   then
-    npm i tap-junit
+    npm install -g tap-junit
     nyc node test/test.js | tee test-output.tap
-    cat test-output.tap|./node_modules/.bin/tap-junit --package="Agent Node.js" > junit-node-report.xml
+    cat test-output.tap | tap-junit --package="Agent Node.js" > junit-node-report.xml
   elif [ -z "$COVERAGE" ]
   then
     node test/test.js


### PR DESCRIPTION
This PR fixes the following CI error:

```
Fail! Modules in package.json not used in code: tap-junit
```

If during CI, `npm install` is run without the `-g` flag, the agents dependencies are updated. This might introduce hard to debug errors or as in this case fail the tests.