### PR TITLE
chore: add .ci folder to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@ Jenkinsfile
 TESTING.md
 
 # Folders to ignore
+.ci
 .github
 docs
 test


### PR DESCRIPTION
We forgot to add this when the `.ci` folder was added