### PR TITLE
test: fix broken intake API schema tests

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -33,10 +33,14 @@ FILES=( \
   "process.json" \
   "request.json" \
   "service.json" \
+  "span_subtype.json" \
+  "span_type.json" \
   "stacktrace_frame.json" \
   "system.json" \
   "tags.json" \
   "timestamp_epoch.json" \
+  "transaction_name.json" \
+  "transaction_type.json" \
   "user.json" \
 )
 


### PR DESCRIPTION
These broke because 4 new files were added in:
https://github.com/elastic/apm-server/pull/2265