### PR TITLE
fix: only log deprecation warning once per function

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -201,7 +201,10 @@ Agent.prototype.setCustomContext = function (context) {
 }
 
 Agent.prototype.setTag = function (key, value) {
-  this.logger.warn('Called deprecated method: apm.setTag(...)')
+  if (!this.setTag._deprecatedLogged) {
+    this.setTag._deprecatedLogged = true
+    this.logger.warn('Called deprecated method: apm.setTag(...)')
+  }
   return this.setLabel(key, value)
 }
 
@@ -212,7 +215,10 @@ Agent.prototype.setLabel = function (key, value) {
 }
 
 Agent.prototype.addTags = function (tags) {
-  this.logger.warn('Called deprecated method: apm.addTags(...)')
+  if (!this.addTags._deprecatedLogged) {
+    this.addTags._deprecatedLogged = true
+    this.logger.warn('Called deprecated method: apm.addTags(...)')
+  }
   return this.addLabels(tags)
 }
 

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -65,7 +65,10 @@ GenericSpan.prototype.duration = function () {
 }
 
 GenericSpan.prototype.setTag = function (key, value) {
-  this._agent.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.setTag(...)`)
+  if (!this.setTag._deprecatedLogged) {
+    this.setTag._deprecatedLogged = true
+    this._agent.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.setTag(...)`)
+  }
   return this.setLabel(key, value)
 }
 
@@ -81,7 +84,10 @@ GenericSpan.prototype.setLabel = function (key, value) {
 }
 
 GenericSpan.prototype.addTags = function (tags) {
-  this._agent.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.addTags(...)`)
+  if (!this.addTags._deprecatedLogged) {
+    this.addTags._deprecatedLogged = true
+    this._agent.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.addTags(...)`)
+  }
   return this.addLabels(tags)
 }
 


### PR DESCRIPTION
The previous implementation would spam the logs if one of these functions were called one or more times per request for instance.

While you're sure to get peoples attention by this, it's also super annoying for the user, which wasn't the intention. So this PR dials it down a bit.