### PR TITLE
ci(jenkins): disable builds in jenkins

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-downstream.yml
+++ b/.ci/jobs/apm-agent-nodejs-downstream.yml
@@ -26,6 +26,7 @@
         shallow-clone: true
         depth: 3
         do-not-fetch-tags: true
+        periodic-folder-trigger: 1d
         submodule:
           disable: false
           recursive: true

--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -11,6 +11,9 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         repo: apm-agent-nodejs
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -17,7 +17,6 @@
     days-to-keep: '1'
     concurrent: true
     node: linux
-    periodic-folder-trigger: 1d
     prune-dead-branches: true
     publishers:
     - email:


### PR DESCRIPTION
## Highlights
- periodic-folder-trigger has now defaulted for the main pipeline.
- Suppresses automatic SCM triggering for the main pipeline.

## Docs
- https://docs.openstack.org/infra/jenkins-job-builder/project_workflow_multibranch.html
 