### PR TITLE
ci(travis): re-add docs build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ jobs:
     -
       script: npm run docs:build
       name: "Build Docs"
-      perl: '5.26'
 
     # Commit Messages
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,12 @@ jobs:
       node_js: '8'
       env: ELASTIC_APM_ASYNC_HOOKS=false
 
+    # Docs
+    -
+      script: npm run docs:build
+      name: "Build Docs"
+      perl: '5.26'
+
     # Commit Messages
     -
       node_js: 'lts/*'


### PR DESCRIPTION
Currently the shared 'elasticsearch-ci/docs-build' CI system is broken and is always failing (we're working on removing it so GitHub builds doesn't fail all the time).

Until we get it back, we need another way to build docs as part of CI. This approach will not do link checking, but it's better than nothing.