### PR TITLE
ci(jenkins): move schedule to a scheduler job

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-schedule-daily.yml
+++ b/.ci/jobs/apm-agent-nodejs-schedule-daily.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: apm-agent-nodejs/apm-agent-nodejs-schedule-daily
+    display-name: Node.js Jobs scheduled daily
+    description: Node.js Jobs scheduled daily from Monday to Friday
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+    - string:
+        name: branch_specifier
+        default: master
+        description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule-daily.groovy
+      scm:
+      - git:
+          url: git@github.com:elastic/apm-agent-nodejs.git
+          refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+          wipe-workspace: 'True'
+          name: origin
+          shallow-clone: true
+          credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-nodejs.git
+          branches:
+          - $branch_specifier
+    triggers:
+    - timed: 'H H(4-5) * * 1-5'

--- a/.ci/jobs/apm-agent-nodejs-schedule-weekly.yml
+++ b/.ci/jobs/apm-agent-nodejs-schedule-weekly.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: apm-agent-nodejs/apm-agent-nodejs-schedule-weekly
+    display-name: Node.js Jobs scheduled weekly (Monday)
+    description: Node.js Jobs scheduled weekly (Monday)
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+    - string:
+        name: branch_specifier
+        default: master
+        description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule-weekly.groovy
+      scm:
+      - git:
+          url: git@github.com:elastic/apm-pipeline-library.git
+          refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+          wipe-workspace: 'True'
+          name: origin
+          shallow-clone: true
+          credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          reference-repo: /var/lib/jenkins/.git-references/apm-pipeline-library.git
+          branches:
+          - $branch_specifier
+    triggers:
+    - timed: 'H H(1-4) * * 1'

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'master' }
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H H(4-5) * * 1-5')
+  }
+  stages {
+    stage('Run Tasks'){
+      steps {
+        build(
+          job: 'apm-agent-nodejs/apm-agent-nodejs-mbp/master',
+          parameters: [
+            booleanParam(name: 'Run_As_Master_Branch', value: false),
+            booleanParam(name: 'doc_ci', value: true),
+            booleanParam(name: 'tav_ci', value: true)
+          ],
+          quietPeriod: 10,
+          wait: false
+        )
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'master' }
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H H(1-4) * * 1')
+  }
+  stages {
+    stage('Run Tasks'){
+      steps {
+        echo "No tasks yet"
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    cron 'H H(3-5) * * 1-5'
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {


### PR DESCRIPTION
Right now, we have the cron task configured on the Jenkins file, this means that every branch and PR uses these settings, so we launch ever branch and PR every day. We want only to launch on daily period only the master branch so we would schedule the task on a special job for that. From here we can schedule daily or weekly whatever we want on a controlled way.

* Daily scheduled job
* Weekly scheduled job
* remove cron from the Jenkinsfile