### PR TITLE
chore: add 'npm run docker:dev' to open cwd in Docker

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ TESTING.md
 # Folders to ignore
 .ci
 .github
+dev-utils
 docs
 test
 

--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  nodejs-agent:
+    image: node:12
+    entrypoint: /bin/bash
+    volumes:
+      - ..:/agent

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "local:stop": "./test/script/local-deps-stop.sh",
     "docker:start": "docker-compose -f ./test/docker-compose.yml up -d",
     "docker:stop": "docker-compose -f ./test/docker-compose.yml down",
-    "docker:clean": "./test/script/docker/cleanup.sh"
+    "docker:clean": "./test/script/docker/cleanup.sh",
+    "docker:dev": "docker-compose -f ./dev-utils/docker-compose.yml run --workdir=/agent nodejs-agent"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
This command will run a temporary Docker container with access to the root of your local agent directory and place you in a bash shell inside it.

This allows you to test things in a Linux environment when you're not running Linux yourself.