### PR TITLE
fix(knex): abort early on unsupported version of knex

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -121,7 +121,7 @@ please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM di
 [options="header"]
 |=================================================
 |Module |Version
-|https://www.npmjs.com/package/knex[knex] |>=0.9.0
+|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <0.18.0
 |=================================================
 
 [float]

--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -1,10 +1,16 @@
 'use strict'
 
+var semver = require('semver')
+
 var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
 
-module.exports = function (Knex, agent, { enabled }) {
+module.exports = function (Knex, agent, { version, enabled }) {
   if (!enabled) return Knex
+  if (semver.gte(version, '0.18.0')) {
+    agent.logger.debug('knex version %s not supported - aborting...', version)
+    return Knex
+  }
   if (Knex.Client && Knex.Client.prototype) {
     var QUERY_FNS = ['queryBuilder', 'raw']
     agent.logger.debug('shimming Knex.Client.prototype.runner')


### PR DESCRIPTION
Knex v0.18.0 was just released, and as has come apparent in #1184, we don't yet support this version.

The issue is in this line:

https://github.com/elastic/apm-agent-nodejs/blob/fe8ff8ac6c71a6a21ba7e0dd787e570e6655f498/lib/instrumentation/modules/knex.js#L36

The `runner` object no longer have a `query` function in knex v0.18.0 and above.