### PR TITLE
chore: clean .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Files to ignore
 .DS_Store
 .vscode
-.schemacache
 package-lock.json
 test/babel/out.js
 test/types/transpile/index.js


### PR DESCRIPTION
This was added in a commit (see https://github.com/elastic/apm-agent-nodejs/commit/d8351ffffe0ce981890dff652b8143146b068bf4#commitcomment-34232598). This file shouldn't exist though. If it comes back, we should look into why and fix the root cause.