### PR TITLE
fix: use npm@6.9.0 fixed version for Node.js < 8

### DIFF
--- a/.ci/docker/node-container/Dockerfile
+++ b/.ci/docker/node-container/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /npm
 RUN ( [ "${NODE_VERSION%%.*}" -le 8  ] \
   && echo "Node.js ${NODE_VERSION} - Manual install npm" \
   && mkdir -p /npm/node_modules \
-  && npm install npm \
+  && npm install npm@6.9.0 \
   && rm /usr/local/bin/npm \
   && ln -s /npm/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm ) || exit 0
 

--- a/.ci/scripts/docker-test.sh
+++ b/.ci/scripts/docker-test.sh
@@ -5,11 +5,7 @@ export
 id
 node --version
 npm --version
-#npm config list
 npm install
-npm list
-#yarn install --no-node-version-check --ignore-engines
-#yarn list
 
 if [[ ! -z ${TAV}  ]]; then
   npm run test:tav|tee tav-output.tap


### PR DESCRIPTION
Node.js 6 is failing to install `http-signature`, locally with docker failed in the same package, outside Docker fails on an optional dependency and can continue, it is a little bit erratic. So I have forced to install `npm@6.9.0` (latest is 6.10.0) and it works so there is something that breaks the `npm install` on `Node.js 6` and `npm@6.10.0`

```
node_tests_1     | 801 http fetch GET 304 https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz 84ms (from cache)
node_tests_1     | 802 silly fetchPackageMetaData error for http-signature@^1.2.0 zlib: zlib binding closed
```

this start happens 6 days ago that it is the same date that npm@6.10.0 was release.