### PR TITLE
fix: user error step, allow empty junit results

### DIFF
--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -124,7 +124,7 @@ class NodeParallelTaskGenerator extends DefaultParallelTaskGenerator {
           saveResult(x, y, 1)
         } catch(e){
           saveResult(x, y, 0)
-          error("${label} tests failed : ${e.toString()}\n")
+          steps.error("${label} tests failed : ${e.toString()}\n")
         } finally {
           steps.wrappingUp()
         }


### PR DESCRIPTION
user error step, allow empty junit results