### PR TITLE
feat(metrics): breakdown graphs

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -128,3 +128,76 @@ The current allocated heap size in bytes.
 * *Format:* Bytes
 
 The currently used heap size in bytes.
+
+[float]
+[[metrics-transaction.duration.sum]]
+=== `transaction.duration.sum`
+
+* *Type:* Long
+* *Type:* Milliseconds
+
+The sum of all transaction durations in ms since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+[float]
+[[metrics-transaction.duration.count]]
+=== `transaction.duration.count`
+
+* *Type:* Long
+* *Type:* Milliseconds
+
+The count of all transactions since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+[float]
+[[metrics-transaction.breakdown.count]]
+=== `transaction.breakdown.count`
+
+* *Type:* Long
+* *Format:* Counter
+
+The number of transactions for which breakdown metrics (`span.self_time`) have been created.
+Breakdown metrics are only collected for sampled transactions.
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+[float]
+[[metrics-span.self_time.sum]]
+=== `span.self_time.sum`
+
+* *Type:* Long
+* *Format:* Milliseconds
+
+The sum of all span self-times in milliseconds since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+* `span.type`: The type of the span, for example `app`, `template` or `db`
+* `span.subtype`: The sub-type of the span, for example `mysql` (optional)
+
+[float]
+[[metrics-span.self_time.count]]
+=== `span.self_time.count`
+
+* *Type:* Long
+* *Format:* Counter
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+* `span.type`: The type of the span, for example `app`, `template` or `db`
+* `span.subtype`: The sub-type of the span, for example `mysql` (optional)

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,7 @@ var DEFAULTS = {
   apiRequestSize: '768kb',
   apiRequestTime: '10s',
   asyncHooks: true,
+  breakdownMetrics: true,
   captureBody: 'off',
   captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
   captureExceptions: true,
@@ -81,6 +82,7 @@ var ENV_TABLE = {
   apiRequestSize: 'ELASTIC_APM_API_REQUEST_SIZE',
   apiRequestTime: 'ELASTIC_APM_API_REQUEST_TIME',
   asyncHooks: 'ELASTIC_APM_ASYNC_HOOKS',
+  breakdownMetrics: 'ELASTIC_APM_BREAKDOWN_METRICS',
   captureBody: 'ELASTIC_APM_CAPTURE_BODY',
   captureErrorLogStackTraces: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
   captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
@@ -123,6 +125,7 @@ var ENV_TABLE = {
 var BOOL_OPTS = [
   'active',
   'asyncHooks',
+  'breakdownMetrics',
   'captureExceptions',
   'captureHeaders',
   'captureSpanStackTraces',

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -16,15 +16,16 @@ module.exports = Span
 util.inherits(Span, GenericSpan)
 
 function Span (transaction, name, type, opts) {
+  var childOf = transaction._agent._instrumentation.activeSpan || transaction
   if (!opts) {
     opts = {
-      timer: transaction._timer,
-      childOf: transaction._agent._instrumentation.activeSpan || transaction
+      timer: childOf._timer,
+      childOf
     }
   } else {
-    opts.timer = transaction._timer
+    opts.timer = childOf._timer
     if (!opts.childOf) {
-      opts.childOf = transaction._agent._instrumentation.activeSpan || transaction
+      opts.childOf = childOf
     }
   }
 

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -62,6 +62,7 @@ Span.prototype.end = function (endTime) {
   this.ended = true
   this._agent.logger.debug('ended span %o', { span: this.id, parent: this.parentId, trace: this.traceId, name: this.name, type: this.type })
   this._agent._instrumentation.addEndedSpan(this)
+  this.transaction._captureBreakdown(this)
 }
 
 Span.prototype.setDbContext = function (context) {

--- a/lib/instrumentation/timer.js
+++ b/lib/instrumentation/timer.js
@@ -2,23 +2,62 @@
 
 var microtime = require('relative-microtime')
 
-module.exports = Timer
-
-// `startTime`: millisecond float
-function Timer (timer, startTime) {
-  this._timer = timer ? timer._timer : microtime()
-  this.start = startTime >= 0 ? startTime * 1000 : this._timer() // microsecond integer
-  this.duration = null // millisecond float
+function maybeTime (timer, time) {
+  return time >= 0 ? time * 1000 : timer._timer()
 }
 
-// `endTime`: millisecond float
-Timer.prototype.end = function (endTime) {
-  if (this.duration !== null) return
-  this.duration = this.elapsed(endTime)
-}
+module.exports = class Timer {
+  // `startTime`: millisecond float
+  constructor (timer, startTime) {
+    this._timer = timer ? timer._timer : microtime()
+    this.start = maybeTime(this, startTime) // microsecond integer
+    this.duration = null // millisecond float
+    this.selfTime = null // millisecond float
 
-// `endTime`: millisecond float
-// returns: millisecond float
-Timer.prototype.elapsed = function (endTime) {
-  return ((endTime >= 0 ? endTime * 1000 : this._timer()) - this.start) / 1000
+    // Track child timings to produce self-time
+    this._parent = timer
+    this.activeChildren = 0
+    this.childStart = 0
+    this.childDuration = 0
+
+    if (this._parent) {
+      this._parent.startChild(startTime)
+    }
+  }
+
+  startChild (startTime) {
+    if (++this.activeChildren === 1) {
+      this.childStart = maybeTime(this, startTime)
+    }
+  }
+
+  endChild (endTime) {
+    if (--this.activeChildren === 0) {
+      this.incrementChildDuration(endTime)
+    }
+  }
+
+  incrementChildDuration (endTime) {
+    this.childDuration = (maybeTime(this, endTime) - this.childStart) / 1000
+    this.childStart = 0
+  }
+
+  // `endTime`: millisecond float
+  end (endTime) {
+    if (this.duration !== null) return
+    this.duration = this.elapsed(endTime)
+    if (this.activeChildren) {
+      this.incrementChildDuration(endTime)
+    }
+    this.selfTime = this.duration - this.childDuration
+    if (this._parent) {
+      this._parent.endChild(endTime)
+    }
+  }
+
+  // `endTime`: millisecond float
+  // returns: millisecond float
+  elapsed (endTime) {
+    return (maybeTime(this, endTime) - this.start) / 1000
+  }
 }

--- a/lib/instrumentation/timer.js
+++ b/lib/instrumentation/timer.js
@@ -3,19 +3,20 @@
 var microtime = require('relative-microtime')
 
 function maybeTime (timer, time) {
+  if (timer._parent) return maybeTime(timer._parent, time)
   return time >= 0 ? time * 1000 : timer._timer()
 }
 
 module.exports = class Timer {
   // `startTime`: millisecond float
   constructor (timer, startTime) {
+    this._parent = timer
     this._timer = timer ? timer._timer : microtime()
     this.start = maybeTime(this, startTime) // microsecond integer
     this.duration = null // millisecond float
     this.selfTime = null // millisecond float
 
     // Track child timings to produce self-time
-    this._parent = timer
     this.activeChildren = 0
     this.childStart = 0
     this.childDuration = 0
@@ -38,7 +39,7 @@ module.exports = class Timer {
   }
 
   incrementChildDuration (endTime) {
-    this.childDuration = (maybeTime(this, endTime) - this.childStart) / 1000
+    this.childDuration += (maybeTime(this, endTime) - this.childStart) / 1000
     this.childStart = 0
   }
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -2,6 +2,9 @@
 
 var util = require('util')
 
+var ObjectIdentityMap = require('object-identity-map')
+var entries = require('object.entries')
+
 var getPathFromRequest = require('./express-utils').getPathFromRequest
 var GenericSpan = require('./generic-span')
 var parsers = require('../parsers')
@@ -30,6 +33,7 @@ function Transaction (agent, name, type, opts = {}) {
   this._droppedSpans = 0
   this._contextLost = false // TODO: Send this up to the server some how
   this._abortTime = 0
+  this._breakdownTimings = new ObjectIdentityMap()
 }
 
 Object.defineProperty(Transaction.prototype, 'name', {
@@ -199,6 +203,7 @@ Transaction.prototype.end = function (result, endTime) {
 
   this._timer.end(endTime)
   this.ended = true
+  this._captureBreakdown(this)
 
   var trans = this._agent._instrumentation.currentTransaction
 
@@ -217,4 +222,73 @@ Transaction.prototype.end = function (result, endTime) {
 
   this._agent._instrumentation.addEndedTransaction(this)
   this._agent.logger.debug('ended transaction %o', { trans: this.id, parent: this.parentId, trace: this.traceId, type: this.type, result: this.result, name: this.name })
+}
+
+Transaction.prototype._captureBreakdown = function (span) {
+  const metrics = this._agent._metrics
+
+  // Record span data
+  captureBreakdown(this, {
+    transaction: transactionBreakdownDetails(this),
+    span: spanBreakdownDetails(span)
+  }, span._timer.selfTime)
+
+  // Record transaction data
+  if (span instanceof Transaction) {
+    const { duration } = this._timer
+    const labels = flattenBreakdown({
+      transaction: transactionBreakdownDetails(this)
+    })
+
+    metrics.getOrCreateCounter('transaction.duration.count', labels).inc()
+    metrics.getOrCreateCounter('transaction.duration.sum.us', labels).inc(duration)
+    metrics.getOrCreateCounter('transaction.breakdown.count', labels).inc(this.sampled ? 1 : 0)
+
+    this._breakdownTimings.forEach(({ labels, time, count }) => {
+      labels = flattenBreakdown(labels)
+      metrics.getOrCreateCounter('span.self_time.count', labels).inc(count)
+      metrics.getOrCreateCounter('span.self_time.sum.us', labels).inc(time)
+    })
+  }
+}
+
+function transactionBreakdownDetails ({ name, type } = {}) {
+  return {
+    name,
+    type
+  }
+}
+
+function spanBreakdownDetails (span) {
+  if (span instanceof Transaction) {
+    return {
+      type: 'app'
+    }
+  }
+
+  const [ type, subtype ] = span.type.split('.')
+  return {
+    type,
+    subtype
+  }
+}
+
+function captureBreakdown (transaction, labels, time) {
+  const build = () => ({ labels, count: 0, time: 0 })
+  const counter = transaction._breakdownTimings.ensure(labels, build)
+  counter.time += time
+  counter.count++
+}
+
+function flattenBreakdown (source, target = {}, prefix = '') {
+  for (const [ key, value ] of entries(source)) {
+    if (typeof value === 'undefined') continue
+    if (typeof value === 'object') {
+      flattenBreakdown(value, target, `${prefix}${key}::`)
+    } else {
+      target[`${prefix}${key}`] = value
+    }
+  }
+
+  return target
 }

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -225,13 +225,17 @@ Transaction.prototype.end = function (result, endTime) {
 }
 
 Transaction.prototype._captureBreakdown = function (span) {
-  const metrics = this._agent._metrics
+  const agent = this._agent
+  const metrics = agent._metrics
+  const conf = agent._conf
 
   // Record span data
-  captureBreakdown(this, {
-    transaction: transactionBreakdownDetails(this),
-    span: spanBreakdownDetails(span)
-  }, span._timer.selfTime)
+  if (this.sampled && conf.breakdownMetrics) {
+    captureBreakdown(this, {
+      transaction: transactionBreakdownDetails(this),
+      span: spanBreakdownDetails(span)
+    }, span._timer.selfTime)
+  }
 
   // Record transaction data
   if (span instanceof Transaction) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -202,8 +202,8 @@ Transaction.prototype.end = function (result, endTime) {
   if (!this._defaultName && this.req) this.setDefaultNameFromRequest()
 
   this._timer.end(endTime)
-  this.ended = true
   this._captureBreakdown(this)
+  this.ended = true
 
   var trans = this._agent._instrumentation.currentTransaction
 
@@ -225,6 +225,7 @@ Transaction.prototype.end = function (result, endTime) {
 }
 
 Transaction.prototype._captureBreakdown = function (span) {
+  if (this.ended) return
   const agent = this._agent
   const metrics = agent._metrics
   const conf = agent._conf

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -20,13 +20,13 @@ class Metrics {
     this[registrySymbol] = null
   }
 
-  start () {
+  start (refTimers) {
     const metricsInterval = this[agentSymbol]._conf.metricsInterval
     this[registrySymbol] = new MetricsRegistry(this[agentSymbol], {
       reporterOptions: {
         defaultReportingIntervalInSeconds: metricsInterval,
         enabled: metricsInterval !== 0,
-        unrefTimers: true,
+        unrefTimers: !refTimers,
         logger: new NoopLogger()
       }
     })

--- a/lib/metrics/registry.js
+++ b/lib/metrics/registry.js
@@ -20,9 +20,10 @@ class MetricsRegistry extends SelfReportingMetricsRegistry {
     }
 
     const options = Object.assign({}, defaultReporterOptions, reporterOptions)
-    const reporter = new MetricsReporter(agent._transport, options)
+    const reporter = new MetricsReporter(agent, options)
 
     super(reporter, registryOptions)
+    this._agent = agent
 
     this._registry.collectors = []
     createSystemMetrics(this)

--- a/lib/metrics/reporter.js
+++ b/lib/metrics/reporter.js
@@ -1,13 +1,15 @@
 'use strict'
 
-const { Reporter } = require('measured-reporting')
 const afterAll = require('after-all-results')
+const { Reporter } = require('measured-reporting')
+const ObjectIdentityMap = require('object-identity-map')
+const entries = require('object.entries')
 
 class MetricsReporter extends Reporter {
-  constructor (transport, options = {}) {
+  constructor (agent, options = {}) {
     super(options)
     this.enabled = options.enabled
-    this.transport = transport
+    this._agent = agent
 
     if (!this.enabled) {
       this.shutdown()
@@ -15,28 +17,60 @@ class MetricsReporter extends Reporter {
   }
 
   _reportMetrics (metrics) {
-    const data = {
+    if (!this.enabled) return
+
+    const baseDimensions = {
       timestamp: Date.now() * 1000,
-      tags: this._getDimensions(metrics),
-      samples: {}
+      tags: this._getDimensions(metrics)
     }
 
     const next = afterAll(() => {
+      const seen = new ObjectIdentityMap()
+
       metrics.forEach(metric => {
+        const data = seen.ensure(metric.dimensions, () => {
+          const metricData = unflattenBreakdown(metric.dimensions)
+          const merged = Object.assign({ samples: {} }, baseDimensions, metricData)
+          Object.assign(merged.tags, baseDimensions.tags, metricData.tags)
+          return merged
+        })
+
         data.samples[metric.name] = {
           value: metric.metricImpl.toJSON()
         }
+
+        if (metric.metricImpl.constructor.name === 'Counter') {
+          metric.metricImpl.reset()
+        }
       })
 
-      if (this.enabled) {
-        this.transport.sendMetricSet(data)
+      for (const metric of seen.values()) {
+        this._agent._transport.sendMetricSet(metric)
       }
     })
 
-    this._registry.collectors.forEach(function (collector) {
+    this._registry.collectors.forEach((collector) => {
       collector.collect(next())
     })
   }
 }
 
 module.exports = MetricsReporter
+
+function unflattenBreakdown (source) {
+  const target = {
+    tags: {}
+  }
+
+  for (const [ key, value ] of entries(source)) {
+    if (key.includes('::')) {
+      const [ parent, child ] = key.split('::')
+      if (!target[parent]) target[parent] = {}
+      target[parent][child] = value
+    } else {
+      target.tags[key] = value
+    }
+  }
+
+  return target
+}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "measured-reporting": "^1.49.0",
     "monitor-event-loop-delay": "^1.0.0",
     "object-filter-sequence": "^1.0.0",
+    "object-identity-map": "^1.0.1",
     "object.entries": "^1.1.0",
     "original-url": "^1.2.2",
     "read-pkg-up": "^4.0.0",

--- a/test/_mock_http_client.js
+++ b/test/_mock_http_client.js
@@ -13,7 +13,7 @@ module.exports = function (expected, done) {
   let timer
 
   const client = {
-    _writes: { length: 0, spans: [], transactions: [], errors: [] },
+    _writes: { length: 0, spans: [], transactions: [], errors: [], metricsets: [] },
     _write (obj, cb) {
       cb = cb || noop
 
@@ -36,8 +36,8 @@ module.exports = function (expected, done) {
     sendError (error, cb) {
       this._write({ error }, cb)
     },
-    sendMetricSet (error, cb) {
-      this._write({ error }, cb)
+    sendMetricSet (metricset, cb) {
+      this._write({ metricset }, cb)
     },
     flush (cb) {
       if (cb) process.nextTick(cb)

--- a/test/instrumentation/github-issue-75.js
+++ b/test/instrumentation/github-issue-75.js
@@ -3,6 +3,7 @@
 var agent = require('../..').start({
   serviceName: 'test',
   captureExceptions: false,
+  metricsInterval: 0,
   asyncHooks: true
 })
 

--- a/test/instrumentation/index.js
+++ b/test/instrumentation/index.js
@@ -2,7 +2,8 @@
 
 var agent = require('../..').start({
   serviceName: 'test',
-  captureExceptions: false
+  captureExceptions: false,
+  metricsInterval: 0
 })
 
 var EventEmitter = require('events')

--- a/test/metrics/breakdown.js
+++ b/test/metrics/breakdown.js
@@ -1,0 +1,142 @@
+'use strict'
+
+process.env.ELASTIC_APM_TEST = true
+
+const agent = require('../..').start({
+  serviceName: 'test',
+  captureExceptions: false,
+  metricsInterval: 0
+})
+
+const http = require('http')
+const test = require('tape')
+
+const Metrics = require('../../lib/metrics')
+const mockClient = require('../_mock_http_client')
+
+const basicMetrics = [
+  'system.cpu.total.norm.pct',
+  'system.memory.total',
+  'system.memory.actual.free',
+  'system.process.cpu.total.norm.pct',
+  'system.process.cpu.system.norm.pct',
+  'system.process.cpu.user.norm.pct',
+  'system.process.memory.rss.bytes',
+  'nodejs.handles.active',
+  'nodejs.requests.active',
+  'nodejs.eventloop.delay.ns',
+  'nodejs.memory.heap.allocated.bytes',
+  'nodejs.memory.heap.used.bytes',
+  'nodejs.eventloop.delay.avg.ms'
+]
+
+if (process.platform === 'linux') {
+  basicMetrics.push('system.process.memory.size')
+}
+
+test('includes breakdown when sampling', t => {
+  resetAgent(7, (data) => {
+    t.equal(data.transactions.length, 1, 'has one transaction')
+    assertTransaction(t, data.transactions[0])
+
+    t.equal(data.spans.length, 1, 'has one span')
+    assertSpan(t, data.spans[0])
+
+    t.equal(data.metricsets.length, 5, 'has five metricsets')
+
+    assertMetricSet(t, 'initial basic', data.metricsets[0], basicMetrics)
+    assertMetricSet(t, 'second tick basic', data.metricsets[1], basicMetrics)
+    assertMetricSet(t, 'transaction', data.metricsets[2], [
+      'transaction.duration.count',
+      'transaction.duration.sum.us',
+      'transaction.breakdown.count'
+    ], {
+      transaction: {
+        name: 'GET unknown route',
+        type: 'request'
+      }
+    })
+    assertMetricSet(t, 'transaction span', data.metricsets[3], [
+      'span.self_time.count',
+      'span.self_time.sum.us'
+    ], {
+      transaction: {
+        name: 'GET unknown route (unnamed)',
+        type: 'request'
+      },
+      span: {
+        type: 'custom'
+      }
+    })
+    assertMetricSet(t, 'span', data.metricsets[4], [
+      'span.self_time.count',
+      'span.self_time.sum.us'
+    ], {
+      transaction: {
+        name: 'GET unknown route',
+        type: 'request'
+      },
+      span: {
+        type: 'app'
+      }
+    })
+
+    agent._metrics.stop()
+    server.close()
+    t.end()
+  })
+
+  var server = http.createServer(function (req, res) {
+    var span = agent.startSpan('test')
+    setTimeout(function () {
+      span.end()
+      res.end()
+    }, 50)
+  })
+
+  server.listen(function () {
+    var port = server.address().port
+    request(`http://localhost:${port}`)
+  })
+})
+
+function assertTransaction (t, trans) {
+  t.comment('transaction')
+  t.equal(trans.type, 'request', 'is a request')
+  t.equal(trans.result, 'HTTP 2xx', 'result is 2xx')
+  t.equal(trans.sampled, true, 'is sampled')
+}
+
+function assertSpan (t, span) {
+  t.comment('span')
+  t.equal(span.type, 'custom', 'is custom type')
+  t.equal(span.name, 'test', 'is named test')
+}
+
+function assertMetricSet (t, name, metricSet, keys, { transaction, span } = {}) {
+  t.comment(`metricSet - ${name} metrics`)
+  t.deepEqual(Object.keys(metricSet.samples).sort(), keys.sort(), 'has expected sample keys')
+  t.deepEqual(metricSet.transaction, transaction, 'has expected transaction data')
+  t.deepEqual(metricSet.span, span, 'has expected span data')
+}
+
+function request (url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, function (res) {
+      const chunks = []
+      res.on('error', reject)
+      res.on('data', chunks.push.bind(chunks))
+      res.on('end', () => resolve(Buffer.concat(chunks)))
+    })
+    req.on('error', reject)
+  })
+}
+
+function resetAgent (expected, cb) {
+  agent._conf.metricsInterval = 5
+  agent._instrumentation.currentTransaction = null
+  agent._transport = mockClient(expected, cb)
+  agent._metrics = new Metrics(agent)
+  agent._metrics.start()
+  agent.captureError = function (err) { throw err }
+}

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -88,6 +88,10 @@ test('fails', function (t) {
 
 function onError (t, assert) {
   agent._transport = {
+    flush () {},
+    sendTransaction () {},
+    sendSpan () {},
+    sendMetricSet () {},
     sendError (error, cb) {
       assert(t, error)
       t.end()


### PR DESCRIPTION
This expands the timer and transaction classes to enable capturing breakdown graph metrics. I don't really like the flatten/unflatten thing, but I'm not sure there's a better way, since measured doesn't support the nested dimensions we need to separate transaction and span data. 🤔 

Closes #1064

### Checklist

- [x] Implement code
- [x] Add tests
- [ ] Update documentation
