### PR TITLE
ci(jenkins): enable polling for change request/branches

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -11,9 +11,6 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        property-strategies:
-          all-branches:
-          - suppress-scm-triggering: true
         repo: apm-agent-nodejs
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -11,13 +11,12 @@
     view: APM-CI
     project-type: multibranch
     logrotate:
-      daysToKeep: 30
       numToKeep: 100
     number-to-keep: '5'
     days-to-keep: '1'
     concurrent: true
     node: linux
-    periodic-folder-trigger: 7d
+    periodic-folder-trigger: 1d
     prune-dead-branches: true
     publishers:
     - email:


### PR DESCRIPTION
## Highlights
- Enable polling once a day even though it's push-based.
- Enable scm triggering for the PRs as it used to be.