### PR TITLE
ci(jenkins): exclude greenkeeper branches

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -6,11 +6,12 @@
     script-path: Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        head-filter-regex: '^(?!greenkeeper).*$'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true
@@ -26,9 +27,6 @@
         - regular-branches: true
         - change-request:
             ignore-target-only-changes: false
-        - named-branches:
-            - wildcards-name:
-                excludes: 'greenkeeper*'
         clean:
           after: true
           before: true


### PR DESCRIPTION
## Highlights
- This is the way to exclude the greenkeeper branches. See the below screenshot as the outcome of applying this change.

![image](https://user-images.githubusercontent.com/2871786/61551173-5f065e00-aa4c-11e9-9f4b-123ab75a641e.png)
