### PR TITLE
ci(travis): cache elasticsearch deb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,23 @@ services:
   - redis-server
   - postgresql
   - cassandra
+  
+cache:
+  directories:
+    - deb-cache
+  
+env:
+  global:
+    - ELASTICSEARCH_DEB_VERSION=6.6.0
+    - ELASTICSEARCH_DEB_PACKAGE=elasticsearch-${ELASTICSEARCH_DEB_VERSION}.deb
 
 before_install:
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.6.0.deb && sudo dpkg -i --force-confnew elasticsearch-6.6.0.deb && sudo service elasticsearch restart
+  - |
+    if [ ! -f ./deb-cache/$ELASTICSEARCH_DEB_PACKAGE ]
+    then
+      curl -o ./deb-cache/$ELASTICSEARCH_DEB_PACKAGE https://artifacts.elastic.co/downloads/elasticsearch/$ELASTICSEARCH_DEB_PACKAGE
+    fi
+  - sudo dpkg -i --force-confnew ./deb-cache/$ELASTICSEARCH_DEB_PACKAGE && sudo service elasticsearch restart
 
 install:
   - for i in {1..3}; do travis_wait 5 npm install && break; rm -rf node_modules; done


### PR DESCRIPTION
Travis CI recipe to cache elasticsearch-6.6.0.deb to make builds more resilient to network connectivity issues.
