### PR TITLE
fix: pin wait-on to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "typescript": "^3.5.2",
     "untildify": "^4.0.0",
     "util.promisify": "^1.0.0",
-    "wait-on": "^3.1.0",
+    "wait-on": "3.2.0",
     "ws": "^7.0.1"
   },
   "greenkeeper": {


### PR DESCRIPTION
v3.3.0 doesn't support Node.js 6 anymore.