### PR TITLE
ci(travis): disable npm cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ services:
   - cassandra
   
 cache:
+  npm: false
   directories:
     - deb-cache
   


### PR DESCRIPTION
The npm cache used to be off by default on Travis, but since July 2019 they changed it to be on by default. This hides errors in our tests as updated to dependencies are no longer installed.

For details see:
https://docs.travis-ci.com/user/caching/#npm-cache