### PR TITLE
[docs] Add information for explicitly calling `apm.start()`

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -135,8 +135,8 @@ for instance with the help of Babel,
 TypeScript,
 or the `--experimental-modules` flag for Node.js,
 all import statements are evaluated prior to calling any functions.
-In this case, you can't configure the agent by passing a configuration object to the `start` function,
-as this call will happen after all of the modules have been loaded.
+**In this case, you can't configure the agent by passing a configuration object to the `start` function,
+as this call will happen after all of the modules have been loaded.**
 Instead you need to import the `elastic-apm-node/start` module:
 
 [source,js]
@@ -146,6 +146,9 @@ import apm from 'elastic-apm-node/start'
 
 Now, you can either configure the agent using the environment variables associated with each <<configuration,configuration option>>,
 or use the optional <<agent-configuration-file,agent configuration file>>.
+
+To explicitly start the agent you need to import `elastic-apm-node` and call the `apm.start()` method with the
+<<agent-configuration-object, agent configuration object>>.
 
 [float]
 [[esm-typescript]]


### PR DESCRIPTION
This is a copy of #1174.