### PR TITLE
ci(jenkins): more debug output for smartTAV

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -307,7 +307,6 @@ def getSmartTAVContext() {
    context.node = readYaml(file: '.ci/.jenkins_tav_nodejs.yml')
 
    // Hard to debug what's going on as there are a few nested conditions. Let's then add more verbose output
-   def isChangeRequest = changeRequest()
    echo """\
    env.GITHUB_COMMENT=${env.GITHUB_COMMENT}
    params.Run_As_Master_Branch=${params.Run_As_Master_Branch}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,6 +306,12 @@ def getSmartTAVContext() {
    context.ghDescription = context.ghContextName
    context.node = readYaml(file: '.ci/.jenkins_tav_nodejs.yml')
 
+   // Hard to debug what's going on as there are a few nested conditions. Let's then add more verbose output
+   echo """env.GITHUB_COMMENT=${env.GITHUB_COMMENT}
+   params.Run_As_Master_Branch=${params.Run_As_Master_Branch}
+   changeRequest()=${changeRequest()}
+   env.TAV_UPDATED=${env.TAV_UPDATED}""".stripIndent()
+
    if (env.GITHUB_COMMENT) {
      def modules = getModulesFromCommentTrigger(regex: '(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?module\\W+tests\\W+for\\W+(.+)')
      if (modules.isEmpty()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -307,9 +307,11 @@ def getSmartTAVContext() {
    context.node = readYaml(file: '.ci/.jenkins_tav_nodejs.yml')
 
    // Hard to debug what's going on as there are a few nested conditions. Let's then add more verbose output
-   echo """env.GITHUB_COMMENT=${env.GITHUB_COMMENT}
+   def isChangeRequest = changeRequest()
+   echo """\
+   env.GITHUB_COMMENT=${env.GITHUB_COMMENT}
    params.Run_As_Master_Branch=${params.Run_As_Master_Branch}
-   changeRequest()=${changeRequest()}
+   env.CHANGE_ID=${env.CHANGE_ID}
    env.TAV_UPDATED=${env.TAV_UPDATED}""".stripIndent()
 
    if (env.GITHUB_COMMENT) {
@@ -330,7 +332,7 @@ def getSmartTAVContext() {
    } else if (params.Run_As_Master_Branch) {
      context.ghDescription = 'TAV Test param-triggered'
      context.tav = readYaml(file: '.ci/.jenkins_tav.yml')
-   } else if (changeRequest() && env.TAV_UPDATED != "false") {
+   } else if (env.CHANGE_ID && env.TAV_UPDATED != "false") {
      context.ghContextName = 'TAV Test Subset'
      context.ghDescription = 'TAV Test changes-triggered'
      sh '.ci/scripts/get_tav.sh .ci/.jenkins_generated_tav.yml'


### PR DESCRIPTION
## Highlights
- Nothing about the smart TV but adding more verbose output when running the smartTAV.
- Caused by https://github.com/elastic/apm-agent-nodejs/pull/1144#issuecomment-519472951
- `changeRequest()` method is not allowed within the steps but within the when sections. 

## Test Cases
- changeRequest is not returning a boolean.

```
[2019-08-08T13:29:06.337Z] env.GITHUB_COMMENT=null
[2019-08-08T13:29:06.337Z]    params.Run_As_Master_Branch=false
[2019-08-08T13:29:06.337Z]    changeRequest()=@changeRequest()
[2019-08-08T13:29:06.337Z]    env.TAV_UPDATED=false
```

## Follow-ups
- There is a potential use case to refactor this particular method and then provide a shared library step. The reason, our lovely shared library does use the JUnitPipeline framework, so, therefore, more test coverage. Meanwhile, let's use this PR to provide some more meaningful traces in the build output.