### PR TITLE
ci(jenkins): support for @path/module in smart tav

### DIFF
--- a/.ci/scripts/get_tav.sh
+++ b/.ci/scripts/get_tav.sh
@@ -22,7 +22,10 @@ if [[ -n "${CHANGE_TARGET}" ]] && [[ -n "${GIT_SHA}" ]] ; then
   grep 'test/instrumentation/modules' ${GIT_DIFF} | sed 's#test/instrumentation/modules/##g' >> ${CHANGES}
 
   if [[ $(wc -l <${CHANGES}) -gt 0 ]]; then
-    sed -iback 's#/.*##g; s#^/##g; s#\..*##g' ${CHANGES}
+    sed -iback '/^@/! s#/.*##g; s#^/##g; s#\..*##g' ${CHANGES}
+
+    ## Let's sort the unique matches
+    sort -u -o ${CHANGES} ${CHANGES}
 
     ## Generate the file with the content
     echo 'TAV:' > "${OUTPUT}"


### PR DESCRIPTION
## Highlights
- Support `@folder/module` format as requested with: https://github.com/elastic/apm-agent-nodejs/pull/1266
- Return a sorted and unique list of TAV modules.

## Test cases
- `CHANGE_TARGET=master GIT_SHA=c4a81ae4a258b447de60bb6eb6f79c1454720b2d .ci/scripts/get_tav.sh /tmp/file.txt`

```
TAV:
  - @elastic/elasticsearch
  - elasticsearch
  - hapi
```

- `CHANGE_TARGET=v2.12.0 GIT_SHA=2cd65f2283c0e3da1b02ba21dc047e10ef044efc .ci/scripts/get_tav.sh /tmp/file.txt`

```
TAV:
  - apollo-server-express
  - bluebird
  - cassandra-driver
  - elasticsearch
  - express
  - express-graphql
  - express-queue
  - fastify
  - finalhandler
  - generic-pool
  - graphql
  - handlebars
  - hapi
  - http
  - http2
  - ioredis
  - jade
  - knex
  - koa
  - koa-router
  - mimic-response
  - mongodb-core
  - mysql
  - mysql2
  - pg
  - pug
  - redis
  - restify
  - tedious
  - ws
```

NOTE: I had to create a branch in the origin to be able to compare with, as the script itself uses the `origin/<branch>...<commit>` format.