### PR TITLE
fix: be less chatty if span stack traces cannot be parsed

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -87,12 +87,7 @@ Span.prototype._recordStackTrace = function (obj) {
 
   // TODO: This is expensive! Consider if there's a way to cache some of this
   stackman.callsites(obj, function (err, callsites) {
-    if (err || !callsites) {
-      self._agent.logger.debug('could not capture stack trace for span %o', { span: self.id, parent: self.parentId, trace: self.traceId, name: self.name, type: self.type, err: err && err.message })
-      stack.reject(err)
-      return
-    }
-
+    if (err) return stack.reject(err)
     if (!TEST) callsites = callsites.filter(filterCallsite)
 
     var next = afterAll((err, res) => {
@@ -121,7 +116,7 @@ Span.prototype._encode = function (cb) {
 
   function done (err, frames) {
     if (err) {
-      self._agent.logger.warn('could not capture stack trace for span %o', { span: self.id, parent: self.parentId, trace: self.traceId, name: self.name, type: self.type, err: err.message })
+      self._agent.logger.debug('could not capture stack trace for span %o', { span: self.id, parent: self.parentId, trace: self.traceId, name: self.name, type: self.type, err: err.message })
     }
 
     var payload = {


### PR DESCRIPTION
The same error was accidentally logged twice (once on the `debug` level and once on the `warning` level). We decided in #1261 to only log on the `debug` level.