### PR TITLE
perf: use for-of instead of forEach

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -369,9 +369,9 @@ Agent.prototype.captureError = function (err, opts, cb) {
         })
 
         if (callsites) {
-          callsites.forEach(function (callsite) {
+          for (const callsite of callsites) {
             parsers.parseCallsite(callsite, true, agent, next())
-          })
+          }
         }
       })
     } else {

--- a/lib/config.js
+++ b/lib/config.js
@@ -319,10 +319,10 @@ class Config {
           if (haveAccepted || haveErrors) {
             if (haveAccepted) msg += `\nAPM Server accepted ${err.accepted} events in the last request`
             if (haveErrors) {
-              err.errors.forEach(error => {
+              for (const error of err.errors) {
                 msg += `\nError: ${error.message}`
                 if (error.document) msg += `\n  Document: ${error.document}`
-              })
+              }
             }
           } else if (err.response) {
             msg += `\n${err.response}`
@@ -340,15 +340,15 @@ class Config {
 function readEnv () {
   var opts = {}
 
-  Object.keys(ENV_TABLE).forEach(function (key) {
-    var env = ENV_TABLE[key]
+  for (const key of Object.keys(ENV_TABLE)) {
+    let env = ENV_TABLE[key]
     if (!Array.isArray(env)) env = [ env ]
-    for (let envKey of env) {
+    for (const envKey of env) {
       if (envKey in process.env) {
         opts[key] = process.env[envKey]
       }
     }
-  })
+  }
 
   return opts
 }
@@ -366,42 +366,42 @@ function normalize (opts) {
 
 function normalizeIgnoreOptions (opts) {
   if (opts.ignoreUrls) {
-    opts.ignoreUrls.forEach(function (ptn) {
+    for (const ptn of opts.ignoreUrls) {
       if (typeof ptn === 'string') opts.ignoreUrlStr.push(ptn)
       else opts.ignoreUrlRegExp.push(ptn)
-    })
+    }
     delete opts.ignoreUrls
   }
 
   if (opts.ignoreUserAgents) {
-    opts.ignoreUserAgents.forEach(function (ptn) {
+    for (const ptn of opts.ignoreUserAgents) {
       if (typeof ptn === 'string') opts.ignoreUserAgentStr.push(ptn)
       else opts.ignoreUserAgentRegExp.push(ptn)
-    })
+    }
     delete opts.ignoreUserAgents
   }
 }
 
 function normalizeNumbers (opts) {
-  NUM_OPTS.forEach(function (key) {
+  for (const key of NUM_OPTS) {
     if (key in opts) opts[key] = Number(opts[key])
-  })
+  }
 
-  MINUS_ONE_EQUAL_INFINITY.forEach(function (key) {
+  for (const key of MINUS_ONE_EQUAL_INFINITY) {
     if (opts[key] === -1) opts[key] = Infinity
-  })
+  }
 }
 
 function normalizeBytes (opts) {
-  BYTES_OPTS.forEach(function (key) {
+  for (const key of BYTES_OPTS) {
     if (key in opts) opts[key] = bytes(String(opts[key]))
-  })
+  }
 }
 
 function normalizeTime (opts) {
-  TIME_OPTS.forEach(function (key) {
+  for (const key of TIME_OPTS) {
     if (key in opts) opts[key] = toSeconds(String(opts[key]))
-  })
+  }
 }
 
 function maybeSplit (separator) {
@@ -414,13 +414,13 @@ const maybeSplitValues = maybeSplit(',')
 const maybeSplitPairs = maybeSplit('=')
 
 function normalizeArrays (opts) {
-  ARRAY_OPTS.forEach(function (key) {
+  for (const key of ARRAY_OPTS) {
     if (key in opts) opts[key] = maybeSplitValues(opts[key])
-  })
+  }
 }
 
 function normalizeKeyValuePairs (opts) {
-  KEY_VALUE_OPTS.forEach(function (key) {
+  for (const key of KEY_VALUE_OPTS) {
     if (key in opts) {
       if (typeof opts[key] === 'object' && !Array.isArray(opts[key])) {
         opts[key] = entries(opts[key])
@@ -435,13 +435,13 @@ function normalizeKeyValuePairs (opts) {
         opts[key] = opts[key].map(maybeSplitPairs)
       }
     }
-  })
+  }
 }
 
 function normalizeBools (opts) {
-  BOOL_OPTS.forEach(function (key) {
+  for (const key of BOOL_OPTS) {
     if (key in opts) opts[key] = strictBool(opts.logger, key, opts[key])
-  })
+  }
 }
 
 function truncateOptions (opts) {

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -94,7 +94,7 @@ GenericSpan.prototype.addTags = function (tags) {
 GenericSpan.prototype.addLabels = function (labels) {
   if (!labels) return false
   var keys = Object.keys(labels)
-  for (let key of keys) {
+  for (const key of keys) {
     if (!this.setLabel(key, labels[key])) {
       return false
     }

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -109,7 +109,7 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
 
       var options = {}
       var newArgs = [ options ]
-      for (let arg of args) {
+      for (const arg of args) {
         if (typeof arg === 'function') {
           newArgs.push(arg)
         } else {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -86,7 +86,7 @@ function Instrumentation (agent) {
 Instrumentation.prototype.addPatch = function (modules, handler) {
   if (!Array.isArray(modules)) modules = [modules]
 
-  modules.forEach(mod => {
+  for (const mod of modules) {
     const type = typeof handler
     if (type !== 'function' && type !== 'string') {
       this._agent.logger.error('Invalid patch handler type:', type)
@@ -94,7 +94,7 @@ Instrumentation.prototype.addPatch = function (modules, handler) {
     }
 
     this._patches.add(mod, handler)
-  })
+  }
 
   this._startHook()
 }
@@ -102,9 +102,9 @@ Instrumentation.prototype.addPatch = function (modules, handler) {
 Instrumentation.prototype.removePatch = function (modules, handler) {
   if (!Array.isArray(modules)) modules = [modules]
 
-  modules.forEach(mod => {
+  for (const mod of modules) {
     this._patches.delete(mod, handler)
-  })
+  }
 
   this._startHook()
 }
@@ -112,9 +112,9 @@ Instrumentation.prototype.removePatch = function (modules, handler) {
 Instrumentation.prototype.clearPatches = function (modules) {
   if (!Array.isArray(modules)) modules = [modules]
 
-  modules.forEach(mod => {
+  for (const mod of modules) {
     this._patches.clear(mod)
-  })
+  }
 
   this._startHook()
 }
@@ -135,7 +135,7 @@ Instrumentation.prototype.start = function () {
 
   const patches = this._agent._conf.addPatch
   if (Array.isArray(patches)) {
-    for (let [mod, path] of patches) {
+    for (const [mod, path] of patches) {
       this.addPatch(mod, path)
     }
   }

--- a/lib/instrumentation/modules/express-graphql.js
+++ b/lib/instrumentation/modules/express-graphql.js
@@ -10,9 +10,9 @@ module.exports = function (graphqlHTTP, agent, { version, enabled }) {
     return graphqlHTTP
   }
 
-  Object.keys(graphqlHTTP).forEach(function (key) {
+  for (const key of Object.keys(graphqlHTTP)) {
     wrappedGraphqlHTTP[key] = graphqlHTTP[key]
-  })
+  }
 
   return wrappedGraphqlHTTP
 

--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -107,10 +107,10 @@ module.exports = function (express, agent, { version, enabled }) {
     // Instead of only copying the `mime` function, let's loop over all
     // properties in case new properties are added in later versions of
     // Express.
-    Object.keys(orig).forEach(function (prop) {
+    for (const prop of Object.keys(orig)) {
       agent.logger.debug('copying property %s from express.static', prop)
       wrappedStatic[prop] = orig[prop]
-    })
+    }
 
     return wrappedStatic
 

--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -22,10 +22,10 @@ module.exports = function (graphql, agent, { version, enabled }) {
     value: true
   })
 
-  Object.keys(graphql).forEach(function (key) {
-    var getter = graphql.__lookupGetter__(key)
-    var setter = graphql.__lookupSetter__(key)
-    var opts = { enumerable: true }
+  for (const key of Object.keys(graphql)) {
+    const getter = graphql.__lookupGetter__(key)
+    const setter = graphql.__lookupSetter__(key)
+    const opts = { enumerable: true }
 
     if (getter) {
       switch (key) {
@@ -49,7 +49,7 @@ module.exports = function (graphql, agent, { version, enabled }) {
     }
 
     Object.defineProperty(wrapped, key, opts)
-  })
+  }
 
   return wrapped
 
@@ -174,13 +174,13 @@ module.exports = function (graphql, agent, { version, enabled }) {
 
       var selections = operation && operation.selectionSet && operation.selectionSet.selections
       if (selections && Array.isArray(selections)) {
-        selections.forEach(function (selection) {
-          var kind = selection.name && selection.name.kind
+        for (const selection of selections) {
+          const kind = selection.name && selection.name.kind
           if (kind === graphql.Kind.NAME) {
-            var queryName = selection.name.value
+            const queryName = selection.name.value
             if (queryName) queries.push(queryName)
           }
-        })
+        }
 
         queries = queries.sort(function (a, b) {
           if (a > b) return 1

--- a/lib/instrumentation/patch-async.js
+++ b/lib/instrumentation/patch-async.js
@@ -151,12 +151,12 @@ module.exports = function (ins) {
 
   function wrapChildProcess (child) {
     if (Array.isArray(child.stdio)) {
-      child.stdio.forEach(function (socket) {
+      for (const socket of child.stdio) {
         if (socket && socket._handle) {
           socket._handle.onread = ins.bindFunction(socket._handle.onread)
           wrap(socket._handle, 'close', activatorFirst)
         }
-      })
+      }
     }
 
     if (child._handle) {

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -93,11 +93,11 @@ function massWrap (nodules, names, wrapper) {
     return
   }
 
-  nodules.forEach(function (nodule) {
-    names.forEach(function (name) {
+  for (const nodule of nodules) {
+    for (const name of names) {
       wrap(nodule, name, wrapper)
-    })
-  })
+    }
+  }
 }
 
 function unwrap (nodule, name) {

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -99,9 +99,9 @@ Span.prototype._recordStackTrace = function (obj) {
       err ? stack.reject(err) : stack.resolve(res)
     })
 
-    callsites.forEach(function (callsite) {
+    for (const callsite of callsites) {
       parsers.parseCallsite(callsite, false, self._agent, next())
-    })
+    }
   })
 }
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -249,11 +249,11 @@ Transaction.prototype._captureBreakdown = function (span) {
     metrics.getOrCreateCounter('transaction.duration.sum.us', labels).inc(duration)
     metrics.getOrCreateCounter('transaction.breakdown.count', labels).inc(this.sampled ? 1 : 0)
 
-    this._breakdownTimings.forEach(({ labels, time, count }) => {
-      labels = flattenBreakdown(labels)
-      metrics.getOrCreateCounter('span.self_time.count', labels).inc(count)
-      metrics.getOrCreateCounter('span.self_time.sum.us', labels).inc(time)
-    })
+    for (const { labels, time, count } of this._breakdownTimings.values()) {
+      const flattenedLabels = flattenBreakdown(labels)
+      metrics.getOrCreateCounter('span.self_time.count', flattenedLabels).inc(count)
+      metrics.getOrCreateCounter('span.self_time.sum.us', flattenedLabels).inc(time)
+    }
   }
 }
 

--- a/lib/metrics/platforms/generic/index.js
+++ b/lib/metrics/platforms/generic/index.js
@@ -33,7 +33,7 @@ module.exports = function createSystemMetrics (registry) {
       'system.process.cpu.user.norm.pct'
     ]
 
-    for (let metric of metrics) {
+    for (const metric of metrics) {
       registry.getOrCreateGauge(metric, () => stats.toJSON()[metric])
     }
   }

--- a/lib/metrics/platforms/linux/index.js
+++ b/lib/metrics/platforms/linux/index.js
@@ -7,7 +7,7 @@ module.exports = function createSystemMetrics (registry) {
 
   registry.registerCollector(stats)
 
-  for (let metric of Object.keys(stats.toJSON())) {
+  for (const metric of Object.keys(stats.toJSON())) {
     registry.getOrCreateGauge(metric, () => stats.toJSON()[metric])
   }
 }

--- a/lib/metrics/platforms/linux/stats.js
+++ b/lib/metrics/platforms/linux/stats.js
@@ -78,9 +78,9 @@ class Stats {
       if (cb) cb()
     })
 
-    files.forEach(function (file) {
+    for (const file of files) {
       fs.readFile(file, next())
-    })
+    }
   }
 
   readStats ([processFile, memoryFile, cpuFile]) {

--- a/lib/metrics/reporter.js
+++ b/lib/metrics/reporter.js
@@ -27,7 +27,7 @@ class MetricsReporter extends Reporter {
     const next = afterAll(() => {
       const seen = new ObjectIdentityMap()
 
-      metrics.forEach(metric => {
+      for (const metric of metrics) {
         const data = seen.ensure(metric.dimensions, () => {
           const metricData = unflattenBreakdown(metric.dimensions)
           const merged = Object.assign({ samples: {} }, baseDimensions, metricData)
@@ -42,16 +42,16 @@ class MetricsReporter extends Reporter {
         if (metric.metricImpl.constructor.name === 'Counter') {
           metric.metricImpl.reset()
         }
-      })
+      }
 
       for (const metric of seen.values()) {
         this._agent._transport.sendMetricSet(metric)
       }
     })
 
-    this._registry.collectors.forEach((collector) => {
+    for (const collector of this._registry.collectors) {
       collector.collect(next())
-    })
+    }
   }
 }
 

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -56,7 +56,7 @@ module.exports = function createRuntimeMetrics (registry) {
   const collector = new RuntimeCollector()
   registry.registerCollector(collector)
 
-  for (let metric of Object.keys(collector.stats)) {
+  for (const metric of Object.keys(collector.stats)) {
     registry.getOrCreateGauge(metric, () => collector.stats[metric])
   }
 }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -81,9 +81,9 @@ exports.parseError = function (err, agent, cb) {
     })
 
     if (callsites) {
-      callsites.forEach(function (callsite) {
+      for (const callsite of callsites) {
         exports.parseCallsite(callsite, true, agent, next())
-      })
+      }
     }
   })
 }

--- a/test/integration/skip-internal-http-spans.js
+++ b/test/integration/skip-internal-http-spans.js
@@ -61,7 +61,7 @@ getPort().then(port => {
         agent.flush(() => {
           // wait for potential span related to the outgoing http request to be processed
           setTimeout(() => {
-            for (let key of Object.keys(expected)) {
+            for (const key of Object.keys(expected)) {
               t.equal(seen[key], expected[key], `has expected value for ${key}`)
             }
 
@@ -69,7 +69,7 @@ getPort().then(port => {
             agent.flush(() => {
               // give the APM Server time to receive an process the 2nd flush
               setTimeout(() => {
-                for (let key of Object.keys(expected)) {
+                for (const key of Object.keys(expected)) {
                   t.equal(seen[key], expected[key], `has expected value for ${key}`)
                 }
 


### PR DESCRIPTION
Changed all uses for `forEach` inside of the `lib` folder to be for-of loops. I left out two instances as they looked better with `forEach`:
- https://github.com/elastic/apm-agent-nodejs/blob/245aa4520ced15e1932bd7d79507739d27090c2f/lib/filters/http-headers.js#L24
- https://github.com/elastic/apm-agent-nodejs/blob/245aa4520ced15e1932bd7d79507739d27090c2f/lib/filters/http-headers.js#L34

There's still quite a few uses of `forEach` in the tests but I didn't feel the need to change those. Let me know if we should do that (though many of those use the `index` argument of the `forEach` callback, so I don't think it's worth it).

I also changed all uses of `let` in existing for-of loops to `const` where possible.