### PR TITLE
ci(jenkins): async hook false runs in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
               node['NODEJS_VERSION'].each{ version ->
                 parallelTasks["Node.js-${version}"] = generateStep(version: version)
                 if (version != '6') {
-                  parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, async: false)
+                  parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsync: true)
                 }
               }
 
@@ -218,7 +218,7 @@ pipeline {
                   def node = readYaml(file: '.ci/.jenkins_edge_nodejs.yml')
                   def parallelTasks = [:]
                   node['NODEJS_VERSION'].findAll{ it != '6' }.each{ version ->
-                    parallelTasks["Node.js-${version}-nightly-no_async_hooks"] = generateStep(version: version, edge: true, async: false)
+                    parallelTasks["Node.js-${version}-nightly-no_async_hooks"] = generateStep(version: version, edge: true, disableAsync: true)
                   }
                   parallel(parallelTasks)
                 }
@@ -262,12 +262,12 @@ def generateStep(Map params = [:]){
   def version = params?.version
   def tav = params.containsKey('tav') ? params.tav : ''
   def edge = params.containsKey('edge') ? params.edge : false
-  def async = params.get('async', true)
+  def disableAsync = params.get('disableAsync', false)
   return {
     node('docker && linux && immutable'){
       try {
         env.HOME = "${WORKSPACE}"
-        if (!async) {
+        if (disableAsync) {
           env.ELASTIC_APM_ASYNC_HOOKS = 'false'
         }
         deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
               node['NODEJS_VERSION'].each{ version ->
                 parallelTasks["Node.js-${version}"] = generateStep(version: version)
                 if (!version.startsWith('6')) {
-                  parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsync: true)
+                  parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsyncHooks: true)
                 }
               }
 
@@ -218,7 +218,7 @@ pipeline {
                   def node = readYaml(file: '.ci/.jenkins_edge_nodejs.yml')
                   def parallelTasks = [:]
                   node['NODEJS_VERSION'].findAll{ it != '6' }.each{ version ->
-                    parallelTasks["Node.js-${version}-nightly-no_async_hooks"] = generateStep(version: version, edge: true, disableAsync: true)
+                    parallelTasks["Node.js-${version}-nightly-no_async_hooks"] = generateStep(version: version, edge: true, disableAsyncHooks: true)
                   }
                   parallel(parallelTasks)
                 }
@@ -262,12 +262,12 @@ def generateStep(Map params = [:]){
   def version = params?.version
   def tav = params.containsKey('tav') ? params.tav : ''
   def edge = params.containsKey('edge') ? params.edge : false
-  def disableAsync = params.get('disableAsync', false)
+  def disableAsyncHooks = params.get('disableAsyncHooks', false)
   return {
     node('docker && linux && immutable'){
       try {
         env.HOME = "${WORKSPACE}"
-        if (disableAsync) {
+        if (disableAsyncHooks) {
           env.ELASTIC_APM_ASYNC_HOOKS = 'false'
         }
         deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
               def parallelTasksWithoutAsyncHooks = [:]
               node['NODEJS_VERSION'].each{ version ->
                 parallelTasks["Node.js-${version}"] = generateStep(version: version)
-                if (version != '6') {
+                if (!version.startsWith('6')) {
                   parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsync: true)
                 }
               }


### PR DESCRIPTION
## Highlights
- Async hooks false branches run in parallel, aka less waste of time for getting feedback.
- Nodejs-6.x with async hook false is disabled.
- `generateStep` is now responsible to inject the `ELASTIC_APM_ASYNC_HOOKS` if `disableAsync` parameter is true. The default behavior as used to be, aka without the env variable.

## Test Cases
- Nodejs6.X for async configuration is not enabled

![image](https://user-images.githubusercontent.com/2871786/62935432-0746e280-bdbf-11e9-831e-b22e366ed42b.png)
