### PR TITLE
chore: prepare code style for new version of linter

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -389,7 +389,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
     }
 
     if (agent._transport) {
-      agent.logger.info(`Sending error to Elastic APM`, { id: error.id })
+      agent.logger.info('Sending error to Elastic APM', { id: error.id })
       agent._transport.sendError(error, function () {
         agent.flush(function (err) {
           if (cb) cb(err, error.id)

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,7 +36,7 @@ if (fs.existsSync(confPath)) {
 
 let serviceName, serviceVersion
 try {
-  let pkg = readPkgUp.sync().pkg
+  const pkg = readPkgUp.sync().pkg
   serviceName = pkg.name
   serviceVersion = pkg.version
 } catch (err) {}
@@ -345,7 +345,7 @@ function readEnv () {
 
   for (const key of Object.keys(ENV_TABLE)) {
     let env = ENV_TABLE[key]
-    if (!Array.isArray(env)) env = [ env ]
+    if (!Array.isArray(env)) env = [env]
     for (const envKey of env) {
       if (envKey in process.env) {
         opts[key] = process.env[envKey]

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -108,7 +108,7 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       agent.logger.debug('intercepted call to %s.%s %o', moduleName, method, { id: id })
 
       var options = {}
-      var newArgs = [ options ]
+      var newArgs = [options]
       for (const arg of args) {
         if (typeof arg === 'function') {
           newArgs.push(arg)
@@ -191,6 +191,6 @@ function shouldPropagateTraceContext (opts) {
 }
 
 function isAWSSigned (opts) {
-  const auth = opts.headers && (opts.headers['Authorization'] || opts.headers['authorization'])
+  const auth = opts.headers && (opts.headers.Authorization || opts.headers.authorization)
   return typeof auth === 'string' ? auth.startsWith('AWS4-') : false
 }

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -27,7 +27,7 @@ module.exports = function (elasticsearch, agent, { enabled }) {
         span.name = `Elasticsearch: ${method} ${path}`
 
         if (queryRegexp.test(path)) {
-          let statement = Array.isArray(body)
+          const statement = Array.isArray(body)
             ? body.map(JSON.stringify).join('\n')
             : JSON.stringify(body || query)
 

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -129,7 +129,7 @@ module.exports = function (http2, agent, { enabled }) {
       } else if (Array.isArray(target[key])) {
         result[key].push(source[key])
       } else {
-        result[key] = [ source[key] ].concat(target[key])
+        result[key] = [source[key]].concat(target[key])
       }
     }
     return result

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -271,7 +271,7 @@ function spanBreakdownDetails (span) {
     }
   }
 
-  const [ type, subtype ] = span.type.split('.')
+  const [type, subtype] = span.type.split('.')
   return {
     type,
     subtype
@@ -286,7 +286,7 @@ function captureBreakdown (transaction, labels, time) {
 }
 
 function flattenBreakdown (source, target = {}, prefix = '') {
-  for (const [ key, value ] of entries(source)) {
+  for (const [key, value] of entries(source)) {
     if (typeof value === 'undefined') continue
     if (typeof value === 'object') {
       flattenBreakdown(value, target, `${prefix}${key}::`)

--- a/lib/metrics/platforms/linux/stats.js
+++ b/lib/metrics/platforms/linux/stats.js
@@ -108,7 +108,7 @@ class Stats {
     let memTotal = 0
 
     let matches = 0
-    for (let line of memoryFile.toString().split('\n')) {
+    for (const line of memoryFile.toString().split('\n')) {
       if (/^MemAvailable:/.test(line)) {
         memAvailable = parseInt(line.split(whitespace)[1], 10) * 1024
         matches++

--- a/lib/metrics/reporter.js
+++ b/lib/metrics/reporter.js
@@ -65,9 +65,9 @@ function unflattenBreakdown (source) {
     tags: {}
   }
 
-  for (const [ key, value ] of entries(source)) {
+  for (const [key, value] of entries(source)) {
     if (key.includes('::')) {
-      const [ parent, child ] = key.split('::')
+      const [parent, child] = key.split('::')
       if (!target[parent]) target[parent] = {}
       target[parent][child] = value
     } else {

--- a/test/config.js
+++ b/test/config.js
@@ -95,7 +95,7 @@ optionFixtures.forEach(function (fixture) {
       agent.start()
 
       if (array) {
-        t.deepEqual(agent._conf[fixture[0]], [ value ])
+        t.deepEqual(agent._conf[fixture[0]], [value])
       } else {
         t.equal(agent._conf[fixture[0]], bool ? !fixture[2] : value)
       }
@@ -134,7 +134,7 @@ optionFixtures.forEach(function (fixture) {
       agent.start(opts)
 
       if (array) {
-        t.deepEqual(agent._conf[fixture[0]], [ value2 ])
+        t.deepEqual(agent._conf[fixture[0]], [value2])
       } else {
         t.equal(agent._conf[fixture[0]], value2)
       }
@@ -347,7 +347,7 @@ var noPrefixValues = [
 ]
 
 noPrefixValues.forEach(function (pair) {
-  const [ key, envVar ] = pair
+  const [key, envVar] = pair
   test(`maps ${envVar} to ${key}`, (t) => {
     var agent = Agent()
     process.env[envVar] = 'test'
@@ -853,9 +853,11 @@ class CaptureLogger {
   warn (message, ...args) {
     this._log('warn', message, args)
   }
+
   info (message, ...args) {
     this._log('info', message, args)
   }
+
   debug (message, ...args) {
     this._log('debug', message, args)
   }

--- a/test/instrumentation/modules/http/aws.js
+++ b/test/instrumentation/modules/http/aws.js
@@ -18,7 +18,7 @@ AWS.config.update({
 
 test('non aws-sdk request', function (t) {
   const server = http.createServer(function (req, res) {
-    t.equal(req.headers['authorization'], undefined, 'no authorization header')
+    t.equal(req.headers.authorization, undefined, 'no authorization header')
     t.ok(req.headers['elastic-apm-traceparent'].length > 0, 'elastic-apm-traceparent header')
     res.end()
     server.close()
@@ -39,7 +39,7 @@ test('non aws-sdk request', function (t) {
 
 test('aws-sdk request', function (t) {
   const server = http.createServer(function (req, res) {
-    t.equal(req.headers['authorization'].substr(0, 5), 'AWS4-', 'AWS authorization header')
+    t.equal(req.headers.authorization.substr(0, 5), 'AWS4-', 'AWS authorization header')
     t.equal(req.headers['elastic-apm-traceparent'], undefined, 'no elastic-apm-traceparent header')
     res.end()
     server.close()

--- a/test/instrumentation/modules/mongodb-core.js
+++ b/test/instrumentation/modules/mongodb-core.js
@@ -123,7 +123,7 @@ test('instrument simple command', function (t) {
         t.error(err)
         t.equal(results.result.n, 3)
 
-        _server.update('elasticapm.test', [{ q: { a: 1 }, u: { '$set': { b: 1 } } }], { writeConcern: { w: 1 }, ordered: true }, function (err, results) {
+        _server.update('elasticapm.test', [{ q: { a: 1 }, u: { $set: { b: 1 } } }], { writeConcern: { w: 1 }, ordered: true }, function (err, results) {
           t.error(err)
           t.equal(results.result.n, 1)
 

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -510,10 +510,10 @@ function mockRequest () {
     method: 'POST',
     url: '/foo?bar=baz',
     headers: {
-      'host': 'example.com',
+      host: 'example.com',
       'user-agent': 'user-agent-header',
       'content-length': 42,
-      'cookie': 'cookie1=foo;cookie2=bar',
+      cookie: 'cookie1=foo;cookie2=bar',
       'x-foo': 'bar',
       'x-bar': 'baz'
     },

--- a/test/metrics/breakdown.js
+++ b/test/metrics/breakdown.js
@@ -56,7 +56,7 @@ const finders = {
     return metricsets.find(metricset => metricset.span && metricset.span.type === 'app')
   },
   span (metricsets, span) {
-    const [ type, subtype ] = span.type.split('.')
+    const [type, subtype] = span.type.split('.')
     return metricsets.find(v => v.span && v.span.type === type && v.span.subtype === subtype)
   }
 }

--- a/test/metrics/index.js
+++ b/test/metrics/index.js
@@ -126,7 +126,7 @@ test('reports expected metrics', function (t) {
     for (const name of Object.keys(metrics)) {
       const metric = metricset.samples[name]
       t.comment(name)
-      t.ok(metric, `is present`)
+      t.ok(metric, 'is present')
       t.equal(typeof metric.value, 'number', 'is a number')
       t.ok(Number.isFinite(metric.value), `is finite (was: ${metric.value})`)
       metrics[name](metric.value)

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -382,7 +382,7 @@ test('#parseError()', function (t) {
     }
     try {
       var o = {}
-      o['...']['Derp']()
+      o['...'].Derp()
     } catch (e) {
       parsers.parseError(e, fakeAgent, function (err, parsed) {
         t.error(err)

--- a/test/script/cli.js
+++ b/test/script/cli.js
@@ -326,9 +326,9 @@ var saveConf = function (conf, cb) {
 loadConf(function (err, conf) {
   if (err) throw err
   var questions = [
-    { name: 'serviceName', message: 'Service name', 'default': conf.serviceName },
-    { name: 'secretToken', message: 'Secret token', 'default': conf.secretToken },
-    { name: 'serverUrl', message: 'APM Server URL', 'default': conf.serverUrl },
+    { name: 'serviceName', message: 'Service name', default: conf.serviceName },
+    { name: 'secretToken', message: 'Secret token', default: conf.secretToken },
+    { name: 'serverUrl', message: 'APM Server URL', default: conf.serverUrl },
     { name: 'suite', message: 'Test suite', type: 'list', choices: ['standard', 'http', 'restify', 'connect', 'express', 'transaction'] },
     { name: 'save', message: 'Save answers?', type: 'confirm' }
   ]

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ function run (test, cb) {
 
   console.log('running: ' + fullPath)
 
-  var ps = spawn('node', [ test.file ], {
+  var ps = spawn('node', [test.file], {
     stdio: 'inherit',
     cwd: test.cwd,
     env: test.env


### PR DESCRIPTION
We can't upgrade to the new version of 'standard' currently because we still use the deprecated `url.parse` API in several locations (see issue no #1254). But to ensure fewer merge conflicts between the 2.x and the upcoming 3.x branch), we'll fix as many future linting issues as possible already now.
