### PR TITLE
feat: use external as span type

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -109,7 +109,7 @@ function ensureUrl (v) {
 }
 
 exports.traceOutgoingRequest = function (agent, moduleName, method) {
-  var spanType = 'ext.' + moduleName + '.http'
+  var spanType = 'external.' + moduleName + '.http'
   var ins = agent._instrumentation
 
   return function (orig) {

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -144,7 +144,7 @@ module.exports = function (http2, agent, { enabled }) {
 
   function wrapRequest (orig, host) {
     return function (headers) {
-      var span = agent.startSpan(null, 'ext.http2')
+      var span = agent.startSpan(null, 'external.http2')
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to http2.request %o', { id })

--- a/test/instrumentation/modules/elasticsearch.js
+++ b/test/instrumentation/modules/elasticsearch.js
@@ -179,7 +179,7 @@ function done (t, method, path, query) {
 
     let span1, span2
     {
-      const type = 'ext.http.http'
+      const type = 'external.http.http'
       span1 = findObjInArray(data.spans, 'type', type)
       t.ok(span1, 'should have span with type ' + type)
     } {

--- a/test/instrumentation/modules/http2.js
+++ b/test/instrumentation/modules/http2.js
@@ -284,7 +284,7 @@ isSecure.forEach(secure => {
 
       var span = findObjInArray(data.spans, 'transaction_id', root.id)
       t.ok(span, 'root transaction should have span')
-      t.equal(span.type, 'ext.http2')
+      t.equal(span.type, 'external.http2')
       t.equal(span.name, `undefined http${secure ? 's' : ''}://localhost:${port}/sub`)
 
       server.close()


### PR DESCRIPTION
Rather than the shortened 'ext' use full 'external' in span types

Fixes #1225

### Checklist

- [x] Implement code
- [x] Add tests
