### PR TITLE
fix(package): bump stackman to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "semver": "^6.1.1",
     "set-cookie-serde": "^1.0.0",
     "sql-summary": "^1.0.1",
-    "stackman": "^3.0.2",
+    "stackman": "^4.0.0",
     "traceparent": "^1.0.0",
     "unicode-byte-truncate": "^1.0.0"
   },


### PR DESCRIPTION
This includes a fix for an issue where stack traces would not be captured in situations where `Error.prepareStackTrace` was overwritten after this module was loaded.

A common culprit for this is the [`source-map-support`](https://www.npmjs.com/package/source-map-support) module, used by - among others - [`@babel/register`](https://www.npmjs.com/package/@babel/register).

Fixes #369