### PR TITLE
fix: change agent active status log message to debug level

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -128,7 +128,7 @@ Agent.prototype.start = function (opts) {
   }
 
   if (!this._conf.active) {
-    this.logger.info('Elastic APM agent is inactive due to configuration')
+    this.logger.debug('Elastic APM agent disabled (`active` is false)')
     return this
   } else if (!this._conf.serviceName) {
     this.logger.error('Elastic APM isn\'t correctly configured: Missing serviceName')

--- a/test/config.js
+++ b/test/config.js
@@ -210,9 +210,9 @@ test('should log invalid booleans', function (t) {
   t.equal(warning.args[0], 'nope')
   t.equal(warning.args[1], 'active')
 
-  var info = logger.calls.shift()
-  t.equal(info.message, 'Elastic APM agent is inactive due to configuration')
-  t.equal(info.args.length, 0)
+  var debug = logger.calls.shift()
+  t.equal(debug.message, 'Elastic APM agent disabled (`active` is false)')
+  t.equal(debug.args.length, 0)
 
   t.end()
 })


### PR DESCRIPTION
Previously, the agent would log the following message on the info level if `active: false`:

    Elastic APM agent is inactive due to configuration

This proved problematic for CLI applications that ships with the agent turned off by default.

In cases where `active` is set to `false` on purpose, it shouldn't be necessary to log this message on the info level, instead we now log this more specific message on the debug level:

    Elastic APM agent disabled (`active` is false)