### PR TITLE
fix(async_hooks): properly update sync flag

### DIFF
--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -80,6 +80,14 @@ module.exports = function (ins) {
   }
 
   function before (asyncId) {
+    const span = activeSpans.get(asyncId)
+    if (span) {
+      span.sync = false
+    }
+    const transaction = span ? span.transaction : activeTransactions.get(asyncId)
+    if (transaction) {
+      transaction.sync = false
+    }
     ins.bindingSpan = null
   }
 

--- a/test/instrumentation/async-hooks.js
+++ b/test/instrumentation/async-hooks.js
@@ -121,6 +121,20 @@ test('post-defined, post-resolved promise', function (t) {
   })
 })
 
+test('sync/async tracking', function (t) {
+  var trans = agent.startTransaction()
+  t.equal(trans.sync, true)
+
+  var span = agent.startSpan()
+  t.equal(span.sync, true)
+
+  setImmediate(() => {
+    t.equal(trans.sync, false)
+    t.equal(span.sync, false)
+    t.end()
+  })
+})
+
 function twice (fn) {
   setImmediate(fn)
   setImmediate(fn)


### PR DESCRIPTION
This fixes an issue discovered in #1298 due to changing the `test/_agent.js` file to use a _real_ config object rather than a mock, which exposed that the mock would implicitly have `asyncHooks: false` in its settings by omission.

### Checklist

- [x] Implement code
- [x] Add tests
