### PR TITLE
test: ensure test environment is setup correctly

### DIFF
--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -106,7 +106,6 @@ containers=$(number_of_started_containers)
 if [[ $healthy -lt $expected_healthy && $containers -eq $expected_containers ]]
 then
   wait_for_healthy
-  setup_env
 elif [[ $healthy -lt $expected_healthy || $containers -lt $expected_containers ]]
 then
   finish () {
@@ -116,7 +115,7 @@ then
 
   docker-compose -f ./test/docker-compose.yml up -d $services
   wait_for_healthy
-  setup_env
 fi
 
+setup_env
 run_test_suite


### PR DESCRIPTION
If pre-started all Docker containers using `npm run docker:start` and waiting for them all to become healthy, the test script would not set the `PGUSER` environment variable as expected.

This commit ensures that the `PGUSER` environment variable gets set even in that scenario.