### PR TITLE
fix(lambda): handle traceparent case-insensitively

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const shimmer = require('./instrumentation/shimmer')
+const entries = require('object.entries') // TODO: Remove when Node.js 6 is no longer supported
 
 module.exports = function elasticApmAwsLambda (agent) {
   function captureContext (trans, payload, context, result) {
@@ -75,7 +76,7 @@ module.exports = function elasticApmAwsLambda (agent) {
     return function wrappedLambda (payload, context, callback) {
       let parentId
       if (payload.headers !== undefined) {
-        for (let [key, value] of Object.entries(payload.headers)) {
+        for (const [key, value] of entries(payload.headers)) {
           if (key.toLowerCase() === 'elastic-apm-traceparent') {
             parentId = value
             break

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -75,7 +75,12 @@ module.exports = function elasticApmAwsLambda (agent) {
     return function wrappedLambda (payload, context, callback) {
       let parentId
       if (payload.headers !== undefined) {
-        parentId = payload.headers['elastic-apm-traceparent']
+        for (let [key, value] of Object.entries(payload.headers)) {
+          if (key.toLowerCase() === 'elastic-apm-traceparent') {
+            parentId = value
+            break
+          }
+        }
       }
       const trans = agent.startTransaction(context.functionName, type, {
         childOf: parentId

--- a/test/lambda/promises.js
+++ b/test/lambda/promises.js
@@ -53,7 +53,7 @@ test('resolve with parent id header present', function (t) {
   const input = {
     name: 'world',
     headers: {
-      'elastic-apm-traceparent': 'test'
+      'Elastic-Apm-Traceparent': 'test'
     }
   }
   const output = 'Hello, world!'
@@ -84,7 +84,7 @@ test('resolve with parent id header present', function (t) {
       t.equal(agent.transactions.length, 1)
       assertTransaction(t, agent.transactions[0], name, context, input, output)
 
-      t.equal(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
+      t.equal(input.headers['Elastic-Apm-Traceparent'], agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
 
       t.end()
     }


### PR DESCRIPTION
Headers coming from API Gateway to Lambda may not be
lowercase, so when extracting the elastic-apm-traceparent
header, compare case-insensitively.

Fixes #1315