### PR TITLE
ci(jenkins): Set GitHub notification context to apm-ci

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-downstream.yml
+++ b/.ci/jobs/apm-agent-nodejs-downstream.yml
@@ -11,6 +11,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        notification-context: 'apm-ci-downstream'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true

--- a/.ci/jobs/apm-agent-nodejs-downstream.yml
+++ b/.ci/jobs/apm-agent-nodejs-downstream.yml
@@ -11,7 +11,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        notification-context: 'apm-ci-downstream'
+        notification-context: 'apm-ci/downstream'
         property-strategies:
           all-branches:
           - suppress-scm-triggering: true

--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -11,6 +11,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        notification-context: 'apm-ci'
         head-filter-regex: '^(?!greenkeeper).*$'
         repo: apm-agent-nodejs
         repo-owner: elastic


### PR DESCRIPTION
it will replace the generic context `continuous-integration/jenkins/*` for a fixed one that points to the name of the instance that generates the context `apm-ci`, it is important when we have multiple multibranch jobs listening on a repo to avoid to overwrite contexts.

**Now**

<img width="715" alt="Screenshot 2019-09-03 at 17 44 35" src="https://user-images.githubusercontent.com/5400788/64188351-86857e80-ce72-11e9-953a-c52c837bd46c.png">

**After**
<img width="736" alt="Screenshot 2019-09-03 at 17 43 59" src="https://user-images.githubusercontent.com/5400788/64188359-8a190580-ce72-11e9-83b5-67071a560bd7.png">
