### PR TITLE
ci(jenkins): run all the stages

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -40,7 +40,7 @@ pipeline {
         build(
           job: 'apm-agent-nodejs/apm-agent-nodejs-mbp/master',
           parameters: [
-            booleanParam(name: 'Run_As_Master_Branch', value: false),
+            booleanParam(name: 'Run_As_Master_Branch', value: true),
             booleanParam(name: 'doc_ci', value: true),
             booleanParam(name: 'tav_ci', value: true),
             booleanParam(name: 'test_edge_ci', value: true)


### PR DESCRIPTION
The `Run_As_Master_Branch` parameter is the one in charge to manage what stages are enabled/disabled. PRs do not run all the stages but branches should run all of them.

In other words, TAV stage will be enabled on a daily basis for the master branch which it's handled within the daily job.
