### PR TITLE
feat: add toString methods for logging

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -783,3 +783,37 @@ apm.clearPatches('timers')
 
 apm.clearPatches(['timers'])
 ----
+
+[[apm-current-trace-ids]]
+==== `apm.currentTraceIds`
+
+[small]#Added in: #2.17.0
+
+Produces an object containing `trace.id` and either `transaction.id` or `span.id` when a current transaction or span is available.
+When no transaction or span is available it will return an empty object.
+This enables log correlation to APM traces with structured loggers.
+
+[source,js]
+----
+{
+  "trace.id": "abc123",
+  "transaction.id": "abc123"
+}
+// or ...
+{
+  "trace.id": "abc123",
+  "span.id": "abc123"
+}
+----
+
+All current trace id objects,
+including the empty form,
+include a `toString()` implementation.
+This enables log correlation to APM traces with text-only loggers.
+
+[source,js]
+----
+"trace.id=abc123 transaction.id=abc123"
+// or ...
+"trace.id=abc123 span.id=abc123"
+----

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -133,13 +133,34 @@ it's converted to a string before being sent to the APM Server
 Add several labels on the span.
 You can add labels multiple times.
 
+[[span-ids]]
+==== `span.ids`
+
+[small]#Added in: #2.17.0
+
+Produces an object containing `span.id` and `trace.id`.
+This enables log correlation to APM traces with structured loggers.
+
+[source,js]
+----
+{
+  "trace.id": "abc123",
+  "span.id": "abc123"
+}
+----
+
 [[span-to-string]]
 ==== `span.toString()`
 
 [small]#Added in: #2.17.0
 
 Produces a string representation of the span to inject in log messages.
-This enables log correlation to APM traces.
+This enables log correlation to APM traces with text-only loggers.
+
+[source,js]
+----
+"trace.id=abc123 span.id=abc123"
+----
 
 [[span-end]]
 ==== `span.end([endTime])`

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -133,6 +133,14 @@ it's converted to a string before being sent to the APM Server
 Add several labels on the span.
 You can add labels multiple times.
 
+[[span-to-string]]
+==== `span.toString()`
+
+[small]#Added in: #2.17.0
+
+Produces a string representation of the span to inject in log messages.
+This enables log correlation to APM traces.
+
 [[span-end]]
 ==== `span.end([endTime])`
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -206,6 +206,14 @@ elasticApm.init({
 
 See the {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
 
+[[transaction-to-string]]
+==== `transaction.toString()`
+
+[small]#Added in: #2.17.0
+
+Produces a string representation of the transaction to inject in log messages.
+This enables log correlation to APM traces.
+
 [[transaction-end]]
 ==== `transaction.end([result][, endTime])`
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -206,13 +206,34 @@ elasticApm.init({
 
 See the {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
 
+[[transaction-ids]]
+==== `transaction.ids`
+
+[small]#Added in: #2.17.0
+
+Produces an object containing `transaction.id` and `trace.id`.
+This enables log correlation to APM traces with structured loggers.
+
+[source,js]
+----
+{
+  "trace.id": "abc123",
+  "transaction.id": "abc123"
+}
+----
+
 [[transaction-to-string]]
 ==== `transaction.toString()`
 
 [small]#Added in: #2.17.0
 
 Produces a string representation of the transaction to inject in log messages.
-This enables log correlation to APM traces.
+This enables log correlation to APM traces with text-only loggers.
+
+[source,js]
+----
+"trace.id=abc123 transaction.id=abc123"
+----
 
 [[transaction-end]]
 ==== `transaction.end([result][, endTime])`

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -70,6 +70,12 @@ Object.defineProperty(Agent.prototype, 'currentTraceparent', {
   }
 })
 
+Object.defineProperty(Agent.prototype, 'currentTraceIds', {
+  get () {
+    return this._instrumentation.ids
+  }
+})
+
 Agent.prototype.destroy = function () {
   if (this._transport) this._transport.destroy()
 }

--- a/lib/instrumentation/ids.js
+++ b/lib/instrumentation/ids.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { stringify } = require('querystring')
+
+class Ids {
+  toString () {
+    return stringify(this, ' ', '=')
+  }
+}
+
+class SpanIds extends Ids {
+  constructor (span) {
+    super()
+    this['trace.id'] = span.traceId
+    this['span.id'] = span.id
+    Object.freeze(this)
+  }
+}
+
+class TransactionIds extends Ids {
+  constructor (transaction) {
+    super()
+    this['trace.id'] = transaction.traceId
+    this['transaction.id'] = transaction.id
+    Object.freeze(this)
+  }
+}
+
+module.exports = {
+  Ids,
+  SpanIds,
+  TransactionIds
+}

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -6,6 +6,7 @@ var path = require('path')
 var hook = require('require-in-the-middle')
 var semver = require('semver')
 
+var { Ids } = require('./ids')
 var NamedArray = require('./named-array')
 var shimmer = require('./shimmer')
 var Transaction = require('./transaction')
@@ -82,6 +83,13 @@ function Instrumentation (agent) {
     })
   }
 }
+
+Object.defineProperty(Instrumentation.prototype, 'ids', {
+  get () {
+    const current = this.currentSpan || this.currentTransaction
+    return current ? current.ids : new Ids()
+  }
+})
 
 Instrumentation.prototype.addPatch = function (modules, handler) {
   if (!Array.isArray(modules)) modules = [modules]

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var querystring = require('querystring')
 var util = require('util')
 
 var afterAll = require('after-all-results')
@@ -9,6 +8,7 @@ var Value = require('async-value-promise')
 var GenericSpan = require('./generic-span')
 var parsers = require('../parsers')
 var stackman = require('../stackman')
+var { SpanIds } = require('./ids')
 
 const TEST = process.env.ELASTIC_APM_TEST
 
@@ -47,11 +47,14 @@ function Span (transaction, name, type, opts) {
   this._agent.logger.debug('start span %o', { span: this.id, parent: this.parentId, trace: this.traceId, name: name, type: type })
 }
 
+Object.defineProperty(Span.prototype, 'ids', {
+  get () {
+    return new SpanIds(this)
+  }
+})
+
 Span.prototype.toString = function () {
-  return querystring.stringify({
-    'trace.id': this.traceId,
-    'span.id': this.id
-  }, ',', '=')
+  return this.ids.toString()
 }
 
 Span.prototype.customStackTrace = function (stackObj) {

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var querystring = require('querystring')
 var util = require('util')
 
 var afterAll = require('after-all-results')
@@ -44,6 +45,13 @@ function Span (transaction, name, type, opts) {
   }
 
   this._agent.logger.debug('start span %o', { span: this.id, parent: this.parentId, trace: this.traceId, name: name, type: type })
+}
+
+Span.prototype.toString = function () {
+  return querystring.stringify({
+    'trace.id': this.traceId,
+    'span.id': this.id
+  }, ',', '=')
 }
 
 Span.prototype.customStackTrace = function (stackObj) {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var querystring = require('querystring')
 var util = require('util')
 
 var ObjectIdentityMap = require('object-identity-map')
@@ -11,6 +10,7 @@ var GenericSpan = require('./generic-span')
 var parsers = require('../parsers')
 var Span = require('./span')
 var symbols = require('../symbols')
+var { TransactionIds } = require('./ids')
 
 module.exports = Transaction
 
@@ -73,6 +73,16 @@ Object.defineProperty(Transaction.prototype, 'result', {
   }
 })
 
+Object.defineProperty(Transaction.prototype, 'ids', {
+  get () {
+    return new TransactionIds(this)
+  }
+})
+
+Transaction.prototype.toString = function () {
+  return this.ids.toString()
+}
+
 Transaction.prototype.setUserContext = function (context) {
   if (!context) return
   this._user = Object.assign(this._user || {}, context)
@@ -102,13 +112,6 @@ Transaction.prototype.startSpan = function (name, type, opts) {
   if (typeof opts === 'string') opts = { childOf: opts }
 
   return new Span(this, name, type, opts)
-}
-
-Transaction.prototype.toString = function () {
-  return querystring.stringify({
-    'trace.id': this.traceId,
-    'transaction.id': this.id
-  }, ',', '=')
 }
 
 Transaction.prototype.toJSON = function () {

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var querystring = require('querystring')
 var util = require('util')
 
 var ObjectIdentityMap = require('object-identity-map')
@@ -101,6 +102,13 @@ Transaction.prototype.startSpan = function (name, type, opts) {
   if (typeof opts === 'string') opts = { childOf: opts }
 
   return new Span(this, name, type, opts)
+}
+
+Transaction.prototype.toString = function () {
+  return querystring.stringify({
+    'trace.id': this.traceId,
+    'transaction.id': this.id
+  }, ',', '=')
 }
 
 Transaction.prototype.toJSON = function () {

--- a/test/agent.js
+++ b/test/agent.js
@@ -224,6 +224,44 @@ test('#currentTraceparent', function (t) {
   })
 })
 
+test('#currentTraceIds', function (t) {
+  t.test('no active transaction or span', function (t) {
+    var agent = Agent()
+    agent.start()
+    t.deepEqual(agent.currentTraceIds, {})
+    t.equal(agent.currentTraceIds.toString(), '')
+    t.end()
+  })
+
+  t.test('with active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    var trans = agent.startTransaction()
+    t.deepEqual(agent.currentTraceIds, {
+      'trace.id': trans.traceId,
+      'transaction.id': trans.id
+    })
+    t.equal(agent.currentTraceIds.toString(), `trace.id=${trans.traceId} transaction.id=${trans.id}`)
+    agent.endTransaction()
+    t.end()
+  })
+
+  t.test('with active span', function (t) {
+    var agent = Agent()
+    agent.start()
+    agent.startTransaction()
+    var span = agent.startSpan()
+    t.deepEqual(agent.currentTraceIds, {
+      'trace.id': span.traceId,
+      'span.id': span.id
+    })
+    t.equal(agent.currentTraceIds.toString(), `trace.id=${span.traceId} span.id=${span.id}`)
+    span.end()
+    agent.endTransaction()
+    t.end()
+  })
+})
+
 test('#setTransactionName', function (t) {
   t.test('no active transaction', function (t) {
     var agent = Agent()

--- a/test/instrumentation/span.js
+++ b/test/instrumentation/span.js
@@ -271,3 +271,10 @@ test('#_encode() - disabled stack traces', function (t) {
     t.end()
   })
 })
+
+test('#toString()', function (t) {
+  var trans = new Transaction(agent)
+  var span = new Span(trans)
+  t.equal(span.toString(), `trace.id=${span.traceId},span.id=${span.id}`)
+  t.end()
+})

--- a/test/instrumentation/span.js
+++ b/test/instrumentation/span.js
@@ -272,9 +272,19 @@ test('#_encode() - disabled stack traces', function (t) {
   })
 })
 
+test('#ids', function (t) {
+  var trans = new Transaction(agent)
+  var span = new Span(trans)
+  t.deepEqual(span.ids, {
+    'trace.id': span.traceId,
+    'span.id': span.id
+  })
+  t.end()
+})
+
 test('#toString()', function (t) {
   var trans = new Transaction(agent)
   var span = new Span(trans)
-  t.equal(span.toString(), `trace.id=${span.traceId},span.id=${span.id}`)
+  t.equal(span.toString(), `trace.id=${span.traceId} span.id=${span.id}`)
   t.end()
 })

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -504,9 +504,18 @@ test('#_encode() - not sampled', function (t) {
   t.end()
 })
 
+test('#ids', function (t) {
+  var trans = new Transaction(agent)
+  t.deepEqual(trans.ids, {
+    'trace.id': trans.traceId,
+    'transaction.id': trans.id
+  })
+  t.end()
+})
+
 test('#toString()', function (t) {
   var trans = new Transaction(agent)
-  t.equal(trans.toString(), `trace.id=${trans.traceId},transaction.id=${trans.id}`)
+  t.equal(trans.toString(), `trace.id=${trans.traceId} transaction.id=${trans.id}`)
   t.end()
 })
 

--- a/test/instrumentation/transaction.js
+++ b/test/instrumentation/transaction.js
@@ -504,6 +504,12 @@ test('#_encode() - not sampled', function (t) {
   t.end()
 })
 
+test('#toString()', function (t) {
+  var trans = new Transaction(agent)
+  t.equal(trans.toString(), `trace.id=${trans.traceId},transaction.id=${trans.id}`)
+  t.end()
+})
+
 function mockRequest () {
   return {
     httpVersion: '1.1',


### PR DESCRIPTION
This enables logging spans and transactions in a string form
which can be used for log correlation.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
