### PR TITLE
fix(http): response context propagation on Node.js 12.0 - 12.2

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -156,6 +156,9 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       return req
 
       function onresponse (res) {
+        // Work around async_hooks bug in Node.js 12.0 - 12.2 (https://github.com/nodejs/node/pull/27477)
+        ins._recoverTransaction(span.transaction)
+
         agent.logger.debug('intercepted http.ClientRequest response event %o', { id: id })
         ins.bindEmitter(res)
 


### PR DESCRIPTION
As discovered in #1298, context propagation breaks in the http response handler on Node.js 12.0 to 12.2. This ensures that continuation is restored.

### Checklist

- [x] Implement code
