### PR TITLE
chore: fix patch method argument names

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -74,12 +74,11 @@ function Instrumentation (agent) {
     if (!Array.isArray(mod)) mod = [mod]
     const pathName = mod[0]
 
-    this.addPatch(mod, (exports, name, version, enabled) => {
+    this.addPatch(mod, (...args) => {
       // Lazy require so that we don't have to use `require.resolve` which
       // would fail in combination with Webpack. For more info see:
       // https://github.com/elastic/apm-agent-nodejs/pull/957
-      const patch = require(`./modules/${pathName}`)
-      return patch(exports, name, version, enabled)
+      return require(`./modules/${pathName}`)(...args)
     })
   }
 }


### PR DESCRIPTION
The patches are not called with the four arguments `exports`, `name`, `version`, and `enabled`, but instead with three arguments: `exports`, `agent`, `options`.

However, this worked fine previously because we were just passing the arguments straight through to the patch function. But it made reading the code very confusing.