### PR TITLE
ci(jenkins): tav with different formats

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -392,7 +392,7 @@ def getSmartTAVContext() {
        } else {
          context.ghContextName = 'TAV Test Subset'
          context.ghDescription = 'TAV Test comment-triggered'
-         context.tav = readYaml(text: """TAV:${modules.collect{ "\n  - ${it}"}.join("") }""")
+         context.tav = readYaml(text: """TAV:${modules.collect{ it.replaceAll('"', '').replaceAll("'", '') }.collect{ "\n  - '${it}'"}.join("") }""")
        }
      }
    } else if (params.Run_As_Master_Branch) {


### PR DESCRIPTION
## Highlights
- Enforce the TAV module when using GitHub comments as stated in https://github.com/elastic/apm-agent-nodejs/pull/1346#issuecomment-531694730
- Replace any `'` or `"` within the GitHub comment and single quote those modules afterward.

## Test cases

```
node {
    def modules = [ 'bla', '@foo/bar', '"@foo/bar"', "'@foo/bar'"]
    def tav = readYaml(text: """TAV:${modules.collect{ it.replaceAll('"', '').replaceAll("'", '') }.collect{ "\n  - '${it}'"}.join("") }""")    
    echo """TAV:${modules.collect{ it.replaceAll('"', '').replaceAll("'", '') }.collect{ "\n  - '${it}'"}.join("") }"""
    echo "$tav"
}
```

caused

```
[Pipeline] readYaml
[Pipeline] echo
TAV:
  - 'bla'
  - '@foo/bar'
  - '@foo/bar'
  - '@foo/bar'
[Pipeline] echo
[TAV:[bla, @foo/bar, @foo/bar, @foo/bar]]
```