### PR TITLE
ci(jenkins): don't run TAV tests for Node.js core modules

### DIFF
--- a/.ci/scripts/get_tav.sh
+++ b/.ci/scripts/get_tav.sh
@@ -9,6 +9,44 @@ OUTPUT=$1
 GIT_DIFF=git-diff.txt
 CHANGES=changes.txt
 
+## Node.js core modules are not on npm and doesn't need to be tested in the
+## same way as regular modules does
+NODE_CORE_MODULES=(
+  assert
+  async_hooks
+  child_process
+  cluster
+  crypto
+  dns
+  domain
+  events
+  fs
+  http
+  http2
+  https
+  inspector
+  net
+  os
+  path
+  perf_hooks
+  punycode
+  querystring
+  readline
+  repl
+  stream
+  string_decoder
+  tls
+  trace_events
+  tty
+  dgram
+  url
+  util
+  v8
+  vm
+  worker_threads
+  zlib
+)
+
 cleanup() {
   rm -f ${CHANGES} ${GIT_DIFF} || true
 }
@@ -18,7 +56,7 @@ if [[ -n "${CHANGE_TARGET}" ]] && [[ -n "${GIT_SHA}" ]] ; then
 
   git diff --name-only origin/"${CHANGE_TARGET}"..."${GIT_SHA}" > ${GIT_DIFF}
 
-  grep 'lib/instrumentation/modules' ${GIT_DIFF}| sed 's#lib/instrumentation/modules/##g' > ${CHANGES}
+  grep 'lib/instrumentation/modules' ${GIT_DIFF} | sed 's#lib/instrumentation/modules/##g' > ${CHANGES}
   grep 'test/instrumentation/modules' ${GIT_DIFF} | sed 's#test/instrumentation/modules/##g' >> ${CHANGES}
 
   if [[ $(wc -l <${CHANGES}) -gt 0 ]]; then
@@ -27,10 +65,23 @@ if [[ -n "${CHANGE_TARGET}" ]] && [[ -n "${GIT_SHA}" ]] ; then
     ## Let's sort the unique matches
     sort -u -o ${CHANGES} ${CHANGES}
 
+    ## Filter out Node.js core modules
+    CHANGES_ARR=()
+    while read -r tav; do
+      skip=
+      for core_module in "${NODE_CORE_MODULES[@]}"; do
+        [[ $tav == $core_module ]] && { skip=1; break; }
+      done
+      [[ -n $skip ]] || CHANGES_ARR+=("$tav")
+    done <${CHANGES}
+    if [ ${#CHANGES_ARR[@]} -eq 0 ]; then
+      exit
+    fi
+
     ## Generate the file with the content
     echo 'TAV:' > "${OUTPUT}"
-    while read -r tav; do
-      echo "  - $tav" >> "${OUTPUT}"
-    done <${CHANGES}
+    for tav in "${CHANGES_ARR[@]}"; do
+      echo "  - '$tav'" >> "${OUTPUT}"
+    done
   fi
 fi


### PR DESCRIPTION
Previously if there was a change to any of our patches for a Node.js core modules (e.g. `http`), Jenkins would try to run TAV tests for the `http` module. This is just a waste of resources as there are no TAV tests for core modules.

This commit will filter out any core module from the list of modules being considered for TAV tests.