### PR TITLE
modified semver check to include v5 express

### DIFF
--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -11,7 +11,7 @@ module.exports = function (express, agent, { version, enabled }) {
 
   agent.setFramework({ name: 'express', version, overwrite: false })
 
-  if (!semver.satisfies(version, '^4.0.0')) {
+  if (!semver.gte(version, '4.0.0')) {
     agent.logger.debug('express version %s not supported - aborting...', version)
     return express
   }


### PR DESCRIPTION

Simple change to `express` instrumentation patch to not exit for versions greater then `^4.0.0`

### Checklist

- [x] Implement code
- [ ] Add tests
- [ ] Update documentation
