### PR TITLE
test: allow mock APM Server to be initiated without args

### DIFF
--- a/test/_apm_server.js
+++ b/test/_apm_server.js
@@ -22,11 +22,9 @@ module.exports = APMServer
 
 util.inherits(APMServer, EventEmitter)
 
-function APMServer (agentOpts, mockOpts) {
+function APMServer (agentOpts, mockOpts = { expect: [] }) {
   if (!(this instanceof APMServer)) return new APMServer(agentOpts, mockOpts)
   var self = this
-
-  mockOpts = mockOpts || {}
 
   var requests = typeof mockOpts.expect === 'string'
     ? ['metadata', mockOpts.expect]


### PR DESCRIPTION
It would throw an error when trying to access `requests[0]` later in the function if no `mockOpts` object was provided. This made it hard to debug certain things.