### PR TITLE
test: don't swallow promise rejections during test

### DIFF
--- a/test/_apm_server.js
+++ b/test/_apm_server.js
@@ -87,5 +87,8 @@ function APMServer (agentOpts, mockOpts) {
     server.listen(port, function () {
       self.emit('listening', port)
     })
+  }).catch(err => {
+    console.error(err.stack)
+    process.exit(1)
   })
 }

--- a/test/_promise_rejection.js
+++ b/test/_promise_rejection.js
@@ -1,0 +1,12 @@
+'use strict'
+
+process.addListener('unhandledRejection', handler)
+
+exports.remove = function stop () {
+  process.removeListener('unhandledRejection', handler)
+}
+
+function handler (promise, reason) {
+  console.error('Unhandled Rejection at:', promise, '\nreason:', reason)
+  process.exit(1)
+}

--- a/test/instrumentation/modules/bluebird/bluebird.js
+++ b/test/instrumentation/modules/bluebird/bluebird.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// The unhandledRejection will be fired by our bluebird tests, which is to be
+// expected.
+require('../../../_promise_rejection').remove()
+
 var agent = require('../../../..').start({
   serviceName: 'test',
   secretToken: 'test',


### PR DESCRIPTION
If the function given to `getPort().then()` accidently threw a syncrounous error in Node.js versions earlier than 6.6.0, we would never know about it and the tests would just fail in weird ways that would take hours to debug.

This commit ensures to log that error and exit the process with a non-zero exit code.

For Node.js version 12+ all tests are run with `--unhandled-rejections=strict` to ensure they crash in case of an unhandled rejection instead of just emitting a warning.

For Node.js versions less than 12, a global `unhandledRejection` listener is added for each test file being run through `test/test.js`.