### PR TITLE
test: fix http disabling test

### DIFF
--- a/test/instrumentation/modules/http/disabling.js
+++ b/test/instrumentation/modules/http/disabling.js
@@ -35,7 +35,7 @@ if (cluster.isMaster) {
 
     function assertSpan (t, span) {
       t.ok(/GET localhost:\d+\//.test(span.name), 'span name')
-      t.equal(span.type, 'ext.http.http', 'span type')
+      t.equal(span.type, 'external.http.http', 'span type')
     }
 
     t.test('incoming enabled + outgoing enabled', makeTest({


### PR DESCRIPTION
The PR #1298 introduced a bug in the tests as it expected the span.type for outgoing http requests to start with `ext.*`. This was changed to `external.*` in the PR #1291, but #1298 was just never updated to be up to date with master before it was merged.