### PR TITLE
ci(jenkins): Mark Node.js stage as UNSTABLE and build as SUCCESS on failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,7 +342,7 @@ def generateStep(Map params = [:]){
           retry(2){
             sleep randomNumber(min:10, max: 30)
             if (version?.startsWith('6')) {
-              catchError {
+              catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                 sh(label: 'Run Tests', script: """.ci/scripts/test.sh "${version}" "${tav}" "${edge}" """)
               }
             } else {


### PR DESCRIPTION
Avoid hiding error on the Node.js 6 stage, this change will mark the build as SUCCESS and the stage as UNSTABLE.