### PR TITLE
chore: update backport tooling and docs

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,5 +1,5 @@
 {
   "upstream": "elastic/apm-agent-nodejs",
-  "branches": [{ "name": "1.x", "checked": true }],
+  "branches": [{ "name": "2.x", "checked": true }, "1.x"],
   "labels": ["backport"]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,18 @@ Once your changes are ready to submit for review:
 For information about how to run the test suite,
 see [TESTING.md](TESTING.md).
 
+### Backporting
+
+If a PR is marked with a `backport:*` label,
+it should be backported to the branch specified by the label after it has been merged.
+
+To backport a commit,
+run the following command and follow the instructions in the terminal:
+
+```
+npm run backport
+```
+
 ### Workflow
 
 All feature development and most bug fixes hit the master branch first.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
+    "backport": "backport",
     "docs:open": "PREVIEW=1 npm run docs:build",
     "docs:build": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
     "lint": "standard",
@@ -116,6 +117,7 @@
     "@types/node": "^12.7.5",
     "apollo-server-express": "^2.9.3",
     "aws-sdk": "^2.529.0",
+    "backport": "^4.7.1",
     "benchmark": "^2.1.4",
     "bluebird": "^3.5.5",
     "cassandra-driver": "^4.1.0",


### PR DESCRIPTION
The commit no longer requires you to have the backport tool installed globally.