### PR TITLE
[2.x] test: ensure proper cleanup between config tests (#1373)

### DIFF
--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -3,9 +3,18 @@
 const asyncHooks = require('async_hooks')
 const shimmer = require('./shimmer')
 
+// FOR INTERNAL TESTING PURPOSES ONLY!
+const resettable = process.env._ELASTIC_APM_ASYNC_HOOKS_RESETTABLE === 'true'
+let _asyncHook
+
 module.exports = function (ins) {
   const asyncHook = asyncHooks.createHook({ init, before, destroy })
   const contexts = new WeakMap()
+
+  if (resettable) {
+    if (_asyncHook) _asyncHook.disable()
+    _asyncHook = asyncHook
+  }
 
   const activeTransactions = new Map()
   Object.defineProperty(ins, 'currentTransaction', {

--- a/test/_agent.js
+++ b/test/_agent.js
@@ -25,8 +25,11 @@ function clean () {
     agent._errorFilters = new Filters()
     agent._transactionFilters = new Filters()
     agent._spanFilters = new Filters()
-    if (agent._instrumentation && agent._instrumentation._hook) {
-      agent._instrumentation._hook.unhook()
+    if (agent._instrumentation) {
+      agent._instrumentation._started = false
+      if (agent._instrumentation._hook) {
+        agent._instrumentation._hook.unhook()
+      }
     }
     agent._metrics.stop()
     if (agent._transport && agent._transport.destroy) {

--- a/test/config.js
+++ b/test/config.js
@@ -24,6 +24,7 @@ var apmName = require('../package').name
 
 process.env.ELASTIC_APM_METRICS_INTERVAL = '0'
 process.env.ELASTIC_APM_CENTRAL_CONFIG = 'false'
+process.env._ELASTIC_APM_ASYNC_HOOKS_RESETTABLE = 'true'
 
 var optionFixtures = [
   ['abortedErrorThreshold', 'ABORTED_ERROR_THRESHOLD', 25],
@@ -428,7 +429,7 @@ test('serviceName defaults to package name', function (t) {
   var exec = promisify(cp.exec)
 
   function testServiceConfig (pkg, handle) {
-    var tmp = path.join(os.tmpdir(), 'elastic-apm-node-test')
+    var tmp = path.join(os.tmpdir(), 'elastic-apm-node-test', String(Date.now()))
     var files = [
       {
         action: 'mkdirp',
@@ -486,6 +487,9 @@ test('serviceName defaults to package name', function (t) {
         // NOTE: Real util.promisify returns an object,
         // the polyfill just returns stdout as a string.
         return JSON.parse(result.stdout || result)
+      })
+      .catch(err => {
+        t.error(err)
       })
 
     return pFinally(promise, () => {


### PR DESCRIPTION
Backports the following commits to 2.x:
 - test: ensure proper cleanup between config tests (#1373)