### PR TITLE
[2.x] fix: capture all non-string http bodies (#1376)

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -115,11 +115,11 @@ exports.getContextFromRequest = function (req, conf, type) {
 
   if (haveBody) {
     if (captureBody) {
-      var bodyStr = typeof body === 'string'
-        ? body
-        : (tryJsonStringify(body) || stringify(body))
-      if (bodyStr.length > exports._MAX_HTTP_BODY_CHARS) {
-        body = truncate(bodyStr, exports._MAX_HTTP_BODY_CHARS)
+      if (typeof body !== 'string') {
+        body = tryJsonStringify(body) || stringify(body)
+      }
+      if (body.length > exports._MAX_HTTP_BODY_CHARS) {
+        body = truncate(body, exports._MAX_HTTP_BODY_CHARS)
       }
       context.body = body
     } else {

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -222,7 +222,7 @@ test('#getContextFromRequest()', function (t) {
     req.body = { foo: 42 }
     req.headers['content-length'] = JSON.stringify(req.body).length
     var parsed = parsers.getContextFromRequest(req, conf)
-    t.deepEqual(parsed.body, { foo: 42 })
+    t.deepEqual(parsed.body, JSON.stringify({ foo: 42 }))
     t.end()
   })
 
@@ -248,7 +248,17 @@ test('#getContextFromRequest()', function (t) {
     req.body.bar = req.body
     req.headers['transfer-encoding'] = 'chunked'
     var parsed = parsers.getContextFromRequest(req, conf)
-    t.deepEqual(parsed.body, req.body)
+    t.deepEqual(parsed.body, JSON.stringify({ foo: 42, bar: '[Circular]' }))
+    t.end()
+  })
+
+  t.test('body is an array', function (t) {
+    var conf = { captureBody: 'all' }
+    var req = getMockReq()
+    req.body = [{ foo: 42 }]
+    req.headers['content-length'] = JSON.stringify(req.body).length
+    var parsed = parsers.getContextFromRequest(req, conf)
+    t.deepEqual(parsed.body, JSON.stringify([{ foo: 42 }]))
     t.end()
   })
 


### PR DESCRIPTION
Backports the following commits to 2.x:
 - fix: capture all non-string http bodies (#1376)