### PR TITLE
[2.x] docs: set upper bounds for current mongo support (#1375)

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -88,9 +88,9 @@ The Node.js agent will automatically instrument the following modules to give yo
 |https://www.npmjs.com/package/mongodb-core[mongodb-core] |>=1.2.19 <4 |Will instrument all queries.
 A lot of higher level MongoDB modules use mongodb-core,
 so those should be supported as well
-|https://www.npmjs.com/package/mongodb[mongodb] |>=2.0.0 |Supported via mongodb-core
-|https://www.npmjs.com/package/mongojs[mongojs] |>=1.0.0 |Supported via mongodb-core
-|https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 |Supported via mongodb-core
+|https://www.npmjs.com/package/mongodb[mongodb] |>=2.0.0 <3.3.0 |Supported via mongodb-core
+|https://www.npmjs.com/package/mongojs[mongojs] |>=1.0.0 <2.7.0 |Supported via mongodb-core
+|https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 <5.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mysql[mysql] |^2.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/mysql2[mysql2] |^1.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <8.0.0 |Will instrument all queries


### PR DESCRIPTION
Backports the following commits to 2.x:
 - docs: set upper bounds for current mongo support (#1375)