### PR TITLE
ci: run esm tests on all 9+ Node.js versions

### DIFF
--- a/.ci/scripts/test_types_babel_esm.sh
+++ b/.ci/scripts/test_types_babel_esm.sh
@@ -10,8 +10,8 @@ npm --version
 npm run test:types
 npm run test:babel
 
-major_node_version=$(node --version | cut -d . -f1 | cut -c2)
+major_node_version=$(node --version | cut -d . -f1 | cut -d v -f2)
 minor_node_version=$(node --version | cut -d . -f2)
-if [[ $major_node_version -ge 8 ]] && [[ $minor_node_version -ge 5 ]] ; then
+if [[ $major_node_version -eq 8 && $minor_node_version -ge 5 ]] || [[ $major_node_version -gt 8 ]]; then
   npm run test:esm
 fi

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:docs": "./test/script/docker/run_docs.sh",
     "test:types": "tsc --project test/types/tsconfig.json && tsc --project test/types/transpile/tsconfig.json && node test/types/transpile/index.js",
     "test:babel": "babel test/babel/src.js --out-file test/babel/out.js && node test/babel/out.js",
-    "test:esm": "node --experimental-modules test/esm",
+    "test:esm": "node --experimental-modules test/esm/index.mjs",
     "bench": "./test/benchmarks/scripts/run-benchmarks.sh",
     "bench:ci": "./test/benchmarks/scripts/run-benchmarks-ci.sh",
     "local:start": "./test/script/local-deps-start.sh",

--- a/test/esm/index.mjs
+++ b/test/esm/index.mjs
@@ -1,6 +1,7 @@
 'use strict'
 
-import agent from '../../'
+// Node.js 12+ requires a fully qualified filename
+import agent from '../../index.js'
 
 agent.start({
   captureExceptions: false,

--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -56,12 +56,12 @@ run_test_suite () {
 
   npm run test:types
   npm run test:babel
-  if [[ $major_node_version -ge 8 ]] && [[ $minor_node_version -ge 5 ]]; then
+  if [[ $major_node_version -eq 8 && $minor_node_version -ge 5 ]] || [[ $major_node_version -gt 8 ]]; then
     npm run test:esm
   fi
 }
 
-major_node_version=`node --version | cut -d . -f1 | cut -c2`
+major_node_version=`node --version | cut -d . -f1 | cut -d v -f2`
 minor_node_version=`node --version | cut -d . -f2`
 
 if [[ "$CI" || "$1" == "none" ]]


### PR DESCRIPTION
I found this bug in the tests while working on #1383.

I've created it as a separate PR so we can backport it to `2.x`.

Once merged, #1383 can be rebased against master.