### PR TITLE
ci(jenkins): 2.x branch on a daily basis

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -37,18 +37,22 @@ pipeline {
   stages {
     stage('Run Tasks'){
       steps {
-        build(
-          job: 'apm-agent-nodejs/apm-agent-nodejs-mbp/master',
-          parameters: [
-            booleanParam(name: 'Run_As_Master_Branch', value: true),
-            booleanParam(name: 'bench_ci', value: false),
-            booleanParam(name: 'doc_ci', value: true),
-            booleanParam(name: 'tav_ci', value: true),
-            booleanParam(name: 'test_edge_ci', value: true)
-          ],
-          quietPeriod: 10,
-          wait: false
-        )
+        script {
+          ['master', '2.x'].each { branch ->
+            build(
+              job: "apm-agent-nodejs/apm-agent-nodejs-mbp/${branch}",
+              parameters: [
+                booleanParam(name: 'Run_As_Master_Branch', value: true),
+                booleanParam(name: 'bench_ci', value: false),
+                booleanParam(name: 'doc_ci', value: true),
+                booleanParam(name: 'tav_ci', value: true),
+                booleanParam(name: 'test_edge_ci', value: true)
+              ],
+              quietPeriod: 10,
+              wait: false
+            )
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Highlights
- Enable the pipeline for the `2.x` branch on a daily basis.
- To clarify the benchmark stage only runs when a new commit is merged into the `master` branch.
