### PR TITLE
[2.x] fix: support all falsy return values from error filters (#1389)

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -385,24 +385,26 @@ Agent.prototype.captureError = function (err, opts, cb) {
   }
 
   function send (error) {
+    const id = error.id
+
     error = agent._errorFilters.process(error)
 
     if (!error) {
-      agent.logger.debug('error ignored by filter %o', { id: error.id })
-      if (cb) cb(null, error.id)
+      agent.logger.debug('error ignored by filter %o', { id })
+      if (cb) cb(null, id)
       return
     }
 
     if (agent._transport) {
-      agent.logger.info('Sending error to Elastic APM', { id: error.id })
+      agent.logger.info('Sending error to Elastic APM', { id })
       agent._transport.sendError(error, function () {
         agent.flush(function (err) {
-          if (cb) cb(err, error.id)
+          if (cb) cb(err, id)
         })
       })
     } else if (cb) {
       // TODO: Swallow this error just as it's done in agent.flush()?
-      process.nextTick(cb.bind(null, new Error('cannot capture error before agent is started'), error.id))
+      process.nextTick(cb.bind(null, new Error('cannot capture error before agent is started'), id))
     }
   }
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -613,127 +613,131 @@ test('filters', function (t) {
       })
   })
 
-  t.test('#addFilter() - abort', function (t) {
-    t.plan(1)
+  const falsyValues = [undefined, null, false, 0, '', NaN]
 
-    const server = http.createServer(function (req, res) {
-      t.fail('should not send any data')
-    })
+  falsyValues.forEach(falsy => {
+    t.test(`#addFilter() - abort with '${String(falsy)}'`, function (t) {
+      t.plan(1)
 
-    server.listen(function () {
-      const agent = Agent().start({ serverUrl: 'http://localhost:' + server.address().port })
-
-      agent.addFilter(function (obj) {
-        t.equal(obj.exception.message, 'foo')
-        return false
-      })
-      agent.addFilter(function () {
-        t.fail('should not call 2nd filter')
+      const server = http.createServer(function (req, res) {
+        t.fail('should not send any data')
       })
 
-      agent.captureError(new Error('foo'))
+      server.listen(function () {
+        const agent = Agent().start({ serverUrl: 'http://localhost:' + server.address().port })
 
-      setTimeout(function () {
-        t.end()
-        server.close()
-      }, 50)
-    })
-  })
+        agent.addFilter(function (obj) {
+          t.equal(obj.exception.message, 'foo')
+          return falsy
+        })
+        agent.addFilter(function () {
+          t.fail('should not call 2nd filter')
+        })
 
-  t.test('#addErrorFilter() - abort', function (t) {
-    t.plan(1)
+        agent.captureError(new Error('foo'))
 
-    const server = http.createServer(function (req, res) {
-      t.fail('should not send any data')
-    })
-
-    server.listen(function () {
-      const agent = Agent().start({
-        serverUrl: 'http://localhost:' + server.address().port,
-        captureExceptions: false
-      })
-
-      agent.addErrorFilter(function (obj) {
-        t.equal(obj.exception.message, 'foo')
-        return false
-      })
-      agent.addErrorFilter(function () {
-        t.fail('should not call 2nd filter')
-      })
-
-      agent.captureError(new Error('foo'))
-
-      setTimeout(function () {
-        t.end()
-        server.close()
-      }, 50)
-    })
-  })
-
-  t.test('#addTransactionFilter() - abort', function (t) {
-    t.plan(1)
-
-    const server = http.createServer(function (req, res) {
-      t.fail('should not send any data')
-    })
-
-    server.listen(function () {
-      const agent = Agent().start({
-        serverUrl: 'http://localhost:' + server.address().port,
-        captureExceptions: false
-      })
-
-      agent.addTransactionFilter(function (obj) {
-        t.equal(obj.name, 'transaction-name')
-        return false
-      })
-      agent.addTransactionFilter(function () {
-        t.fail('should not call 2nd filter')
-      })
-
-      agent.startTransaction('transaction-name')
-      agent.endTransaction()
-      agent.flush()
-
-      setTimeout(function () {
-        t.end()
-        server.close()
-      }, 50)
-    })
-  })
-
-  t.test('#addSpanFilter() - abort', function (t) {
-    t.plan(1)
-
-    const server = http.createServer(function (req, res) {
-      t.fail('should not send any data')
-    })
-
-    server.listen(function () {
-      const agent = Agent().start({
-        serverUrl: 'http://localhost:' + server.address().port,
-        captureExceptions: false
-      })
-
-      agent.addSpanFilter(function (obj) {
-        t.equal(obj.name, 'span-name')
-        return false
-      })
-      agent.addSpanFilter(function () {
-        t.fail('should not call 2nd filter')
-      })
-
-      agent.startTransaction()
-      const span = agent.startSpan('span-name')
-      span.end()
-
-      setTimeout(function () {
-        agent.flush()
         setTimeout(function () {
           t.end()
           server.close()
         }, 50)
-      }, 50)
+      })
+    })
+
+    t.test(`#addErrorFilter() - abort with '${String(falsy)}'`, function (t) {
+      t.plan(1)
+
+      const server = http.createServer(function (req, res) {
+        t.fail('should not send any data')
+      })
+
+      server.listen(function () {
+        const agent = Agent().start({
+          serverUrl: 'http://localhost:' + server.address().port,
+          captureExceptions: false
+        })
+
+        agent.addErrorFilter(function (obj) {
+          t.equal(obj.exception.message, 'foo')
+          return falsy
+        })
+        agent.addErrorFilter(function () {
+          t.fail('should not call 2nd filter')
+        })
+
+        agent.captureError(new Error('foo'))
+
+        setTimeout(function () {
+          t.end()
+          server.close()
+        }, 50)
+      })
+    })
+
+    t.test(`#addTransactionFilter() - abort with '${String(falsy)}'`, function (t) {
+      t.plan(1)
+
+      const server = http.createServer(function (req, res) {
+        t.fail('should not send any data')
+      })
+
+      server.listen(function () {
+        const agent = Agent().start({
+          serverUrl: 'http://localhost:' + server.address().port,
+          captureExceptions: false
+        })
+
+        agent.addTransactionFilter(function (obj) {
+          t.equal(obj.name, 'transaction-name')
+          return falsy
+        })
+        agent.addTransactionFilter(function () {
+          t.fail('should not call 2nd filter')
+        })
+
+        agent.startTransaction('transaction-name')
+        agent.endTransaction()
+        agent.flush()
+
+        setTimeout(function () {
+          t.end()
+          server.close()
+        }, 50)
+      })
+    })
+
+    t.test(`#addSpanFilter() - abort with '${String(falsy)}'`, function (t) {
+      t.plan(1)
+
+      const server = http.createServer(function (req, res) {
+        t.fail('should not send any data')
+      })
+
+      server.listen(function () {
+        const agent = Agent().start({
+          serverUrl: 'http://localhost:' + server.address().port,
+          captureExceptions: false
+        })
+
+        agent.addSpanFilter(function (obj) {
+          t.equal(obj.name, 'span-name')
+          return falsy
+        })
+        agent.addSpanFilter(function () {
+          t.fail('should not call 2nd filter')
+        })
+
+        agent.startTransaction()
+        const span = agent.startSpan('span-name')
+        span.end()
+
+        setTimeout(function () {
+          agent.flush()
+          setTimeout(function () {
+            t.end()
+            server.close()
+          }, 50)
+        }, 50)
+      })
     })
   })
 })


### PR DESCRIPTION
Backports the following commits to 2.x:
 - fix: support all falsy return values from error filters (#1389)