### PR TITLE
[2.x] docs: fix 'added in' for span API docs (#1397)

### DIFF
--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -136,7 +136,7 @@ You can add labels multiple times.
 [[span-ids]]
 ==== `span.ids`
 
-[small]#Added in: #2.17.0
+[small]#Added in: v2.17.0#
 
 Produces an object containing `span.id` and `trace.id`.
 This enables log correlation to APM traces with structured loggers.
@@ -152,7 +152,7 @@ This enables log correlation to APM traces with structured loggers.
 [[span-to-string]]
 ==== `span.toString()`
 
-[small]#Added in: #2.17.0
+[small]#Added in: v2.17.0#
 
 Produces a string representation of the span to inject in log messages.
 This enables log correlation to APM traces with text-only loggers.
@@ -165,7 +165,7 @@ This enables log correlation to APM traces with text-only loggers.
 [[span-end]]
 ==== `span.end([endTime])`
 
-// [small]#Added in: #
+[small]#Added in: v0.1.0#
 
 * `endTime` +{type-number}+ The time when the span ended.
 Must be a Unix Time Stamp representing the number of milliseconds since January 1, 1970, 00:00:00 UTC.


### PR DESCRIPTION
Backports the following commits to 2.x:
 - docs: fix 'added in' for span API docs (#1397)