### PR TITLE
ci(jenkins): time out problematic test if running too long

### DIFF
--- a/test/instrumentation/modules/http/aborted-requests-enabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-enabled.js
@@ -12,7 +12,7 @@ var mockClient = require('../../../_mock_http_client')
 var addEndedTransaction = agent._instrumentation.addEndedTransaction
 agent._conf.errorOnAbortedRequests = true
 
-test('client-side abort below error threshold - call end', function (t) {
+test('client-side abort below error threshold - call end', { timeout: 10000 }, function (t) {
   var clientReq
   t.plan(9)
 


### PR DESCRIPTION
This test has a tendency to get stuck on Jenkins and never complete. Instead of waiting 3 hours until Jenkins times out, we'll just time out the test after 10 seconds.

Obviously this doesn't fix the issue but merely stops us from consuming Jenkins resources.