### PR TITLE
ci(jenkins): don't suppress Node.js 6 errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,13 +341,7 @@ def generateStep(Map params = [:]){
         dir("${BASE_DIR}"){
           retry(2){
             sleep randomNumber(min:10, max: 30)
-            if (version?.startsWith('6')) {
-              catchError {
-                sh(label: 'Run Tests', script: """.ci/scripts/test.sh "${version}" "${tav}" "${edge}" """)
-              }
-            } else {
-              sh(label: "Run Tests", script: """.ci/scripts/test.sh "${version}" "${tav}" "${edge}" """)
-            }
+            sh(label: "Run Tests", script: """.ci/scripts/test.sh "${version}" "${tav}" "${edge}" """)
           }
         }
       } catch(e){


### PR DESCRIPTION
This is a replacement for #1374 to not suppress any errors on Node.js 6 in the `2.x` branch.