### PR TITLE
[2.x] ci(jenkins): time out problematic test if running too long (#1400)

### DIFF
--- a/test/instrumentation/modules/http/aborted-requests-enabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-enabled.js
@@ -12,7 +12,7 @@ var mockClient = require('../../../_mock_http_client')
 var addEndedTransaction = agent._instrumentation.addEndedTransaction
 agent._conf.errorOnAbortedRequests = true
 
-test('client-side abort below error threshold - call end', function (t) {
+test('client-side abort below error threshold - call end', { timeout: 10000 }, function (t) {
   var clientReq
   t.plan(9)
 


### PR DESCRIPTION
Backports the following commits to 2.x:
 - ci(jenkins): time out problematic test if running too long (#1400)