### PR TITLE
[2.x] docs: fix 'added in' for transaction+agent API docs (#1399)

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -78,7 +78,7 @@ These config options can also be provided as part of the <<configuration,regular
 [[apm-add-filter]]
 ==== `apm.addFilter(callback)`
 
-// [small]#Added in: #
+[small]#Added in: v0.1.0#
 
 Use `addFilter()` to supply a filter function.
 
@@ -787,7 +787,7 @@ apm.clearPatches(['timers'])
 [[apm-current-trace-ids]]
 ==== `apm.currentTraceIds`
 
-[small]#Added in: #2.17.0
+[small]#Added in: v2.17.0#
 
 Produces an object containing `trace.id` and either `transaction.id` or `span.id` when a current transaction or span is available.
 When no transaction or span is available it will return an empty object.

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -209,7 +209,7 @@ See the {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
 [[transaction-ids]]
 ==== `transaction.ids`
 
-[small]#Added in: #2.17.0
+[small]#Added in: v2.17.0#
 
 Produces an object containing `transaction.id` and `trace.id`.
 This enables log correlation to APM traces with structured loggers.
@@ -225,7 +225,7 @@ This enables log correlation to APM traces with structured loggers.
 [[transaction-to-string]]
 ==== `transaction.toString()`
 
-[small]#Added in: #2.17.0
+[small]#Added in: v2.17.0#
 
 Produces a string representation of the transaction to inject in log messages.
 This enables log correlation to APM traces with text-only loggers.


### PR DESCRIPTION
Backports the following commits to 2.x:
 - docs: fix 'added in' for transaction+agent API docs (#1399)