### PR TITLE
chore: don't use parseUrl fallback anymore

### DIFF
--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -1,12 +1,12 @@
 'use strict'
 
 var symbols = require('../symbols')
-var parsers = require('../parsers')
 
 var parseUrl
 try {
   parseUrl = require('parseurl')
 } catch (e) {
+  const parsers = require('../parsers')
   parseUrl = req => parsers.parseUrl(req.url)
 }
 

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -4,7 +4,7 @@ var url = require('url')
 
 var endOfStream = require('end-of-stream')
 
-var parsers = require('../parsers')
+var { parseUrl } = require('../parsers')
 
 const transactionForResponse = new WeakMap()
 exports.transactionForResponse = transactionForResponse
@@ -102,7 +102,7 @@ function formatURL (item) {
 // to a format which can be mixed into the options object.
 function ensureUrl (v) {
   if (typeof v === 'string') {
-    return formatURL(parsers.parseUrl(v))
+    return formatURL(parseUrl(v))
   } else if (url.URL && v instanceof url.URL) {
     return formatURL(v)
   } else {
@@ -157,7 +157,7 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
 
       ins.bindEmitter(req)
 
-      span.name = req.method + ' ' + req._headers.host + parsers.parseUrl(req.path).pathname
+      span.name = req.method + ' ' + req._headers.host + parseUrl(req.path).pathname
 
       // TODO: Research if it's possible to add this to the prototype instead.
       // Or if it's somehow preferable to listen for when a `response` listener

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -4,7 +4,7 @@ var eos = require('end-of-stream')
 
 var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
-var parsers = require('../../parsers')
+var { parseUrl } = require('../../parsers')
 
 module.exports = function (http2, agent, { enabled }) {
   if (agent._conf.instrumentIncomingHTTPRequests) {
@@ -158,7 +158,7 @@ module.exports = function (http2, agent, { enabled }) {
 
       ins.bindEmitter(req)
 
-      var urlObj = parsers.parseUrl(headers[':path'])
+      var urlObj = parseUrl(headers[':path'])
       var path = urlObj.pathname
       span.name = headers[':method'] + ' ' + host + path
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -217,9 +217,7 @@ exports.parseCallsite = function (callsite, isError, agent, cb) {
 }
 
 exports.parseUrl = function (urlStr) {
-  return url.URL
-    ? new url.URL(urlStr, 'relative:///')
-    : url.parse(urlStr) // eslint-disable-line node/no-deprecated-api
+  return new url.URL(urlStr, 'relative:///')
 }
 
 // Default `culprit` to the top of the stack or the highest non `library_frame`

--- a/test/central-config-enabled.js
+++ b/test/central-config-enabled.js
@@ -3,7 +3,7 @@
 const existingValue = process.env.ELASTIC_APM_CENTRAL_CONFIG
 delete process.env.ELASTIC_APM_CENTRAL_CONFIG
 
-const { URL, parse: parseUrl } = require('url') // eslint-disable-line node/no-deprecated-api
+const { URL } = require('url')
 const http = require('http')
 
 const test = require('tape')
@@ -13,7 +13,7 @@ test('remote config enabled', function (t) {
 
   let agent, timer
   const server = http.createServer((req, res) => {
-    const url = URL ? new URL(req.url, 'relative:///') : parseUrl(req.url)
+    const url = new URL(req.url, 'relative:///')
     t.equal(url.pathname, '/config/v1/agents')
     res.writeHead(200, {
       Etag: 1,


### PR DESCRIPTION
All supported versions of Node.js now supports the new `url.URL` API.