### PR TITLE
chore: remove deprecated APIs

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -198,28 +198,6 @@ and any custom context given as the 2nd argument to <<apm-capture-error,`apm.cap
 TIP: Before using custom context, ensure you understand the different types of
 {apm-overview-ref-v}/metadata.html[metadata] that are available.
 
-[[apm-set-tag]]
-==== `apm.setTag(name, value)`
-
-deprecated[2.10.0,Replaced by <<apm-set-label>>]
-
-[small]#Added in: v0.1.0#
-
-* `name` +{type-string}+
-Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
-as those characters have special meaning in Elasticsearch
-* `value` +{type-string}+
-If a non-string data type is given,
-it's converted to a string before being sent to the APM Server
-
-Set a tag on the current transaction.
-You can set multiple tags on the same transaction.
-If an error happens during the current transaction,
-it will also get tagged with the same tags.
-
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
-
-
 [[apm-set-label]]
 ==== `apm.setLabel(name, value)`
 
@@ -247,29 +225,6 @@ Before using custom labels, ensure you understand the different types of
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
 {ref}/mapping.html#mapping-limit-settings[mapping explosion].
-
-[[apm-add-tags]]
-==== `apm.addTags({ [name]: value })`
-
-deprecated[2.10.0,Replaced by <<apm-add-labels>>]
-
-[small]#Added in: v1.5.0#
-
-* `tags` +{type-object}+ Contains key/value pairs:
-** `name` +{type-string}+
-Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
-as those characters have special meaning in Elasticsearch
-** `value` +{type-string}+
-If a non-string data type is given,
-it's converted to a string before being sent to the APM Server
-
-Add several tags on the current transaction.
-You can add tags multiple times.
-If an error happens during the current transaction,
-it will also get tagged with the same tags.
-
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
-
 
 [[apm-add-labels]]
 ==== `apm.addLabels({ [name]: value })`

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -8,35 +8,32 @@ The following pages have moved or been deleted.
 
 This page has moved. Please see <<supported-technologies>>.
 
-// The following headings have been deprecated.
-// When they are ready to be removed they can be uncommented.
+[role="exclude",id="apm-set-tag"]
+=== `apm.setTag(name, value)`
 
-// [role="exclude",id="apm-set-tag"]
-// === `apm.setTag(name, value)`
+This endpoint has moved. Please see <<apm-set-label>>.
 
-// This endpoint has moved. Please see <<apm-set-label>>.
+[role="exclude",id="apm-add-tags"]
+=== `apm.addTags({ [name]: value })`
 
-// [role="exclude",id="apm-add-tags"]
-// === `apm.addTags({ [name]: value })`
+This endpoint has moved. Please see <<apm-add-labels>>.
 
-// This endpoint has moved. Please see <<apm-add-labels>>.
+[role="exclude",id="span-set-tag"]
+=== `span.setTag(name, value)`
 
-// [role="exclude",id="span-set-tag"]
-// === `span.setTag(name, value)`
+This endpoint has moved. Please see <<span-set-label>>.
 
-// This endpoint has moved. Please see <<span-set-label>>.
+[role="exclude",id="span-add-tags"]
+=== `span.addTags({ [name]: value })`
 
-// [role="exclude",id="span-add-tags"]
-// === `span.addTags({ [name]: value })`
+This endpoint has moved. Please see <<span-add-labels>>.
 
-// This endpoint has moved. Please see <<span-add-labels>>.
+[role="exclude",id="transaction-set-tag"]
+=== `transaction.setTag(name, value)`
 
-// [role="exclude",id="transaction-set-tag"]
-// === `transaction.setTag(name, value)`
+This endpoint has moved. Please see <<transaction-set-label>>.
 
-// This endpoint has moved. Please see <<transaction-set-label>>.
+[role="exclude",id="transaction-add-tags"]
+=== `transaction.addTags({ [name]: value })`
 
-// [role="exclude",id="transaction-add-tags"]
-// === `transaction.addTags({ [name]: value })`
-
-// This endpoint has moved. Please see <<transaction-add-labels>>.
+This endpoint has moved. Please see <<transaction-add-labels>>.

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -94,23 +94,6 @@ a database query would generally have an action of `query`.
 
 Get the serialized traceparent string of the span.
 
-[[span-set-tag]]
-==== `span.setTag(name, value)`
-
-deprecated[2.10.0,Replaced by <<span-set-label>>]
-
-[small]#Added in: v2.1.0#
-
-* `name` +{type-string}+
-Periods (`.`), asterisks (`*`), and double quotation marks (`"`) will be replaced by underscores (`_`),
-as those characters have special meaning in Elasticsearch
-* `value` +{type-string}+
-If a non-string data type is given,
-it's converted to a string before being sent to the APM Server
-
-Set a tag on the span.
-You can set multiple tags on the same span.
-
 [[span-set-label]]
 ==== `span.setLabel(name, value)`
 
@@ -127,24 +110,6 @@ it's converted to a string before being sent to the APM Server
 
 Set a label on the span.
 You can set multiple labels on the same span.
-
-[[span-add-tags]]
-==== `span.addTags({ [name]: value })`
-
-deprecated[2.10.0,Replaced by <<span-add-labels>>]
-
-[small]#Added in: v2.1.0#
-
-* `tags` +{type-object}+ Contains key/value pairs:
-** `name` +{type-string}+
-Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
-as those characters have special meaning in Elasticsearch
-** `value` +{type-string}+
-If a non-string data type is given,
-it's converted to a string before being sent to the APM Server
-
-Add several tags on the span.
-You can add tags multiple times.
 
 [[span-add-labels]]
 ==== `span.addLabels({ [name]: value })`

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -112,28 +112,6 @@ When a span is started it will measure the time until <<span-end,`span.end()`>> 
 
 See <<span-api,Span API>> docs for details on how to use custom spans.
 
-[[transaction-set-tag]]
-==== `transaction.setTag(name, value)`
-
-deprecated[2.10.0,Replaced by <<transaction-set-label>>]
-
-[small]#Added in: v0.1.0#
-
-* `name` +{type-string}+
-Periods (`.`), asterisks (`*`), and double quotation marks (`"`) will be replaced by underscores (`_`),
-as those characters have special meaning in Elasticsearch
-* `value` +{type-string}+
-If a non-string data type is given,
-it's converted to a string before being sent to the APM Server
-
-Set a tag on the transaction.
-You can set multiple tags on the same transaction.
-If an error happens during the transaction,
-it will also get tagged with the same tags.
-
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
-
-
 [[transaction-set-label]]
 ==== `transaction.setLabel(name, value)`
 
@@ -154,29 +132,6 @@ If an error happens during the transaction,
 it will also get tagged with the same labels.
 
 Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
-
-[[transaction-add-tags]]
-==== `transaction.addTags({ [name]: value })`
-
-deprecated[2.10.0,Replaced by <<transaction-add-labels>>]
-
-[small]#Added in: v1.5.0#
-
-* `tags` +{type-object}+ Contains key/value pairs:
-** `name` +{type-string}+
-Any periods (`.`), asterisks (`*`), or double quotation marks (`"`) will be replaced by underscores (`_`),
-as those characters have special meaning in Elasticsearch
-** `value` +{type-string}+
-If a non-string data type is given,
-it's converted to a string before being sent to the APM Server
-
-Add several tags on the transaction.
-You can add tags multiple times.
-If an error happens during the transaction,
-it will also get tagged with the same tags.
-
-Tags are key/value pairs that are indexed by Elasticsearch and therefore searchable (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
-
 
 [[transaction-add-labels]]
 ==== `transaction.addLabels({ [name]: value })`

--- a/docs/upgrade-to-v3.asciidoc
+++ b/docs/upgrade-to-v3.asciidoc
@@ -38,6 +38,15 @@ This has resulted in changes to the following API's:
 - <<transaction-type,`transaction.type`>>: String format changed
 - <<span-type,`span.type`>>: String format changed
 
+The following deprecated API's has been removed:
+
+- `apm.setTag()`: Replaced by <<apm-set-label,`apm.setLabel()`>>
+- `apm.addTags()`: Replaced by <<apm-add-labels,`apm.addLabels()`>>
+- `transaction.setTag()`: Replaced by <<transaction-set-label,`transaction.setLabel()`>>
+- `transaction.addTags()`: Replaced by <<transaction-add-labels,`transaction.addLabels()`>>
+- `span.setTag()`: Replaced by <<span-set-label,`span.setLabel()`>>
+- `span.addTags()`: Replaced by <<span-add-labels,`span.addLabels()`>>
+
 [[v3-changes-in-collected-data]]
 ==== Changes in collected data
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,9 +95,7 @@ declare class Agent implements Taggable, StartSpanFn {
 
   // Context
   setLabel (name: string, value: LabelValue): boolean;
-  setTag (name: string, value: LabelValue): boolean; // Deprecated
   addLabels (labels: Labels): boolean;
-  addTags (labels: Labels): boolean; // Deprecated
   setUserContext (user: UserObject): void;
   setCustomContext (custom: object): void;
 
@@ -124,9 +122,7 @@ declare class GenericSpan implements Taggable {
 
   setType (type?: string | null, subtype?: string | null, action?: string | null): void;
   setLabel (name: string, value: LabelValue): boolean;
-  setTag (name: string, value: LabelValue): boolean; // Deprecated
   addLabels (labels: Labels): boolean;
-  addTags (labels: Labels): boolean; // Deprecated
 }
 
 declare class Transaction extends GenericSpan implements StartSpanFn {
@@ -295,9 +291,7 @@ interface PatchOptions {
 
 interface Taggable {
   setLabel (name: string, value: LabelValue): boolean;
-  setTag (name: string, value: LabelValue): boolean; // Deprecated
   addLabels (labels: Labels): boolean;
-  addTags (labels: Labels): boolean; // Deprecated
 }
 
 interface StartSpanFn {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -205,26 +205,10 @@ Agent.prototype.setCustomContext = function (context) {
   return true
 }
 
-Agent.prototype.setTag = function (key, value) {
-  if (!this.setTag._deprecatedLogged) {
-    this.setTag._deprecatedLogged = true
-    this.logger.warn('Called deprecated method: apm.setTag(...)')
-  }
-  return this.setLabel(key, value)
-}
-
 Agent.prototype.setLabel = function (key, value) {
   var trans = this.currentTransaction
   if (!trans) return false
   return trans.setLabel(key, value)
-}
-
-Agent.prototype.addTags = function (tags) {
-  if (!this.addTags._deprecatedLogged) {
-    this.addTags._deprecatedLogged = true
-    this.logger.warn('Called deprecated method: apm.addTags(...)')
-  }
-  return this.addLabels(tags)
 }
 
 Agent.prototype.addLabels = function (labels) {

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -72,14 +72,6 @@ GenericSpan.prototype.duration = function () {
   return this._timer.duration
 }
 
-GenericSpan.prototype.setTag = function (key, value) {
-  if (!this.setTag._deprecatedLogged) {
-    this.setTag._deprecatedLogged = true
-    this._agent.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.setTag(...)`)
-  }
-  return this.setLabel(key, value)
-}
-
 GenericSpan.prototype.setLabel = function (key, value) {
   if (!key) return false
   if (!this._labels) this._labels = {}
@@ -89,14 +81,6 @@ GenericSpan.prototype.setLabel = function (key, value) {
   }
   this._labels[skey] = truncate(String(value), config.INTAKE_STRING_MAX_SIZE)
   return true
-}
-
-GenericSpan.prototype.addTags = function (tags) {
-  if (!this.addTags._deprecatedLogged) {
-    this.addTags._deprecatedLogged = true
-    this._agent.logger.warn(`Called deprecated method: ${this.constructor.name.toLowerCase()}.addTags(...)`)
-  }
-  return this.addLabels(tags)
 }
 
 GenericSpan.prototype.addLabels = function (labels) {

--- a/test/agent.js
+++ b/test/agent.js
@@ -356,52 +356,40 @@ test('#setCustomContext()', function (t) {
   })
 })
 
-var singleLabelTests = [
-  { name: '#setLabel()', method: 'setLabel' },
-  { name: '#setTag() - deprecated', method: 'setTag' }
-]
-singleLabelTests.forEach((labelTest) => {
-  test(labelTest.name, function (t) {
-    t.test('no active transaction', function (t) {
-      var agent = Agent()
-      agent.start()
-      t.equal(agent[labelTest.method]('foo', 1), false)
-      t.end()
-    })
+test('#setLabel()', function (t) {
+  t.test('no active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    t.equal(agent.setLabel('foo', 1), false)
+    t.end()
+  })
 
-    t.test('active transaction', function (t) {
-      var agent = Agent()
-      agent.start()
-      var trans = agent.startTransaction()
-      t.equal(agent[labelTest.method]('foo', 1), true)
-      t.deepEqual(trans._labels, { foo: '1' })
-      t.end()
-    })
+  t.test('active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    var trans = agent.startTransaction()
+    t.equal(agent.setLabel('foo', 1), true)
+    t.deepEqual(trans._labels, { foo: '1' })
+    t.end()
   })
 })
 
-var multipleLabelTests = [
-  { name: '#addLabels()', method: 'addLabels' },
-  { name: '#addTags() - deprecated', method: 'addTags' }
-]
-multipleLabelTests.forEach((multipleTest) => {
-  test(multipleTest.name, function (t) {
-    t.test('no active transaction', function (t) {
-      var agent = Agent()
-      agent.start()
-      t.equal(agent[multipleTest.method]({ foo: 1 }), false)
-      t.end()
-    })
+test('#addLabels()', function (t) {
+  t.test('no active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    t.equal(agent.addLabels({ foo: 1 }), false)
+    t.end()
+  })
 
-    t.test('active transaction', function (t) {
-      var agent = Agent()
-      agent.start()
-      var trans = agent.startTransaction()
-      t.equal(agent[multipleTest.method]({ foo: 1, bar: 2 }), true)
-      t.equal(agent[multipleTest.method]({ foo: 3 }), true)
-      t.deepEqual(trans._labels, { foo: '3', bar: '2' })
-      t.end()
-    })
+  t.test('active transaction', function (t) {
+    var agent = Agent()
+    agent.start()
+    var trans = agent.startTransaction()
+    t.equal(agent.addLabels({ foo: 1, bar: 2 }), true)
+    t.equal(agent.addLabels({ foo: 3 }), true)
+    t.deepEqual(trans._labels, { foo: '3', bar: '2' })
+    t.end()
   })
 })
 


### PR DESCRIPTION
BREAKING CHANGE: The following deprecated APIs has been removed:

- `apm.setTag()`
- `apm.addTags()`
- `transaction.setTag()`
- `transaction.addTags()`
- `span.setTag()`
- `span.addTags()`