### PR TITLE
ci(jenkins): enable commit lint

### DIFF
--- a/.ci/scripts/test_basic.sh
+++ b/.ci/scripts/test_basic.sh
@@ -8,4 +8,5 @@ node --version
 npm --version
 
 npm run lint
+npm run lint:commit
 npm run test:deps

--- a/test/lint-commits.sh
+++ b/test/lint-commits.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
+set -xeo pipefail
 
-set -e
-
-# Only run if we're not on a CI system
-if [[ -z "$CI" ]]; then
-  GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+# Run if we're not on Travis
+if [[ -n "${JENKINS_URL}" ]]; then
+  export PATH=$(npm bin):${PATH}
+  export HOME=$(pwd)
+  if [[ -z "${CHANGE_ID}" ]]; then
+    # If on master, just test the latest commit
+    commitlint --from="${GIT_SHA}~1"
+  else
+    # If on a branch, test all commits between this branch and master
+    commitlint --from="origin/${CHANGE_TARGET}" --to="${GIT_BASE_COMMIT}"
+  fi
+elif [[ -z "$CI" ]]; then
+  GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
   if [[ "$GIT_BRANCH" == "master" ]]; then
     # If on master, just test the latest commit


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-nodejs/issues/1407

## Highlights
- Enable support to Jenkins using https://github.com/elastic/apm-agent-nodejs/pull/1325/files#diff-04fe4fa9c5ef3988af8ec44be5151292 in addition.

## Test Cases
- https://github.com/elastic/apm-agent-nodejs/pull/1416/commits/af4e267f0da883b86c9499676e5edfd9431dd44f caused a lint error, see [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-linting-mbp/detail/PR-1416/4/pipeline)

```
[2019-09-30T10:48:07.919Z] + commitlint --from=origin/master --to=af4e267f0da883b86c9499676e5edfd9431dd44f
[2019-09-30T10:48:08.490Z] ⧗   input: Trigger notification to test the commit-lint
[2019-09-30T10:48:08.490Z] ✖   subject may not be empty [subject-empty]
[2019-09-30T10:48:08.490Z] ✖   type may not be empty [type-empty]
[2019-09-30T10:48:08.490Z] 
[2019-09-30T10:48:08.490Z] ✖   found 2 problems, 0 warnings
[2019-09-30T10:48:08.490Z] ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```

- https://github.com/elastic/apm-agent-nodejs/commit/353dca7fa3af5249046070d7f34972c803f6076e passed the validation. See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-linting-mbp/detail/PR-1416/3/pipeline)