### PR TITLE
workaround(s) to suppress DEP0066 warnings

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -110,6 +110,10 @@ function ensureUrl (v) {
   }
 }
 
+function getSafeHost (res) {
+  return res.getHeader ? res.getHeader('Host') : res._headers.host
+}
+
 exports.traceOutgoingRequest = function (agent, moduleName, method) {
   var ins = agent._instrumentation
 
@@ -147,17 +151,17 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       var req = orig.apply(this, newArgs)
       if (!span) return req
 
-      if (req._headers.host === agent._conf.serverHost) {
+      if (getSafeHost(req) === agent._conf.serverHost) {
         agent.logger.debug('ignore %s request to intake API %o', moduleName, { id: id })
         return req
       } else {
         var protocol = req.agent && req.agent.protocol
-        agent.logger.debug('request details: %o', { protocol: protocol, host: req._headers.host, id: id })
+        agent.logger.debug('request details: %o', { protocol: protocol, host: getSafeHost(req), id: id })
       }
 
       ins.bindEmitter(req)
 
-      span.name = req.method + ' ' + req._headers.host + parseUrl(req.path).pathname
+      span.name = req.method + ' ' + getSafeHost(req) + parseUrl(req.path).pathname
 
       // TODO: Research if it's possible to add this to the prototype instead.
       // Or if it's somehow preferable to listen for when a `response` listener

--- a/lib/instrumentation/modules/http.js
+++ b/lib/instrumentation/modules/http.js
@@ -3,6 +3,10 @@
 var httpShared = require('../http-shared')
 var shimmer = require('../shimmer')
 
+function getSafeHeaders (res) {
+  return res.getHeaders ? res.getHeaders() : res._headers
+}
+
 module.exports = function (http, agent, { enabled }) {
   if (agent._conf.instrumentIncomingHTTPRequests) {
     agent.logger.debug('shimming http.Server.prototype.emit function')
@@ -25,7 +29,7 @@ module.exports = function (http, agent, { enabled }) {
   function wrapWriteHead (original) {
     return function wrappedWriteHead () {
       var headers = arguments.length === 1
-        ? this._headers // might be because of implicit headers.
+        ? getSafeHeaders(this) // might be because of implicit headers.
         : arguments[arguments.length - 1]
 
       var result = original.apply(this, arguments)


### PR DESCRIPTION
I wrapped `req._headers` calls in a ternary operator to not access `req._headers` in Node 12.x and above.

REF: elastic/apm-agent-nodejs#1073 

### Checklist
- [x] Implement code
