### PR TITLE
ci(jenkins): reuse top level agent

### DIFF
--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def nodeTasksGen
 
 pipeline {
-  agent { label 'immutable' }
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-nodejs'
     BASE_DIR="src/github.com/elastic/${REPO}"

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def nodeTasksGen
 
 pipeline {
-  agent any
+  agent { label 'immutable' }
   environment {
     REPO = 'apm-agent-nodejs'
     BASE_DIR="src/github.com/elastic/${REPO}"
@@ -40,7 +40,6 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -57,7 +56,6 @@ pipeline {
       Run TAV tests.
     */
     stage('TAV Test') {
-      agent { label 'docker && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'docker && immutable' }
+  agent { label 'linux && immutable' }
   environment {
     HOME = "${env.WORKSPACE}"
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'immutable' }
   environment {
     REPO = 'apm-agent-nodejs'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -38,7 +38,6 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
@@ -59,7 +58,6 @@ pipeline {
       Run tests.
     */
     stage('Test') {
-      agent { label 'docker && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'immutable' }
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-nodejs'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -96,7 +96,7 @@ pipeline {
       Run TAV tests.
     */
     stage('TAV Test') {
-      agent { label 'docker && immutable' }
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -155,7 +155,7 @@ pipeline {
       }
       parallel {
         stage('Nightly Test') {
-          agent { label 'docker && immutable' }
+          agent { label 'linux && immutable' }
           environment {
             NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/nightly/"
           }
@@ -177,7 +177,7 @@ pipeline {
           }
         }
         stage('Nightly Test - No async hooks') {
-          agent { label 'docker && immutable' }
+          agent { label 'linux && immutable' }
           environment {
             NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/nightly/"
           }
@@ -199,7 +199,7 @@ pipeline {
           }
         }
         stage('RC Test') {
-          agent { label 'docker && immutable' }
+          agent { label 'linux && immutablee' }
           environment {
             NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/rc/"
           }
@@ -221,7 +221,7 @@ pipeline {
           }
         }
         stage('RC Test - No async hooks') {
-          agent { label 'docker && immutable' }
+          agent { label 'linux && immutable' }
           environment {
             NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/rc/"
           }
@@ -326,7 +326,7 @@ def generateStep(Map params = [:]){
   def edge = params.containsKey('edge') ? params.edge : false
   def disableAsyncHooks = params.get('disableAsyncHooks', false)
   return {
-    node('docker && linux && immutable'){
+    node('linux && immutable'){
       try {
         env.HOME = "${WORKSPACE}"
         if (disableAsyncHooks) {
@@ -403,7 +403,7 @@ def getSmartTAVContext() {
 
  def linting(){
    return {
-    node('docker && linux && immutable') {
+    node('linux && immutable') {
       catchError(stageResult: 'UNSTABLE', message: 'Linting failures') {
         withGithubNotify(context: 'Linting') {
           deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,6 @@ pipeline {
       Run TAV tests.
     */
     stage('TAV Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"


### PR DESCRIPTION
### Highlights
- Let's reuse the top-level agent to reduce the number of fo requested agents and speed up just a bit the builds.
- Reset labels to be `linux && immutable` to help with what kind of OS is required to be used.
- Time improvements per Stage
  - From the very beginning to the tests stage used to take ~3 minutes and now 1.30 minutes.
  - TAV stage doesn't require a new worker, so roughly another 1minute approx of improvement.

### Test Cases
- TAV has been launched explicitly with the comment: https://github.com/elastic/apm-agent-nodejs/pull/1425#issuecomment-538056979