### PR TITLE
fix: change logUncaughtExceptions default to false

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -389,11 +389,11 @@ Whether or not the agent should monitor for uncaught exceptions and send them to
 ==== `logUncaughtExceptions`
 
 * *Type:* Boolean
-* *Default:* `true`
+* *Default:* `false`
 * *Env:* `ELASTIC_APM_LOG_UNCAUGHT_EXCEPTIONS`
 
-By default the stack trace of uncaught exceptions is written to STDERR.
-Set this config option to `false` to turn this behaviour off.
+By default the stack trace of a uncaught exception is not written to STDERR when the agent is active.
+Set this config option to `true` to have the agent write stack traces of uncaught exceptions to STDERR.
 
 [[capture-error-log-stack-traces]]
 ==== `captureErrorLogStackTraces`

--- a/lib/config.js
+++ b/lib/config.js
@@ -60,7 +60,7 @@ var DEFAULTS = {
   kubernetesPodName: undefined,
   kubernetesPodUID: undefined,
   logLevel: 'info',
-  logUncaughtExceptions: true,
+  logUncaughtExceptions: false, // TODO: Change to `true` in the v4.0.0
   metricsInterval: '30s',
   metricsLimit: 1000,
   serverTimeout: '30s',

--- a/test/config.js
+++ b/test/config.js
@@ -53,7 +53,7 @@ var optionFixtures = [
   ['kubernetesPodName', 'KUBERNETES_POD_NAME'],
   ['kubernetesPodUID', 'KUBERNETES_POD_UID'],
   ['logLevel', 'LOG_LEVEL', 'info'],
-  ['logUncaughtExceptions', 'LOG_UNCAUGHT_EXCEPTIONS', true],
+  ['logUncaughtExceptions', 'LOG_UNCAUGHT_EXCEPTIONS', false],
   ['metricsInterval', 'METRICS_INTERVAL', 30],
   ['metricsLimit', 'METRICS_LIMIT', 1000],
   ['secretToken', 'SECRET_TOKEN'],

--- a/test/uncaught-exceptions/log-uncaught-exceptions-off.js
+++ b/test/uncaught-exceptions/log-uncaught-exceptions-off.js
@@ -2,8 +2,7 @@
 
 const agent = require('../..').start({
   metricsInterval: 0,
-  centralConfig: false,
-  logUncaughtExceptions: false
+  centralConfig: false
 })
 
 const test = require('tape')

--- a/test/uncaught-exceptions/log-uncaught-exceptions-on.js
+++ b/test/uncaught-exceptions/log-uncaught-exceptions-on.js
@@ -2,7 +2,8 @@
 
 const agent = require('../..').start({
   metricsInterval: 0,
-  centralConfig: false
+  centralConfig: false,
+  logUncaughtExceptions: true
 })
 
 const test = require('tape')


### PR DESCRIPTION
Even though it would be best to log stack traces of uncaught exception to STDERR by default, this would be a breaking change. To land this feature in the current major, we'll change the default to be `false`.