### PR TITLE
[2.x] perf: cache 'ids' value of transactions and spans (#1434)

### DIFF
--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -13,6 +13,7 @@ function GenericSpan (agent, type, opts) {
   this._context = TraceParent.startOrResume(opts.childOf, agent._conf) // _context is used by the OT bridge, and should unfortunately therefore be considered public
   this._agent = agent
   this._labels = null
+  this._ids = null // Populated by sub-types of GenericSpan
 
   this.timestamp = this._timer.start
   this.type = type || 'custom'

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -49,7 +49,9 @@ function Span (transaction, name, type, opts) {
 
 Object.defineProperty(Span.prototype, 'ids', {
   get () {
-    return new SpanIds(this)
+    return this._ids === null
+      ? (this._ids = new SpanIds(this))
+      : this._ids
   }
 })
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -75,7 +75,9 @@ Object.defineProperty(Transaction.prototype, 'result', {
 
 Object.defineProperty(Transaction.prototype, 'ids', {
   get () {
-    return new TransactionIds(this)
+    return this._ids === null
+      ? (this._ids = new TransactionIds(this))
+      : this._ids
   }
 })
 


### PR DESCRIPTION
Backports the following commits to 2.x:
 - perf: cache 'ids' value of transactions and spans (#1434)