### PR TITLE
fix: always end transaction when socket is closed prematurely

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -35,9 +35,10 @@ exports.instrumentRequest = function (agent, moduleName) {
           ins.bindEmitter(res)
 
           endOfStream(res, function (err) {
+            if (trans.ended) return
             if (!err) return trans.end()
 
-            if (agent._conf.errorOnAbortedRequests && !trans.ended) {
+            if (agent._conf.errorOnAbortedRequests) {
               var duration = trans._timer.elapsed()
               if (duration > (agent._conf.abortedErrorThreshold * 1000)) {
                 agent.captureError('Socket closed with active HTTP request (>' + agent._conf.abortedErrorThreshold + ' sec)', {
@@ -49,9 +50,12 @@ exports.instrumentRequest = function (agent, moduleName) {
 
             // Handle case where res.end is called after an error occurred on the
             // stream (e.g. if the underlying socket was prematurely closed)
-            res.on('prefinish', function () {
+            const end = res.end
+            res.end = function () {
+              const result = end.apply(this, arguments)
               trans.end()
-            })
+              return result
+            }
           })
         }
       }

--- a/test/instrumentation/modules/http/aborted-requests-enabled.js
+++ b/test/instrumentation/modules/http/aborted-requests-enabled.js
@@ -37,12 +37,13 @@ test('client-side abort below error threshold - call end', { timeout: 10000 }, f
   var server = http.createServer(function (req, res) {
     setTimeout(function () {
       clientReq.abort()
-      setTimeout(function () {
-        res.write('Hello') // server emits clientError if written in same tick as abort
+      res.write('sync write')
+      process.nextTick(function () {
+        res.write('nextTick write')
         setTimeout(function () {
-          res.end(' World')
+          res.end('setTimeout write')
         }, 10)
-      }, 10)
+      })
     }, (agent._conf.abortedErrorThreshold * 1000) / 2)
   })
 


### PR DESCRIPTION
This fixes a race condition that in some cases meant that a request transaction was never ended if the underlying TCP socket was closed by the client and the server didn't discover this in time.

Fixes #1411