### PR TITLE
fix(metrics): do not send transaction breakdowns when disabled

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -258,7 +258,10 @@ Transaction.prototype._captureBreakdown = function (span) {
 
     metrics.incrementCounter('transaction.duration.count', labels)
     metrics.incrementCounter('transaction.duration.sum.us', labels, duration)
-    metrics.incrementCounter('transaction.breakdown.count', labels, this.sampled ? 1 : 0)
+
+    if (conf.breakdownMetrics) {
+      metrics.incrementCounter('transaction.breakdown.count', labels, this.sampled ? 1 : 0)
+    }
 
     for (const { labels, time, count } of this._breakdownTimings.values()) {
       const flattenedLabels = flattenBreakdown(labels)

--- a/test/metrics/breakdown.js
+++ b/test/metrics/breakdown.js
@@ -162,6 +162,45 @@ test('does not include breakdown when not sampling', t => {
   transaction.end()
 })
 
+test('does not include transaction breakdown when disabled', t => {
+  const conf = {
+    metricsInterval: 1,
+    transactionSampleRate: 0,
+    breakdownMetrics: false
+  }
+
+  resetAgent(3, conf, (data) => {
+    t.equal(data.transactions.length, 1, 'has one transaction')
+    assertTransaction(t, transaction, data.transactions[0])
+
+    t.equal(data.spans.length, 0, 'has no spans')
+
+    const { metricsets } = data
+
+    t.comment('metricSet - transaction metrics')
+
+    const metricSet = finders.transaction(metricsets, span)
+    t.ok(metricSet, 'found metricset')
+
+    assertMetricSetKeys(t, metricSet, [
+      'transaction.duration.count',
+      'transaction.duration.sum.us'
+    ])
+    assertMetricSetData(t, metricSet, expectations.transaction(transaction, span))
+
+    t.comment('metricSet - span')
+    t.notOk(metricsets.find(metricset => !!metricset.span), 'should not have any span metricsets')
+
+    agent._metrics.stop()
+    t.end()
+  })
+
+  var transaction = agent.startTransaction('foo', 'bar')
+  var span = agent.startSpan('s0 name', 's0 type')
+  if (span) span.end()
+  transaction.end()
+})
+
 test('acceptance', t => {
   const conf = {
     metricsInterval: 1
@@ -590,7 +629,15 @@ function assertMetricSet (t, name, metricsets, { transaction, span } = {}) {
 
   t.comment(`metricSet - ${name} metrics`)
   t.ok(metricSet, 'found metricset')
+  assertMetricSetKeys(t, metricSet, keys)
+  assertMetricSetData(t, metricSet, expected)
+}
+
+function assertMetricSetKeys (t, metricSet, keys) {
   t.deepEqual(Object.keys(metricSet.samples).sort(), keys.sort(), 'has expected sample keys')
+}
+
+function assertMetricSetData (t, metricSet, expected) {
   t.deepEqual(metricSet.transaction, expected.transaction, 'has expected transaction data')
   t.deepEqual(metricSet.span, expected.span, 'has expected span data')
 }


### PR DESCRIPTION
The `transaction.breakdown.count` value in metricsets should not be reported when breakdown metrics are disabled. This issue was discovered in #1460.

### Checklist

- [x] Implement code
- [x] Add tests