### PR TITLE
fix(tedious): support 6.5+

### DIFF
--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -3,8 +3,6 @@
 var semver = require('semver')
 var sqlSummary = require('sql-summary')
 
-var shimmer = require('../shimmer')
-
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious
   if (!semver.satisfies(version, '>=0.0.5')) {
@@ -13,11 +11,14 @@ module.exports = function (tedious, agent, { version, enabled }) {
   }
 
   const ins = agent._instrumentation
-  agent.logger.debug('shimming tedious.Connection')
-  shimmer.wrap(tedious, 'Connection', wrapConnection)
-  shimmer.wrap(tedious, 'Request', wrapRequest)
 
-  return tedious
+  // NOTE: shimmer doesn't work because the TypeScript build used in tedious
+  // locks the property descriptors of all exports, preventing re-assignment.
+  return {
+    ...tedious,
+    Connection: wrapConnection(tedious.Connection),
+    Request: wrapRequest(tedious.Request)
+  }
 
   function wrapRequest (OriginalRequest) {
     class Request extends OriginalRequest {


### PR DESCRIPTION
In 6.5, tedious began using a version of TypeScript which locks property descriptors of exports. This prevents us from being able to re-assign functions with shimmer.

Fixes #1472

### Checklist

- [x] Implement code
