### PR TITLE
ci(memcached): ensure host env var is available in edge tests

### DIFF
--- a/.ci/docker/docker-compose-node-edge-test.yml
+++ b/.ci/docker/docker-compose-node-edge-test.yml
@@ -21,6 +21,7 @@ services:
       CASSANDRA_HOST: 'cassandra'
       PGHOST: 'postgres'
       PGUSER: 'postgres'
+      MEMCACHED_HOST: 'memcached'
       NODE_VERSION: ${NODE_VERSION}
       NVM_NODEJS_ORG_MIRROR: ${NVM_NODEJS_ORG_MIRROR}
       ELASTIC_APM_ASYNC_HOOKS: ${ELASTIC_APM_ASYNC_HOOKS}


### PR DESCRIPTION
The edge test stuff missed an environment variable for memcached. The instrumentation for memcached landed around the same time, so I think it was just overlooked when merging the two.