### PR TITLE
[2.x] fix(metrics): do not send transaction breakdowns when disabled (#1466)

### DIFF
--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -260,7 +260,10 @@ Transaction.prototype._captureBreakdown = function (span) {
 
     metrics.incrementCounter('transaction.duration.count', labels)
     metrics.incrementCounter('transaction.duration.sum.us', labels, duration)
-    metrics.incrementCounter('transaction.breakdown.count', labels, this.sampled ? 1 : 0)
+
+    if (conf.breakdownMetrics) {
+      metrics.incrementCounter('transaction.breakdown.count', labels, this.sampled ? 1 : 0)
+    }
 
     for (const { labels, time, count } of this._breakdownTimings.values()) {
       const flattenedLabels = flattenBreakdown(labels)


### PR DESCRIPTION
Backports the following commits to 2.x:
 - fix(metrics): do not send transaction breakdowns when disabled (#1466)