### PR TITLE
[2.x] refactor: use smarter shimming of graphql module (#1476)

### DIFF
--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var semver = require('semver')
+var clone = require('shallow-clone-shim')
 
 var getPathFromRequest = require('../express-utils').getPathFromRequest
 
@@ -16,42 +17,26 @@ module.exports = function (graphql, agent, { version, enabled }) {
     return graphql
   }
 
-  var wrapped = {}
-
-  Object.defineProperty(wrapped, '__esModule', {
-    value: true
-  })
-
-  for (const key of Object.keys(graphql)) {
-    const getter = graphql.__lookupGetter__(key)
-    const setter = graphql.__lookupSetter__(key)
-    const opts = { enumerable: true }
-
-    if (getter) {
-      switch (key) {
-        case 'graphql':
-          opts.get = function get () {
-            return wrapGraphql(getter())
-          }
-          break
-        case 'execute':
-          opts.get = function get () {
-            return wrapExecute(getter())
-          }
-          break
-        default:
-          opts.get = getter
+  return clone({}, graphql, {
+    graphql (descriptor) {
+      const getter = descriptor.get
+      if (getter) {
+        descriptor.get = function get () {
+          return wrapGraphql(getter())
+        }
       }
+      return descriptor
+    },
+    execute (descriptor) {
+      const getter = descriptor.get
+      if (getter) {
+        descriptor.get = function get () {
+          return wrapExecute(getter())
+        }
+      }
+      return descriptor
     }
-
-    if (setter) {
-      opts.set = setter
-    }
-
-    Object.defineProperty(wrapped, key, opts)
-  }
-
-  return wrapped
+  })
 
   function wrapGraphql (orig) {
     return function wrappedGraphql (schema, requestString, rootValue, contextValue, variableValues, operationName) {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "require-in-the-middle": "^5.0.0",
     "semver": "^6.1.1",
     "set-cookie-serde": "^1.0.0",
+    "shallow-clone-shim": "^1.0.0",
     "sql-summary": "^1.0.1",
     "stackman": "^4.0.0",
     "traceparent": "^1.0.0",


### PR DESCRIPTION
Backports the following commits to 2.x:
 - refactor: use smarter shimming of graphql module (#1476)