### PR TITLE
[2.x] ci(memcached): ensure host env var is available in edge tests (#1484)

### DIFF
--- a/.ci/docker/docker-compose-node-edge-test.yml
+++ b/.ci/docker/docker-compose-node-edge-test.yml
@@ -21,6 +21,7 @@ services:
       CASSANDRA_HOST: 'cassandra'
       PGHOST: 'postgres'
       PGUSER: 'postgres'
+      MEMCACHED_HOST: 'memcached'
       NODE_VERSION: ${NODE_VERSION}
       NVM_NODEJS_ORG_MIRROR: ${NVM_NODEJS_ORG_MIRROR}
       ELASTIC_APM_ASYNC_HOOKS: ${ELASTIC_APM_ASYNC_HOOKS}


### PR DESCRIPTION
Backports the following commits to 2.x:
 - ci(memcached): ensure host env var is available in edge tests (#1484)