### PR TITLE
[2.x] fix(tedious): ensure shimmed module exposes same API (#1477)

### DIFF
--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var semver = require('semver')
+var clone = require('shallow-clone-shim')
 var sqlSummary = require('sql-summary')
 
 module.exports = function (tedious, agent, { version, enabled }) {
@@ -12,13 +13,36 @@ module.exports = function (tedious, agent, { version, enabled }) {
 
   const ins = agent._instrumentation
 
-  // NOTE: shimmer doesn't work because the TypeScript build used in tedious
-  // locks the property descriptors of all exports, preventing re-assignment.
-  return {
-    ...tedious,
-    Connection: wrapConnection(tedious.Connection),
-    Request: wrapRequest(tedious.Request)
-  }
+  return clone({}, tedious, {
+    Connection (descriptor) {
+      const getter = descriptor.get
+      if (getter) {
+        // tedious v6.5.0+
+        descriptor.get = function get () {
+          return wrapConnection(getter())
+        }
+      } else if (typeof descriptor.value === 'function') {
+        descriptor.value = wrapConnection(descriptor.value)
+      } else {
+        agent.logger.debug('could not patch `tedious.Connection` property for tedious version %s - aborting...', version)
+      }
+      return descriptor
+    },
+    Request (descriptor) {
+      const getter = descriptor.get
+      if (getter) {
+        // tedious v6.5.0+
+        descriptor.get = function get () {
+          return wrapRequest(getter())
+        }
+      } else if (typeof descriptor.value === 'function') {
+        descriptor.value = wrapRequest(descriptor.value)
+      } else {
+        agent.logger.debug('could not patch `tedious.Request` property for tedious version %s - aborting...', version)
+      }
+      return descriptor
+    }
+  })
 
   function wrapRequest (OriginalRequest) {
     class Request extends OriginalRequest {


### PR DESCRIPTION
Backports the following commits to 2.x:
 - fix(tedious): ensure shimmed module exposes same API (#1477)