### PR TITLE
fix(knex): make stack traces work in 0.18+

### DIFF
--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -7,7 +7,7 @@ var symbols = require('../../symbols')
 
 module.exports = function (Knex, agent, { version, enabled }) {
   if (!enabled) return Knex
-  if (semver.gte(version, '0.18.0')) {
+  if (semver.gte(version, '0.21.0')) {
     agent.logger.debug('knex version %s not supported - aborting...', version)
     return Knex
   }

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -32,7 +32,7 @@ function logger () {
 }
 
 function isFunction (funktion) {
-  return funktion && {}.toString.call(funktion) === '[object Function]'
+  return typeof funktion === 'function'
 }
 
 function wrap (nodule, name, wrapper) {

--- a/test/instrumentation/modules/pg/knex.js
+++ b/test/instrumentation/modules/pg/knex.js
@@ -125,14 +125,9 @@ function assertBasicQuery (t, data) {
   t.equal(data.spans[0].type, 'db')
   t.equal(data.spans[0].subtype, 'postgresql')
   t.equal(data.spans[0].action, 'query')
-
-  // From 0.18 on, knex uses a bluebird queue internally,
-  // which terminates the stacktrace before user code.
-  if (semver.lt(knexVersion, '0.18.0')) {
-    t.ok(data.spans[0].stacktrace.some(function (frame) {
-      return frame.function === 'userLandCode'
-    }), 'include user-land code frame')
-  }
+  t.ok(data.spans[0].stacktrace.some(function (frame) {
+    return frame.function === 'userLandCode'
+  }), 'include user-land code frame')
 }
 
 function createClient (t, cb) {


### PR DESCRIPTION
I figured out how to get stack traces working properly in knex. It was a result of knex switching from Bluebird to native promises in 0.18. In the process, they also switched to using async functions, which our version of shimmer apparently was unable to patch correctly because it used a `toString()` check to identify functions rather than a simple `typeof`, and async functions have a different name than regular functions.

### Checklist

- [x] Implement code
- [x] Add tests