### PR TITLE
[2.x] fix(knex): make stack traces work in 0.18+ (#1497)

### DIFF
--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -7,7 +7,7 @@ var symbols = require('../../symbols')
 
 module.exports = function (Knex, agent, { version, enabled }) {
   if (!enabled) return Knex
-  if (semver.gte(version, '0.18.0')) {
+  if (semver.gte(version, '0.21.0')) {
     agent.logger.debug('knex version %s not supported - aborting...', version)
     return Knex
   }

--- a/lib/instrumentation/shimmer.js
+++ b/lib/instrumentation/shimmer.js
@@ -32,7 +32,7 @@ function logger () {
 }
 
 function isFunction (funktion) {
-  return funktion && {}.toString.call(funktion) === '[object Function]'
+  return typeof funktion === 'function'
 }
 
 function wrap (nodule, name, wrapper) {


### PR DESCRIPTION
Backports the following commits to 2.x:
 - fix(knex): make stack traces work in 0.18+ (#1497)