### PR TITLE
docs: deprecate lambda support

### DIFF
--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -7,7 +7,9 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs/current/lambda.html[elastic.co]
 endif::[]
 
-=== Get started with Lambda
+=== Get started with Lambda (Deprecated)
+
+WARNING: *Lambda functions are no longer supported by the Elastic APM Node.js Agent.*
 
 Getting Elastic APM set up for your lambda functions is easy,
 and there are various ways you can tweak it to fit your needs.

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -11,7 +11,7 @@ To get you off the ground, we've prepared guides for setting up the Agent with a
 * <<koa>>
 * <<restify>>
 * <<fastify>>
-* <<lambda>>
+// * <<lambda>>
 // end::web-frameworks-list[]
 
 Alternatively, you can <<custom-stack>>.
@@ -35,9 +35,9 @@ include::./restify.asciidoc[]
 
 include::./fastify.asciidoc[]
 
-include::./lambda.asciidoc[]
-
 include::./custom-stack.asciidoc[]
+
+include::./lambda.asciidoc[]
 
 [[starting-the-agent]]
 === Starting the agent


### PR DESCRIPTION
Adds a note to the documentation that Lambda functions are no longer supported.

Closes https://github.com/elastic/apm-agent-nodejs/issues/1511.