### PR TITLE
fix(metrics): only register collectors if enabled

### DIFF
--- a/lib/metrics/registry.js
+++ b/lib/metrics/registry.js
@@ -31,8 +31,10 @@ class MetricsRegistry extends SelfReportingMetricsRegistry {
     this._agent = agent
 
     this._registry.collectors = []
-    createSystemMetrics(this)
-    createRuntimeMetrics(this)
+    if (reporter.enabled) {
+      createSystemMetrics(this)
+      createRuntimeMetrics(this)
+    }
   }
 
   registerCollector (collector) {


### PR DESCRIPTION
If metrics are disabled (metricsInterval is 0), then we should not register any collectors.

Later we might want to make this dynamic, starting/stopping collectors in response to dynamic changes to the metricsInterval value made via central config. For now, let's just fix the bug.

The runtime collector creates a loop delay monitor which will accumulate data while enabled until it is either disabled or reset. As we only reset the monitor when collecting metrics, starting the collector without later calling its "collect" method would lead to unbounded memory growth.

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation

Closes https://github.com/elastic/apm-agent-nodejs/issues/1515