### PR TITLE
ci(jenkins): update argument

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
               "^lib/instrumentation/modules/",
               "^test/instrumentation/modules/"
             ]
-            env.TAV_UPDATED = isGitRegionMatch(regexps: regexps)
+            env.TAV_UPDATED = isGitRegionMatch(patterns: regexps)
           }
         }
       }


### PR DESCRIPTION
The signature for isGitRegionMatch has been changed to support different comparators, such as glob or regexp. By default glob is the comparator.
This should be merged only once the library has been released. Likely sometime this week.