### PR TITLE
fix(ioredis): prevent unhandled promise rejection

### DIFF
--- a/lib/instrumentation/modules/ioredis.js
+++ b/lib/instrumentation/modules/ioredis.js
@@ -67,11 +67,7 @@ module.exports = function (ioredis, agent, { version, enabled }) {
           const endSpan = function () {
             if (!span.ended) span.end()
           }
-
-          if (typeof command.promise.finally === 'function') {
-            // Bluebird and Node.js 10+
-            command.promise.finally(endSpan)
-          } else if (typeof command.promise.then === 'function') {
+          if (typeof command.promise.then === 'function') {
             command.promise.then(endSpan).catch(endSpan)
           }
         }


### PR DESCRIPTION
Fixes #1518

The use of `finally` without updating `command.promise` causes a bifurcation. The onFinally handler will rethrow, and nothing can catch it, leading to an unhandled promise rejection.

Let's simplify the code a bit, and just use `.then` regardless, which avoids this issue.

### Checklist

- [x] Implement code
- [x] Add tests
~- [ ] Update TypeScript typings~
~- [ ] Update documentation~