### PR TITLE
chore: add Node 13 to supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": "^8.6.0 || 10 || 12"
+    "node": "^8.6.0 || 10 || 12 || 13"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
- [x] Implement code
~- [ ] Add tests~
~- [ ] Update TypeScript typings~
~- [ ] Update documentation~

CI has already been updated to test against Node 13 in https://github.com/elastic/apm-agent-nodejs/pull/1464

Closes #1516