### PR TITLE
ci(jenkins): Update CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ If you have any feedback or questions,
 please post them on the [Discuss forum](https://discuss.elastic.co/c/apm).
 
 [![npm](https://img.shields.io/npm/v/elastic-apm-node.svg)](https://www.npmjs.com/package/elastic-apm-node)
-[![Build status](https://travis-ci.org/elastic/apm-agent-nodejs.svg?branch=2.x)](https://travis-ci.org/elastic/apm-agent-nodejs)
+[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-nodejs%2Fapm-agent-nodejs-mbp%2F3.x)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/3.x/)
+[![Build status](https://travis-ci.org/elastic/apm-agent-nodejs.svg?branch=3.x)](https://travis-ci.org/elastic/apm-agent-nodejs)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/standard/standard)
 
 ## Installation


### PR DESCRIPTION
## What is this PR doing?
It updates Jenkins badge for the master branch, using the unprotected one, so that anybody wit ViewStatus access can read it.

**protected** exposes the badge to users having at least Read permission on the job
**unprotected** exposes the badge to users having at least ViewStatus permission on the job

## Why is it important?
We want to keep al projects in sync in terms of CI, so that we can be even more transparent about the status of the project.