### PR TITLE
fix(package): bump semver to ^6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "relative-microtime": "^2.0.0",
     "require-ancestors": "^1.0.0",
     "require-in-the-middle": "^5.0.0",
-    "semver": "^6.1.1",
+    "semver": "^6.3.0",
     "set-cookie-serde": "^1.0.0",
     "shallow-clone-shim": "^1.0.0",
     "sql-summary": "^1.0.1",


### PR DESCRIPTION
Bumping non-dev-dependencies in separate PR's to make a future `git bisect` easier in case any of these has unforeseen side-effects