### PR TITLE
fix(package): bump shallow-clone-shim to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "require-in-the-middle": "^5.0.0",
     "semver": "^6.1.1",
     "set-cookie-serde": "^1.0.0",
-    "shallow-clone-shim": "^1.0.0",
+    "shallow-clone-shim": "^2.0.0",
     "sql-summary": "^1.0.1",
     "stackman": "^4.0.0",
     "traceparent": "^1.0.0",


### PR DESCRIPTION
Bumping non-dev-dependencies in separate PR's to make a future `git bisect` easier in case any of these has unforeseen side-effects