### PR TITLE
ci(travis): don't update npm to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - for i in {1..3}; do travis_wait 5 npm install && break; rm -rf node_modules; done
 
 before_script:
-  - npm install -g npm@latest
   - wait-on tcp:9200
 
 node_js:


### PR DESCRIPTION
Fixes elastic/apm-agent-nodejs#1532