### PR TITLE
ci(jenkins): add memcached to edge tests

### DIFF
--- a/.ci/docker/docker-compose-edge.yml
+++ b/.ci/docker/docker-compose-edge.yml
@@ -9,6 +9,10 @@ services:
     extends:
       file: docker-compose.yml
       service: elasticsearch
+  memcached:
+    extends:
+      file: docker-compose.yml
+      service: memcached
   mongodb:
     extends:
       file: docker-compose.yml
@@ -37,6 +41,8 @@ services:
       cassandra:
         condition: service_healthy
       elasticsearch:
+        condition: service_healthy
+      memcached:
         condition: service_healthy
       mongodb:
         condition: service_healthy


### PR DESCRIPTION
## What is this PR doing
This PR adds memcached to the docker-compose used in edge tests

## Why is it important?
Tests are failing because of this reason, although they bring up different failures related to Node Edge and APM Server. With this change, the test code is not waiting for a memcached service.

## Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] Fixed automation scripts
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)

## Related issues
Closes #1537 