### PR TITLE
ci(jenkins): trigger opbeans release process

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-nodejs-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    OPBEANS_REPO = 'opbeans-node'
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -262,6 +263,32 @@ pipeline {
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+      }
+    }
+    stage('Release') {
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+      }
+      stages {
+        stage('Opbeans') {
+          environment {
+            REPO_NAME = "${OPBEANS_REPO}"
+          }
+          steps {
+            deleteDir()
+            dir("${OPBEANS_REPO}"){
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                  url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              // The opbeans pipeline will trigger a release for the master branch
+              gitPush()
+              // The opbeans pipeline will trigger a release for the release tag
+              gitCreateTag(tag: "${env.BRANCH_NAME}")
+            }
+          }
+        }
       }
     }
     /**

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -283,7 +283,8 @@ pipeline {
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git"
-              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              // It's required to transform the tag value to the artifact version
+              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
               // The opbeans pipeline will trigger a release for the master branch
               gitPush()
               // The opbeans pipeline will trigger a release for the release tag


### PR DESCRIPTION
## What does this pull request do?

Add a final stage in the release process to bump the opbeans agent dependency.

## Why is it important?

When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:
- [x] Bump dependency versions in the opbeans-node
- [x] Push changes. (Implementation within the opbeans-node but the call it's done within this pipeline)
- [x] Create a tag to trigger the release pipeline in the opbeans-node. That particular tag will match with the same one that the one in the agent itself.

This particular pipeline will push the changes into the `master` branch for the opbeans-node and tag it with the name of the tag version too. Therefore, the opbeans-node pipeline will trigger two builds, the one for its master branch and the other one for the just created tag. This particular flow is implemented within the opbeans-node.