### PR TITLE
feat(config): extend central config support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -129,7 +129,9 @@ var ENV_TABLE = {
 }
 
 var CENTRAL_CONFIG = {
-  transaction_sample_rate: 'transactionSampleRate'
+  transaction_sample_rate: 'transactionSampleRate',
+  transaction_max_spans: 'transactionMaxSpans',
+  capture_body: 'captureBody'
 }
 
 var VALIDATORS = {


### PR DESCRIPTION
Extend central config support to accept `transaction_max_spans` and `capture_body`.

Relates to https://github.com/elastic/apm/issues/138

### Checklist

- [x] Implement code
- [x] Add tests
~- [ ] Update TypeScript typings~
~- [ ] Update documentation~
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)