### PR TITLE
fix(elasticsearch): ensure requests can be aborted

### DIFF
--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -55,14 +55,22 @@ module.exports = function (elasticsearch, agent, { enabled }) {
           }
           return original.apply(this, args)
         } else {
-          return original.apply(this, arguments)
-            .then(function (originalP) {
+          const originalPromise = original.apply(this, arguments)
+
+          const inspectedPromise = originalPromise
+            .then(function (value) {
               span.end()
-              return originalP
+              return value
             }, function (err) {
               span.end()
               throw err
             })
+
+          const descriptors = Object.getOwnPropertyDescriptors(originalPromise)
+          delete descriptors.domain
+          Object.defineProperties(inspectedPromise, descriptors)
+
+          return inspectedPromise
         }
       } else {
         agent.logger.debug('could not instrument elasticsearch request %o', { id: id })

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -57,6 +57,9 @@ module.exports = function (elasticsearch, agent, { enabled }) {
         } else {
           const originalPromise = original.apply(this, arguments)
 
+          const descriptors = Object.getOwnPropertyDescriptors(originalPromise)
+          delete descriptors.domain
+
           const inspectedPromise = originalPromise
             .then(function (value) {
               span.end()
@@ -66,8 +69,6 @@ module.exports = function (elasticsearch, agent, { enabled }) {
               throw err
             })
 
-          const descriptors = Object.getOwnPropertyDescriptors(originalPromise)
-          delete descriptors.domain
           Object.defineProperties(inspectedPromise, descriptors)
 
           // we have to properly end the span when user aborts the request

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -75,8 +75,9 @@ module.exports = function (elasticsearch, agent, { enabled }) {
             return function wrappedAbort () {
               if (span.ended) return
               agent.logger.debug('intercepted call to elasticsearch.Transport.request.abort %o', { id: id, method: method, path: path })
+              const originalReturn = originalAbort.apply(this, args)
               span.end()
-              return originalAbort.apply(this, args)
+              return originalReturn
             }
           })
 

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -70,6 +70,16 @@ module.exports = function (elasticsearch, agent, { enabled }) {
           delete descriptors.domain
           Object.defineProperties(inspectedPromise, descriptors)
 
+          // we have to properly end the span when user aborts the request
+          shimmer.wrap(inspectedPromise, 'abort', function wrapAbort (originalAbort) {
+            return function wrappedAbort () {
+              if (span.ended) return
+              agent.logger.debug('intercepted call to elasticsearch.Transport.request.abort %o', { id: id, method: method, path: path })
+              span.end()
+              return originalAbort.apply(this, args)
+            }
+          })
+
           return inspectedPromise
         }
       } else {

--- a/test/instrumentation/modules/elasticsearch.js
+++ b/test/instrumentation/modules/elasticsearch.js
@@ -68,6 +68,7 @@ test('client.ping with unhandled promise', function userLandCode (t) {
 
   function unhandledRejection (reason, promise) {
     t.equal(promise, unhandledPromise)
+    t.strictEqual(typeof promise.abort, 'function', 'promise.abort should be a function')
     agent.endTransaction()
     agent.flush()
     client.close()


### PR DESCRIPTION
Fixes #1565

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
