### PR TITLE
ci(jenkins): fix linting in branches and tidyup

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -436,8 +436,8 @@ def getSmartTAVContext() {
         withGithubNotify(context: 'Linting') {
           deleteDir()
           unstash 'source'
-          script {
-            docker.image('node:12').inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+          docker.image('node:12').inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+            withEnv(["HOME=/app"]) {
               sh(label: 'Basic tests I', script: 'cd /app && .ci/scripts/test_basic.sh')
               sh(label: 'Basic tests II', script: 'cd /app && .ci/scripts/test_types_babel_esm.sh')
             }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -116,7 +116,7 @@ class NodeParallelTaskGenerator extends DefaultParallelTaskGenerator {
   */
   public Closure generateStep(x, y){
     return {
-      steps.node('docker && linux && immutable'){
+      steps.node('linux && immutable'){
         try {
           steps.runScript(node: x, tav: y)
           saveResult(x, y, 1)

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -39,7 +39,7 @@ pipeline {
 def generateStep(Map params = [:]){
   def version = params?.version
   return {
-    node('docker && linux && immutable'){
+    node('linux && immutable'){
       dir(version) {
         unstash 'source'
         docker.image("node:${version}").inside("-v ${WORKSPACE}/${version}:/app"){


### PR DESCRIPTION
The linting in the branches are not working properly.
docker label is not required anymore for linux agents.