### PR TITLE
Add reference-repo for CI

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-downstream.yml
+++ b/.ci/jobs/apm-agent-nodejs-downstream.yml
@@ -32,6 +32,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-nodejs.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-agent-nodejs-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-linting-mbp.yml
@@ -33,6 +33,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-nodejs.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -37,6 +37,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-nodejs.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'


### PR DESCRIPTION

Adds reference repos.

These correspond to repos and download locations which can be seen in [the Jenkins job which mirrors them](https://apm-ci.elastic.co/job/jenkins-git-fetch-reference/).

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
