### PR TITLE
test: add missing API schema file

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -29,6 +29,7 @@ FILES=( \
   "transactions/mark.json" \
   "transactions/transaction.json" \
   "context.json" \
+  "message.json" \
   "metadata.json" \
   "process.json" \
   "request.json" \


### PR DESCRIPTION
The file `message.json` has been added to the `docs/spec` folder in the APM Server repo and also needs to be downloaded here for the tests for work properly.