### PR TITLE
[2.x] test: add missing API schema file (#1584)

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -29,6 +29,7 @@ FILES=( \
   "transactions/mark.json" \
   "transactions/transaction.json" \
   "context.json" \
+  "message.json" \
   "metadata.json" \
   "process.json" \
   "request.json" \


### PR DESCRIPTION
Backports the following commits to 2.x:
 - test: add missing API schema file (#1584)