### PR TITLE
test: fix babel tests

### DIFF
--- a/.ci/scripts/test_types_babel_esm.sh
+++ b/.ci/scripts/test_types_babel_esm.sh
@@ -7,6 +7,13 @@ npm install
 node --version
 npm --version
 
+major_node_version=`node --version | cut -d . -f1 | cut -d v -f2`
+minor_node_version=`node --version | cut -d . -f2`
+
 npm run test:types
-npm run test:babel
+
+if [[ $major_node_version -ne 13 ]] || [[ $minor_node_version -gt 1 ]]; then
+  npm run test:babel
+fi
+
 npm run test:esm

--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -55,7 +55,9 @@ run_test_suite () {
   fi
 
   npm run test:types
-  npm run test:babel
+  if [[ $major_node_version -ne 13 ]] || [[ $minor_node_version -gt 1 ]]; then
+    npm run test:babel
+  fi
   npm run test:esm
 }
 


### PR DESCRIPTION
Babel has an issue under Node.js 13.0 and 13.1. This commit just skips the babel tests in those circumstances.