### PR TITLE
feat: parse error stacks manually

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -41,15 +41,14 @@ exports.parseMessage = function (msg) {
 }
 
 exports.parseStackTrace = function (err) {
+  // graphqljs adds the `originalError` property which represents the original
+  // error thrown within the resolver
   err = err.originalError || err
   let stackframes = []
   if (err.stack == null) {
     return stackframes
   }
-  try {
-    stackframes = stacktrace.parse(err)
-  } catch (_) {}
-  const frames = stackframes.map((frame) => {
+  return stacktrace.parse(err).map((frame) => {
     const filename = frame.getFileName() || ''
     return {
       abs_path: filename,
@@ -59,7 +58,6 @@ exports.parseStackTrace = function (err) {
       library_frame: !isApp(frame)
     }
   })
-  return frames
 }
 
 exports.parseError = function (err, agent, cb) {
@@ -95,11 +93,13 @@ exports.parseError = function (err, agent, cb) {
       // they were passed on, we would want to suppress them here anyway
 
       if (frames.length === 0) {
-        /**
-         * If we cannot able to extract callsite information from the error, then
-         * we fallback to parsing the error manually
-         */
-        frames = exports.parseStackTrace(err)
+         // If we are not able to extract callsite information from the error, then
+         // we fallback to parsing the error manually
+        try {
+          frames = exports.parseStackTrace(err)
+        } catch (parseError) {
+          agent.logger.debug('error parsing the stack: %s', parseError.message)
+        }
       }
       var culprit = getCulprit(frames)
       var module = getModule(frames)
@@ -287,14 +287,12 @@ function getRelativeFileName (filename) {
   return !~filename.indexOf(root) ? filename : filename.substr(root.length)
 }
 
-/**
- * Below two functions expects the passed in object to be of type stackframe
- * https://github.com/stacktracejs/stackframe
- */
+// stackframe argument resembles structured stack trace of v8 https://v8.dev/docs/stack-trace-api
 function isApp (stackframe) {
   return !isNode(stackframe) && !~(stackframe.getFileName() || '').indexOf('node_modules' + path.sep)
 }
 
+// stackframe argument resembles structured stack trace of v8 https://v8.dev/docs/stack-trace-api
 function isNode (stackframe) {
   if (stackframe.isNative) return true
   var filename = stackframe.getFileName() || ''

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -2,6 +2,7 @@
 
 var util = require('util')
 var url = require('url')
+var path = require('path')
 
 var afterAll = require('after-all-results')
 var basicAuth = require('basic-auth')
@@ -9,6 +10,7 @@ var getUrlFromRequest = require('original-url')
 var httpHeaders = require('http-headers')
 var stringify = require('fast-safe-stringify')
 var truncate = require('unicode-byte-truncate')
+var stacktrace = require('error-stack-parser')
 
 var stackman = require('./stackman')
 
@@ -36,6 +38,28 @@ exports.parseMessage = function (msg) {
   }
 
   return error
+}
+
+exports.parseStackTrace = function (err) {
+  err = err.originalError || err
+  let stackframes = []
+  if (err.stack == null) {
+    return stackframes
+  }
+  try {
+    stackframes = stacktrace.parse(err)
+  } catch (_) {}
+  const frames = stackframes.map((frame) => {
+    const filename = frame.getFileName() || ''
+    return {
+      abs_path: filename,
+      filename: getRelativeFileName(filename),
+      function: frame.getFunctionName(),
+      lineno: frame.getLineNumber(),
+      library_frame: !isApp(frame)
+    }
+  })
+  return frames
 }
 
 exports.parseError = function (err, agent, cb) {
@@ -70,14 +94,18 @@ exports.parseError = function (err, agent, cb) {
       // As of now, parseCallsite suppresses errors internally, but even if
       // they were passed on, we would want to suppress them here anyway
 
-      if (frames) {
-        var culprit = getCulprit(frames)
-        var module = getModule(frames)
-        if (culprit) error.culprit = culprit // TODO: consider moving culprit to exception
-        if (module) error.exception.module = module // TODO: consider if we should include this as it's not originally what module was intended for
-        error.exception.stacktrace = frames
+      if (frames.length === 0) {
+        /**
+         * If we cannot able to extract callsite information from the error, then
+         * we fallback to parsing the error manually
+         */
+        frames = exports.parseStackTrace(err)
       }
-
+      var culprit = getCulprit(frames)
+      var module = getModule(frames)
+      if (culprit) error.culprit = culprit // TODO: consider moving culprit to exception
+      if (module) error.exception.module = module // TODO: consider if we should include this as it's not originally what module was intended for
+      error.exception.stacktrace = frames
       cb(null, error)
     })
 
@@ -251,4 +279,24 @@ function tryJsonStringify (obj) {
   try {
     return JSON.stringify(obj)
   } catch (e) {}
+}
+
+function getRelativeFileName (filename) {
+  var root = process.cwd()
+  if (root[root.length - 1] !== path.sep) root += path.sep
+  return !~filename.indexOf(root) ? filename : filename.substr(root.length)
+}
+
+/**
+ * Below two functions expects the passed in object to be of type stackframe
+ * https://github.com/stacktracejs/stackframe
+ */
+function isApp (stackframe) {
+  return !isNode(stackframe) && !~(stackframe.getFileName() || '').indexOf('node_modules' + path.sep)
+}
+
+function isNode (stackframe) {
+  if (stackframe.isNative) return true
+  var filename = stackframe.getFileName() || ''
+  return (!path.isAbsolute(filename) && filename[0] !== '.')
 }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -44,9 +44,8 @@ exports.parseStackTrace = function (err) {
   // graphqljs adds the `originalError` property which represents the original
   // error thrown within the resolver
   err = err.originalError || err
-  let stackframes = []
   if (err.stack == null) {
-    return stackframes
+    return []
   }
   return stacktrace.parse(err).map((frame) => {
     const filename = frame.getFileName() || ''
@@ -93,8 +92,8 @@ exports.parseError = function (err, agent, cb) {
       // they were passed on, we would want to suppress them here anyway
 
       if (frames.length === 0) {
-         // If we are not able to extract callsite information from the error, then
-         // we fallback to parsing the error manually
+        // If we are not able to extract callsite information from the error, then
+        // we fallback to parsing the error manually
         try {
           frames = exports.parseStackTrace(err)
         } catch (parseError) {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "core-util-is": "^1.0.2",
     "elastic-apm-http-client": "^9.3.0",
     "end-of-stream": "^1.4.4",
+    "error-stack-parser": "^2.0.6",
     "fast-safe-stringify": "^2.0.7",
     "http-headers": "^3.0.2",
     "http-request-to-url": "^1.0.0",

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -464,7 +464,7 @@ test('#parseError()', function (t) {
         t.ok('function' in frame)
         t.ok('lineno' in frame)
         t.ok('library_frame' in frame)
-      });
+      })
       t.end()
     })
   })
@@ -501,7 +501,7 @@ test('#parseError()', function (t) {
         t.ok('function' in frame)
         t.ok('lineno' in frame)
         t.ok('library_frame' in frame)
-      });
+      })
       t.end()
     })
   })

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -458,6 +458,13 @@ test('#parseError()', function (t) {
       t.notOk('attributes' in parsed.exception)
       t.ok('stacktrace' in parsed.exception)
       t.ok(parsed.exception.stacktrace.length > 0)
+      parsed.exception.stacktrace.forEach(frame => {
+        t.ok('abs_path' in frame)
+        t.ok('filename' in frame)
+        t.ok('function' in frame)
+        t.ok('lineno' in frame)
+        t.ok('library_frame' in frame)
+      });
       t.end()
     })
   })
@@ -488,6 +495,13 @@ test('#parseError()', function (t) {
       t.notOk('attributes' in parsed.exception)
       t.ok('stacktrace' in parsed.exception)
       t.ok(parsed.exception.stacktrace.length > 0)
+      parsed.exception.stacktrace.forEach(frame => {
+        t.ok('abs_path' in frame)
+        t.ok('filename' in frame)
+        t.ok('function' in frame)
+        t.ok('lineno' in frame)
+        t.ok('library_frame' in frame)
+      });
       t.end()
     })
   })


### PR DESCRIPTION
+ fix #1590 
+ Currently our error stack construction depends on v8 API stack generation function hook which would be called whenever error stack is created, but when the error stack property is changed somewhere in the code/modules, we wont be able to access the callsite information. 
+ This PR provides a sensible fallback when we cannot access the callsite information for errors and also for errors that have additional `originalError` property which reveals the true error (graphqljs adds this property and creates GraphqlError which has this originalError property). 

An example error in Apollo server would look like this in our UI. 
<img width="863" alt="Screenshot 2020-02-05 at 15 35 22" src="https://user-images.githubusercontent.com/3902525/73851038-26ce3d80-482d-11ea-88e7-2cc97072efa8.png">


### Checklist

- [x] Implement code
- [x] Add tests