### PR TITLE
ci(jenkins): cache docker images in the CI workers

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source /usr/local/bin/bash_standard_lib.sh
+
+docker-compose \
+  --no-ansi \
+  --log-level ERROR \
+  -f .ci/docker/docker-compose-all.yml \
+  pull --quiet --ignore-pull-failures

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,6 +2,16 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
+grep "-" .ci/.jenkins_nodejs.yml | cut -d'-' -f2- | \
+while read -r version;
+do
+    transformedVersion=$(echo "${version}" | sed 's#"##g' | cut -d":" -f2)
+    imageName="apm-agent-nodejs"
+    registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedVersion}"
+    (retry 2 docker pull "${registryImageName}")
+    docker tag "${registryImageName}" "node:${transformedVersion}"
+done
+
 docker-compose \
   --no-ansi \
   --log-level ERROR \

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -44,6 +44,26 @@ if [ "${IS_EDGE}" = "true" ]; then
   DOCKER_COMPOSE_FILE=docker-compose-edge.yml
 fi
 
+set +e
+NVM_NODEJS_ORG_MIRROR=${NVM_NODEJS_ORG_MIRROR} \
+ELASTIC_APM_ASYNC_HOOKS=${ELASTIC_APM_ASYNC_HOOKS} \
+NODE_VERSION=${NODE_VERSION} \
+TAV_VERSIONS=${TAV_VERSIONS} \
+USER_ID="$(id -u):$(id -g)" \
+docker-compose \
+  --no-ansi \
+  --log-level ERROR \
+  -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
+  build >docker-compose.log 2>docker-compose.err
+
+if [ $? -gt 0 ] ; then
+  echo "Docker compose failed, see the below log output"
+  cat docker-compose.log && rm docker-compose.log
+  cat docker-compose.err && rm docker-compose.err
+  exit 1
+fi
+
+set -e
 NVM_NODEJS_ORG_MIRROR=${NVM_NODEJS_ORG_MIRROR} \
 ELASTIC_APM_ASYNC_HOOKS=${ELASTIC_APM_ASYNC_HOOKS} \
 NODE_VERSION=${NODE_VERSION} \
@@ -55,10 +75,10 @@ docker-compose \
   -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
   up \
   --exit-code-from node_tests \
-  --build \
   --remove-orphans \
   --abort-on-container-exit \
   node_tests
+
 NODE_VERSION=${NODE_VERSION} docker-compose \
   --no-ansi \
   --log-level ERROR \


### PR DESCRIPTION
## What does this pull request do?

Cache the docker images used in the test stage. For such, it does build the docker image with docker-compose and trap the error to be reported afterward, then it does run the docker-compose.

### Tasks
- [x] is this enough?

## Why is it important?

Speed up the CI overall execution time.

## How to test this

```bash
$ hub checkout pr 701
$ sh .ci/packer_cache.sh 
```

Output should look like the below snippet:

```

13: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:cd3d5d77b2e0d689f3a16363188e98e5a9f9365ef4fa521ae9af559ebe845320
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:13
docker.elastic.co/observability-ci/apm-agent-nodejs:13
13.0: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:12061362c5c2c7db1a842bb535d4f38b867df5f0f3b169817aa9a3b26003061b
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:13.0
docker.elastic.co/observability-ci/apm-agent-nodejs:13.0
12: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:7de421b7e8143dddfce3834d365586fc348ea7c687629381d6c4eac0d3e75ea6
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:12
docker.elastic.co/observability-ci/apm-agent-nodejs:12
12.0: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:ba4b32cda49335abb63dcf4840b2ccd77cd8bfd96c7bc5806a7b8f7bd54d8f70
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:12.0
docker.elastic.co/observability-ci/apm-agent-nodejs:12.0
10: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:0e05f7f00c4c93e1b0dacf1d216e58313088403981f94cfe5e3f6a020296b712
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:10
docker.elastic.co/observability-ci/apm-agent-nodejs:10
10.0: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:5292f7074363efa0b954f0cec0accf6d72288c5ad7bd119aa39824f657d63b13
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:10.0
docker.elastic.co/observability-ci/apm-agent-nodejs:10.0
8: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:ed7d26b5c7d5a0eeaf203da5fdc125d40c09708e08d991db9fc941e7c16f32be
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:8
docker.elastic.co/observability-ci/apm-agent-nodejs:8
8.6: Pulling from observability-ci/apm-agent-nodejs
Digest: sha256:fcb9857757b9e357f32595d9243c7d6dcf1cfd5beb1d398cd319ae629c27957a
Status: Image is up to date for docker.elastic.co/observability-ci/apm-agent-nodejs:8.6
docker.elastic.co/observability-ci/apm-agent-nodejs:8.6
```

It did require to build the docker images previously. See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-docker-images-pipeline/detail/apm-docker-images-pipeline/130/pipeline)

_NOTE_: `/usr/local/bin/bash_standard_lib.sh` is required to exist. That particular requirement is already in place for the CI workers.
