### PR TITLE
[2.x] Fix CI (#1636)

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_DB: 'test_elastic_apm'
+      POSTGRES_HOST_AUTH_METHOD: 'trust'
     healthcheck:
       test: ["CMD", "pg_isready"]
       interval: 1s
@@ -101,7 +102,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-  
+
   memcached:
     image: memcached:alpine
     user: "11211"

--- a/.tav.yml
+++ b/.tav.yml
@@ -244,9 +244,14 @@ tedious:
   versions: '>=1.9 <2.7 || 3.x || >4.0.0'
   commands: node test/instrumentation/modules/tedious.js
 
-cassandra-driver:
-  # 3.1.0 is broken
-  versions: '>=3 <3.1.0 || >3.1.0 <5'
+cassandra-driver-old:
+  name: cassandra-driver
+  versions: '>=3 <3.1.0 || >3.1.0 <4.4.0' # 3.1.0 is broken
+  commands: node test/instrumentation/modules/cassandra-driver/index.js
+cassandra-driver-new:
+  name: cassandra-driver
+  versions: '>=4.4.0 <5'
+  node: '>=8'
   commands: node test/instrumentation/modules/cassandra-driver/index.js
 
 restify-old:

--- a/.tav.yml
+++ b/.tav.yml
@@ -238,9 +238,17 @@ hapi-async-await:
   commands:
     - node test/instrumentation/modules/hapi/basic-legacy-path.js
     - node test/instrumentation/modules/hapi/set-framework.js
-'@hapi/hapi':
+'@hapi/hapi-old':
+  name: '@hapi/hapi'
   node: '>=8.2'
-  versions: '>=17.0.0'
+  versions: '>=17.0.0 <19.0.0'
+  commands:
+    - node test/instrumentation/modules/hapi/basic.js
+    - node test/instrumentation/modules/hapi/set-framework-2.js
+'@hapi/hapi-new':
+  name: '@hapi/hapi'
+  node: '>=12'
+  versions: '>=19.0.0'
   commands:
     - node test/instrumentation/modules/hapi/basic.js
     - node test/instrumentation/modules/hapi/set-framework-2.js

--- a/.tav.yml
+++ b/.tav.yml
@@ -4,15 +4,20 @@ generic-pool:
 mimic-response:
   versions: ^1.0.0
   commands: node test/instrumentation/modules/mimic-response.js
-got-old:
+got-very-old:
   name: got
   versions: '>=4.0.0 <9.0.0'
   node: '>=5'
   commands: node test/instrumentation/modules/http/github-423.js
+got-old:
+  name: got
+  versions: ^9.0.0
+  node: '>=8.3'
+  commands: node test/instrumentation/modules/http/github-423.js
 got-new:
   name: got
-  versions: '>=9.0.0'
-  node: '>=8.3'
+  versions: '>=10.0.0 <10.5.1 || >10.5.1' # v10.5.1 is broken
+  node: '>=10'
   commands: node test/instrumentation/modules/http/github-423.js
 mysql:
   versions: ^2.0.0

--- a/lib/instrumentation/modules/cassandra-driver/_async_connect_patch.js
+++ b/lib/instrumentation/modules/cassandra-driver/_async_connect_patch.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = function (agent) {
+  return function wrapAsyncConnect (original) {
+    return async function wrappedAsyncConnect () {
+      const span = agent.startSpan('Cassandra: Connect', 'db.cassandra.connect')
+      try {
+        return await original.apply(this, arguments)
+      } finally {
+        if (span) span.end()
+      }
+    }
+  }
+}

--- a/lib/instrumentation/modules/cassandra-driver/index.js
+++ b/lib/instrumentation/modules/cassandra-driver/index.js
@@ -3,7 +3,7 @@
 const semver = require('semver')
 const sqlSummary = require('sql-summary')
 
-const shimmer = require('../shimmer')
+const shimmer = require('../../shimmer')
 
 module.exports = function (cassandra, agent, { version, enabled }) {
   if (!enabled) return cassandra
@@ -13,7 +13,15 @@ module.exports = function (cassandra, agent, { version, enabled }) {
   }
 
   if (cassandra.Client) {
-    shimmer.wrap(cassandra.Client.prototype, 'connect', wrapConnect)
+    if (semver.gte(version, '4.4.0')) {
+      // Prior to v4.4.0, the regular `connect` function would be called by the
+      // other functions (e.g. `execute`). In newer versions an internal
+      // `_connect` function is called instead (this is also called by
+      // `connect`).
+      shimmer.wrap(cassandra.Client.prototype, '_connect', require('./_async_connect_patch')(agent))
+    } else {
+      shimmer.wrap(cassandra.Client.prototype, 'connect', wrapConnect)
+    }
     shimmer.wrap(cassandra.Client.prototype, 'execute', wrapExecute)
     shimmer.wrap(cassandra.Client.prototype, 'eachRow', wrapEachRow)
     shimmer.wrap(cassandra.Client.prototype, 'batch', wrapBatch)

--- a/lib/instrumentation/patch-async.js
+++ b/lib/instrumentation/patch-async.js
@@ -17,6 +17,8 @@
  * BSD-2-Clause, http://opensource.org/licenses/BSD-2-Clause
  */
 
+var { promisify } = require('util')
+
 var isNative = require('is-native')
 var semver = require('semver')
 
@@ -418,6 +420,7 @@ module.exports = function (ins) {
 
   // Shim activator for functions that have callback last
   function activator (fn) {
+    var wrapper
     var fallback = function () {
       var args
       var cbIdx = arguments.length - 1
@@ -430,51 +433,65 @@ module.exports = function (ins) {
       }
       return fn.apply(this, args || arguments)
     }
+
     // Preserve function length for small arg count functions.
     switch (fn.length) {
       case 1:
-        return function (cb) {
+        wrapper = function (cb) {
           if (arguments.length !== 1) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb)
         }
+        break
       case 2:
-        return function (a, cb) {
+        wrapper = function (a, cb) {
           if (arguments.length !== 2) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, a, cb)
         }
+        break
       case 3:
-        return function (a, b, cb) {
+        wrapper = function (a, b, cb) {
           if (arguments.length !== 3) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, a, b, cb)
         }
+        break
       case 4:
-        return function (a, b, c, cb) {
+        wrapper = function (a, b, c, cb) {
           if (arguments.length !== 4) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, a, b, c, cb)
         }
+        break
       case 5:
-        return function (a, b, c, d, cb) {
+        wrapper = function (a, b, c, d, cb) {
           if (arguments.length !== 5) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, a, b, c, d, cb)
         }
+        break
       case 6:
-        return function (a, b, c, d, e, cb) {
+        wrapper = function (a, b, c, d, e, cb) {
           if (arguments.length !== 6) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, a, b, c, d, e, cb)
         }
+        break
       default:
-        return fallback
+        wrapper = fallback
     }
+
+    if (promisify && promisify.custom in fn) {
+      wrapper[promisify.custom] = fn[promisify.custom]
+    }
+
+    return wrapper
   }
 
   // Shim activator for functions that have callback first
   function activatorFirst (fn) {
+    var wrapper
     var fallback = function () {
       var args
       if (typeof arguments[0] === 'function') {
@@ -486,47 +503,60 @@ module.exports = function (ins) {
       }
       return fn.apply(this, args || arguments)
     }
+
     // Preserve function length for small arg count functions.
     switch (fn.length) {
       case 1:
-        return function (cb) {
+        wrapper = function (cb) {
           if (arguments.length !== 1) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb)
         }
+        break
       case 2:
-        return function (cb, a) {
+        wrapper = function (cb, a) {
           if (arguments.length !== 2) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb, a)
         }
+        break
       case 3:
-        return function (cb, a, b) {
+        wrapper = function (cb, a, b) {
           if (arguments.length !== 3) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb, a, b)
         }
+        break
       case 4:
-        return function (cb, a, b, c) {
+        wrapper = function (cb, a, b, c) {
           if (arguments.length !== 4) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb, a, b, c)
         }
+        break
       case 5:
-        return function (cb, a, b, c, d) {
+        wrapper = function (cb, a, b, c, d) {
           if (arguments.length !== 5) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb, a, b, c, d)
         }
+        break
       case 6:
-        return function (cb, a, b, c, d, e) {
+        wrapper = function (cb, a, b, c, d, e) {
           if (arguments.length !== 6) return fallback.apply(this, arguments)
           if (typeof cb === 'function') cb = ins.bindFunction(cb)
           return fn.call(this, cb, a, b, c, d, e)
         }
+        break
       default:
-        return fallback
+        wrapper = fallback
     }
+
+    if (promisify && promisify.custom in fn) {
+      wrapper[promisify.custom] = fn[promisify.custom]
+    }
+
+    return wrapper
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "aws-sdk": "^2.529.0",
     "benchmark": "^2.1.4",
     "bluebird": "^3.5.5",
-    "cassandra-driver": "^4.1.0",
+    "cassandra-driver": "4.3.1",
     "columnify": "^1.5.4",
     "commitlint-config-squash-pr": "^1.0.1",
     "connect": "^3.7.0",

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_DB: 'test_elastic_apm'
+      POSTGRES_HOST_AUTH_METHOD: 'trust'
     healthcheck:
       test: ["CMD", "pg_isready"]
       interval: 1s

--- a/test/instrumentation/modules/pg/pg.js
+++ b/test/instrumentation/modules/pg/pg.js
@@ -443,7 +443,14 @@ if (global.Promise || semver.satisfies(pgVersion, '<6')) {
         connector(function (err, client, release) {
           t.error(err)
           client.query(sql, basicQueryCallback(t))
-          release()
+
+          if (semver.gte(pgVersion, '7.5.0')) {
+            release()
+          } else {
+            // Race-condition: Wait a bit so the query callback isn't called
+            // with a "Connection terminated by user" error
+            setTimeout(release, 100)
+          }
         })
       })
     })

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -29,6 +29,7 @@ FILES=( \
   "transactions/mark.json" \
   "transactions/transaction.json" \
   "context.json" \
+  "http_response.json" \
   "message.json" \
   "metadata.json" \
   "process.json" \


### PR DESCRIPTION
Backports the following commits to 2.x:
 - test: fix APM Server schema tests (#1636)
 - fix(cassandra): improve support for cassandra-driver v4.4.0+ (#1636)
 - ci(jenkins): ensure postgres container doesn't need password (#1636)
 - fix: support promisifying setTimeout and friends (#1636)
 - ci(tav): fix got TAV tests (#1636)
 - ci(tav): fix @hapi/hapi TAV tests (#1636)
 - test(pg): fix pg TAV tests (#1636)