### PR TITLE
[docs] Add distributed tracing guide

### DIFF
--- a/docs/distributed-tracing.asciidoc
+++ b/docs/distributed-tracing.asciidoc
@@ -1,0 +1,92 @@
+[[distributed-tracing]]
+== Distributed tracing
+
+// Content from APM Overview documentation
+// https://www.elastic.co/guide/en/apm/get-started/current/distributed-tracing.html
+Distributed tracing enables you to analyze performance throughout your microservices architecture all in one view.
+This is accomplished by tracing all of the requests --
+from the initial web request to your front-end service -- to queries made to your back-end services.
+This makes finding possible bottlenecks throughout your application much easier and faster.
+
+Elastic APM automatically supports distributed tracing,
+but there are some cases, outlined below, where additional setup is necessary.
+
+[float]
+[[tracing-rum-correlation]]
+=== Real User Monitoring (RUM) correlation
+
+// Content from RUM documentation
+// https://www.elastic.co/guide/en/apm/agent/rum-js/master/distributed-tracing-guide.html
+If your backend service generates an HTML page dynamically,
+the trace ID and parent span ID must be injected into the page when the RUM Agent is initialized.
+This ensures that the web browser’s page load appears as the root of the trace,
+and allows you to analyze the time spent in the browser vs in backend services.
+
+// Content from transaction-api.asciidoc
+include::./transaction-api.asciidoc[tag=ensure-parent-id-snippet]
+
+For more information, see <<transaction-ensure-parent-id>>.
+
+[float]
+[[tracing-custom-protocol]]
+=== Custom protocols
+
+Distributed tracing is automatically supported with HTTP/HTTPS.
+If you're using another protocol, like TCP, UDP, WebSocket, or Protocol Buffers,
+there are a few manual setup steps you must follow.
+
+In a distributed trace, multiple transactions are linked together with a `traceparent`.
+To create your own distributed trace, you must pass the current `traceparent` from an outgoing service,
+to a receiving service, and create a new transaction as a child of that `traceparent`:
+
+1. In one service, start a transaction with <<apm-start-transaction>>, or a span with <<apm-start-span>>.
+
+2. Get the serialized `traceparent` string of the started transaction/span with <<apm-current-traceparent>>.
+
+3. Encode the `traceparent` and send it to the receiving service inside your regular request.
+
+4. Decode and store the `traceparent` in the receiving service.
+
+5. Manually start a new transaction as a child of the received `traceparent`, with <<apm-start-transaction>>.
+Pass in the `traceparent` as the `childOf` option.
+
+[float]
+[[tracing-custom-example]]
+==== Example
+
+Consider a scenario where you're using raw UDP to communicate between two services, A and B:
+
+**Service A**
+
+Service A starts a transaction, and gets the current `traceparent`.
+
+[source,js]
+----
+agent.startTransaction('my-service-a-transaction')
+const traceparent = agent.currentTraceparent
+----
+
+Service A then sends the `traceparent` as a "header" to service B.
+
+[source,js]
+----
+// Pseudocode for sending data
+sendMetadata(`traceparent: ${traceparent}\n`)
+----
+
+**Service B**
+
+Service B reads the `traceparent` from the incoming request.
+
+[source,js]
+----
+// Pseudocode for reading incoming request
+const traceparent = readTraceparentFromUDPPacket()
+----
+
+Service B uses the `traceparent` to initialize a new transaction that is a child of the original `traceparent`.
+
+[source,js]
+----
+agent.startTransaction('my-service-b-transaction', { childOf: traceparent })
+----

--- a/docs/distributed-tracing.asciidoc
+++ b/docs/distributed-tracing.asciidoc
@@ -39,7 +39,8 @@ In a distributed trace, multiple transactions are linked together with a `tracep
 To create your own distributed trace, you must pass the current `traceparent` from an outgoing service,
 to a receiving service, and create a new transaction as a child of that `traceparent`:
 
-1. In one service, start a transaction with <<apm-start-transaction>>, or a span with <<apm-start-span>>.
+1. In one service, start a transaction with <<apm-start-transaction,`apm.startTransaction()`>>,
+or a span with <<apm-start-span,`apm.startSpan()`>>.
 
 2. Get the serialized `traceparent` string of the started transaction/span with <<apm-current-traceparent>>.
 
@@ -47,7 +48,8 @@ to a receiving service, and create a new transaction as a child of that `tracepa
 
 4. Decode and store the `traceparent` in the receiving service.
 
-5. Manually start a new transaction as a child of the received `traceparent`, with <<apm-start-transaction>>.
+5. Manually start a new transaction as a child of the received `traceparent`,
+with <<apm-start-transaction,`apm.startTransaction()`>>.
 Pass in the `traceparent` as the `childOf` option.
 
 [float]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -37,6 +37,8 @@ include::./log-correlation.asciidoc[]
 
 include::./source-maps.asciidoc[]
 
+include::./distributed-tracing.asciidoc[]
+
 include::./performance-tuning.asciidoc[]
 
 include::./troubleshooting.asciidoc[]

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -171,6 +171,9 @@ This enables the correlation of the spans the JavaScript Real User Monitoring (R
 If your backend service generates the HTML page dynamically,
 initializing the JavaScript RUM agent with the value of this method allows analyzing the time spent in the browser vs in the backend services.
 
+// WARNING: The below content is reused in distributed-tracing.asciidoc
+// Ensure any changes made here are safe to include on that page as well.
+// tag::ensure-parent-id-snippet[]
 To enable the JavaScript RUM agent,
 add a snippet similar to this to the body of your HTML page,
 preferably before other JavaScript libraries:
@@ -185,6 +188,7 @@ elasticApm.init({
   pageLoadSampled: ${transaction.sampled}
 })
 ----
+// end::ensure-parent-id-snippet[]
 
 See the {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
 


### PR DESCRIPTION
## Doc build preview

**http://apm-agent-nodejs_1650.docs-preview.app.elstc.co/guide/en/apm/agent/nodejs/master/distributed-tracing.html**

## Motivation

This PR adds a distributed tracing guide to the Node.js documentation. The guide explains the following:
1. What distributed tracing is (briefly).
2. How to correlate distributed tracing with the RUM Agent.
3. How to use distributed tracing with a protocol other than HTTP(S).

## Related PRs

Closes https://github.com/elastic/apm-agent-nodejs/issues/1155.
Related to https://github.com/elastic/apm-agent-rum-js/pull/632.

## Screenshot (snippet)

<img width="578" alt="Screen Shot 2020-02-25 at 2 39 41 PM" src="https://user-images.githubusercontent.com/5618806/75294218-ae7bec00-57dc-11ea-9535-2e3f9a2e1206.png">


