### PR TITLE
[2.x] fix(package): bump require-in-the-middle to ^5.0.2 (#1544)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "redact-secrets": "^1.0.0",
     "relative-microtime": "^2.0.0",
     "require-ancestors": "^1.0.0",
-    "require-in-the-middle": "^5.0.0",
+    "require-in-the-middle": "^5.0.2",
     "semver": "^6.1.1",
     "set-cookie-serde": "^1.0.0",
     "shallow-clone-shim": "^1.0.0",


### PR DESCRIPTION
Backports the following commits to 2.x:
 - fix(package): bump require-in-the-middle to ^5.0.2 (#1544)