### PR TITLE
[2.x] docs: add @hapi/hapi v19.x to support matrix (#1643)

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -46,7 +46,7 @@ These are the frameworks that we officially support:
 |Framework |Version
 |<<express,Express>> |^4.0.0
 |<<hapi,hapi>> |>=9.0.0 <19.0.0
-|<<hapi,@hapi/hapi>> |>=17.9.0 <19.0.0
+|<<hapi,@hapi/hapi>> |>=17.9.0 <20.0.0
 |<<koa,Koa>> via koa-router or @koa/router |>=5.2.0 <9.0.0
 2+|Koa doesn't have a built in router, so we can't support Koa directly since we rely on
 router information for full support. We currently support the most popular Koa router called


### PR DESCRIPTION
Backports the following commits to 2.x:
 - docs: add @hapi/hapi v19.x to support matrix (#1643)