### PR TITLE
[2.x] chore: bump copyright year (#1648)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ BSD 2-Clause License
 
 Copyright (c) 2012, Matt Robenolt
 Copyright (c) 2013-2014, Thomas Watson Steen and Elasticsearch BV
-Copyright (c) 2015-2018, Elasticsearch BV
+Copyright (c) 2015-2020, Elasticsearch BV
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Backports the following commits to 2.x:
 - chore: bump copyright year (#1648)