### PR TITLE
ci(jenkins): mount ref repo in the docker container

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -77,16 +77,16 @@ pipeline {
             script {
               def node = readYaml(file: '.ci/.jenkins_nodejs.yml')
               def parallelTasks = [:]
-              //node['NODEJS_VERSION'].each{ version ->
-              //  parallelTasks["Node.js-${version}"] = generateStep(version: version)
-              //  parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsyncHooks: true)
-              //}
+              node['NODEJS_VERSION'].each{ version ->
+                parallelTasks["Node.js-${version}"] = generateStep(version: version)
+                parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsyncHooks: true)
+              }
 
               // PRs don't require to run here as it's now managed within the linting pipeline
-              //if (!env.CHANGE_ID) {
+              if (!env.CHANGE_ID) {
                 // Linting in parallel with the test stage
                 parallelTasks['linting'] = linting()
-              //}
+              }
 
               parallel(parallelTasks)
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -433,7 +433,7 @@ def getSmartTAVContext() {
         withGithubNotify(context: 'Linting') {
           deleteDir()
           unstash 'source'
-          docker.image('node:12').inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
+          docker.image('node:12').inside("-v ${WORKSPACE}/${BASE_DIR}:/app -v /var/lib/jenkins/.git-references/:/var/lib/jenkins/.git-references"){
             withEnv(["HOME=/app"]) {
               sh(label: 'Basic tests I', script: 'cd /app && .ci/scripts/test_basic.sh')
               sh(label: 'Basic tests II', script: 'cd /app && .ci/scripts/test_types_babel_esm.sh')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -77,16 +77,16 @@ pipeline {
             script {
               def node = readYaml(file: '.ci/.jenkins_nodejs.yml')
               def parallelTasks = [:]
-              node['NODEJS_VERSION'].each{ version ->
-                parallelTasks["Node.js-${version}"] = generateStep(version: version)
-                parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsyncHooks: true)
-              }
+              //node['NODEJS_VERSION'].each{ version ->
+              //  parallelTasks["Node.js-${version}"] = generateStep(version: version)
+              //  parallelTasks["Node.js-${version}-async-hooks-false"] = generateStep(version: version, disableAsyncHooks: true)
+              //}
 
               // PRs don't require to run here as it's now managed within the linting pipeline
-              if (!env.CHANGE_ID) {
+              //if (!env.CHANGE_ID) {
                 // Linting in parallel with the test stage
                 parallelTasks['linting'] = linting()
-              }
+              //}
 
               parallel(parallelTasks)
             }


### PR DESCRIPTION
Let's fix the linting issues when running in the master branch. This is caused by the git reference repo that's not exposed in the docker container.


```
[2020-02-26T11:55:05.964Z] + npm run lint:commit
[2020-02-26T11:55:05.965Z] 
[2020-02-26T11:55:05.965Z] > elastic-apm-node@3.4.0 lint:commit /app
[2020-02-26T11:55:05.965Z] > test/lint-commits.sh
[2020-02-26T11:55:05.965Z] 
[2020-02-26T11:55:05.965Z] + [[ -n https://apm-ci.elastic.co/ ]]
[2020-02-26T11:55:05.965Z] ++ npm bin
[2020-02-26T11:55:05.965Z] + export PATH=/app/node_modules/.bin:/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[2020-02-26T11:55:05.965Z] + PATH=/app/node_modules/.bin:/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[2020-02-26T11:55:05.965Z] ++ pwd
[2020-02-26T11:55:05.965Z] + export HOME=/app
[2020-02-26T11:55:05.965Z] + HOME=/app
[2020-02-26T11:55:05.965Z] + [[ -z '' ]]
[2020-02-26T11:55:05.965Z] + commitlint --from=a370e6af490a5c6930f66f67f767df4a83a07772~1
[2020-02-26T11:55:05.965Z] /app/node_modules/@commitlint/cli/lib/cli.js:124
[2020-02-26T11:55:05.965Z] 	throw err;
[2020-02-26T11:55:05.965Z] 	^
[2020-02-26T11:55:05.965Z] 
[2020-02-26T11:55:05.965Z] Error: error: object directory /var/lib/jenkins/.git-references/apm-agent-nodejs.git/objects does not exist; check .git/objects/info/alternates.
```

### Tests

I did force a build with the linting and got

```
[2020-02-26T13:03:30.589Z] 
[2020-02-26T13:03:40.773Z] + npm run lint:commit
[2020-02-26T13:03:40.773Z] 
[2020-02-26T13:03:40.773Z] > elastic-apm-node@3.4.0 lint:commit /app
[2020-02-26T13:03:40.773Z] > test/lint-commits.sh
[2020-02-26T13:03:40.773Z] 
[2020-02-26T13:03:40.773Z] + [[ -n https://apm-ci.elastic.co/ ]]
[2020-02-26T13:03:40.773Z] ++ npm bin
[2020-02-26T13:03:40.773Z] + export PATH=/app/node_modules/.bin:/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[2020-02-26T13:03:40.773Z] + PATH=/app/node_modules/.bin:/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[2020-02-26T13:03:40.773Z] ++ pwd
[2020-02-26T13:03:40.773Z] + export HOME=/app
[2020-02-26T13:03:40.773Z] + HOME=/app
[2020-02-26T13:03:40.773Z] + [[ -z 1654 ]]
[2020-02-26T13:03:40.773Z] + commitlint --from=origin/master --to=49a9c5543345df90157869faf396e66a5c16a8ce
[2020-02-26T13:03:40.773Z] + npm run test:deps
[2020-02-26T13:03:40.773Z] 
[2020-02-26T13:03:40.773Z] > elastic-apm-node@3.4.0 test:deps /app
[2020-02-26T13:03:40.773Z] > dependency-check *.js 'lib/**/*.js' 'test/**/*.js' --no-dev -i async_hooks -i perf_hooks -i parseurl
[2020-02-26T13:03:40.773Z]
```