### PR TITLE
chore: pin @types/node to 8.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@commitlint/travis-cli": "^8.3.5",
     "@hapi/hapi": "^18.4.1",
     "@koa/router": "^8.0.8",
-    "@types/node": "^13.7.4",
+    "@types/node": "8.5.x",
     "apollo-server-express": "^2.10.1",
     "aws-sdk": "^2.622.0",
     "backport": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@commitlint/travis-cli": "^8.3.5",
     "@hapi/hapi": "^18.4.1",
     "@koa/router": "^8.0.8",
-    "@types/node": "8.5.x",
+    "@types/node": "~8.5.10",
     "apollo-server-express": "^2.10.1",
     "aws-sdk": "^2.622.0",
     "backport": "^4.9.0",


### PR DESCRIPTION
3.x of this module needs to be able to run on Node.js 8.6.0. By pinning @types/node to this version (there's no version 8.6.x), we ensure developers will not see APIs from newer versions that they can't use anyway.