### PR TITLE
[2.x] chore: pin @types/node to 6.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@commitlint/travis-cli": "^8.2.0",
     "@hapi/hapi": "^18.4.0",
     "@koa/router": "^8.0.1",
-    "@types/node": "^12.7.5",
+    "@types/node": "6.0.x",
     "apollo-server-express": "^2.9.3",
     "aws-sdk": "^2.529.0",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
2.x of this module needs to be able to run on Node.js 6.0.0. By pinning @types/node to this version, we ensure developers will not see APIs from newer versions that they can't use anyway.