### PR TITLE
fix(package): bump stackman to ^4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "set-cookie-serde": "^1.0.0",
     "shallow-clone-shim": "^2.0.0",
     "sql-summary": "^1.0.1",
-    "stackman": "^4.0.0",
+    "stackman": "^4.0.1",
     "traceparent": "^1.0.0",
     "unicode-byte-truncate": "^1.0.0"
   },


### PR DESCRIPTION
This ensures that we use the latest `error-callsites` module which is a dependency of `stackman`. The old version could end up in an infinite loop if used together with the `stackback` module as both would overwrite the `Error.prepareStackTrace` function and both would call each other when `Error.prepareStackTrace` was called.