### PR TITLE
[2.x] chore(package): bump standard to version ^14.3.3 (#1677)

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "restify-clients": "^2.6.7",
     "rimraf": "^3.0.0",
     "send": "^0.17.1",
-    "standard": "^14.3.1",
+    "standard": "^14.3.3",
     "tape": "^4.11.0",
     "tedious": "^6.4.0",
     "test-all-versions": "^4.1.1",


### PR DESCRIPTION
Backports the following commits to 2.x:
 - chore(package): bump standard to version ^14.3.3 (#1677)