### PR TITLE
docs: Add link to Agent/Server compatibility

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -30,7 +30,6 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server],
-{ref}/index.html[Elasticsearch],
-and {kibana-ref}/index.html[Kibana].
-Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
+APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].


### PR DESCRIPTION
## What does this PR do?
This PR adds a link to the Agent/Server compatibility matrix.

## Related issues

For https://github.com/elastic/apm/issues/229.

## Screenshots

<img width="695" alt="Screen Shot 2020-03-25 at 4 04 17 PM" src="https://user-images.githubusercontent.com/5618806/77593911-55be7280-6eb2-11ea-95f4-06486ade9250.png">
