### PR TITLE
ci(jenkins): use nodejs lts in the windows stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -482,7 +482,7 @@ def generateStepForWindows(Map params = [:]){
           deleteDir()
           unstash 'source'
           dir(BASE_DIR) {
-            installTools([ [tool: 'nodejs', version: "${version}" ] ])
+            installTools([ [tool: 'nodejs-lts', version: "${version}" ] ])
             bat label: 'Tool versions', script: '''
               npm --version
               node --version


### PR DESCRIPTION
Use the chocolatey nodejs-lts to see if the 12.16.1 version is solved there.


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)

### Tests

```
[2020-03-31T12:47:34.649Z] Getting latest nodejs-lts version for 12 ...
[2020-03-31T12:47:37.975Z] 
[2020-03-31T12:47:37.975Z] nodejs-lts 12.16.1 [Approved]
[2020-03-31T12:47:37.975Z] nodejs-lts 12.16.0 [Approved]
[2020-03-31T12:47:37.975Z] nodejs-lts 12.15.0 [Approved]
[2020-03-31T12:47:37.975Z] nodejs-lts 12.14.1 [Approved]
[2020-03-31T12:47:37.975Z] nodejs-lts 12.14.0 [Approved]
[2020-03-31T12:47:37.975Z] nodejs-lts 12.13.1 [Approved]
[2020-03-31T12:47:37.975Z] nodejs-lts 12.13.0 [Approved]
[2020-03-31T12:47:42.187Z] Installing nodejs-lts version: 12.16.1 ...
[2020-03-31T12:47:42.187Z] Chocolatey v0.10.11
[2020-03-31T12:47:42.449Z] Installing the following packages:
[2020-03-31T12:47:42.449Z] nodejs-lts
[2020-03-31T12:47:42.449Z] By installing you accept licenses for the packages.
[2020-03-31T12:47:46.660Z] 
[2020-03-31T12:47:46.661Z] nodejs-lts v12.16.1 [Approved]
[2020-03-31T12:47:46.661Z] nodejs-lts package files install completed. Performing other installation steps.
[2020-03-31T12:47:51.963Z] Installing 64 bit version
[2020-03-31T12:47:51.963Z] Installing nodejs-lts...
[2020-03-31T12:48:13.919Z] nodejs-lts has been installed.
[2020-03-31T12:48:13.919Z]   nodejs-lts may be able to be automatically uninstalled.
[2020-03-31T12:48:13.919Z] Environment Vars (like PATH) have changed. Close/reopen your shell to
[2020-03-31T12:48:13.919Z]  see the changes (or in powershell/cmd.exe just type `refreshenv`).
[2020-03-31T12:48:13.919Z]  The install of nodejs-lts was successful.
[2020-03-31T12:48:13.919Z]   Software installed as 'MSI', install location is likely default.

[2020-03-31T12:48:13.919Z] Chocolatey installed 1/1 packages. 
[2020-03-31T12:48:13.919Z]  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```

### Issues

Closes https://github.com/elastic/apm-agent-nodejs/issues/1700