### PR TITLE
[3.x] ci(jenkins): use nodejs lts in the windows stage (#1702) (7b933627)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -471,7 +471,7 @@ def generateStepForWindows(Map params = [:]){
           deleteDir()
           unstash 'source'
           dir(BASE_DIR) {
-            installTools([ [tool: 'nodejs', version: "${version}" ] ])
+            installTools([ [tool: 'nodejs-lts', version: "${version}" ] ])
             bat label: 'Tool versions', script: '''
               npm --version
               node --version


### PR DESCRIPTION
Backports the following commits to 3.x:
 - ci(jenkins): use nodejs lts in the windows stage (#1702) (7b933627)