### PR TITLE
Add metrics for external memory

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -130,6 +130,25 @@ The current allocated heap size in bytes.
 The currently used heap size in bytes.
 
 [float]
+[[metric-nodejs.memory.external.bytes]]
+=== `nodejs.memory.external.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+Memory usage of C++ objects bound to JavaScript objects managed by V8.
+
+[float]
+[[metric-nodejs.memory.arrayBuffers.bytes]]
+=== `nodejs.memory.arrayBuffers.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+Memory allocated for ArrayBuffers and SharedArrayBuffers, including all Node.js Buffers.
+This is also included in the `nodejs.memory.external.bytes` value.
+
+[float]
 [[metrics-transaction.duration.sum]]
 === `transaction.duration.sum`
 

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const v8 = require('v8')
-
 const eventLoopMonitor = require('monitor-event-loop-delay')
 
 const activeHandles = typeof process._getActiveHandles === 'function'
@@ -43,10 +41,10 @@ class RuntimeCollector {
     this.stats['nodejs.eventloop.delay.avg.ms'] = loopDelay
     this.loopMonitor.reset()
 
-    // Heap
-    const heap = v8.getHeapStatistics()
-    this.stats['nodejs.memory.heap.allocated.bytes'] = heap.total_heap_size
-    this.stats['nodejs.memory.heap.used.bytes'] = heap.used_heap_size
+    // Memory / Heap
+    const memoryUsage = process.memoryUsage()
+    this.stats['nodejs.memory.heap.allocated.bytes'] = memoryUsage.heapTotal
+    this.stats['nodejs.memory.heap.used.bytes'] = memoryUsage.heapUsed
 
     if (cb) process.nextTick(cb)
   }

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -19,7 +19,9 @@ class RuntimeCollector {
       'nodejs.requests.active': 0,
       'nodejs.eventloop.delay.ns': 0,
       'nodejs.memory.heap.allocated.bytes': 0,
-      'nodejs.memory.heap.used.bytes': 0
+      'nodejs.memory.heap.used.bytes': 0,
+      'nodejs.memory.external.bytes': 0,
+      'nodejs.memory.arrayBuffers.bytes': 0
     }
 
     const monitor = eventLoopMonitor({
@@ -45,6 +47,9 @@ class RuntimeCollector {
     const memoryUsage = process.memoryUsage()
     this.stats['nodejs.memory.heap.allocated.bytes'] = memoryUsage.heapTotal
     this.stats['nodejs.memory.heap.used.bytes'] = memoryUsage.heapUsed
+
+    this.stats['nodejs.memory.external.bytes'] = memoryUsage.external
+    this.stats['nodejs.memory.arrayBuffers.bytes'] = memoryUsage.arrayBuffers || 0 // Only available in NodeJS +13.0
 
     if (cb) process.nextTick(cb)
   }

--- a/test/metrics/index.js
+++ b/test/metrics/index.js
@@ -117,6 +117,12 @@ test('reports expected metrics', function (t) {
       'nodejs.memory.heap.used.bytes': (value) => {
         t.ok(value >= 0, 'is positive')
       },
+      'nodejs.memory.external.bytes': (value) => {
+        t.ok(value >= 0, 'is positive')
+      },
+      'nodejs.memory.arrayBuffers.bytes': (value) => {
+        t.ok(value >= 0, 'is positive')
+      },
       'ws.connections': (value) => {
         t.equal(value, 23)
       }


### PR DESCRIPTION
This ticket adds some metrics missing of #309.

I've added the metrics `nodejs.memory.external.bytes` and `nodejs.memory.arrayBuffers.bytes` (available from node 13.x).

All memory related data is now collected using `process.memoryUsage()` which has a better documentation than the internal v8 methods: https://nodejs.org/docs/latest/api/process.html#process_process_memoryusage

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)