### PR TITLE
Rename rss metric from `system.process.memory.*` to `nodejs.memory.*`

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -130,6 +130,25 @@ The current allocated heap size in bytes.
 The currently used heap size in bytes.
 
 [float]
+[[metric-nodejs.memory.external.bytes]]
+=== `nodejs.memory.external.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+Memory usage of C++ objects bound to JavaScript objects managed by V8.
+
+[float]
+[[metric-nodejs.memory.arrayBuffers.bytes]]
+=== `nodejs.memory.arrayBuffers.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+Memory allocated for ArrayBuffers and SharedArrayBuffers, including all Node.js Buffers.
+This is also included in the `nodejs.memory.external.bytes` value.
+
+[float]
 [[metrics-transaction.duration.sum]]
 === `transaction.duration.sum`
 

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -52,16 +52,6 @@ The percentage of CPU time spent by the process since the last event.
 This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
 
 [float]
-[[metric-system.process.memory.rss.bytes]]
-=== `system.process.memory.rss.bytes`
-
-* *Type:* Long
-* *Format:* Bytes
-
-The Resident Set Size,
-the amount of memory the process occupies in main memory (RAM).
-
-[float]
 [[metric-nodejs.handles.active]]
 === `nodejs.handles.active`
 
@@ -110,6 +100,16 @@ The number of milliseconds of event loop delay.
 Event loop delay is sampled every 10 milliseconds.
 Delays shorter than 10ms may not be observed,
 for example if a blocking operation starts and ends within the same sampling period.
+
+[float]
+[[metric-nodejs.memory.rss.bytes]]
+=== `nodejs.memory.rss.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+The Resident Set Size,
+the amount of memory the process occupies in main memory (RAM).
 
 [float]
 [[metric-nodejs.memory.heap.allocated.bytes]]

--- a/lib/metrics/platforms/generic/index.js
+++ b/lib/metrics/platforms/generic/index.js
@@ -32,9 +32,4 @@ module.exports = function createSystemMetrics (registry) {
   for (const metric of metrics) {
     registry.getOrCreateGauge(metric, () => stats.toJSON()[metric])
   }
-
-  registry.getOrCreateGauge(
-    'system.process.memory.rss.bytes',
-    () => process.memoryUsage().rss
-  )
 }

--- a/lib/metrics/platforms/linux/stats.js
+++ b/lib/metrics/platforms/linux/stats.js
@@ -34,8 +34,7 @@ class Stats {
       'system.process.cpu.total.norm.pct': 0,
       'system.process.cpu.system.norm.pct': 0,
       'system.process.cpu.user.norm.pct': 0,
-      'system.process.memory.size': 0,
-      'system.process.memory.rss.bytes': 0
+      'system.process.memory.size': 0
     }
 
     this.inProgress = false
@@ -150,8 +149,7 @@ class Stats {
       memAvailable,
       utime,
       stime,
-      vsize,
-      rss: process.memoryUsage().rss // TODO: Calculate using field 24 (rss) * PAGE_SIZE
+      vsize
     }
   }
 
@@ -186,7 +184,6 @@ class Stats {
     stats['system.process.cpu.user.norm.pct'] = cpuProcessUserPercent
     stats['system.process.cpu.system.norm.pct'] = cpuProcessSystemPercent
     stats['system.process.memory.size'] = next.vsize
-    stats['system.process.memory.rss.bytes'] = next.rss
 
     this.previous = next
     this.inProgress = false

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const v8 = require('v8')
-
 const eventLoopMonitor = require('monitor-event-loop-delay')
 
 const activeHandles = typeof process._getActiveHandles === 'function'
@@ -43,10 +41,10 @@ class RuntimeCollector {
     this.stats['nodejs.eventloop.delay.avg.ms'] = loopDelay
     this.loopMonitor.reset()
 
-    // Heap
-    const heap = v8.getHeapStatistics()
-    this.stats['nodejs.memory.heap.allocated.bytes'] = heap.total_heap_size
-    this.stats['nodejs.memory.heap.used.bytes'] = heap.used_heap_size
+    // Memory / Heap
+    const memoryUsage = process.memoryUsage()
+    this.stats['nodejs.memory.heap.allocated.bytes'] = memoryUsage.heapTotal
+    this.stats['nodejs.memory.heap.used.bytes'] = memoryUsage.heapUsed
 
     if (cb) process.nextTick(cb)
   }

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -19,7 +19,9 @@ class RuntimeCollector {
       'nodejs.requests.active': 0,
       'nodejs.eventloop.delay.ns': 0,
       'nodejs.memory.heap.allocated.bytes': 0,
-      'nodejs.memory.heap.used.bytes': 0
+      'nodejs.memory.heap.used.bytes': 0,
+      'nodejs.memory.external.bytes': 0,
+      'nodejs.memory.arrayBuffers.bytes': 0
     }
 
     const monitor = eventLoopMonitor({
@@ -45,6 +47,9 @@ class RuntimeCollector {
     const memoryUsage = process.memoryUsage()
     this.stats['nodejs.memory.heap.allocated.bytes'] = memoryUsage.heapTotal
     this.stats['nodejs.memory.heap.used.bytes'] = memoryUsage.heapUsed
+
+    this.stats['nodejs.memory.external.bytes'] = memoryUsage.external
+    this.stats['nodejs.memory.arrayBuffers.bytes'] = memoryUsage.arrayBuffers || 0 // Only available in NodeJS +13.0
 
     if (cb) process.nextTick(cb)
   }

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -20,6 +20,7 @@ class RuntimeCollector {
       'nodejs.eventloop.delay.ns': 0,
       'nodejs.memory.heap.allocated.bytes': 0,
       'nodejs.memory.heap.used.bytes': 0,
+      'nodejs.memory.rss.bytes': 0,
       'nodejs.memory.external.bytes': 0,
       'nodejs.memory.arrayBuffers.bytes': 0
     }
@@ -48,6 +49,7 @@ class RuntimeCollector {
     this.stats['nodejs.memory.heap.allocated.bytes'] = memoryUsage.heapTotal
     this.stats['nodejs.memory.heap.used.bytes'] = memoryUsage.heapUsed
 
+    this.stats['nodejs.memory.rss.bytes'] = memoryUsage.rss
     this.stats['nodejs.memory.external.bytes'] = memoryUsage.external
     this.stats['nodejs.memory.arrayBuffers.bytes'] = memoryUsage.arrayBuffers || 0 // Only available in NodeJS +13.0
 

--- a/test/metrics/index.js
+++ b/test/metrics/index.js
@@ -81,10 +81,6 @@ test('reports expected metrics', function (t) {
           t.ok(isRoughly(value, free, 0.1), `is close to current free memory (value: ${value}, free: ${free})`)
         }
       },
-      'system.process.memory.rss.bytes': (value) => {
-        const rss = process.memoryUsage().rss
-        t.ok(isRoughly(value, rss, 0.1), `is close to current rss (value: ${value}, rss: ${rss})`)
-      },
       'system.process.cpu.total.norm.pct': (value) => {
         if (count === 1) {
           t.ok(value >= 0 && value <= 1, 'is betewen 0 and 1')
@@ -116,6 +112,10 @@ test('reports expected metrics', function (t) {
       },
       'nodejs.memory.heap.used.bytes': (value) => {
         t.ok(value >= 0, 'is positive')
+      },
+      'nodejs.memory.rss.bytes': (value) => {
+        const rss = process.memoryUsage().rss
+        t.ok(isRoughly(value, rss, 0.1), `is close to current rss (value: ${value}, rss: ${rss})`)
       },
       'nodejs.memory.external.bytes': (value) => {
         t.ok(value >= 0, 'is positive')

--- a/test/metrics/index.js
+++ b/test/metrics/index.js
@@ -117,6 +117,12 @@ test('reports expected metrics', function (t) {
       'nodejs.memory.heap.used.bytes': (value) => {
         t.ok(value >= 0, 'is positive')
       },
+      'nodejs.memory.external.bytes': (value) => {
+        t.ok(value >= 0, 'is positive')
+      },
+      'nodejs.memory.arrayBuffers.bytes': (value) => {
+        t.ok(value >= 0, 'is positive')
+      },
       'ws.connections': (value) => {
         t.equal(value, 23)
       }


### PR DESCRIPTION
This PR was created based on the changes of #1724.

I've renamed the metric `system.process.memory.rss.bytes` to `nodejs.memory.rss.bytes` because the value is fetched from within nodejs, not from the system.

This is a backwards incompatible change, which I originally wanted to include in #1724 but created it in a separate PR because it changes an existing metric.

It makes the naming of metrics consistent. All memory related metrics, taken from within the application, are now organised in `nodejs.memory.*`.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
