### PR TITLE
add support for pg >= 8

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -130,6 +130,25 @@ The current allocated heap size in bytes.
 The currently used heap size in bytes.
 
 [float]
+[[metric-nodejs.memory.external.bytes]]
+=== `nodejs.memory.external.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+Memory usage of C++ objects bound to JavaScript objects managed by V8.
+
+[float]
+[[metric-nodejs.memory.arrayBuffers.bytes]]
+=== `nodejs.memory.arrayBuffers.bytes`
+
+* *Type:* Long
+* *Format:* Bytes
+
+Memory allocated for ArrayBuffers and SharedArrayBuffers, including all Node.js Buffers.
+This is also included in the `nodejs.memory.external.bytes` value.
+
+[float]
 [[metrics-transaction.duration.sum]]
 === `transaction.duration.sum`
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -89,7 +89,7 @@ so those should be supported as well
 |https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 <5.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mysql[mysql] |^2.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <3.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/pg[pg] |>=4.0.0 <8.0.0 |Will instrument all queries
+|https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/redis[redis] |^2.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/tedious[tedious] |>=1.9 |Will instrument all queries
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages

--- a/lib/instrumentation/modules/pg.js
+++ b/lib/instrumentation/modules/pg.js
@@ -7,10 +7,12 @@ var shimmer = require('../shimmer')
 var symbols = require('../../symbols')
 
 module.exports = function (pg, agent, { version, enabled }) {
-  if (!semver.satisfies(version, '>=4.0.0 <8.0.0')) {
+  if (!semver.satisfies(version, '>=4.0.0 <9.0.0')) {
     agent.logger.debug('pg version %s not supported - aborting...', version)
     return pg
   }
+
+  const isGte8 = semver.satisfies(version, '>=8.0.0')
 
   patchClient(pg.Client, 'pg.Client', agent, enabled)
 
@@ -18,18 +20,35 @@ module.exports = function (pg, agent, { version, enabled }) {
   // "Cannot find module 'pg-native'" to STDERR if the module isn't installed.
   // Overwriting the getter we can lazily patch the native client only if the
   // user is acually requesting it.
-  var getter = pg.__lookupGetter__('native')
+  let getter = null
+  if (isGte8) {
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(pg, 'native')
+    getter = propertyDescriptor && propertyDescriptor.get
+  } else {
+    getter = pg.__lookupGetter__('native')
+  }
+
   if (getter) {
-    delete pg.native
-    // To be as true to the original pg module as possible, we use
-    // __defineGetter__ instead of Object.defineProperty.
-    pg.__defineGetter__('native', function () {
-      var native = getter()
-      if (native && native.Client) {
-        patchClient(native.Client, 'pg.native.Client', agent, enabled)
-      }
-      return native
-    })
+    if (isGte8) {
+      Object.defineProperty(pg, 'native', {
+        configurable: true,
+        enumerable: false,
+        get: patchedGetter
+      })
+    } else {
+      delete pg.native
+      // To be as true to the original pg module as possible, we use
+      // __defineGetter__ instead of Object.defineProperty.
+      pg.__defineGetter__('native', patchedGetter)
+    }
+  }
+
+  function patchedGetter () {
+    const native = getter()
+    if (native && native.Client) {
+      patchClient(native.Client, 'pg.native.Client', agent, enabled)
+    }
+    return native
   }
 
   return pg

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const v8 = require('v8')
-
 const eventLoopMonitor = require('monitor-event-loop-delay')
 
 const activeHandles = typeof process._getActiveHandles === 'function'
@@ -21,7 +19,9 @@ class RuntimeCollector {
       'nodejs.requests.active': 0,
       'nodejs.eventloop.delay.ns': 0,
       'nodejs.memory.heap.allocated.bytes': 0,
-      'nodejs.memory.heap.used.bytes': 0
+      'nodejs.memory.heap.used.bytes': 0,
+      'nodejs.memory.external.bytes': 0,
+      'nodejs.memory.arrayBuffers.bytes': 0
     }
 
     const monitor = eventLoopMonitor({
@@ -43,10 +43,13 @@ class RuntimeCollector {
     this.stats['nodejs.eventloop.delay.avg.ms'] = loopDelay
     this.loopMonitor.reset()
 
-    // Heap
-    const heap = v8.getHeapStatistics()
-    this.stats['nodejs.memory.heap.allocated.bytes'] = heap.total_heap_size
-    this.stats['nodejs.memory.heap.used.bytes'] = heap.used_heap_size
+    // Memory / Heap
+    const memoryUsage = process.memoryUsage()
+    this.stats['nodejs.memory.heap.allocated.bytes'] = memoryUsage.heapTotal
+    this.stats['nodejs.memory.heap.used.bytes'] = memoryUsage.heapUsed
+
+    this.stats['nodejs.memory.external.bytes'] = memoryUsage.external
+    this.stats['nodejs.memory.arrayBuffers.bytes'] = memoryUsage.arrayBuffers || 0 // Only available in NodeJS +13.0
 
     if (cb) process.nextTick(cb)
   }

--- a/test/metrics/index.js
+++ b/test/metrics/index.js
@@ -117,6 +117,12 @@ test('reports expected metrics', function (t) {
       'nodejs.memory.heap.used.bytes': (value) => {
         t.ok(value >= 0, 'is positive')
       },
+      'nodejs.memory.external.bytes': (value) => {
+        t.ok(value >= 0, 'is positive')
+      },
+      'nodejs.memory.arrayBuffers.bytes': (value) => {
+        t.ok(value >= 0, 'is positive')
+      },
       'ws.connections': (value) => {
         t.equal(value, 23)
       }


### PR DESCRIPTION
`pg` now uses `defineProperty`: https://github.com/brianc/node-postgres/blob/2ef55503738eb2cbb6326744381a92c0bc0439ab/packages/pg/lib/index.js#L39-L62

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
