### PR TITLE
test: add missing APM Server API Schema file cloud.json

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -28,6 +28,7 @@ FILES=( \
   "spans/span.json" \
   "transactions/mark.json" \
   "transactions/transaction.json" \
+  "cloud.json" \
   "context.json" \
   "http_response.json" \
   "message.json" \


### PR DESCRIPTION
This file was added to the APM Server repo in:
https://github.com/elastic/apm-server/pull/3729