### PR TITLE
[2.x] test: add missing APM Server API Scheme file cloud.json (#1738)

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -28,6 +28,7 @@ FILES=( \
   "spans/span.json" \
   "transactions/mark.json" \
   "transactions/transaction.json" \
+  "cloud.json" \
   "context.json" \
   "http_response.json" \
   "message.json" \


### PR DESCRIPTION
Backports the following commits to 2.x:
 - test: add missing APM Server API Scheme file cloud.json (#1738)