### PR TITLE
[2.x] test: fix APM Server cert test to work with 13.9.0+ (c3c119b1) | test: add missing APM Server API Scheme file cloud.json (#1738)

### DIFF
--- a/test/integration/allow-invalid-cert.js
+++ b/test/integration/allow-invalid-cert.js
@@ -28,15 +28,8 @@ getPort().then(function (port) {
     server.listen(port, function () {
       agent.captureError(new Error('boom!'), function () {
         t.pass('agent.captureError callback called')
-
-        // The async execution order is different in Node.js 8 and below, so in
-        // other to ensure that server request event fires in older versions of
-        // Node before we end the test, we wrap this in a setImmediate
-        setImmediate(function () {
-          t.end()
-          server.close()
-          agent.destroy()
-        })
+        server.close()
+        agent.destroy()
       })
     })
   })

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -28,6 +28,7 @@ FILES=( \
   "spans/span.json" \
   "transactions/mark.json" \
   "transactions/transaction.json" \
+  "cloud.json" \
   "context.json" \
   "http_response.json" \
   "message.json" \


### PR DESCRIPTION
Backports the following commits to 2.x:
 - test: fix APM Server cert test to work with 13.9.0+ (c3c119b1)
 - test: add missing APM Server API Scheme file cloud.json (#1738)