### PR TITLE
ci: retry to grab the worker IP

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -464,7 +464,7 @@ def generateStepForWindows(Map params = [:]){
   def disableAsyncHooks = params.get('disableAsyncHooks', false)
   return {
     sh label: 'Prepare services', script: ".ci/scripts/windows/prepare-test.sh ${version}"
-    def linuxIp = sh(label: 'Get IP', script: '''hostname -I | awk '{print $1}' ''', returnStdout: true)?.trim()
+    def linuxIp = grabWorkerIP()
     node('windows-2019-docker-immutable'){
       // When installing with choco the PATH might not be updated within the already connected worker.
       withEnv(["PATH=${PATH};C:\\Program Files\\nodejs",
@@ -501,4 +501,16 @@ def generateStepForWindows(Map params = [:]){
     // If the above execution failed, then it will not reach this section. TBD
     sh label: 'Stop services', script: ".ci/scripts/windows/stop-test.sh ${version}"
   }
+}
+
+def grabWorkerIP(){
+  def linuxIp = ''
+  retry(3){
+    linuxIp = sh(label: 'Get IP', script: '''hostname -I | awk '{print $1}' ''', returnStdout: true)?.trim()
+    if(linuxIp == null || ''.equals(linuxIp)){
+      sleep(10)
+      error('Unable to get the Linux worker IP')
+    }
+  }
+  return linuxIp
 }


### PR DESCRIPTION
It retries to get the worker IP if the return string is empty or null

closes https://github.com/elastic/apm-agent-nodejs/issues/1744
