### PR TITLE
chore: rule to enforce license header on source

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  env: {
+    node: true,
+    es6: true
+  },
+  extends: [
+    'standard'
+  ],
+  parserOptions: {
+    ecmaVersion: 2018
+  },
+  rules: {
+    'require-license-header': 2
+  }
+}

--- a/dev-utils/eslint-rules/require-license-header.js
+++ b/dev-utils/eslint-rules/require-license-header.js
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function normalizeWhitespace (string) {
+  return string.replace(/\s+/g, ' ').trim()
+}
+
+// License to be appended to every source file
+const LICENSE = `/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */`
+
+function getComparableLicenseAST () {
+  const lines = LICENSE.split('\n')
+  return lines.slice(1, lines.length - 1).join('')
+}
+
+module.exports = context => {
+  return {
+    Program () {
+      const license = {
+        source: LICENSE,
+        value: normalizeWhitespace(getComparableLicenseAST())
+      }
+
+      const sourceCode = context.getSourceCode()
+      const comment = sourceCode
+        .getAllComments()
+        .find(node => {
+          return normalizeWhitespace(node.value) === license.value
+        })
+
+      // no licence comment
+      if (!comment) {
+        context.report({
+          message: 'File must start with a license header',
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: sourceCode.lines[0].length - 1 }
+          },
+          fix (fixer) {
+            return fixer.replaceTextRange([0, 0], license.source + '\n\n')
+          }
+        })
+        return
+      }
+
+      // ensure there is nothing before the comment
+      const sourceBeforeNode = sourceCode
+        .getText()
+        .slice(0, sourceCode.getIndexFromLoc(comment.loc.start))
+      if (sourceBeforeNode.length) {
+        context.report({
+          node: comment,
+          message: 'License header must be at the very beginning of the file',
+          fix (fixer) {
+            // replace leading whitespace if possible
+            if (sourceBeforeNode.trim() === '') {
+              return fixer.replaceTextRange([0, sourceBeforeNode.length], '')
+            }
+
+            // inject content at top and remove node from current location
+            // if removing whitespace is not possible
+            return [
+              fixer.remove(comment),
+              fixer.replaceTextRange([0, 0], license.source + '\n\n')
+            ]
+          }
+        })
+      }
+    }
+  }
+}

--- a/dev-utils/eslint-rules/require-license-header.js
+++ b/dev-utils/eslint-rules/require-license-header.js
@@ -1,45 +1,48 @@
 /*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * BSD 2-Clause License
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (c) 2012, Matt Robenolt
+ * Copyright (c) 2013-2014, Thomas Watson Steen and Elasticsearch BV
+ * Copyright (c) 2015-2020, Elasticsearch BV
+ * All rights reserved.
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  */
+
+const { join } = require('path')
+const { readFileSync } = require('fs')
+
+const LICENSE_CONTENTS = readFileSync(join(__dirname, '../../LICENSE'), 'utf-8')
+const LICENSE =
+  '/*\n' +
+  LICENSE_CONTENTS.split('\n')
+    .map(line => ` * ${line}`)
+    .join('\n') +
+  '\n */'
 
 function normalizeWhitespace (string) {
   return string.replace(/\s+/g, ' ').trim()
 }
-
-// License to be appended to every source file
-const LICENSE = `/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */`
 
 function getComparableLicenseAST () {
   const lines = LICENSE.split('\n')
@@ -57,9 +60,7 @@ module.exports = context => {
       const sourceCode = context.getSourceCode()
       const comment = sourceCode
         .getAllComments()
-        .find(node => {
-          return normalizeWhitespace(node.value) === license.value
-        })
+        .find(node => normalizeWhitespace(node.value) === license.value)
 
       // no licence comment
       if (!comment) {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "backport": "backport",
     "docs:open": "PREVIEW=1 npm run docs:build",
     "docs:build": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
-    "lint": "standard",
-    "lint:fix": "standard --fix",
+    "lint": "eslint . --rulesdir dev-utils/eslint-rules",
+    "lint:fix": "eslint . --fix --rulesdir dev-utils/eslint-rules",
     "lint:commit": "test/lint-commits.sh",
     "coverage": "COVERAGE=true ./test/script/run_tests.sh",
     "coverage:prereport": "npm run coverage",
@@ -130,6 +130,8 @@
     "container-info": "^1.0.1",
     "dependency-check": "^4.1.0",
     "elasticsearch": "^16.5.0",
+    "eslint": "^7.0.0",
+    "eslint-plugin-standard": "^4.0.1",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
     "express-queue": "^0.0.12",
@@ -170,7 +172,6 @@
     "restify-clients": "^2.6.9",
     "rimraf": "^3.0.2",
     "send": "^0.17.1",
-    "standard": "^14.3.3",
     "tape": "^4.13.0",
     "tedious": "^8.0.1",
     "test-all-versions": "^4.1.1",
@@ -185,11 +186,9 @@
       "inquirer"
     ]
   },
-  "standard": {
-    "ignore": [
-      "/test/sourcemaps/fixtures/lib"
-    ]
-  },
+  "eslintIgnore": [
+    "/test/sourcemaps/fixtures/lib"
+  ],
   "commitlint": {
     "extends": [
       "squash-pr",

--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -38,7 +38,7 @@ setup_env () {
 }
 
 run_test_suite () {
-  standard
+  eslint .
   npm run test:deps
   npm run lint:commit
   


### PR DESCRIPTION
+ fix elastic/apm-agent-nodejs#1718 
+ Uses `eslint` to enforce the standard style as we cannot extend rules with standard. 
+ Project specific rules are applied with `--rulesdir` option when on lint runs. 

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
