### PR TITLE
ci(jenkins): debug windows worker reqs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -482,6 +482,7 @@ def generateStepForWindows(Map params = [:]){
           deleteDir()
           unstash 'source'
           dir(BASE_DIR) {
+            bat label: 'Ping linux worker', script: "ping -n 3 ${linuxIp}"
             installTools([ [tool: 'nodejs-lts', version: "${version}" ] ])
             bat label: 'Tool versions', script: '''
               npm --version
@@ -507,7 +508,8 @@ def grabWorkerIP(){
   def linuxIp = ''
   retry(3){
     linuxIp = sh(label: 'Get IP', script: '''hostname -I | awk '{print $1}' ''', returnStdout: true)?.trim()
-    if(linuxIp == null || ''.equals(linuxIp)){
+    log(level: 'INFO', text: "Worker IP '${linuxIp}'")
+    if(!linuxIp?.trim()){
       sleep(10)
       error('Unable to get the Linux worker IP')
     }


### PR DESCRIPTION
### What

Enable some debug logs to gather the IP for the Linux CI Worker that's used internally to spin up all the services that are required to run the tests in Windows.

### Tests

![image](https://user-images.githubusercontent.com/2871786/82344231-b0280b00-99eb-11ea-9839-1cb6ecd3fab0.png)

[here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/PR-1757/1/pipeline/148#step-404-log-2) and [here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/PR-1757/1/pipeline/148#step-173-log-1)
### Issues

Closes https://github.com/elastic/apm-agent-nodejs/issues/1744
