### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,18 +2,22 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
-grep "-" .ci/.jenkins_nodejs.yml | cut -d'-' -f2- | \
-while read -r version;
-do
-    transformedVersion=$(echo "${version}" | sed 's#"##g' | cut -d":" -f2)
-    imageName="apm-agent-nodejs"
-    registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedVersion}"
-    (retry 2 docker pull "${registryImageName}")
-    docker tag "${registryImageName}" "node:${transformedVersion}"
-done
+if [ -x "$(command -v docker)" ]; then
+  grep "-" .ci/.jenkins_nodejs.yml | cut -d'-' -f2- | \
+  while read -r version;
+  do
+      transformedVersion=$(echo "${version}" | sed 's#"##g' | cut -d":" -f2)
+      imageName="apm-agent-nodejs"
+      registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedVersion}"
+      (retry 2 docker pull "${registryImageName}")
+      docker tag "${registryImageName}" "node:${transformedVersion}"
+  done
+fi
 
-docker-compose \
-  --no-ansi \
-  --log-level ERROR \
-  -f .ci/docker/docker-compose-all.yml \
-  pull --quiet --ignore-pull-failures
+if [ -x "$(command -v docker-compose)" ]; then
+  docker-compose \
+    --no-ansi \
+    --log-level ERROR \
+    -f .ci/docker/docker-compose-all.yml \
+    pull --quiet --ignore-pull-failures
+fi


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.