### PR TITLE
feat(knex): add support for 0.21.x

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -90,6 +90,11 @@ knex-new:
   node: '>=8.6.0'
   versions: '>=0.17 <0.21'
   commands: node test/instrumentation/modules/pg/knex.js
+knex-gt-nodev8:
+  name: knex
+  node: '>=10.22.0'
+  versions: '>=0.21 <0.22'
+  commands: node test/instrumentation/modules/pg/knex.js
 ws-old:
   name: ws
   versions: '>=1 <7'

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -119,7 +119,7 @@ please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM di
 [options="header"]
 |=================================================
 |Module |Version
-|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <0.21.0
+|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <0.22.0
 |=================================================
 
 [float]

--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -7,7 +7,7 @@ var symbols = require('../../symbols')
 
 module.exports = function (Knex, agent, { version, enabled }) {
   if (!enabled) return Knex
-  if (semver.gte(version, '0.21.0')) {
+  if (semver.gte(version, '0.22.0')) {
     agent.logger.debug('knex version %s not supported - aborting...', version)
     return Knex
   }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "ioredis": "^4.16.0",
     "is-my-json-valid": "^2.20.0",
     "jade": "^1.11.0",
-    "knex": "^0.20.10",
+    "knex": "^0.21.2",
     "koa": "^2.11.0",
     "koa-router": "^9.0.1",
     "lambda-local": "^1.7.1",


### PR DESCRIPTION
Only breaking change that affects us is the drop of support for Node.js v8, due to that I've created a new tav item for versions that require Node.js > 8

Fixes #1786

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
