### PR TITLE
feat(parsers): add support for truncating body at specified length

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -263,12 +263,20 @@ Possible options are: `off`, `all`, `errors`, and `transactions`.
 * `transactions` - request bodies will only be reported with request transactions
 * `all` - request bodies will be reported with both errors and request transactions
 
-The recorded body will be truncated if larger than 2 KiB.
+By default the recorded body will be truncated if larger than 2 KiB, this can be configured with `maxHttpBodyChars`.
 
 For the agent to be able to access the body,
 the body needs to be available as a property on the incoming HTTP https://nodejs.org/api/http.html#http_class_http_incomingmessage[`request`] object.
 The agent will look for the body on the following properties:
 `req.json || req.body || req.payload`
+
+[[max-http-body-chars]]
+==== `maxHttpBodyChars`
+* *Type:* Number
+* *Default:* `2048`
+* *Env:* `ELASTIC_APM_MAX_BODY_CHARS`
+
+Specify the value at which the body will be truncated.
 
 [[capture-headers]]
 ==== `captureHeaders`

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,7 @@ interface AgentConfigOptions {
   logLevel?: LogLevel;
   logUncaughtExceptions?: boolean;
   logger?: Logger;
+  maxHttpBodyChars?: number;
   metricsInterval?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
   payloadLogFile?: string;
   centralConfig?: boolean;

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,6 +61,7 @@ var DEFAULTS = {
   kubernetesPodUID: undefined,
   logLevel: 'info',
   logUncaughtExceptions: false, // TODO: Change to `true` in the v4.0.0
+  maxHttpBodyChars: 2048,
   metricsInterval: '30s',
   metricsLimit: 1000,
   serviceNodeName: undefined,
@@ -109,6 +110,7 @@ var ENV_TABLE = {
   kubernetesPodUID: ['ELASTIC_APM_KUBERNETES_POD_UID', 'KUBERNETES_POD_UID'],
   logLevel: 'ELASTIC_APM_LOG_LEVEL',
   logUncaughtExceptions: 'ELASTIC_APM_LOG_UNCAUGHT_EXCEPTIONS',
+  maxHttpBodyChars: 'ELASTIC_APM_MAX_BODY_CHARS',
   metricsInterval: 'ELASTIC_APM_METRICS_INTERVAL',
   metricsLimit: 'ELASTIC_APM_METRICS_LIMIT',
   payloadLogFile: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
@@ -159,6 +161,7 @@ var BOOL_OPTS = [
 ]
 
 var NUM_OPTS = [
+  'maxHttpBodyChars',
   'metricsLimit',
   'sourceLinesErrorAppFrames',
   'sourceLinesErrorLibraryFrames',

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -118,6 +118,7 @@ exports.parseError = function (err, agent, cb) {
 
 exports.getContextFromRequest = function (req, conf, type) {
   var captureBody = conf.captureBody === type || conf.captureBody === 'all'
+  var maxBodyHttpChars = conf.maxBodyHttpChars || exports._MAX_HTTP_BODY_CHARS
 
   var context = {
     http_version: req.httpVersion,
@@ -145,8 +146,8 @@ exports.getContextFromRequest = function (req, conf, type) {
       if (typeof body !== 'string') {
         body = tryJsonStringify(body) || stringify(body)
       }
-      if (body.length > exports._MAX_HTTP_BODY_CHARS) {
-        body = truncate(body, exports._MAX_HTTP_BODY_CHARS)
+      if (body.length > maxBodyHttpChars) {
+        body = truncate(body, maxBodyHttpChars)
       }
       context.body = body
     } else {

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -205,6 +205,20 @@ test('#getContextFromRequest()', function (t) {
     t.end()
   })
 
+  t.test('should slice too large body\'s at configured length', function (t) {
+    var configuredSliceLength = 10
+    var conf = { captureBody: 'all', maxBodyHttpChars: configuredSliceLength }
+    var req = getMockReq()
+    req.body = ''
+    for (var n = 0; n < configuredSliceLength + 10; n++) {
+      req.body += 'x'
+    }
+    req.headers['content-length'] = String(req.body.length)
+    var parsed = parsers.getContextFromRequest(req, conf)
+    t.strictEqual(parsed.body.length, configuredSliceLength)
+    t.end()
+  })
+
   t.test('should not log body if opts.body is false', function (t) {
     var conf = { captureBody: 'off' }
     var req = getMockReq()


### PR DESCRIPTION
Add supports for truncating the body of a request at a specified value, the default used is 2048 which is the previous default. This can be configured either using the configuration option `maxHttpBodyChars` or the environment variable `ELASTIC_APM_MAX_BODY_CHARS`.

Fixes #1078 

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
