### PR TITLE
fix(tests): api-schema has a new schema ref

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -35,6 +35,7 @@ FILES=( \
   "metadata.json" \
   "process.json" \
   "request.json" \
+  "rum_experience.json" \
   "service.json" \
   "span_subtype.json" \
   "span_type.json" \


### PR DESCRIPTION
The new schema ref was introduced in elastic/apm-server#4056.

Fixes #1809