### PR TITLE
fix: add missing dependency parseurl

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,14 @@
     "wait-on": "^3.3.0",
     "ws": "^7.2.1"
   },
+  "peerDependencies": {
+    "parseurl": "^1.3.3"
+  },
+  "peerDependenciesMeta": {
+    "parseurl": {
+      "optional": true
+    }
+  },
   "greenkeeper": {
     "ignore": [
       "inquirer"


### PR DESCRIPTION
Adds a missing dependency `parseurl`

Fixes https://github.com/yarnpkg/berry/issues/1911
Fixes https://github.com/elastic/apm-agent-nodejs/issues/1822

### Checklist

- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
