### PR TITLE
ci: fix schema downloader and make less fragile, suggest PRs have tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ Once your changes are ready to submit for review:
 
 2. Test your changes
 
-    Run the test suite to make sure that nothing is broken.
+    Run the test suite to make sure that nothing is broken. If you're adding
+    new code or changing existing code, write some automated tests that
+    exercise this code.
     See [testing](#testing) for details.
 
 3. Rebase your changes

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -1,61 +1,35 @@
+
 #!/usr/bin/env bash
 
-set -x
+set -ex
+if ! [ -n "$1" ]; then
+    echo "USAGE: ./download-json-schemas.sh /path/to/folder"
+    echo ""
+    echo "Downloads the APM Server Schema files to the specified folder"
+    exit 1
+fi
 
 download_schema()
 {
-  from=$1
-  to=$2
+    rm -rf ${1} && mkdir -p ${1}
+    for run in 1 2 3 4 5
+    do
+        if [ -x "$(command -v gtar)" ]; then
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+        else
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+        fi
+        result=$?
+        if [ $result -eq 0 ]; then break; fi
+        sleep 1
+    done
 
-  for run in {1..5}
-  do
-    curl -sf --compressed ${from} > ${to}
-    result=$?
-    if [ $result -eq 0 ]; then break; fi
-    sleep 1
-  done
+    if [ $result -ne 0 ]; then exit $result; fi
 
-  if [ $result -ne 0 ]; then exit $result; fi
+    mv -f ${1}/docs/spec/* ${1}/
+    rm -rf ${1}/docs
 }
 
-schemadir="${1:-.schemacache}"
+download_schema $1 master
 
-FILES=( \
-  "errors/error.json" \
-  "metricsets/sample.json" \
-  "metricsets/metricset.json" \
-  "sourcemaps/payload.json" \
-  "spans/span.json" \
-  "transactions/mark.json" \
-  "transactions/transaction.json" \
-  "cloud.json" \
-  "context.json" \
-  "http_response.json" \
-  "message.json" \
-  "metadata.json" \
-  "process.json" \
-  "request.json" \
-  "rum_experience.json" \
-  "service.json" \
-  "span_subtype.json" \
-  "span_type.json" \
-  "stacktrace_frame.json" \
-  "system.json" \
-  "tags.json" \
-  "timestamp_epoch.json" \
-  "transaction_name.json" \
-  "transaction_type.json" \
-  "user.json" \
-)
-
-mkdir -p \
-  ${schemadir}/errors \
-  ${schemadir}/transactions \
-  ${schemadir}/spans \
-  ${schemadir}/metricsets \
-  ${schemadir}/sourcemaps
-
-for i in "${FILES[@]}"; do
-  download_schema https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} ${schemadir}/${i}
-done
 echo "Done."


### PR DESCRIPTION
This PR makes a small addition to `CONTRIBUTING.md` to encourage folks to continue tests with any new code.  It also fixes the CI so we can land this PR.

Prior to this PR the CI was broken due to `download-json-schemas.sh` failing. The `download-json-schemas.sh` was failing [because the APM Server's schema had changed](https://github.com/elastic/apm-server/tree/master/docs/spec) and `download-json-schemas.sh` was missing files.  

Since [this isn't the first time this has happened](https://github.com/elastic/apm-agent-nodejs/pull/1810), this PR changes our approach to downloading these schema files, [cribbing from our friends in python](https://github.com/elastic/apm-agent-python/blob/master/tests/scripts/download_json_schema.sh) 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
