### PR TITLE
feat: tracestate

### DIFF
--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -4,8 +4,7 @@ const truncate = require('unicode-byte-truncate')
 
 const config = require('../config')
 const Timer = require('./timer')
-const TraceParent = require('traceparent')
-
+const TraceContext = require('../tracecontext')
 module.exports = GenericSpan
 
 function GenericSpan (agent, ...args) {
@@ -14,7 +13,10 @@ function GenericSpan (agent, ...args) {
     : {}
 
   this._timer = new Timer(opts.timer, opts.startTime)
-  this._context = TraceParent.startOrResume(opts.childOf, agent._conf) // _context is used by the OT bridge, and should unfortunately therefore be considered public
+
+  // _context is used by the OT bridge, and should unfortunately therefore be considered public
+  this._context = TraceContext.startOrResume(opts.childOf, agent._conf, opts.tracestate)
+
   this._agent = agent
   this._labels = null
   this._ids = null // Populated by sub-types of GenericSpan

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -24,8 +24,10 @@ exports.instrumentRequest = function (agent, moduleName) {
           agent._instrumentation.currentTransaction = null
         } else {
           var traceparent = req.headers['elastic-apm-traceparent'] || req.headers.traceparent
+          var tracestate = req.headers.tracestate
           var trans = agent.startTransaction(null, null, {
-            childOf: traceparent
+            childOf: traceparent,
+            tracestate: tracestate
           })
           trans.type = 'request'
           trans.req = req
@@ -151,8 +153,11 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       // Use the transaction context as the parent, in this case.
       var parent = span || agent.currentTransaction
       if (parent && parent._context && shouldPropagateTraceContext(options)) {
-        const headerValue = parent._context.toString()
+        const headerValue = parent._context.toTraceParentString()
+        const traceStateValue = parent._context.toTraceStateString()
+
         options.headers.traceparent = headerValue
+        options.headers.tracestate = traceStateValue
         if (agent._conf.useElasticTraceparentHeader) {
           options.headers['elastic-apm-traceparent'] = headerValue
         }

--- a/lib/tracecontext/index.js
+++ b/lib/tracecontext/index.js
@@ -1,0 +1,74 @@
+'use strict'
+const TraceParent = require('traceparent')
+const TraceState = require('./tracestate')
+
+const definePassthroughProp = (objMe, objToPassTo, propName) => {
+  // properties that call through to traceparent
+  Object.defineProperty(objMe, propName, {
+    configurable: true,
+    enumerable: true,
+    get () {
+      return objToPassTo[propName]
+    }
+  })
+}
+
+class TraceContext {
+  constructor (traceparent, tracestate) {
+    this.traceparent = traceparent
+    this.tracestate = tracestate
+
+    definePassthroughProp(this, this.traceparent, 'recorded')
+    definePassthroughProp(this, this.traceparent, 'version')
+    definePassthroughProp(this, this.traceparent, 'traceId')
+    definePassthroughProp(this, this.traceparent, 'id')
+    definePassthroughProp(this, this.traceparent, 'flags')
+    definePassthroughProp(this, this.traceparent, 'parentId')
+  }
+
+  static startOrResume (childOf, conf, tracestateString) {
+    if (childOf && childOf._context instanceof TraceContext) return childOf._context.child()
+    const traceparent = TraceParent.startOrResume(childOf, conf)
+    const tracestate = TraceState.fromStringFormatString(tracestateString)
+    tracestate.setValue('s', conf.transactionSampleRate)
+
+    return new TraceContext(traceparent, tracestate)
+  }
+
+  static fromString (header) {
+    return TraceParent.fromString(header)
+  }
+
+  ensureParentId () {
+    return this.traceparent.ensureParentId()
+  }
+
+  child () {
+    const childTraceParent = this.traceparent.child()
+    const childTraceContext = new TraceContext(
+      childTraceParent, this.tracestate
+    )
+    return childTraceContext
+  }
+
+  /**
+   * Returns traceparent string only
+   *
+   * @todo legacy -- can we remove to avoid confusion?
+   */
+  toString () {
+    return this.traceparent.toString()
+  }
+
+  toTraceStateString () {
+    return this.tracestate.toW3cString()
+  }
+
+  toTraceParentString () {
+    return this.traceparent.toString()
+  }
+}
+
+TraceContext.FLAGS = TraceParent.FLAGS
+
+module.exports = TraceContext

--- a/lib/tracecontext/tracestate.js
+++ b/lib/tracecontext/tracestate.js
@@ -1,0 +1,346 @@
+/**
+ * Class for Managing Tracestate
+ *
+ * Class that creates objects for managing trace state.
+ * This class is capable of parsing both tracestate strings
+ * and tracestate binary representations, allowing clients
+ * to get and set values in a single list-member/namespace
+ * while preserving values in the other namespaces.
+ *
+ * Capable of working with either the binary of string
+ * formatted tracestate values.
+ *
+ * Usage:
+ *   const tracestate = TraceState.fromStringFormatString(headerTracestate, 'es')
+ *   tracestate.setValue('s',1)
+ *   const newHeader = tracestate.toW3cString()
+ */
+class TraceState {
+  constructor (sourceBuffer, listMemberNamespace = 'es', defaultValues = {}, logger) {
+    if (!this._validateVendorKey(listMemberNamespace)) {
+      throw new Error('Vendor namespace failed validation.')
+    }
+
+    // buffer representation of the trace state string.
+    // The initial value of this.buffer will keep the
+    // values set in the listMemberNamespace list-member,
+    // but as soon as an initial value is set (via setValue)
+    // then the listMemberNamespace values will be removed
+    // from this.buffer and stored in the this.values.  While
+    // slightly more complicated, this allows us to maintain
+    // the order of list-member keys in an un-mutated tracestate
+    // string, per the W3C spec
+    this.buffer = sourceBuffer
+
+    this.listMemberNamespace = listMemberNamespace
+
+    // values for our namespace, set via setValue to
+    // ensure names conform
+    this.values = {}
+    for (const [key, value] of Object.entries(defaultValues)) {
+      this.setValue(key, value)
+    }
+
+    // if no logger, then fallback to agent singleton
+    logger = logger || require('../..').logger
+    this.logger = logger
+  }
+
+  setValue (key, value) {
+    const strKey = String(key)
+    const strValue = String(value)
+    if (!this._validateElasicKeyAndValue(strKey, strValue)) {
+      this.logger.trace('could not set tracestate key, invaliad characters detected')
+      return false
+    }
+    const isFirstSet = (Object.keys(this.values).length === 0)
+    const oldValue = this.values[strKey]
+    this.values[strKey] = value
+
+    // per: https://github.com/elastic/apm/blob/d5b2c87326548befcfec6731713932a00e430b99/specs/agents/tracing-distributed-tracing.md
+    // If adding another key/value pair to the es entry would exceed the limit
+    // of 256 chars, that key/value pair MUST be ignored by agents.
+    // The key/value and entry separators : and ; have to be considered as well.
+    const serializedValue = this._serializeValues(this.values)
+    if (serializedValue.length > 256 && (typeof oldValue === 'undefined')) {
+      delete this.values[strKey]
+      return false
+    }
+    if (serializedValue.length > 256 && (typeof oldValue !== 'undefined')) {
+      this.values[strKey] = oldValue
+      return false
+    }
+
+    // the first time we set a value, extract the mutable values from the
+    // buffer and set this.values appropriately
+    if (isFirstSet && Object.keys(this.values).length === 1) {
+      const [buffer, values] = TraceState._removeMemberNamespaceFromBuffer(
+        this.buffer,
+        this.listMemberNamespace
+      )
+      this.buffer = buffer
+      this.values = values
+      values[strKey] = value
+    }
+
+    return true
+  }
+
+  getValue (keyToGet) {
+    const allValues = this.toObject()
+    const rawValue = allValues[this.listMemberNamespace]
+    const values = TraceState._parseValues(rawValue)
+    return values[keyToGet]
+  }
+
+  toHexString () {
+    const newBuffer = Buffer.alloc(this.buffer.length)
+    let newBufferOffset = 0
+    for (let i = 0; i < this.buffer.length; i++) {
+      const byte = this.buffer[i]
+      if (byte === 0) {
+        const indexOfKeyLength = i + 1
+        const indexOfKey = i + 2
+        const lengthKey = this.buffer[indexOfKeyLength]
+
+        const indexOfValueLength = indexOfKey + lengthKey
+        const indexOfValue = indexOfValueLength + 1
+        const lengthValue = this.buffer[indexOfValueLength]
+
+        const key = this.buffer.slice(indexOfKey, indexOfKey + lengthKey).toString()
+        // bail out if this is our mutable namespace
+        if (key === this.listMemberNamespace) { continue }
+
+        // if this is not our key copy from the `0` byte to the end of the value
+        this.buffer.copy(newBuffer, newBufferOffset, i, indexOfValue + lengthValue)
+        newBufferOffset += (indexOfValue + lengthValue)
+
+        // skip ahead to first byte after end of value
+        i = indexOfValue + lengthValue - 1
+        continue
+      }
+    }
+
+    // now serialize the internal representation
+    const ourBytes = []
+    if (Object.keys(this.values).length > 0) {
+      // the zero byte
+      ourBytes.push(0)
+
+      // the length of the vendor namespace
+      ourBytes.push(this.listMemberNamespace.length)
+      // the chars of the vendor namespace
+      for (let i = 0; i < this.listMemberNamespace.length; i++) {
+        ourBytes.push(this.listMemberNamespace.charCodeAt(i))
+      }
+
+      // add the length of the value
+      const serializedValue = this._serializeValues(this.values)
+      ourBytes.push(serializedValue.length)
+
+      // add the bytes of the value
+      for (let i = 0; i < serializedValue.length; i++) {
+        ourBytes.push(serializedValue.charCodeAt(i))
+      }
+    }
+    const ourBuffer = Buffer.from(ourBytes)
+    return Buffer.concat(
+      [newBuffer, ourBuffer],
+      newBuffer.length + ourBuffer.length
+    ).toString('hex')
+  }
+
+  /**
+   * Returns JSON reprenstation of tracestate key/value pairs
+   *
+   * Does not parse the mutable list namespace
+   */
+  toObject () {
+    const map = this.toMap()
+    const obj = {}
+    for (const key of map.keys()) {
+      obj[key] = map.get(key)
+    }
+    return obj
+  }
+
+  toMap () {
+    const map = new Map()
+
+    // first, serialize values from the internal representation. This means
+    // The W3C spec dictates that mutated values need to be on
+    // the left of the new trace string
+    if (Object.keys(this.values).length) {
+      map.set(this.listMemberNamespace, this._serializeValues(
+        this.values
+      ))
+    }
+    for (let i = 0; i < this.buffer.length; i++) {
+      const byte = this.buffer[i]
+      if (byte === 0) {
+        const indexOfKeyLength = i + 1
+        const indexOfKey = i + 2
+        const lengthKey = this.buffer[indexOfKeyLength]
+
+        const indexOfValueLength = indexOfKey + lengthKey
+        const indexOfValue = indexOfValueLength + 1
+        const lengthValue = this.buffer[indexOfValueLength]
+
+        const key = this.buffer.slice(indexOfKey, indexOfKey + lengthKey).toString()
+        const value = this.buffer.slice(indexOfValue, indexOfValue + lengthValue).toString()
+
+        map.set(key, value)
+
+        // skip ahead
+        i = indexOfValue + lengthValue - 1
+        continue
+      }
+    }
+
+    return map
+  }
+
+  toString () {
+    return this.toW3cString()
+  }
+
+  toW3cString () {
+    const json = this.toObject()
+    const chars = []
+    for (const [key, value] of Object.entries(json)) {
+      if (!value) { continue }
+      chars.push(key)
+      chars.push('=')
+      chars.push(value)
+      chars.push(',')
+    }
+    chars.pop() // remove final comma
+    return chars.join('')
+  }
+
+  _serializeValues (keyValues) {
+    const chars = []
+    for (const [key, value] of Object.entries(keyValues)) {
+      chars.push(`${key}:${value}`)
+      chars.push(';')
+    }
+    chars.pop() // last semi-colon
+    return chars.join('')
+  }
+
+  _validateVendorKey (key) {
+    if (key.length > 256 || key.length < 1) {
+      return false
+    }
+
+    const re = new RegExp(
+      '^[abcdefghijklmnopqrstuvwxyz0123456789_\\-\\*/]*$'
+    )
+    if (!key.match(re)) {
+      return false
+    }
+    return true
+  }
+
+  _validateElasicKeyAndValue (key, value) {
+    // 0x20` to `0x7E WITHOUT `,` or `=` or `;` or `;`
+    const re = /^[ \][!"#$%&'()*+\-./0123456789<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_abcdefghijklmnopqrstuvwxyz{|}~]*$/
+
+    if (!key.match(re) || !value.match(re)) {
+      return false
+    }
+
+    if (key.length > 256 || value.length > 256) {
+      return false
+    }
+
+    return true
+  }
+
+  static fromBinaryFormatHexString (string, listMemberNamespace = 'es') {
+    return new TraceState(Buffer.from(string, 'hex'), listMemberNamespace)
+  }
+
+  static fromStringFormatString (string = '', listMemberNamespace = 'es') {
+    // converts string format to byte format
+    const bytes = []
+
+    const parts = string.split(',')
+    for (const [, part] of parts.entries()) {
+      if (!part) { continue }
+      const [listMember, value] = part.split('=')
+      if (!listMember || !value) { continue }
+      bytes.push(0)
+      bytes.push(listMember.length)
+      for (let i = 0; i < listMember.length; i++) {
+        bytes.push(listMember.charCodeAt(i))
+      }
+      bytes.push(value.length)
+      for (let i = 0; i < value.length; i++) {
+        bytes.push(value.charCodeAt(i))
+      }
+    }
+
+    return new TraceState(Buffer.from(bytes), listMemberNamespace)
+  }
+
+  static _parseValues (rawValues) {
+    const parsedValues = {}
+    for (const [, keyValue] of rawValues.split(';').entries()) {
+      if (!keyValue) { continue }
+      const [key, value] = keyValue.split(':')
+      if (!key || !value) { continue }
+      parsedValues[key] = value
+    }
+    return parsedValues
+  }
+
+  static _removeMemberNamespaceFromBuffer (buffer, listMemberNamespace) {
+    const newBuffer = Buffer.alloc(buffer.length)
+    let newBufferOffset = 0
+    const values = {}
+    for (let i = 0; i < buffer.length; i++) {
+      const byte = buffer[i]
+      if (byte === 0) {
+        const indexOfKeyLength = i + 1
+        const indexOfKey = i + 2
+        const lengthKey = buffer[indexOfKeyLength]
+
+        const indexOfValueLength = indexOfKey + lengthKey
+        const indexOfValue = indexOfValueLength + 1
+        const lengthValue = buffer[indexOfValueLength]
+
+        const key = buffer.slice(indexOfKey, indexOfKey + lengthKey).toString()
+
+        // if this is our mutable namespace extract
+        // and set the value in values, otherwise
+        // copy into new buffer
+        if (key === listMemberNamespace) {
+          const rawValues = buffer.slice(indexOfValue, indexOfValue + lengthValue).toString()
+          const parsedValues = TraceState._parseValues(rawValues)
+          for (const [key, value] of Object.entries(parsedValues)) {
+            values[key] = value
+          }
+          continue
+        } else {
+          buffer.copy(newBuffer, newBufferOffset, i, indexOfValue + lengthValue)
+          newBufferOffset += (indexOfValue + lengthValue - i)
+        }
+
+        // skip ahead to first byte after end of value
+        i = indexOfValue + lengthValue - 1
+        continue
+      }
+    }
+
+    // trim off extra 0 bytes
+    const trimmedBuffer = newBuffer.slice(0, newBufferOffset)
+
+    return [
+      trimmedBuffer,
+      values
+    ]
+  }
+}
+
+module.exports = TraceState

--- a/test/tracecontext/tracestate.js
+++ b/test/tracecontext/tracestate.js
@@ -1,0 +1,289 @@
+var test = require('tape')
+
+const TraceState = require('../../lib/tracecontext/tracestate')
+test('TraceState binary format functionality', function (t) {
+  const stringFormat = 'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,34@ree=xxxy'
+  const tracestate = TraceState.fromStringFormatString(stringFormat)
+
+  const json = tracestate.toObject()
+
+  t.equals(json.foo, '34f067aa0ba902b7', 'preserved value of key foo')
+  t.equals(json.bar, '0.25', 'preserved value of key bar')
+  t.equals(json.es, 'a:b;cee:de', 'preserved value of key es')
+  t.equals(json['34@ree'], 'xxxy', 'preserved value of key 34@ree')
+
+  t.equals(tracestate.getValue('a'), 'b', 'a key parsed from es correctly')
+  t.equals(tracestate.getValue('cee'), 'de', 'cee key parsed from es correctly')
+
+  const string = tracestate.toW3cString()
+
+  const tracestate2 = TraceState.fromStringFormatString(string)
+
+  t.equals(
+    string,
+    'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,34@ree=xxxy',
+    'w3c string is correct string'
+  )
+
+  t.same(tracestate2.toObject(), tracestate.toObject())
+
+  const tracestate3 = TraceState.fromStringFormatString('')
+  tracestate3.setValue('a', 1.0)
+  tracestate3.setValue('b', 1.1)
+  t.equals(tracestate3.toW3cString(), 'es=a:1;b:1.1', 'can handle numerical types')
+
+  const tracestate4 = TraceState.fromStringFormatString('')
+  t.equals(tracestate4.toW3cString(), '', 'no values renders empty')
+  t.end()
+})
+
+test('TraceState binary format functionality', function (t) {
+  const mutableKey = 'mutable-key'
+  const tracestate1 = new TraceState()
+  t.ok(tracestate1, 'could instantiate TraceState')
+
+  const string = '0003666f6f1033346630363761613062613930326237000362617204302e3235'
+  const obj = { foo: '34f067aa0ba902b7', bar: '0.25' }
+  const tracestate2 = TraceState.fromBinaryFormatHexString(string, mutableKey)
+  t.ok(tracestate2, 'could instantiate tracestate from hex string')
+
+  t.equal(tracestate2.toHexString(), string, 'renders as hex string correctly')
+
+  t.same(tracestate2.toObject(), obj, 'renders as object correctly')
+
+  this.ok(tracestate2.setValue('a', 'c'), 'accepts value from mutable key')
+
+  this.ok(tracestate2.setValue('blue', 'red'), 'accepts second value from mutable key')
+
+  this.equals(tracestate2.getValue('a'), 'c', 'can fetch value from mutable namespace')
+  this.equals(tracestate2.getValue('blue'), 'red', 'can fetch second value from mutable namespace')
+
+  // the es vendor namespace has the value `a:d;blue:red;` in this hex string
+  const hexStringWithEsValues =
+    '0003666f6f1033346630363761613062613930326237000265730c613a643b626c75653a7265643b000362617204302e3235'
+
+  const tracestate3 = TraceState.fromBinaryFormatHexString(hexStringWithEsValues, 'es')
+  this.equals(
+    tracestate3.getValue('a'),
+    'd',
+    'can fetch mutable namespace value set from start'
+  )
+
+  this.equals(
+    tracestate3.getValue('blue'),
+    'red',
+    'can fetch mutable namespace value set from start'
+  )
+
+  tracestate3.setValue('a', 'c')
+  this.equals(
+    tracestate3.getValue('a'),
+    'c',
+    'can overwrite value set in initial buffer'
+  )
+
+  tracestate3.setValue('a', 'c')
+  this.equals(
+    tracestate3.getValue('blue'),
+    'red',
+    'overwriten value does not effect others set'
+  )
+  t.end()
+})
+
+test('TraceState binary format serializing', function (t) {
+  // hex string with no es value
+  const string = '0003666f6f1033346630363761613062613930326237000362617204302e3235'
+  const tracestate = TraceState.fromBinaryFormatHexString(string, 'es')
+  tracestate.setValue('foo', 'bar')
+  tracestate.setValue('zip', 'zap')
+  const newString = tracestate.toHexString()
+
+  const tracestate2 = TraceState.fromBinaryFormatHexString(newString, 'es')
+
+  // the new values should be fetchable
+  t.equals(tracestate2.getValue('foo'), 'bar', 'value was serialized/unserialized correctly')
+  t.equals(tracestate2.getValue('zip'), 'zap', 'value was serialized/unserialized correctly')
+
+  const json = tracestate2.toObject()
+
+  // the non-es raw values should be untouched
+  t.equals(json.foo, '34f067aa0ba902b7', 'foo vendor untouched')
+  t.equals(json.bar, '0.25', 'bar vendor untouched')
+
+  t.end()
+})
+
+test('TraceState format validation', function (t) {
+  const didCreatingTraceStateThrow = (buffer, ns) => {
+    try {
+      const t2 = new TraceState(buffer, ns)
+      t.ok(t2, 'create TraceState without throwing')
+    } catch (e) {
+      return true
+    }
+    return false
+  }
+
+  const justFits = new Array(256 + 1).join('x')
+  const tooBig = new Array(257 + 1).join('x')
+  const validVendorKey = [
+    'abcdefghijklmnopqrstuvwxyz',
+    '0123456789',
+    '_-*/'
+  ].join('')
+  const invalidVendorKey = [
+    'abcdefghijklmnopqrstuvwxyz',
+    ':',
+    '0123456789',
+    '_-*/'
+  ].join('')
+  const buffer = Buffer.from([])
+
+  t.ok(
+    !didCreatingTraceStateThrow(buffer, justFits),
+    'vendor namespace of 256 characters allowed'
+  )
+
+  t.ok(
+    didCreatingTraceStateThrow(buffer, tooBig),
+    'TraceState refuses to instantiate vendor namespace of 257 characters'
+  )
+
+  t.ok(
+    !didCreatingTraceStateThrow(buffer, validVendorKey),
+    'TraceState instantiates with valid vendor namespae'
+  )
+
+  t.ok(
+    didCreatingTraceStateThrow(buffer, invalidVendorKey),
+    'TraceState refusees to instantiate with invalid vendor namespae'
+  )
+
+  t.ok(
+    didCreatingTraceStateThrow(buffer, 'fo=o'),
+    'TraceState refusees to instantiate with invalid vendor namespae fo=o'
+  )
+
+  t.ok(
+    didCreatingTraceStateThrow(buffer, 'fo,o'),
+    'TraceState refusees to instantiate with invalid vendor namespae fo,o'
+  )
+
+  const t1 = new TraceState(buffer, 'es')
+  t.ok(!t1.setValue('f:oo', 'bar'), 'failed to set invalid key f:oo')
+  t.ok(!t1.setValue('foo-colon', 'ba:r'), 'failed to set invalid value ba:r')
+  t.ok(!t1.setValue('f;oo', 'bar'), 'failed to set invalid key bar')
+  t.ok(!t1.setValue('foo-semicolon', 'b;ar'), 'failed to set invalid value b;ar')
+  t.ok(!t1.setValue('f,oo', 'bar'), 'failed to set invalid key f,oo')
+  t.ok(!t1.setValue('foo-comma', 'b,ar'), 'failed to set invalid value b,ar')
+  t.ok(!t1.setValue('f=oo', 'bar'), 'failed to set invalid key f=oo')
+  t.ok(!t1.setValue('foo-equals', 'b,ar'), 'failed to set invalid value b,ar')
+
+  t.ok(!t1.setValue('foo-toolong', tooBig), 'failed to set value > 256 chars')
+  t.ok(!t1.setValue(tooBig, 'foo'), 'failed to set key > 256 chars')
+
+  t.ok(t1.setValue('foo', 'bar'), 'set valid key and value')
+
+  t.ok(!t1.getValue('f:oo'), 'did not set invalid key f:oo')
+  t.ok(!t1.getValue('f;oo'), 'did not set invalid key f;oo')
+  t.ok(!t1.getValue(tooBig), 'did not set super long key')
+  t.ok(!t1.getValue('foo-colon'), 'did not set invalid value for foo-colon key')
+  t.ok(!t1.getValue('foo-semicolon'), 'did not set invalid value for foo-semicolon key')
+  t.ok(!t1.getValue('foo-comma'), 'did not set invalid value for foo-comma key')
+  t.ok(!t1.getValue('foo-equals'), 'did not set invalid value for foo-equals key')
+  t.ok(!t1.getValue('foo-toolong'), 'did not set invalid value for foo-toolong key')
+
+  t.equals(t1.getValue('foo'), 'bar', 'did set valid value')
+
+  const t2 = new TraceState(Buffer.from([]), 'es')
+  t2.setValue('foo', 'bar')
+  t2.setValue('zip', 'zap')
+  // now, set a key and value that are <257 characters, but that
+  // would result in the entire `es` value being greater than 256
+  const oneTwenty = new Array(120 + 1).join('x')
+  t.ok(!t2.setValue(oneTwenty, oneTwenty), 'call to setValue returned false when key too long')
+  t.equals(t2.getValue('foo'), 'bar', 'maintained value of foo key')
+  t.equals(t2.getValue('zip'), 'zap', 'maintained value of zip key')
+  t.ok(!t2.getValue(oneTwenty), 'did not set key/value that would put us over total character limit')
+
+  // same as t2 test, but oneTwenty key is previously set
+  const t3 = new TraceState(Buffer.from([]), 'es')
+  t3.setValue('foo', 'bar')
+  t3.setValue('zip', 'zap')
+  t3.setValue(oneTwenty, 'bees')
+  // now, set a key and value that are <257 characters, but that
+  // would result in the entire `es` value being greater than 256
+
+  t3.setValue(oneTwenty, oneTwenty)
+  t.equals(t3.getValue('foo'), 'bar', 'maintained value of foo key')
+  t.equals(t3.getValue('zip'), 'zap', 'maintained value of zip key')
+  t.equals(t3.getValue(oneTwenty), 'bees', 'maintained value of zip key')
+
+  t.end()
+})
+
+test('TraceState delimiter edge cases', function (t) {
+  // makes sure weird stuff doesn't blow anything up
+  const stringFormats = [
+    'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,34@ree=xxxy',
+    'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,34@ree=xxxy,',
+    'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,;34@ree=xxxy,',
+    'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de;,34@ree=xxxy,',
+    'foo=34f067aa0ba902b7,,bar=0.25,es=a:b;;cee:de,34@ree=xxxy;',
+    'foo=34f067aa,0ba902b7,,bar=0.25,es=a:b;;cee:de,34@ree=xxxy;',
+    'foo=34f067aa,0ba9,02b7,,bar=0.25,es=a:b;;;cee:de,,,34@ree=xxxy;',
+    'foo=34f067aa0ba902b7,bar=0.25,es=a::b;cee:de,34@ree=xxxy',
+    'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,es=xxxy'
+  ]
+  for (const [, format] of stringFormats.entries()) {
+    this.ok(TraceState.fromStringFormatString(format))
+  }
+
+  t.end()
+})
+
+test('TraceState W3C Order', function (t) {
+  // Vendors receiving a tracestate request header MUST
+  // send it to outgoing requests. It MAY mutate the value
+  // of this header before passing to outgoing requests.
+  // When mutating tracestate, the order of unmodified
+  // key/value pairs MUST be preserved. Modified keys MUST
+  // be moved to the beginning (left) of the list.
+
+  const string = 'foo=34f067aa0ba902b7,bar=0.25,es=a:b;cee:de,34@ree=xxxy'
+  const stringIfModified = 'es=a:b;cee:d,foo=34f067aa0ba902b7,bar=0.25,34@ree=xxxy'
+
+  const tracestate = TraceState.fromStringFormatString(string)
+  const map = tracestate.toMap()
+  t.ok(map.get('es'), 'a:b;cee:de', 'toMap method works')
+  // t.equals(tracestate.toW3cString(), string, 'unmodified tracestate remains in same order order')
+
+  const tracestate2 = TraceState.fromStringFormatString(string)
+  tracestate2.setValue('cee', 'd')
+  t.equals(tracestate2.toW3cString(), stringIfModified, 'modified tracestate shifts modified key to left side')
+
+  t.end()
+})
+
+test('TraceState defaultValues', function (t) {
+  const tracestate = new TraceState(
+    Buffer.from('', 'hex'), 'es', { foo: 'bar', zip: 'zap' }
+  )
+  t.equals(tracestate.getValue('foo'), 'bar', 'default value foo set correctly')
+  t.equals(tracestate.getValue('zip'), 'zap', 'default value zap set correctly')
+  t.equals(tracestate.toW3cString(), 'es=foo:bar;zip:zap')
+  t.equals(tracestate.toHexString(), '000265730f666f6f3a6261723b7a69703a7a6170')
+
+  // hex string has foo=bar and zip=zap in binary format
+  const tracestate2 = new TraceState(
+    Buffer.from('000265730f666f6f3a6261723b7a69703a7a6170', 'hex'),
+    'es',
+    { foo: 'bar2', zip: 'zap2' }
+  )
+
+  t.equals(tracestate2.getValue('foo'), 'bar2', 'prefers defaultValues over binary in constructor')
+  t.equals(tracestate2.getValue('zip'), 'zap2', 'prefers defaultValues over binary in constructor')
+  t.equals(tracestate2.toW3cString(), 'es=foo:bar2;zip:zap2', 'prefers defautlValues over binary in constructor')
+  t.end()
+})


### PR DESCRIPTION
This PR closes #1797.

This pull request implements the tracestate functionality for the elastic node agent.  The new `TraceState` class is capable of getting/setting values under a single list-member of the tracestate string while preserving the values of the other list-members.  It can also produce output in either the W3C string format or the W3C binary format (via a hex string). 

The pull request also uses this new tracestate functionality to add an `es` list-member to the root trace node with an `s` key that records the transaction sample rate.  This header is initially set on the root trace node.  If the transaction is the child of another transaction the priority is not explicitly set, and instead the tracestate header is simply propagated on. 

This pull request also replaces the `TraceParent` class with a `TraceContext` class that includes both a `TraceParent` and `TraceState` functionality. 

The `tracestate` headers is not added to http2 transactions, as http2 transaction do not currently support distributed tracing. See: https://github.com/elastic/apm-agent-nodejs/issues/1830

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
