### PR TITLE
fix(tests): fix hang in ioredis test

### DIFF
--- a/test/instrumentation/modules/ioredis.js
+++ b/test/instrumentation/modules/ioredis.js
@@ -51,7 +51,7 @@ test('not nested', function (t) {
     t.strictEqual(calls, 3)
 
     agent.endTransaction()
-    redis.quit()
+    redis.disconnect()
     agent.flush()
   })
 })
@@ -91,7 +91,7 @@ test('nested', function (t) {
       t.strictEqual(calls, 2)
 
       agent.endTransaction()
-      redis.quit()
+      redis.disconnect()
       agent.flush()
     })
   })
@@ -123,7 +123,7 @@ test('rejections_handled', function (t) {
   redis.get('a', function (err, result) {
     t.ok(err)
     trans.end()
-    redis.quit()
+    redis.disconnect()
     agent.flush()
   }) // wrong type, should reject
 })


### PR DESCRIPTION
ioredis@4.19.0 includes a bug when using `redis.quit()` that can leave
a setInterval uncleared. See luin/ioredis#1215.

Fixes elastic/apm-agent-nodejs#1838
