### PR TITLE
fix(tests): skip testing knex >=0.21 with node v8

### DIFF
--- a/test/instrumentation/modules/pg/knex.js
+++ b/test/instrumentation/modules/pg/knex.js
@@ -13,6 +13,11 @@ var agent = require('../../../..').start({
 var knexVersion = require('knex/package').version
 var semver = require('semver')
 
+if (semver.gte(knexVersion, '0.21.0') && semver.lt(process.version, '10.0.0')) {
+  // Skip these tests: knex@0.21.x dropped support for node v8.
+  process.exit(0)
+}
+
 var Knex = require('knex')
 var test = require('tape')
 


### PR DESCRIPTION
Fixes #1842
