### PR TITLE
ci: skip TAP/JUnit and codecov processing for TAV tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -382,7 +382,7 @@ def generateStep(Map params = [:]){
           } finally {
             // TAV tests run 'npm run test:tav' which does *not* produce TAP
             // output or code coverage .
-            if (! "${tav}") {
+            if (!tav?.trim()) {
               tap2Junit(pattern: '*-output.tap', suffix: 'junit.xml', package: 'Node.js', failNever: true)
               codecov(repo: env.REPO, basedir: '.', secret: "${CODECOV_SECRET}")
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -380,8 +380,12 @@ def generateStep(Map params = [:]){
           } catch(e){
             error(e.toString())
           } finally {
-            tap2Junit(pattern: '*-output.tap', suffix: 'junit.xml', package: 'Node.js', failNever: true)
-            codecov(repo: env.REPO, basedir: '.', secret: "${CODECOV_SECRET}")
+            // TAV tests run 'npm run test:tav' which does *not* produce TAP
+            // output or code coverage .
+            if (! "${tav}") {
+              tap2Junit(pattern: '*-output.tap', suffix: 'junit.xml', package: 'Node.js', failNever: true)
+              codecov(repo: env.REPO, basedir: '.', secret: "${CODECOV_SECRET}")
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes elastic/apm-agent-nodejs#1847
