### PR TITLE
fix: redis@2.x instrumentation was broken

### DIFF
--- a/lib/instrumentation/modules/redis.js
+++ b/lib/instrumentation/modules/redis.js
@@ -6,9 +6,23 @@ var shimmer = require('../shimmer')
 var { getDBDestination } = require('../context')
 
 module.exports = function (redis, agent, { version, enabled }) {
-  if (!semver.satisfies(version, '^3.0.0')) {
+  if (!semver.satisfies(version, '>=2.0.0 <4.0.0')) {
     agent.logger.debug('redis version %s not supported - aborting...', version)
     return redis
+  }
+
+  // The undocumented field on a RedisClient instance on which connection
+  // options are stored has changed a few times.
+  let connOptsFromRedisClient
+  if (semver.gte(version, '2.4.0')) {
+    connOptsFromRedisClient = (rc) => rc.connection_options
+  } else if (semver.gte(version, '2.3.0')) {
+    connOptsFromRedisClient = (rc) => rc.connection_option
+  } else if (semver.gte(version, '0.12.0')) {
+    connOptsFromRedisClient = (rc) => rc.connectionOption
+  } else {
+    // *Maybe* available on `client.{host|port}`, but not verified.
+    connOptsFromRedisClient = () => {}
   }
 
   var proto = redis.RedisClient && redis.RedisClient.prototype
@@ -41,8 +55,10 @@ module.exports = function (redis, agent, { version, enabled }) {
 
       if (span) {
         let host, port
-        if (typeof this.connection_options === 'object') {
-          ({ host, port } = this.connection_options)
+        let connOpts = connOptsFromRedisClient(this)
+        if (connOpts) {
+          host = connOpts.host
+          port = connOpts.port
         }
         span.setDestinationContext(getDBDestination(span, host, port))
       }
@@ -67,8 +83,10 @@ module.exports = function (redis, agent, { version, enabled }) {
 
       if (span) {
         let host, port
-        if (typeof this.connectionOption === 'object') {
-          ({ host, port } = this.connectionOption)
+        let connOpts = connOptsFromRedisClient(this)
+        if (connOpts) {
+          host = connOpts.host
+          port = connOpts.port
         }
         span.setDestinationContext(getDBDestination(span, host, port))
       }

--- a/lib/instrumentation/modules/redis.js
+++ b/lib/instrumentation/modules/redis.js
@@ -13,17 +13,13 @@ module.exports = function (redis, agent, { version, enabled }) {
 
   // The undocumented field on a RedisClient instance on which connection
   // options are stored has changed a few times.
-  let connOptsFromRedisClient
-  if (semver.gte(version, '2.4.0')) {
-    connOptsFromRedisClient = (rc) => rc.connection_options
-  } else if (semver.gte(version, '2.3.0')) {
-    connOptsFromRedisClient = (rc) => rc.connection_option
-  } else if (semver.gte(version, '0.12.0')) {
-    connOptsFromRedisClient = (rc) => rc.connectionOption
-  } else {
-    // *Maybe* available on `client.{host|port}`, but not verified.
-    connOptsFromRedisClient = () => {}
-  }
+  //
+  // - >=2.4.0: `client.connection_options.{host,port}`, commit eae5596a
+  // - >=2.3.0, <2.4.0: `client.connection_option.{host,port}`, commit d454e402
+  // - >=0.12.0, <2.3.0: `client.connectionOption.{host,port}`, commit 064260d1
+  // - <0.12.0: *maybe* `client.{host,port}`
+  const connOptsFromRedisClient = (rc) => rc.connection_options ||
+    rc.connection_option || rc.connectionOption || {}
 
   var proto = redis.RedisClient && redis.RedisClient.prototype
   if (semver.satisfies(version, '>2.5.3')) {
@@ -55,7 +51,7 @@ module.exports = function (redis, agent, { version, enabled }) {
 
       if (span) {
         let host, port
-        let connOpts = connOptsFromRedisClient(this)
+        const connOpts = connOptsFromRedisClient(this)
         if (connOpts) {
           host = connOpts.host
           port = connOpts.port
@@ -83,7 +79,7 @@ module.exports = function (redis, agent, { version, enabled }) {
 
       if (span) {
         let host, port
-        let connOpts = connOptsFromRedisClient(this)
+        const connOpts = connOptsFromRedisClient(this)
         if (connOpts) {
           host = connOpts.host
           port = connOpts.port


### PR DESCRIPTION
- instrumentation of redis 2.x was accidentally in v3.7.0
- before the addition of destination metadata in commit aa8eb56 (v3.6.0)
  didn't work for redis 2.3.0 .. 2.5.3

Fixes #1850
