### PR TITLE
fix(tedious): fix tedious@9.x breakage and clarify supported version range

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -278,9 +278,12 @@ hapi-async-await:
   commands:
     - node test/instrumentation/modules/hapi/basic.js
     - node test/instrumentation/modules/hapi/set-framework-2.js
+
 tedious:
   name: tedious
-  versions: '>=1.9 <2.7 || 3.x || >4.0.0'
+  # - tedious@4.0.0 was broken, fixed in 4.0.1 by
+  #   https://github.com/tediousjs/tedious/commit/4eceb48
+  versions: '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x'
   commands: node test/instrumentation/modules/tedious.js
 
 cassandra-driver:

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -91,7 +91,7 @@ so those should be supported as well
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <3.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/redis[redis] |>=2.0.0 <4.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/tedious[tedious] |>=1.9 |Will instrument all queries
+|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <10.0.0 | (Excluding v4.0.0.) Will instrument all queries
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages
 |=======================================================================
 

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -8,7 +8,7 @@ var { getDBDestination } = require('../context')
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious
-  if (!semver.satisfies(version, '>=0.0.5')) {
+  if (!semver.satisfies(version, '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x')) {
     agent.logger.debug('tedious version %s not supported - aborting...', version)
     return tedious
   }

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "send": "^0.17.1",
     "standard": "^14.3.3",
     "tape": "^5.0.0",
-    "tedious": "^8.0.1",
+    "tedious": "^9.2.1",
     "test-all-versions": "^4.1.1",
     "thunky": "^1.1.0",
     "typescript": "^3.7.5",


### PR DESCRIPTION
This PR will do a couple things:
- Clarify which tedious versions are supported (current state is a little inconsistent between .tav.yml, the guard in the actual instrumentation code, and the "supported modules" doc).
- Fix tedious@9.x breakage (at least breakage of the tests).

The intent is to fix elastic/apm-agent-nodejs#1849
