### PR TITLE
chore: convenience Makefile, ignore local tmp dir for scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,16 @@
 # Files to ignore
 .DS_Store
-.vscode
-package-lock.json
-test/babel/out.js
-test/types/transpile/index.js
+/.vscode
+/coverage.lcov
+/package-lock.json
+/test/babel/out.js
+/test/types/transpile/index.js
+/test-suite-output.tap
 
 # Folders to ignore
-.nyc_output
-build
-coverage
-node_modules
-test/benchmarks/.tmp
-coverage.lcov
-test-suite-output.tap
+/.nyc_output
+/build
+/coverage
+/node_modules
+/test/benchmarks/.tmp
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# All development tasks are typically available via npm scripts, i.e.
+# `npm run <script> ...`.  This Makefile exists as a convenience for some
+# of the common tasks.
+
+.PHONY: all
+all:
+	npm install
+
+.PHONY: check
+check:
+	npm run lint
+	npm run lint:commit
+
+.PHONY: fmt
+fmt:
+	npm run lint:fix
+
+# Prerequisite: Docker server is running.
+# See TESTING.md for more details on tests, TAV tests, coverage, benchmarks.
+.PHONY: test
+test:
+	npm run test


### PR DESCRIPTION
Also anchor many gitignore'd files to the top project dir with '/'.
