### PR TITLE
fix: remove gtar dep

### DIFF
--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -10,7 +10,7 @@ if ! [ -n "$1" ]; then
     exit 1
 fi
 
-# download_schema [/path/to/download/to] [branch]
+# download_schema </path/to/download/to> <branch>
 download_schema()
 {
     rm -rf ${1} && mkdir -p ${1}

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -5,9 +5,12 @@ if ! [ -n "$1" ]; then
     echo "USAGE: ./download-json-schemas.sh /path/to/folder"
     echo ""
     echo "Downloads the APM Server Schema files to the specified folder"
+    echo ""
+    echo "Sources from: https://codeload.github.com/elastic/apm-server/"
     exit 1
 fi
 
+# download_schema [/path/to/download/to] [branch]
 download_schema()
 {
     rm -rf ${1} && mkdir -p ${1}

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 set -ex
@@ -14,8 +13,9 @@ download_schema()
     rm -rf ${1} && mkdir -p ${1}
     for run in 1 2 3 4 5
     do
-        if [ -x "$(command -v gtar)" ]; then
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # MacOS tar doesn't need --wildcards, that's how it behaves by default
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/*"
         else
             curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
         fi


### PR DESCRIPTION
Fixes: #1859

MacOS `tar` has `--wildcards` behavior by default.  This PR sniffs for Darwin (I don't know of a an easy/clean feature sniff for a tar flag) and then invokes the same tar command, just without the `--wildcards`.

Tested locally, but since none of our CI a second set of eyes/fingers would be appreciated here. 

# Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
