### PR TITLE
fix: tests correct codepath for pg span ending

### DIFF
--- a/test/instrumentation/modules/pg/pg.js
+++ b/test/instrumentation/modules/pg/pg.js
@@ -452,9 +452,8 @@ if (global.Promise || semver.satisfies(pgVersion, '<6')) {
   // https://github.com/elastic/apm-agent-nodejs/blob/8a5e908b8e9ee83bb1b828a3bef980388ea6e08e/lib/instrumentation/modules/pg.js#L91
   //
   // ensures this tests runs when ending a span via promise.then
-  if( typeof pg.Client.prototype.query.on !== 'function' &&
+  if (typeof pg.Client.prototype.query.on !== 'function' &&
       typeof pg.Client.prototype.query.then === 'function') {
-
     test.test('handles promise rejections from pg', function (t) {
       function unhandledRejection (e) {
         t.fail('had unhandledRejection')


### PR DESCRIPTION
Fixes: https://github.com/elastic/apm-agent-nodejs/issues/1866

It looks like there was an incorrect assumption in the the test that was submitted along with https://github.com/elastic/apm-agent-nodejs/pull/1846  

This PR adds guard clauses that match the behavior of the guard clauses in the `pg` instrumentation 

https://github.com/elastic/apm-agent-nodejs/blob/8a5e908b8e9ee83bb1b828a3bef980388ea6e08e/lib/instrumentation/modules/pg.js#L93

to ensure this test only runs when/where it needs to. 

The tests were failing in older versions of `pg` without promise support.  Putting the tests behind the `pg@5.1` guard clause resulted in errors in the 6.x branch because the agent is adding `then` and `catch` callbacks to the promise in versions of `pg` without an `on` method (i.e. the 6.x line of `pg`)

This PR adds a guard clause to ensure the test is run only when the agent is manipulating the returned promise.  This test will not run on versions of `pg` without promise support, (<5.1) or for versions of `pg` where the agent is using event handlers instead of promise-manipulation (anything in the 6.x line)


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
