### PR TITLE
test(api-schema): update to new apm-server schemata

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "unicode-byte-truncate": "^1.0.0"
   },
   "devDependencies": {
-    "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
@@ -124,6 +123,7 @@
     "@hapi/hapi": "^18.4.1",
     "@koa/router": "^9.0.1",
     "@types/node": "^13.7.4",
+    "ajv": "^6.12.6",
     "apollo-server-express": "^2.10.1",
     "aws-sdk": "^2.622.0",
     "backport": "^5.1.2",
@@ -150,7 +150,6 @@
     "https-pem": "^2.0.0",
     "inquirer": "^0.12.0",
     "ioredis": "^4.16.0",
-    "is-my-json-valid": "^2.20.0",
     "jade": "^1.11.0",
     "knex": "^0.21.2",
     "koa": "^2.11.0",

--- a/test/integration/api-schema/_utils.js
+++ b/test/integration/api-schema/_utils.js
@@ -5,19 +5,20 @@ const fs = require('fs')
 const tmpdir = require('os').tmpdir
 const join = require('path').join
 
-const validator = require('is-my-json-valid')
-const refParser = require('@apidevtools/json-schema-ref-parser')
+const Ajv = require('ajv')
 const rimraf = require('rimraf')
 const thunky = require('thunky')
 
+const ajv = new Ajv({ allErrors: true })
+
 const schemaDir = thunky(function (cb) {
-  const dir = join(tmpdir(), '.schemacache')
+  const dir = join(tmpdir(), 'apm-schema-v2-cache')
   fs.stat(dir, function (err) {
     if (!err) return cb(null, dir)
 
     const script = join(__dirname, 'download-json-schemas.sh')
     const cmd = `"${script}" "${dir}"`
-    console.log('downloading schemas from GitHub to %s...', dir)
+    console.log('downloading apm-server schemas from GitHub to "%s"...', dir)
     exec(cmd, function (err) {
       if (err) {
         console.log('download failed. cleaning up...')
@@ -36,25 +37,41 @@ exports.metadataValidator = thunky(function (cb) {
 })
 
 exports.transactionValidator = thunky(function (cb) {
-  loadSchema(join('transactions', 'transaction.json'), cb)
+  loadSchema('transaction.json', cb)
 })
 
 exports.spanValidator = thunky(function (cb) {
-  loadSchema(join('spans', 'span.json'), cb)
+  loadSchema('span.json', cb)
 })
 
 exports.errorValidator = thunky(function (cb) {
-  loadSchema(join('errors', 'error.json'), cb)
+  loadSchema('error.json', cb)
 })
 
 function loadSchema (relativePath, cb) {
   schemaDir(function (err, dir) {
-    if (err) return cb(err)
+    if (err) {
+      return cb(err)
+    }
+
     const path = join(dir, relativePath)
-    console.log('processing %s...', path)
-    refParser.dereference(path, function (err, schema) {
-      if (err) return cb(err)
-      cb(null, validator(schema, { verbose: true }))
+    console.log('processing "%s"...', path)
+    fs.readFile(path, { encoding: 'utf8' }, function (readErr, content) {
+      if (readErr) {
+        cb(readErr)
+        return
+      }
+
+      let schema
+      try {
+        schema = JSON.parse(content)
+      } catch (parseErr) {
+        cb(parseErr)
+        return
+      }
+
+      const validator = ajv.compile(schema)
+      cb(null, validator)
     })
   })
 }

--- a/test/integration/api-schema/download-json-schemas.sh
+++ b/test/integration/api-schema/download-json-schemas.sh
@@ -18,9 +18,9 @@ download_schema()
     do
         if [[ "$OSTYPE" == "darwin"* ]]; then
             # MacOS tar doesn't need --wildcards, that's how it behaves by default
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/*"
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/v2/*"
         else
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/v2/*"
         fi
         result=$?
         if [ $result -eq 0 ]; then break; fi
@@ -29,7 +29,7 @@ download_schema()
 
     if [ $result -ne 0 ]; then exit $result; fi
 
-    mv -f ${1}/docs/spec/* ${1}/
+    mv -f ${1}/docs/spec/v2/* ${1}/
     rm -rf ${1}/docs
 }
 


### PR DESCRIPTION
In https://github.com/elastic/apm-server/pull/4393 apm-server updated to
new and generate JSON schema. This commit updates the tests to get the
schema files from the new location and switches from the
"is-my-json-valid" JSON Schema validator to the more capable "ajv"
validator. This also changes the schema file cache dir so developers
need not manually delete the old cache.

Fixes #1867
