### PR TITLE
feat: transaction_ignore_urls wildcard matching

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -12,6 +12,10 @@ endif::[]
 
 [float]
 ===== Features
+* feat: transactionIgnoreUrl wildcard matching {pull}1870[#1870]
+  Allows users to ignore URLs using simple wildcard matching patterns that behave
+  the same across language agents. See https://github.com/elastic/apm/issues/144
+
 * Cool new feature: {pull}2526[#2526]
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -185,6 +185,42 @@ please https://github.com/elastic/apm-agent-nodejs/issues[open an issue].
 
 Note that not all core Node.js API's can be instrumented without the use of Async Hooks if running Node.js 8 or above.
 
+[[transaction-ignore-urls]]
+==== `transactionIgnoreUrls`
+
+* *Type:* Array
+* *Default:* `[]`
+* *Env:* `ELASTIC_TRANSACTION_IGNORE_URLS`
+
+Array or comma-separated string used to restrict requests for certain URLs from being instrumented.
+
+This property should be set to an array containing one or more string patterns.
+
+When an incoming HTTP request is detected, its URL pathname will be tested against each element
+in this list.  The `transactionIgnoreUrls` property supports exact string matches,
+simple wildcard (`*`) matches, and may not include commas.  Wildcard matches are
+case insensative by default. You may make wildcard searches case sensative by
+using the `(?-i)` prefix.
+
+Note that all errors that are captured during a request to an ignored URL are still sent
+to the APM Server regardless of this setting.
+
+If you need full regular expression pattern matching, see <<ignore-urls>>.
+
+Example usage:
+
+[source,js]
+----
+require('elastic-apm-node').start({
+  transactionIgnoreUrls: [
+    '/ping',
+    '/fetch/*',
+    '(?-i)/caseSensitiveSearch'
+  ]
+})
+----
+
+
 [[ignore-urls]]
 ==== `ignoreUrls`
 
@@ -202,6 +238,8 @@ If an element in the array is a `RegExp` object,
 its test function will be called with the URL being tested.
 
 Note that all errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of this setting.
+
+If you'd prefer simple wildcard pattern matching, see <<transaction-ignore-urls>>.
 
 Example usage:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -227,6 +227,7 @@ interface AgentConfigOptions {
   sourceLinesSpanAppFrames?: number;
   sourceLinesSpanLibraryFrames?: number;
   stackTraceLimit?: number;
+  transactionIgnoreUrls?: Array<string>;
   transactionMaxSpans?: number;
   transactionSampleRate?: number;
   usePathAsTransactionName?: boolean;

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,9 @@ var truncate = require('unicode-byte-truncate')
 
 var version = require('../package').version
 var packageName = require('../package').name
+
+const { WildcardMatcher } = require('./wildcard-matcher')
+
 // Standardize user-agent header. Only use "elasticapm-node" if it matches "elastic-apm-node".
 if (packageName === 'elastic-apm-node') {
   packageName = 'elasticapm-node'
@@ -70,6 +73,7 @@ var DEFAULTS = {
   sourceLinesSpanAppFrames: 0,
   sourceLinesSpanLibraryFrames: 0,
   stackTraceLimit: 50,
+  transactionIgnoreUrls: [],
   transactionMaxSpans: 500,
   transactionSampleRate: 1.0,
   useElasticTraceparentHeader: true,
@@ -124,6 +128,7 @@ var ENV_TABLE = {
   sourceLinesSpanAppFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
   sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
   stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
+  transactionIgnoreUrls: 'ELASTIC_TRANSACTION_IGNORE_URLS',
   transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
   transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
   useElasticTraceparentHeader: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
@@ -134,7 +139,8 @@ var ENV_TABLE = {
 var CENTRAL_CONFIG = {
   transaction_sample_rate: 'transactionSampleRate',
   transaction_max_spans: 'transactionMaxSpans',
-  capture_body: 'captureBody'
+  capture_body: 'captureBody',
+  transaction_ignore_urls: 'transactionIgnoreUrls'
 }
 
 var VALIDATORS = {
@@ -186,7 +192,8 @@ var MINUS_ONE_EQUAL_INFINITY = [
 ]
 
 var ARRAY_OPTS = [
-  'disableInstrumentations'
+  'disableInstrumentations',
+  'transactionIgnoreUrls'
 ]
 
 var KEY_VALUE_OPTS = [
@@ -204,7 +211,7 @@ class Config {
     this.ignoreUrlRegExp = []
     this.ignoreUserAgentStr = []
     this.ignoreUserAgentRegExp = []
-
+    this.transactionIgnoreUrlRegExp = []
     // If we didn't find a config file on process boot, but a path to one is
     // provided as a config option, let's instead try to load that
     if (confFile === null && opts && opts.configFile) {
@@ -369,17 +376,31 @@ function readEnv () {
 }
 
 function normalize (opts) {
-  normalizeIgnoreOptions(opts)
   normalizeKeyValuePairs(opts)
   normalizeNumbers(opts)
   normalizeBytes(opts)
   normalizeArrays(opts)
   normalizeTime(opts)
   normalizeBools(opts)
+  normalizeIgnoreOptions(opts)
   truncateOptions(opts)
 }
 
 function normalizeIgnoreOptions (opts) {
+  if (opts.transactionIgnoreUrls) {
+    // We can't guarantee that opts will be a Config so set a
+    // default value. This is to work around CENTRAL_CONFIG tests
+    // that call this method with a plain object `{}`
+    if (!opts.transactionIgnoreUrlRegExp) {
+      opts.transactionIgnoreUrlRegExp = []
+    }
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.transactionIgnoreUrls) {
+      const re = wildcard.compile(ptn)
+      opts.transactionIgnoreUrlRegExp.push(re)
+    }
+  }
+
   if (opts.ignoreUrls) {
     for (const ptn of opts.ignoreUrls) {
       if (typeof ptn === 'string') opts.ignoreUrlStr.push(ptn)

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -78,6 +78,9 @@ function isRequestBlacklisted (agent, req) {
   for (i = 0; i < agent._conf.ignoreUrlRegExp.length; i++) {
     if (agent._conf.ignoreUrlRegExp[i].test(req.url)) return true
   }
+  for (i = 0; i < agent._conf.transactionIgnoreUrlRegExp.length; i++) {
+    if (agent._conf.transactionIgnoreUrlRegExp[i].test(req.url)) return true
+  }
 
   var ua = req.headers['user-agent']
   if (!ua) return false

--- a/lib/wildcard-matcher.js
+++ b/lib/wildcard-matcher.js
@@ -1,0 +1,48 @@
+'use strict'
+/**
+ * Implements a Wildcard matcher
+ *
+ * Exports a function that implements a simple wildcard matcher
+ * per: https://github.com/elastic/apm/issues/144
+ */
+const escapeStringRegexp = require('escape-string-regexp')
+
+// coverts elastic-wildcard pattern into a
+// a javascript regular expression.
+const starMatchToRegex = (pattern) => {
+  // case insensative by default
+  let regexOpts = ['i']
+  if (pattern.startsWith('(?-i)')) {
+    regexOpts = []
+    pattern = pattern.slice(5)
+  }
+
+  const patternLength = pattern.length
+  const reChars = ['^']
+  for (let i = 0; i < patternLength; i++) {
+    const char = pattern[i]
+    switch (char) {
+      case '*':
+        reChars.push('.*')
+        break
+      default:
+        reChars.push(
+          escapeStringRegexp(char)
+        )
+    }
+  }
+  reChars.push('$')
+  return new RegExp(reChars.join(''), regexOpts.join(''))
+}
+
+class WildcardMatcher {
+  compile (pattern) {
+    return starMatchToRegex(pattern)
+  }
+
+  match (string, pattern) {
+    const re = this.compile(pattern)
+    return string.search(re) !== -1
+  }
+}
+module.exports = { WildcardMatcher }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "elastic-apm-http-client": "^9.4.1",
     "end-of-stream": "^1.4.4",
     "error-stack-parser": "^2.0.6",
+    "escape-string-regexp": "^4.0.0",
     "fast-safe-stringify": "^2.0.7",
     "http-headers": "^3.0.2",
     "http-request-to-url": "^1.0.0",

--- a/test/config.js
+++ b/test/config.js
@@ -431,6 +431,7 @@ test('should default to empty request blacklist arrays', function (t) {
   t.strictEqual(agent._conf.ignoreUrlRegExp.length, 0)
   t.strictEqual(agent._conf.ignoreUserAgentStr.length, 0)
   t.strictEqual(agent._conf.ignoreUserAgentRegExp.length, 0)
+  t.strictEqual(agent._conf.transactionIgnoreUrlRegExp.length, 0)
   t.end()
 })
 
@@ -451,6 +452,21 @@ test('should separate strings and regexes into their own blacklist arrays', func
   t.strictEqual(agent._conf.ignoreUserAgentRegExp.length, 1)
   t.ok(isRegExp(agent._conf.ignoreUserAgentRegExp[0]))
   t.strictEqual(agent._conf.ignoreUserAgentRegExp[0].toString(), '/regex2/')
+
+  t.end()
+})
+
+test('should compile wildcards from string', function (t) {
+  var agent = Agent()
+  agent.start({
+    transactionIgnoreUrls: ['foo', '/str1', '/wil*card']
+  })
+
+  t.strictEqual(
+    agent._conf.transactionIgnoreUrlRegExp.length,
+    3,
+    'was everything added?'
+  )
 
   t.end()
 })

--- a/test/instrumentation/modules/http/blacklisting.js
+++ b/test/instrumentation/modules/http/blacklisting.js
@@ -8,6 +8,8 @@ var test = require('tape')
 
 var mockClient = require('../../../_mock_http_client')
 
+const { WildcardMatcher } = require('../../../../lib/wildcard-matcher')
+
 test('ignore url string - no match', function (t) {
   resetAgent({
     ignoreUrlStr: ['/exact']
@@ -46,6 +48,29 @@ test('ignore url regex - match', function (t) {
     t.fail('should not have any data')
   })
   request('/foo/regex/bar', null, function () {
+    t.end()
+  })
+})
+
+test('ignore url wildcard - no match', function (t) {
+  const wc = new WildcardMatcher()
+  resetAgent({
+    transactionIgnoreUrlRegExp: [wc.compile('/wil*card')]
+  }, function (data) {
+    assertNoMatch(t, data)
+    t.end()
+  })
+  request('/tamecard')
+})
+
+test('ignore url wildcard - match', function (t) {
+  const wc = new WildcardMatcher()
+  resetAgent({
+    transactionIgnoreUrlRegExp: [wc.compile('/wil*card')]
+  }, function () {
+    t.fail('should not have any data')
+  })
+  request('/wildcard', null, function () {
     t.end()
   })
 })
@@ -124,5 +149,6 @@ function resetAgent (opts, cb) {
   agent._conf.ignoreUrlRegExp = opts.ignoreUrlRegExp || []
   agent._conf.ignoreUserAgentStr = opts.ignoreUserAgentStr || []
   agent._conf.ignoreUserAgentRegExp = opts.ignoreUserAgentRegExp || []
+  agent._conf.transactionIgnoreUrlRegExp = opts.transactionIgnoreUrlRegExp || []
   agent._instrumentation.currentTransaction = null
 }

--- a/test/wildcard-matcher.js
+++ b/test/wildcard-matcher.js
@@ -1,0 +1,18 @@
+'use strict'
+var test = require('tape')
+
+const { WildcardMatcher } = require('../lib/wildcard-matcher')
+
+test('tests cross agent transaction_ignore_urls globs', function (t) {
+  const matcher = new WildcardMatcher()
+  const fixtures = require('./fixtures/json-specs/wildcard_matcher_tests.json')
+  for (const [name, fixture] of Object.entries(fixtures)) {
+    for (const [pattern, cases] of Object.entries(fixture)) {
+      for (const [string, expected] of Object.entries(cases)) {
+        const result = matcher.match(string, pattern)
+        t.equals(result, expected, `Fixture ${name}, testing ${pattern} vs. ${string}`)
+      }
+    }
+  }
+  t.end()
+})


### PR DESCRIPTION
Will Fix: elastic/apm-agent-nodejs#1689

Implements `ELASTIC_TRANSACTION_IGNORE_URL`/`transactionIgnoreUrls` configuration for wildcard URL ignoring.  The intent of this new configuration is to gives users the ability to skip generating transactions for a request to a URL that matches an exact string, or a URL that matches simple wildcard pattern.  This wildcard pattern will behave consistently across language agents.

This PR leaves the existing `ignoreUrls` configuration in place to allow users access to more powerful regular expression matching _and_ to preserve existing functionality for users using this older configuration setting. 

This PR also introduces a new dependency, [`escape-string-regexp`](https://www.npmjs.com/package/escape-string-regexp).  In order to implement the suggested wildcard matching algorithm we needed the ability to escape a string for use in a regular expression.  Since Node.js doesn't have this functionality natively, I pulled in `escape-string-regexp` rather than attempt to write (easy) and maintain (harder) this functionality ourselves.  Happy to revisit this decision if we'd rather implement this functionality ourselves. 

### Open items for consideration/completion
- [x] is `escape-string-regexp` an acceptable dependency for ignore regular expressions?
- [x] Docs
- [x] Fixture downloading
- [x] central config handling? How does this work in Node Agent, do we need more here?
- [x] should leading `/` be assumed? (we'll prepend this, meaning a configured value of 'foo*' and '/foo*' will match the same)
- [x] need clarity on `(?-i)` and `(?+i)` prefixes across agents
- [x] Does this apply only to transactions? (yes, `isRequestBlacklisted` is only called in `instrumentRequest`, and `instrumentRequest` is only used when wrapping http(s).Server's `emit` method (i.e. it's used in transaction starting)

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
