### PR TITLE
fix: spans started in same async op should be children

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -17,7 +17,14 @@ module.exports = Span
 util.inherits(Span, GenericSpan)
 
 function Span (transaction, name, ...args) {
-  var childOf = transaction._agent._instrumentation.activeSpan || transaction
+  var childOf = transaction._agent._instrumentation.activeSpan ||
+    transaction._agent._instrumentation.bindingSpan ||
+    transaction
+  console.log('XXX new Span: childOf set to',
+    'activeSpan?', !!transaction._agent._instrumentation.activeSpan,
+    'bindingSpan?', !!transaction._agent._instrumentation.bindingSpan,
+    'transaction?', !!transaction,
+    'childOf.id:', childOf.id)
   const opts = typeof args[args.length - 1] === 'object'
     ? (args.pop() || {})
     : {}
@@ -71,6 +78,7 @@ Span.prototype.end = function (endTime) {
 
   this._timer.end(endTime)
   this._agent._instrumentation._recoverTransaction(this.transaction)
+  this._agent._instrumentation.bindingSpan = null
 
   this.ended = true
   this._agent.logger.debug('ended span %o', { span: this.id, parent: this.parentId, trace: this.traceId, name: this.name, type: this.type, subtype: this.subtype, action: this.action })


### PR DESCRIPTION
This commit is just a start. There are still tests and discussion to be
had.

Fixes #1889
