### PR TITLE
feat: support fastify 3

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,6 +8,10 @@ endif::[]
 ==== x.x.x - YYYY/MM/DD
 
 * fix: Synchronous spans would never have `span.sync == true`. {pull}1879[#1879]
+* feat: support fastify 3
+  Adds .default and .fastify module.exports to instrumented fastify function
+  for 3.x line, and prefers req.routerMethod and req.routerPath for
+  transaction name
 
 [float]
 ===== Breaking changes

--- a/lib/instrumentation/modules/fastify.js
+++ b/lib/instrumentation/modules/fastify.js
@@ -9,7 +9,36 @@ module.exports = function (fastify, agent, { version, enabled }) {
 
   agent.logger.debug('wrapping fastify build function')
 
-  return semver.gte(version, '2.0.0-rc') ? wrappedBuild2Plus : wrappedBuildPre2
+  if (semver.gte(version, '3.0.0')) {
+    wrappedBuild3Plus.default = wrappedBuild3Plus
+    wrappedBuild3Plus.fastify = wrappedBuild3Plus
+    return wrappedBuild3Plus
+  }
+
+  if (semver.gte(version, '2.0.0-rc')) return wrappedBuild2Plus
+
+  return wrappedBuildPre2
+
+  function wrappedBuild3Plus () {
+    const _fastify = fastify.apply(null, arguments)
+
+    agent.logger.debug('adding onRequest hook to fastify')
+    _fastify.addHook('onRequest', (req, reply, next) => {
+      const method = req.routerMethod || req.raw.method // Fallback for fastify >3 <3.3.0
+      const url = req.routerPath || reply.context.config.url // Fallback for fastify >3 <3.3.0
+      const name = method + ' ' + url
+      agent._instrumentation.setDefaultTransactionName(name)
+      next()
+    })
+
+    agent.logger.debug('adding onError hook to fastify')
+    _fastify.addHook('onError', (req, reply, err, next) => {
+      agent.captureError(err, { request: req.raw })
+      next()
+    })
+
+    return _fastify
+  }
 
   function wrappedBuild2Plus () {
     const _fastify = fastify.apply(null, arguments)


### PR DESCRIPTION
Hi,

This module seems to break fastify v3 when used with typescript as `default` and `fastify` are not exposed on the exported module anymore, so the imports are invalid. Also, starting from fastify 3.3 a few properties are exposed directly on the request but I don't think it's worth an entirely different wrapper.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
