### PR TITLE
chore: have a visible 'Unreleased' section in changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,23 +19,31 @@ endif::[]
 [float]
 ===== Features
 
-* feat: Set "destination" context on spans for "mongodb". {pull}1893[#1893] +
-  This allows Kibana APM Service Maps to show a "mongodb" node for services using
-  the https://www.npmjs.com/package/mongodb[mongodb] package (which includes
-  mongoose and mongojs).
-
-* feat: transactionIgnoreUrl wildcard matching {pull}1870[#1870] +
-  Allows users to ignore URLs using simple wildcard matching patterns that behave
-  the same across language agents. See https://github.com/elastic/apm/issues/144
-
-* Cool new feature: {pull}2526[#2526]
-
 [float]
 ===== Bug fixes
 ////
 
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
+
+==== Unreleased
+
+[float]
+===== Features
+
+* feat: Set "destination" context on spans for "mongodb". {pull}1893[#1893] +
+  This allows Kibana APM Service Maps to show a "mongodb" node for services using
+  the https://www.npmjs.com/package/mongodb[mongodb] package (which includes
+  mongoose and mongojs).
+* feat: transactionIgnoreUrl wildcard matching {pull}1870[#1870] +
+  Allows users to ignore URLs using simple wildcard matching patterns that behave
+  the same across language agents. See https://github.com/elastic/apm/issues/144
+
+[float]
+===== Bug fixes
+
+* fix: Synchronous spans would never have `span.sync == true`. {pull}1879[#1879]
+
 
 [[release-notes-3.8.0]]
 ==== 3.8.0 - 2020/11/09

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -4,14 +4,33 @@ https://www.elastic.co/guide/en/apm/agent/nodejs/current/release-notes.html[elas
 endif::[]
 
 ////
-[[release-notes-x.x.x]]
-==== x.x.x - YYYY/MM/DD
+Notes:
+1. When adding a changelog entry, if the "Unreleased" section doesn't yet exist,
+   please add the following under the "=== Node.js Agent version 3.x" header:
 
-* fix: Synchronous spans would never have `span.sync == true`. {pull}1879[#1879]
-* feat: support fastify 3
-  Adds .default and .fastify module.exports to instrumented fastify function
-  for 3.x line, and prefers req.routerMethod and req.routerPath for
-  transaction name
+        ==== Unreleased
+
+        [float]
+        ===== Breaking changes
+
+        [float]
+        ===== Features
+
+        [float]
+        ===== Bug fixes
+
+2. When making a release, change the "==== Unreleased" section header to:
+
+        [[release-notes-x.x.x]]
+        ==== x.x.x - YYYY/MM/DD
+////
+
+
+[[release-notes-3.x]]
+=== Node.js Agent version 3.x
+
+
+==== Unreleased
 
 [float]
 ===== Breaking changes
@@ -19,18 +38,10 @@ endif::[]
 [float]
 ===== Features
 
-[float]
-===== Bug fixes
-////
-
-[[release-notes-3.x]]
-=== Node.js Agent version 3.x
-
-==== Unreleased
-
-[float]
-===== Features
-
+* feat: support fastify 3 {pull}1891[#1891] +
+  Adds .default and .fastify module.exports to instrumented fastify function
+  for 3.x line, and prefers req.routerMethod and req.routerPath for
+  transaction name
 * feat: Set "destination" context on spans for "mongodb". {pull}1893[#1893] +
   This allows Kibana APM Service Maps to show a "mongodb" node for services using
   the https://www.npmjs.com/package/mongodb[mongodb] package (which includes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ If you have access to make releases, the process is as follows:
         [[release-notes-x.x.x]]
         ==== x.x.x - YYYY/MM/DD
         ```
-    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.
+    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.)
 1. If a major or minor release, update the EOL table in `docs/upgrading.asciidoc`. EOL is 18 months after release date.
 1. Commit changes with message `x.y.z` where `x.y.z` is the version in `package.json`
 1. Tag the commit with `git tag vx.y.x`, for example `git tag v1.2.3`
@@ -190,7 +190,7 @@ If you have access to make releases, the process is as follows:
         [[release-notes-x.x.x]]
         ==== x.x.x - YYYY/MM/DD
         ```
-    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.
+    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.)
 1. Commit changes with message `x.y.z` where `x.y.z` is the version in `package.json`
 1. Tag the commit with `git tag vx.y.x`, for example `git tag v1.2.3`
 1. Run tests with `npm test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,11 +164,17 @@ If you have access to make releases, the process is as follows:
 
 1. Be sure you have checked out the `master` branch and have pulled latest changes
 1. Update the version in `package.json` according to the scale of the change. (major, minor or patch)
-1. Add commit messages to `CHANGELOG.asciidoc` (You may skip non-user-visible changes)
+1. Update `CHANGELOG.asciidoc`:
+    - Change the "Unreleased" section title to:
+        ```
+        [[release-notes-x.x.x]]
+        ==== x.x.x - YYYY/MM/DD
+        ```
+    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.
 1. If a major or minor release, update the EOL table in `docs/upgrading.asciidoc`. EOL is 18 months after release date.
 1. Commit changes with message `x.y.z` where `x.y.z` is the version in `package.json`
 1. Tag the commit with `git tag vx.y.x`, for example `git tag v1.2.3`
-1. Reset the latest major branch (`1.x`, `2.x` etc) to point to the current master, e.g. `git branch -f 3.x master`
+1. Reset the latest major branch (currently `3.x`) to point to the current master, e.g. `git branch -f 3.x master`
 1. Run tests with `npm test`
 1. Push commits and tags upstream with `git push upstream master && git push upstream --tags` (and optionally to your own fork as well)
 1. Update the latest major branch on upstream with `git push upstream <major_branch>`
@@ -178,7 +184,13 @@ If you have access to make releases, the process is as follows:
 
 1. Be sure you have checked out the branch associated with the major you wish to release and have pulled latest changes, e.g. `2.x`
 1. Update the version in `package.json` according to the scale of the change. (major, minor or patch)
-1. Add commit messages to `CHANGELOG.asciidoc` (You may skip non-user-visible changes)
+1. Update `CHANGELOG.asciidoc`:
+    - Change the "Unreleased" section title to:
+        ```
+        [[release-notes-x.x.x]]
+        ==== x.x.x - YYYY/MM/DD
+        ```
+    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.
 1. Commit changes with message `x.y.z` where `x.y.z` is the version in `package.json`
 1. Tag the commit with `git tag vx.y.x`, for example `git tag v1.2.3`
 1. Run tests with `npm test`


### PR DESCRIPTION
We're in the process of moving dev process to have PRs include an update to CHANGELOG.asciidoc so that we are authoring the changelog as part of making changes.  We started by adding unreleased changes to the *block comment* at the top of the changelog file. One pain point with that is that you cannot see those in the GitHub rendering.

I asked Brandon and he says that having an "Unreleased" section will not cause a problem for doc rendering for releases. In retrospect, I understand why because we have the release branches for those.