### PR TITLE
chore: use merge=union for changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.asciidoc merge=union


### PR DESCRIPTION
One (possibly minor) concern with having PRs include updates to CHANGELOG.asciidoc is more common merge conflicts. Time will tell if that proves to be a PITA and barrier.

Gil suggested using:

```
% cat .gitattributes
CHANGELOG.asciidoc merge=union
```

from the docs:
  Run 3-way file level merge for text files, but take lines from both
  versions, instead of leaving conflict markers. This tends to leave the
  added lines in the resulting file in random order and the user should
  verify the result. Do not use this if you do not understand the
  implications.
