### PR TITLE
fix: fixes intent of filter test

### DIFF
--- a/test/filters.js
+++ b/test/filters.js
@@ -5,14 +5,14 @@ const test = require('tape')
 const Filters = require('object-filter-sequence')
 const filterHttpHeaders = require('../lib/filters/http-headers')
 
-function makeTransactionWithHeaders (headers) {
+function makeTransactionWithHeaders (requestHeaders, responseHeaders) {
   return {
     context: {
       request: {
-        headers
+        headers: requestHeaders
       },
       response: {
-        headers
+        headers: responseHeaders
       }
     }
   }
@@ -41,7 +41,14 @@ test('set-cookie', function (t) {
         'password=this-is-a-password',
         'card=1234%205678%201234%205678; Secure'
       ]
-    })
+    },
+    {
+      'set-cookie': [
+        'password=this-is-a-password',
+        'card=1234%205678%201234%205678; Secure'
+      ]
+    }
+    )
   )
 
   t.deepEqual(getRequestHeaders(result), {


### PR DESCRIPTION
This PR fixes the intent of the test in `test/filters.js`.

The intent of this test is to make sure that both the request response objects are filtered correctly. 

The problem with the old test was that `context.request.headers` and `context.response.headers` referenced _the same_ object.  

This means when `context.request.headers` was filtered that `context.response.headers` also appeared filtered regardless of whether code explicitly filtered it or not. 

This PR ensures that `context.request.headers` and `context.response.headers` are two separate object instances. 

This is a follow on PR to https://github.com/elastic/apm-agent-nodejs/pull/1886
