### PR TITLE
feat: add `captureAttributes` option to `apm.captureError()`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,10 @@ Notes:
 [float]
 ===== Features
 
+* feat: Add `captureAttributes` boolean option to `apm.captureError()` to
+  allow *disabling* the automatic capture of Error object properties. This
+  is useful for cases where those properties should not be sent to the APM
+  Server, e.g. for performance (large string fields) or security (PII data).
 * feat: Add `log_level` central config support. {pull}1908[#1908] +
   Spec: https://github.com/elastic/apm/blob/master/specs/agents/logging.md
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -57,7 +57,7 @@ See the <<configuration,Configuration documentation>> for available options.
 [small]#Added in: v1.5.0#
 
 Use `isStarted()` to check if the agent has already started.
-Returns `true` if the agent has started, 
+Returns `true` if the agent has started,
 otherwise returns `false`.
 
 [[apm-set-framework]]
@@ -292,6 +292,8 @@ See <<http-responses,http responses section>> for more details.
 
 ** `labels` +{type-object}+ Add additional context with labels, these labels will be added to the error along with the labels from the current transaction.
 See the <<apm-add-labels,`apm.addLabels()`>> method for details about the format.
+
+** `captureAttributes` +{type-boolean}+ Whether to include properties on the given +{type-error}+ object in the data sent to the APM Server (as `error.exception.attributes`). *Default:* `true`.
 
 * `callback` - Will be called after the error has been sent to the APM Server.
 It will receive an `Error` instance if the agent failed to send the error,

--- a/index.d.ts
+++ b/index.d.ts
@@ -244,6 +244,7 @@ interface CaptureErrorOptions {
   tags?: Labels;
   custom?: object;
   message?: string;
+  captureAttributes?: boolean;
 }
 
 interface Labels {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -264,6 +264,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
   var res = opts && opts.response instanceof ServerResponse
     ? opts.response
     : trans && trans.res
+  var captureAttributes = opts && opts.captureAttributes
   var _isError = isError(err)
 
   if ((!opts || opts.handled !== false) &&
@@ -277,7 +278,7 @@ Agent.prototype.captureError = function (err, opts, cb) {
   if (!_isError) {
     prepareError(parsers.parseMessage(err))
   } else {
-    parsers.parseError(err, agent, function (_, error) {
+    parsers.parseError(err, captureAttributes, agent, function (_, error) {
       // As of now, parseError suppresses errors internally, but even if they
       // were passed on, we would want to suppress them here anyway
       prepareError(error)

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -59,7 +59,19 @@ exports.parseStackTrace = function (err) {
   })
 }
 
-exports.parseError = function (err, agent, cb) {
+// `parseError` starts the serialization of the given Error instance into the
+// object to be sent to the APM server.
+//
+// APM error fields filled in are `error.exception` and `error.culprit`.
+//
+// By default, some properties on the given `err` (according to
+// https://github.com/watson/stackman/tree/master/#var-properties--stackmanpropertieserr)
+// are added to `error.exception.attributes`, unless overridden by
+// `captureAttributes === false`.
+// TODO: Consider changing this default to false in v4.0.0.
+exports.parseError = function (err, captureAttributes, agent, cb) {
+  captureAttributes = captureAttributes !== false
+
   stackman.callsites(err, function (_err, callsites) {
     if (_err) {
       agent.logger.debug('error while getting error callsites: %s', _err.message)
@@ -83,9 +95,11 @@ exports.parseError = function (err, agent, cb) {
       if (match) error.exception.code = match[1]
     }
 
-    var props = stackman.properties(err)
-    if (props.code) delete props.code // we already have it directly on the exception
-    if (Object.keys(props).length > 0) error.exception.attributes = props
+    if (captureAttributes) {
+      var props = stackman.properties(err)
+      if (props.code) delete props.code // we already have it directly on the exception
+      if (Object.keys(props).length > 0) error.exception.attributes = props
+    }
 
     var next = afterAll(function (_, frames) {
       // As of now, parseCallsite suppresses errors internally, but even if

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -289,7 +289,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
+    parsers.parseError(new Error(), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
@@ -313,7 +313,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new Error('Crap'), fakeAgent, function (err, parsed) {
+    parsers.parseError(new Error('Crap'), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
@@ -337,7 +337,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new TypeError('Crap'), fakeAgent, function (err, parsed) {
+    parsers.parseError(new TypeError('Crap'), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
@@ -364,7 +364,7 @@ test('#parseError()', function (t) {
     try {
       throw new Error('Derp')
     } catch (e) {
-      parsers.parseError(e, fakeAgent, function (err, parsed) {
+      parsers.parseError(e, true, fakeAgent, function (err, parsed) {
         t.error(err)
         t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
         t.notOk('log' in parsed)
@@ -393,7 +393,7 @@ test('#parseError()', function (t) {
       var o = {}
       o['...'].Derp()
     } catch (e) {
-      parsers.parseError(e, fakeAgent, function (err, parsed) {
+      parsers.parseError(e, true, fakeAgent, function (err, parsed) {
         t.error(err)
         t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
         t.notOk('log' in parsed)
@@ -420,7 +420,7 @@ test('#parseError()', function (t) {
     }
     var err = new Error('foo')
     t.ok(typeof err.stack === 'string')
-    parsers.parseError(err, fakeAgent, function (err, parsed) {
+    parsers.parseError(err, true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
@@ -446,7 +446,7 @@ test('#parseError()', function (t) {
     }
     var err = new Error('foo')
     err.stack = 'foo'
-    parsers.parseError(err, fakeAgent, function (err, parsed) {
+    parsers.parseError(err, true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.ok('culprit' in parsed)
       t.notOk('log' in parsed)
@@ -483,7 +483,7 @@ test('#parseError()', function (t) {
       message: 'foo',
       stack: 'original stack'
     }
-    parsers.parseError(err, fakeAgent, function (err, parsed) {
+    parsers.parseError(err, true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.strictEqual(parsed.culprit, 'original stack')
       t.notOk('log' in parsed)
@@ -506,6 +506,38 @@ test('#parseError()', function (t) {
     })
   })
 
+  t.test('should handle captureAttributes', function (t) {
+    var fakeAgent = {
+      _conf: {
+        sourceLinesErrorAppFrames: 5,
+        sourceLinesErrorLibraryFrames: 5
+      },
+      logger: logger
+    }
+
+    var err = new Error('boom')
+    err.stack = ''
+    err.aProperty = 'this is my property'
+
+    // captureAttributes=true
+    parsers.parseError(err, true, fakeAgent, function (parseErr1, parsed) {
+      t.error(parseErr1)
+      t.ok('exception' in parsed)
+      t.ok('attributes' in parsed.exception)
+      t.strictEqual(parsed.exception.attributes.aProperty, 'this is my property')
+
+      // captureAttributes=false
+      parsers.parseError(err, false, fakeAgent, function (parseErr2, parsed) {
+        t.error(parseErr2)
+        t.ok('exception' in parsed)
+        t.notOk('attributes' in parsed.exception,
+          'should not have captured any attributes')
+
+        t.end()
+      })
+    })
+  })
+
   t.test('should be able to exclude source context data', function (t) {
     var fakeAgent = {
       _conf: {
@@ -514,7 +546,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
+    parsers.parseError(new Error(), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.strictEqual(parsed.culprit, `Test.<anonymous> (${path.join('test', 'parsers.js')})`)
       t.notOk('log' in parsed)
@@ -548,7 +580,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
+    parsers.parseError(new Error(), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.ok(parsed.exception.stacktrace.length > 0)
       parsed.exception.stacktrace.forEach(function (callsite) {
@@ -577,7 +609,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
+    parsers.parseError(new Error(), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.ok(parsed.exception.stacktrace.length > 0)
       parsed.exception.stacktrace.forEach(function (callsite) {
@@ -607,7 +639,7 @@ test('#parseError()', function (t) {
       },
       logger: logger
     }
-    parsers.parseError(new Error(), fakeAgent, function (err, parsed) {
+    parsers.parseError(new Error(), true, fakeAgent, function (err, parsed) {
       t.error(err)
       t.ok(parsed.exception.stacktrace.length > 0)
       parsed.exception.stacktrace.forEach(function (callsite) {


### PR DESCRIPTION
This adds a `captureAttributes` boolean option to `apm.captureError()` to
allow *disabling* the automatic capture of Error object properties. This
is useful for cases where those properties should not be sent to the APM
Server, e.g. for performance (large string fields) or security (PII data).
