### PR TITLE
fix: trim whitespace around comma-separate string config vars

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,11 +42,26 @@ Notes:
   allow *disabling* the automatic capture of Error object properties. This
   is useful for cases where those properties should not be sent to the APM
   Server, e.g. for performance (large string fields) or security (PII data).
+  {pull}1912[#1912]
 * feat: Add `log_level` central config support. {pull}1908[#1908] +
   Spec: https://github.com/elastic/apm/blob/master/specs/agents/logging.md
 
 [float]
 ===== Bug fixes
+
+* fix: Fix parsing of comma-separated strings for relevant config vars to allow
+  whitespace around the commas. E.g.:
++
+----
+export ELASTIC_APM_TRANSACTION_IGNORE_URLS='/ping, /metrics*'
+----
++
+Config vars affected are: `disableInstrumentations`, `transactionIgnoreUrls`
+`addPatch`, and `globalLabels`.
+* fix: Correct the environment variable for setting `transactionIgnoreUrl`
+  (added in v3.9.0) from `ELASTIC_TRANSACTION_IGNORE_URLS` to
+  `ELASTIC_APM_TRANSACTION_IGNORE_URLS`.
+
 
 
 [[release-notes-3.9.0]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -190,7 +190,7 @@ Note that not all core Node.js API's can be instrumented without the use of Asyn
 
 * *Type:* Array
 * *Default:* `[]`
-* *Env:* `ELASTIC_TRANSACTION_IGNORE_URLS`
+* *Env:* `ELASTIC_APM_TRANSACTION_IGNORE_URLS`
 
 Array or comma-separated string used to restrict requests for certain URLs from being instrumented.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -128,7 +128,7 @@ var ENV_TABLE = {
   sourceLinesSpanAppFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
   sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
   stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
-  transactionIgnoreUrls: 'ELASTIC_TRANSACTION_IGNORE_URLS',
+  transactionIgnoreUrls: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
   transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
   transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
   useElasticTraceparentHeader: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
@@ -463,21 +463,21 @@ function normalizeTime (opts) {
   }
 }
 
-function maybeSplit (separator) {
-  return (value) => {
-    return typeof value === 'string' ? value.split(separator) : value
-  }
-}
-
-const maybeSplitValues = maybeSplit(',')
-const maybeSplitPairs = maybeSplit('=')
-
+// Array config vars are either already an array of strings, or a
+// comma-separated string (whitespace is trimmed):
+//    'foo, bar' => ['foo', 'bar']
 function normalizeArrays (opts) {
   for (const key of ARRAY_OPTS) {
-    if (key in opts) opts[key] = maybeSplitValues(opts[key])
+    if (key in opts && typeof opts[key] === 'string') {
+      opts[key] = opts[key].split(',').map(v => v.trim())
+    }
   }
 }
 
+// KeyValuePairs config vars are either an object or a comma-separated string
+// of key=value pairs (whitespace around the "key=value" strings is trimmed):
+//    {'foo': 'bar', 'eggs': 'spam'} => [['foo', 'bar'], ['eggs', 'spam']]
+//    foo=bar, eggs=spam             => [['foo', 'bar'], ['eggs', 'spam']]
 function normalizeKeyValuePairs (opts) {
   for (const key of KEY_VALUE_OPTS) {
     if (key in opts) {
@@ -486,12 +486,15 @@ function normalizeKeyValuePairs (opts) {
         return
       }
 
-      if (!Array.isArray(opts[key])) {
-        opts[key] = maybeSplitValues(opts[key])
+      if (!Array.isArray(opts[key]) && typeof opts[key] === 'string') {
+        opts[key] = opts[key].split(',').map(v => v.trim())
       }
 
       if (Array.isArray(opts[key])) {
-        opts[key] = opts[key].map(maybeSplitPairs)
+        // Note: Currently this assumes no '=' in the value. Also this does not
+        // trim whitespace.
+        opts[key] = opts[key].map(
+          value => typeof value === 'string' ? value.split('=') : value)
       }
     }
   }

--- a/test/central-config-enabled.js
+++ b/test/central-config-enabled.js
@@ -91,13 +91,13 @@ test('remote config enabled: receives comma delimited', function (t) {
     transaction_sample_rate: '0.42',
     transaction_max_spans: '99',
     capture_body: 'all',
-    transaction_ignore_urls: 'foo,bar'
+    transaction_ignore_urls: 'foo,bar , baz , bling'
   }
   const expect = {
     transactionSampleRate: 0.42,
     transactionMaxSpans: 99,
     captureBody: 'all',
-    transactionIgnoreUrls: ['foo', 'bar']
+    transactionIgnoreUrls: ['foo', 'bar', 'baz', 'bling']
   }
 
   runTestsWithServer(t, updates, expect)


### PR DESCRIPTION
Fix parsing of comma-separated strings for relevant config vars to allow
whitespace around the commas. E.g.:
    export ELASTIC_APM_TRANSACTION_IGNORE_URLS='/ping, /metrics*'
This affects ARRAY_OPTS and KEY_VALUE_OPTS.

Also, correct the environment variable for setting `transactionIgnoreUrl` from
`ELASTIC_TRANSACTION_IGNORE_URLS` to `ELASTIC_APM_TRANSACTION_IGNORE_URLS`.

Fixes: #1913
