### PR TITLE
Pull redact-secret and is-secret into Agent

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,7 +45,8 @@ Notes:
   {pull}1912[#1912]
 * feat: Add `log_level` central config support. {pull}1908[#1908] +
   Spec: https://github.com/elastic/apm/blob/master/specs/agents/logging.md
-
+* chore: Pulled `is-secret` and `redact-secrets` into agent as private modules
+  and removed them as external dependencies.
 [float]
 ===== Bug fixes
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,8 +58,7 @@ slightly to commonalize:
 
 * feat: Add `log_level` central config support. {pull}1908[#1908] +
   Spec: https://github.com/elastic/apm/blob/master/specs/agents/logging.md
-* chore: Pulled `is-secret` and `redact-secrets` into agent as private modules
-  and removed them as external dependencies.
+
 [float]
 ===== Bug fixes
 

--- a/lib/filters/http-headers.js
+++ b/lib/filters/http-headers.js
@@ -3,7 +3,7 @@
 const REDACTED = '[REDACTED]'
 
 const cookie = require('cookie')
-const redact = require('redact-secrets')(REDACTED)
+const redact = require('./redact-secrets')(REDACTED)
 const SetCookie = require('set-cookie-serde')
 
 module.exports = httpHeaders

--- a/lib/filters/http-headers.js
+++ b/lib/filters/http-headers.js
@@ -3,7 +3,7 @@
 const REDACTED = '[REDACTED]'
 
 const cookie = require('cookie')
-const redact = require('./redact-secrets')(REDACTED)
+const redact = require('../redact-secrets')(REDACTED)
 const SetCookie = require('set-cookie-serde')
 
 module.exports = httpHeaders

--- a/lib/redact-secrets/index.js
+++ b/lib/redact-secrets/index.js
@@ -1,0 +1,45 @@
+'use strict'
+// This module is a fork of
+// https://github.com/watson/redact-secrets/blob/cf8f95aaa343a85978c09222096fde5f4d608aea/index.js
+// The MIT License (MIT)
+
+// Copyright (c) 2016 Thomas Watson Steen
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+var traverse = require('traverse')
+var isSecret = require('./is-secret')
+
+module.exports = function (redacted) {
+  return {
+    map: map,
+    forEach: forEach
+  }
+
+  function map (obj) {
+    return traverse(obj).map(function (val) {
+      if (isSecret.key(this.key) || isSecret.value(val)) this.update(redacted)
+    })
+  }
+
+  function forEach (obj) {
+    traverse(obj).forEach(function (val) {
+      if (isSecret.key(this.key) || isSecret.value(val)) this.update(redacted)
+    })
+  }
+}

--- a/lib/redact-secrets/index.js
+++ b/lib/redact-secrets/index.js
@@ -1,6 +1,6 @@
 'use strict'
 // This module is a fork of
-// https://github.com/watson/redact-secrets/blob/cf8f95aaa343a85978c09222096fde5f4d608aea/index.js
+// https://github.com/watson/redact-secrets/blob/v1.0.0/index.js
 // The MIT License (MIT)
 
 // Copyright (c) 2016 Thomas Watson Steen

--- a/lib/redact-secrets/is-secret.js
+++ b/lib/redact-secrets/is-secret.js
@@ -1,0 +1,56 @@
+'use strict'
+// This module is a fork of
+// https://github.com/watson/is-secret/blob/563cce48b4b89fd3f99221432a3f37b4662672b0/index.js
+// The MIT License (MIT)
+
+// Copyright (c) 2016-2018 Thomas Watson Steen
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+var KEYS = [
+  // generic
+  /passw(or)?d/i,
+  /^pw$/,
+  /^pass$/i,
+  /secret/i,
+  /token/i,
+  /api[-._]?key/i,
+  /session[-._]?id/i,
+
+  // specific
+  /^connect\.sid$/ // https://github.com/expressjs/session
+]
+
+var VALUES = [
+  /^\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}$/ // credit card number
+]
+
+exports.key = key
+exports.value = value
+
+function key (str) {
+  return KEYS.some(function (regex) {
+    return regex.test(str)
+  })
+}
+
+function value (str) {
+  return VALUES.some(function (regex) {
+    return regex.test(str)
+  })
+}

--- a/lib/redact-secrets/is-secret.js
+++ b/lib/redact-secrets/is-secret.js
@@ -1,6 +1,6 @@
 'use strict'
 // This module is a fork of
-// https://github.com/watson/is-secret/blob/563cce48b4b89fd3f99221432a3f37b4662672b0/index.js
+// https://github.com/watson/is-secret/blob/v1.2.1/index.js
 // The MIT License (MIT)
 
 // Copyright (c) 2016-2018 Thomas Watson Steen

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "object-identity-map": "^1.0.2",
     "original-url": "^1.2.3",
     "read-pkg-up": "^7.0.1",
-    "redact-secrets": "^1.0.0",
     "relative-microtime": "^2.0.0",
     "require-ancestors": "^1.0.0",
     "require-in-the-middle": "^5.0.3",
@@ -111,6 +110,7 @@
     "sql-summary": "^1.0.1",
     "stackman": "^4.0.1",
     "traceparent": "^1.0.0",
+    "traverse": "^0.6.6",
     "unicode-byte-truncate": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "benchmark": "^2.1.4",
     "bluebird": "^3.7.2",
     "cassandra-driver": "^4.4.0",
+    "clone": "^2.0.0",
     "columnify": "^1.5.4",
     "connect": "^3.7.0",
     "container-info": "^1.0.1",

--- a/test/redact-secrets/is-secret.js
+++ b/test/redact-secrets/is-secret.js
@@ -1,6 +1,6 @@
 'use strict'
 // This module is a fork of
-// https://github.com/watson/is-secret/blob/563cce48b4b89fd3f99221432a3f37b4662672b0/test.js
+// https://github.com/watson/is-secret/blob/v1.2.1/test.js
 // The MIT License (MIT)
 
 // Copyright (c) 2016-2018 Thomas Watson Steen

--- a/test/redact-secrets/is-secret.js
+++ b/test/redact-secrets/is-secret.js
@@ -1,0 +1,55 @@
+'use strict'
+// This module is a fork of
+// https://github.com/watson/is-secret/blob/563cce48b4b89fd3f99221432a3f37b4662672b0/test.js
+// The MIT License (MIT)
+
+// Copyright (c) 2016-2018 Thomas Watson Steen
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+var test = require('tape')
+var isSecret = require('../../lib/redact-secrets/is-secret')
+
+test('isSecret.key true', function (t) {
+  t.equal(isSecret.key('pass'), true)
+  t.equal(isSecret.key('password'), true)
+  t.equal(isSecret.key('api-key'), true)
+  t.equal(isSecret.key('api.key'), true)
+  t.equal(isSecret.key('api_key'), true)
+  t.equal(isSecret.key('apikey'), true)
+  t.end()
+})
+
+test('isSecret.key false', function (t) {
+  t.equal(isSecret.key('passport'), false)
+  t.equal(isSecret.key('copenhagen'), false)
+  t.equal(isSecret.key('api*key'), false)
+  t.end()
+})
+
+test('isSecret.value credt card number', function (t) {
+  t.equal(isSecret.value('1234 1234 1234 1234'), true)
+  t.equal(isSecret.value('1234-1234-1234-1234'), true)
+  t.equal(isSecret.value('1234123412341234'), true)
+  t.end()
+})
+
+test('isSecret.value false', function (t) {
+  t.equal(isSecret.value('foobar'), false)
+  t.end()
+})

--- a/test/redact-secrets/redact-secrets.js
+++ b/test/redact-secrets/redact-secrets.js
@@ -1,0 +1,96 @@
+'use strict'
+// This module is a fork of
+// https://github.com/watson/redact-secrets/blob/cf8f95aaa343a85978c09222096fde5f4d608aea/test.js
+// The MIT License (MIT)
+
+// Copyright (c) 2016 Thomas Watson Steen
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+var test = require('tape')
+var clone = require('clone')
+var redact = require('../../lib/redact-secrets')
+
+test('redact.map', function (t) {
+  var input = {
+    foo: 'non-secret',
+    secret: 'secret',
+    sub1: {
+      foo: 'non-secret',
+      password: 'secret'
+    },
+    sub2: [{
+      foo: 'non-secret',
+      token: 'secret'
+    }]
+  }
+
+  var expected = {
+    foo: 'non-secret',
+    secret: 'redacted',
+    sub1: {
+      foo: 'non-secret',
+      password: 'redacted'
+    },
+    sub2: [{
+      foo: 'non-secret',
+      token: 'redacted'
+    }]
+  }
+
+  var orig = clone(input)
+  var result = redact('redacted').map(input)
+
+  t.deepEqual(result, expected)
+  t.deepEqual(input, orig)
+  t.end()
+})
+
+test('redact.forEach', function (t) {
+  var input = {
+    foo: 'non-secret',
+    secret: 'secret',
+    sub1: {
+      foo: 'non-secret',
+      password: 'secret'
+    },
+    sub2: [{
+      foo: 'non-secret',
+      token: 'secret'
+    }]
+  }
+
+  var expected = {
+    foo: 'non-secret',
+    secret: 'redacted',
+    sub1: {
+      foo: 'non-secret',
+      password: 'redacted'
+    },
+    sub2: [{
+      foo: 'non-secret',
+      token: 'redacted'
+    }]
+  }
+
+  var result = redact('redacted').forEach(input)
+
+  t.equal(result, undefined)
+  t.deepEqual(input, expected)
+  t.end()
+})

--- a/test/redact-secrets/redact-secrets.js
+++ b/test/redact-secrets/redact-secrets.js
@@ -1,6 +1,6 @@
 'use strict'
 // This module is a fork of
-// https://github.com/watson/redact-secrets/blob/cf8f95aaa343a85978c09222096fde5f4d608aea/test.js
+// https://github.com/watson/redact-secrets/blob/v1.0.0/test.js
 // The MIT License (MIT)
 
 // Copyright (c) 2016 Thomas Watson Steen

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,7 @@ var directories = [
   'test/integration/api-schema',
   'test/lambda',
   'test/metrics',
+  'test/redact-secrets',
   'test/sourcemaps',
   'test/uncaught-exceptions'
 ]


### PR DESCRIPTION
This PR comes out of work in #1898.  

The functionality of the new `sanitize_field_names` functionality and our existing filters (implemented via the external `redact-secret` module and it's dependency, `is-secret`) overlap slightly. It would greatly simplify things if these modules were forked and pulled into the agent proper.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
