### PR TITLE
feat: improve/change processing of Buffer objects in post body

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,9 @@ Notes:
 ===== Features
 
 
+* feat: Improve handling of raw body parsing
+  The agent will now report raw/`Buffer` encoded post bodies as '<Buffer>'.
+
 * feat: Add support for api keys {pull}1818[#1818] +
   This allows the usage of API keys for authentication to the APM server
 
@@ -53,7 +56,7 @@ slightly to commonalize:
    on "span.context.db.statement" has changed (a) to include *both* the
    query params and the request body if both exist (separated by `\n\n`) and
    (b) to *URL encode* the query params, rather than JSON encoding.
-   
+
 * feat: Add `captureAttributes` boolean option to `apm.captureError()` to
   allow *disabling* the automatic capture of Error object properties. This
   is useful for cases where those properties should not be sent to the APM

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -314,6 +314,8 @@ Possible options are: `off`, `all`, `errors`, and `transactions`.
 
 The recorded body will be truncated if larger than 2 KiB.
 
+If the body parsing middleware captures the body as raw `Buffer` data, the request body will be represtend as the string `"<Buffer>"`.
+
 For the agent to be able to access the body,
 the body needs to be available as a property on the incoming HTTP https://nodejs.org/api/http.html#http_class_http_incomingmessage[`request`] object.
 The agent will look for the body on the following properties:

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -314,7 +314,7 @@ Possible options are: `off`, `all`, `errors`, and `transactions`.
 
 The recorded body will be truncated if larger than 2 KiB.
 
-If the body parsing middleware captures the body as raw `Buffer` data, the request body will be represtend as the string `"<Buffer>"`.
+If the body parsing middleware captures the body as raw `Buffer` data, the request body will be represented as the string `"<Buffer>"`.
 
 For the agent to be able to access the body,
 the body needs to be available as a property on the incoming HTTP https://nodejs.org/api/http.html#http_class_http_incomingmessage[`request`] object.

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -155,7 +155,11 @@ function getContextFromRequest (req, conf, type) {
   var haveBody = body && (chunked || contentLength > 0)
 
   if (haveBody) {
-    if (captureBody) {
+    if (!captureBody) {
+      context.body = '[REDACTED]'
+    } else if (Buffer.isBuffer(body)) {
+      context.body = '<Buffer>'
+    } else {
       if (typeof body !== 'string') {
         body = tryJsonStringify(body) || stringify(body)
       }
@@ -163,8 +167,6 @@ function getContextFromRequest (req, conf, type) {
         body = truncate(body, _MAX_HTTP_BODY_CHARS)
       }
       context.body = body
-    } else {
-      context.body = '[REDACTED]'
     }
   }
 

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -263,8 +263,8 @@ test('#getContextFromRequest()', function (t) {
 
   t.test('body is a Buffer', function (t) {
     const conf = { captureBody: 'all' }
-    const requestPropsToTest = ['body','json','payload']
-    for(const [,prop] of requestPropsToTest.entries()) {
+    const requestPropsToTest = ['body', 'json', 'payload']
+    for (const [, prop] of requestPropsToTest.entries()) {
       const req = getMockReq()
       req[prop] = Buffer.from('almost, but not quite, entirely unlike a string.')
       req.headers['content-length'] = req[prop].length

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -261,6 +261,19 @@ test('#getContextFromRequest()', function (t) {
     t.end()
   })
 
+  t.test('body is a Buffer', function (t) {
+    const conf = { captureBody: 'all' }
+    const requestPropsToTest = ['body','json','payload']
+    for(const [,prop] of requestPropsToTest.entries()) {
+      const req = getMockReq()
+      req[prop] = Buffer.from('almost, but not quite, entirely unlike a string.')
+      req.headers['content-length'] = req[prop].length
+      const parsed = parsers.getContextFromRequest(req, conf)
+      t.equals(parsed.body, '<Buffer>')
+    }
+    t.end()
+  })
+
   function getMockReq () {
     return {
       httpVersion: '1.1',


### PR DESCRIPTION
PR for #1925.  If a middleware processes `request.body` as Buffer, rather than report the potentially large binary object we'll report the string `<Buffer>` to indicate binary data was detected. 

Also updates public docs to reflect this. 

- [x] Implement code
- [x] Update documentation
