### PR TITLE
3.10.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,14 +29,11 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-3.10.0]]
+==== 3.10.0 - 2021/01/11
 
 [float]
 ===== Features
-
 
 * feat: Improve handling of raw body parsing
   The agent will now report raw/`Buffer` encoded post bodies as '<Buffer>'.
@@ -64,6 +61,7 @@ slightly to commonalize:
 
 * feat: Add `log_level` central config support. {pull}1908[#1908] +
   Spec: https://github.com/elastic/apm/blob/master/specs/agents/logging.md
+
 * feat: implemented sanitize_feature_names specification +
   Allows users to configure a list of wildcard patterns to _remove_ items
   from the agent's HTTP header and `application/x-www-form-urlencoded` payloads.
@@ -85,7 +83,6 @@ Config vars affected are: `disableInstrumentations`, `transactionIgnoreUrls`
 * fix: Correct the environment variable for setting `transactionIgnoreUrl`
   (added in v3.9.0) from `ELASTIC_TRANSACTION_IGNORE_URLS` to
   `ELASTIC_APM_TRANSACTION_IGNORE_URLS`.
-
 
 
 [[release-notes-3.9.0]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -31,6 +31,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.10.x |2022-07-11 |3.11.0
 |3.9.x |2022-05-30 |3.10.0
 |3.8.x |2022-05-09 |3.9.0
 |3.7.x |2022-02-10 |3.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Another release will be coming up for the stack 7.11 release, but it is useful to get a release out with the `@elastic/elasticsearch` new instrumentation to help those working with Kibana+APM at least. As well, there are a number of other fixes and features here.
