### PR TITLE
feat: add apm.getServiceName()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,10 @@ Notes:
 [float]
 ===== Features
 
+* feat: add `apm.getServiceName()` {pull}1949[#1949] +
+  This will be used by https://github.com/elastic/ecs-logging-js[ecs-logging packages]
+  to integrate with APM.
+
 * feat: support numeric and boolean labels {pull}1909[#1909] +
   Add an optional `stringify` option to `apm.setLabel(name, version, stringify = true)`
   and `apm.addLabels(labels, stringify = true)`, which can be set `false` to

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -60,6 +60,14 @@ Use `isStarted()` to check if the agent has already started.
 Returns `true` if the agent has started,
 otherwise returns `false`.
 
+[[apm-get-service-name]]
+==== `apm.getServiceName()`
+
+[small]#Added in: v3.11.0#
+
+Get the configured <<service-name,`serviceName`>>. If a service name was not
+explicitly configured, this value may have been automatically determined.
+
 [[apm-set-framework]]
 ==== `apm.setFramework(options)`
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -68,6 +68,10 @@ otherwise returns `false`.
 Get the configured <<service-name,`serviceName`>>. If a service name was not
 explicitly configured, this value may have been automatically determined.
 
+This may be called before `agent.start()`, but the values before and after
+might differ as config is reloaded during and can be set from options given to
+`.start()`. A misconfigured agent can have an `undefined` service name.
+
 [[apm-set-framework]]
 ==== `apm.setFramework(options)`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare class Agent implements Taggable, StartSpanFn {
   // Configuration
   start (options?: AgentConfigOptions): Agent;
   isStarted (): boolean;
+  getServiceName (): string;
   setFramework (options: {
     name?: string;
     version?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare class Agent implements Taggable, StartSpanFn {
   // Configuration
   start (options?: AgentConfigOptions): Agent;
   isStarted (): boolean;
-  getServiceName (): string;
+  getServiceName (): string | undefined;
   setFramework (options: {
     name?: string;
     version?: string;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -183,6 +183,10 @@ Agent.prototype.start = function (opts) {
   return this
 }
 
+Agent.prototype.getServiceName = function () {
+  return this._conf.serviceName
+}
+
 Agent.prototype.setFramework = function ({ name, version, overwrite = true }) {
   if (!this._transport || !this._conf) return
   const conf = {}

--- a/test/agent.js
+++ b/test/agent.js
@@ -18,6 +18,13 @@ var inContainer = 'containerId' in (containerInfo() || {})
 process.env.ELASTIC_APM_METRICS_INTERVAL = '0'
 process.env.ELASTIC_APM_CENTRAL_CONFIG = 'false'
 
+test('#getServiceName()', function (t) {
+  var agent = Agent()
+  agent.start()
+  t.strictEqual(agent.getServiceName(), agent._conf.serviceName)
+  t.end()
+})
+
 test('#setFramework()', function (t) {
   var agent = Agent()
   agent.start()


### PR DESCRIPTION
This will be used by ecs-logging-js libs to set "service.name" in log
records.

### Checklist

- [x] Implement code
- [x] Discuss APM standardization of this (possibly overkill) at https://github.com/elastic/apm/pull/404
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
