### PR TITLE
Traverse context to find active span/transaction

### DIFF
--- a/lib/instrumentation/async-hooks.js
+++ b/lib/instrumentation/async-hooks.js
@@ -11,16 +11,28 @@ module.exports = function (ins) {
   const asyncHook = asyncHooks.createHook({ init, before, destroy })
   const contexts = new WeakMap()
 
+  const resources = new Map()
+
   if (resettable) {
     if (_asyncHook) _asyncHook.disable()
     _asyncHook = asyncHook
   }
 
+  function traverseContext ( asyncId, map ) {
+    const event = map.get(asyncId)
+    if (!event) {
+      const resource = resources.get(asyncId)
+      if (resource) {
+        return traverseContext(resource.triggerAsyncId, map)
+      }
+    }
+    return event
+  }
+
   const activeTransactions = new Map()
   Object.defineProperty(ins, 'currentTransaction', {
     get () {
-      const asyncId = asyncHooks.executionAsyncId()
-      return activeTransactions.get(asyncId) || null
+      return traverseContext(asyncHooks.executionAsyncId(), activeTransactions)
     },
     set (trans) {
       const asyncId = asyncHooks.executionAsyncId()
@@ -35,8 +47,7 @@ module.exports = function (ins) {
   const activeSpans = new Map()
   Object.defineProperty(ins, 'activeSpan', {
     get () {
-      const asyncId = asyncHooks.executionAsyncId()
-      return activeSpans.get(asyncId) || null
+      return traverseContext(asyncHooks.executionAsyncId(), activeSpans)
     },
     set (span) {
       const asyncId = asyncHooks.executionAsyncId()
@@ -63,7 +74,39 @@ module.exports = function (ins) {
     }
   })
 
+  shimmer.wrap(ins, 'addEndedSpan', function (addEndedSpan) {
+    return function wrapEndedSpan (span) {
+      const asyncIds = contexts.get(span)
+      if (asyncIds) {
+        for (const asyncId of asyncIds) {
+          activeSpans.delete(asyncId)
+        }
+        contexts.delete(span)
+      }
+
+      return addEndedSpan.call(this, span)
+    }
+  })
+
   asyncHook.enable()
+
+  function trackContext ( asyncId, transactionOrSpan ) {
+    let asyncIds = contexts.get(transactionOrSpan)
+    if (!asyncIds) {
+      asyncIds = []
+      contexts.set(transactionOrSpan, asyncIds)
+    }
+    
+    asyncIds.push(asyncId)
+  }
+
+  function untrackContext ( asyncId, transactionOrSpan ) {
+    const asyncIds = contexts.get(transactionOrSpan)
+    if (asyncIds) {
+      const index = asyncIds.indexOf(asyncId)
+      asyncIds.splice(index, 1)
+    }
+  }
 
   function init (asyncId, type, triggerAsyncId, resource) {
     // We don't care about the TIMERWRAP, as it will only init once for each
@@ -74,18 +117,17 @@ module.exports = function (ins) {
     const transaction = ins.currentTransaction
     if (!transaction) return
 
+    resources.set(asyncId, { triggerAsyncId })
+
     activeTransactions.set(asyncId, transaction)
 
-    // Track the context by the transaction
-    let asyncIds = contexts.get(transaction)
-    if (!asyncIds) {
-      asyncIds = []
-      contexts.set(transaction, asyncIds)
-    }
-    asyncIds.push(asyncId)
+    trackContext(asyncId, transaction)
 
     const span = ins.bindingSpan || ins.activeSpan
-    if (span) activeSpans.set(asyncId, span)
+    if (span) {
+      trackContext(asyncId, span)
+      activeSpans.set(asyncId, span)
+    }
   }
 
   function before (asyncId) {
@@ -105,14 +147,16 @@ module.exports = function (ins) {
     const transaction = span ? span.transaction : activeTransactions.get(asyncId)
 
     if (transaction) {
-      const asyncIds = contexts.get(transaction)
-      if (asyncIds) {
-        const index = asyncIds.indexOf(asyncId)
-        asyncIds.splice(index, 1)
-      }
+      untrackContext(asyncId, transaction)
+    }
+
+    if (span) {
+      untrackContext(asyncId, span)
     }
 
     activeTransactions.delete(asyncId)
     activeSpans.delete(asyncId)
+
+    resources.delete(asyncId)
   }
 }

--- a/test/instrumentation/async-hooks.js
+++ b/test/instrumentation/async-hooks.js
@@ -143,6 +143,41 @@ test('sync/async tracking', function (t) {
   })
 })
 
+test.only('span.end()', function ( t ) {
+  var transaction = agent.startTransaction()
+  
+  var firstSpan = agent.startSpan('first-span')
+  t.strictEqual(firstSpan.parentId, transaction.id, 'first span is a child of the active transaction')
+
+  process.nextTick(function ( ) {
+
+    var childSpan = agent.startSpan('child-span')
+
+    t.equal(childSpan.parentId, firstSpan.id, 'child-span is a direct child of first-span')
+
+    process.nextTick(function ( ) {
+
+      childSpan.end()
+
+      var siblingSpan = agent.startSpan('sibling-span')
+
+      t.notEqual(siblingSpan.parentId, transaction.id, 'sibling-span is not a direct child of the active transaction')
+      t.equal(siblingSpan.parentId, firstSpan.id, 'sibling-span is a direct child of first-span')
+
+      siblingSpan.end()
+
+      firstSpan.end()
+      
+      transaction.end()
+
+      t.end()
+
+    })
+
+  })
+
+})
+
 function twice (fn) {
   setImmediate(fn)
   setImmediate(fn)


### PR DESCRIPTION
**(Keeping this in draft, as I expect this PR is mostly just suitable for discussion)**


I'm running into an issue where if the active span for the current async context ends, and a new span immediately starts, the ended span is the parent of the new span. 

This PR attempts to address this issue by:
- when a span ends, unset the active span for the current async context
- when activeSpan or activeTransaction is requested, walk back up the context hierarchy to return the first span or transaction it finds

This assumes that each transaction/span is executed in its own async context. If that's not the case, weird things might happen.