### PR TITLE
jenkins: enable github check .status

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     OPBEANS_REPO = 'opbeans-node'
+    GITHUB_CHECK = 'true'
   }
   options {
     timeout(time: 3, unit: 'HOURS')


### PR DESCRIPTION
### What

Enable GitHub check in addition to the GitHub commit status.

Add a `.Status` GitHub check with the digested build details, similar to the GitHub PR comments.

NOTE: This is a pretty new `feature`, we are working on adding more features, so feel free to suggest what things could be good to see. :)

### Checklist

- [x] Implement code
- ~~[ ] Add tests
- ~~[ ] Update TypeScript typings~~
- ~~[ ] Update documentation~~
- ~~[ ] Add CHANGELOG.asciidoc entry~~
- ~~[ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)~~