### PR TITLE
fix: local `cloudProvider` config is overwritten by a central config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,8 @@ Notes:
 [float]
 ===== Bug fixes
 
+* fix: It was possible for fetching central config to result in the
+  `cloudProvider` config value being reset to its default. {issues}1976[#1976]
 * fix: fixes bug where tedious could crash the agent on bulk inserts {pull}1935[#1935] +
   Reported https://discuss.elastic.co/t/apm-agent-crashes-nodejs-after-reporting-exception-in-tedious-instrumentation-code/259851[via the forum].
   The error symptom was: `Cannot read property 'statement' of undefined`

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,4 +1,5 @@
 :pull: https://github.com/elastic/apm-agent-nodejs/pull/
+:issues: https://github.com/elastic/apm-agent-nodejs/issues/
 
 [[release-notes]]
 == Release notes

--- a/lib/config.js
+++ b/lib/config.js
@@ -249,7 +249,7 @@ class Config {
       this.logger = logging.createLogger(this.logLevel)
     }
 
-    normalize(this)
+    normalize(this, this.logger)
 
     if (typeof this.transport !== 'function') {
       this.transport = function httpTransport (conf, agent) {
@@ -317,7 +317,7 @@ class Config {
           }
 
           if (Object.keys(conf).length > 0) {
-            normalize(conf)
+            normalize(conf, agent.logger)
 
             for (const [key, value] of Object.entries(conf)) {
               const validator = VALIDATORS[key]
@@ -412,16 +412,16 @@ function readEnv () {
   return opts
 }
 
-function normalize (opts) {
+function normalize (opts, logger) {
   normalizeKeyValuePairs(opts)
   normalizeNumbers(opts)
   normalizeBytes(opts)
   normalizeArrays(opts)
   normalizeTime(opts)
-  normalizeBools(opts)
+  normalizeBools(opts, logger)
   normalizeIgnoreOptions(opts)
   normalizeSanitizeFieldNames(opts)
-  normalizeCloudProvider(opts)
+  normalizeCloudProvider(opts, logger)
   truncateOptions(opts)
 }
 
@@ -435,15 +435,13 @@ function normalizeSanitizeFieldNames (opts) {
   }
 }
 
-function normalizeCloudProvider (opts) {
-  const allowedValues = ['auto', 'gcp', 'azure', 'aws', 'none']
-  if (allowedValues.indexOf(opts.cloudProvider) === -1) {
-    opts.cloudProvider = 'auto'
-    if (opts.logger) {
-      opts.logger.warn(
-        'Unexpected cloudProvider value %s, changing to auto',
-        opts.cloudProvider
-      )
+function normalizeCloudProvider (opts, logger) {
+  if ('cloudProvider' in opts) {
+    const allowedValues = ['auto', 'gcp', 'azure', 'aws', 'none']
+    if (allowedValues.indexOf(opts.cloudProvider) === -1) {
+      logger.warn('Invalid "cloudProvider" config value %s, falling back to default %s',
+        opts.cloudProvider, DEFAULTS.cloudProvider)
+      opts.cloudProvider = DEFAULTS.cloudProvider
     }
   }
 }
@@ -539,9 +537,9 @@ function normalizeKeyValuePairs (opts) {
   }
 }
 
-function normalizeBools (opts) {
+function normalizeBools (opts, logger) {
   for (const key of BOOL_OPTS) {
-    if (key in opts) opts[key] = strictBool(opts.logger, key, opts[key])
+    if (key in opts) opts[key] = strictBool(logger, key, opts[key])
   }
 }
 

--- a/test/central-config-enabled.js
+++ b/test/central-config-enabled.js
@@ -164,7 +164,7 @@ test('agent.logger updates for central config `log_level` change', { timeout: 10
 
 // Ensure that a central config that updates some var other than `cloudProvider`
 // does not result in *cloudProvider* being updated (issue #1976).
-test('central config change does not erroneously update cloudProvider', {timeout: 1000}, function (t) {
+test('central config change does not erroneously update cloudProvider', { timeout: 1000 }, function (t) {
   let agent
 
   const server = http.createServer((req, res) => {


### PR DESCRIPTION
Fixes: #1976


### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
