### PR TITLE
feat: transaction_sample_rate precision

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,13 +34,20 @@ Notes:
 
 [float]
 ===== Breaking changes
+
 [float]
 ===== Features
+
+* Limit the `transactionSampleRate` value to 4 decimal places of precision
+  according to the shared https://github.com/elastic/apm/blob/master/specs/agents/tracing-sampling.md#transaction_sample_rate-configuration[APM spec]. This ensures that propagated sampling rate
+  in the `tracestate` header is short and consistent.
+
 [float]
 ===== Bug fixes
 
 * fix: It was possible for fetching central config to result in the
   `cloudProvider` config value being reset to its default. {issues}1976[#1976]
+
 * fix: fixes bug where tedious could crash the agent on bulk inserts {pull}1935[#1935] +
   Reported https://discuss.elastic.co/t/apm-agent-crashes-nodejs-after-reporting-exception-in-tedious-instrumentation-code/259851[via the forum].
   The error symptom was: `Cannot read property 'statement' of undefined`

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,7 +40,7 @@ Notes:
 
 * Limit the `transactionSampleRate` value to 4 decimal places of precision
   according to the shared https://github.com/elastic/apm/blob/master/specs/agents/tracing-sampling.md#transaction_sample_rate-configuration[APM spec]. This ensures that propagated sampling rate
-  in the `tracestate` header is short and consistent.
+  in the `tracestate` header is short and consistent. {pull}1979[#1979]
 
 [float]
 ===== Bug fixes

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -367,7 +367,11 @@ If the `errorOnAbortedRequests` property is `false`, this property is ignored.
 
 Specify the sampling rate to use when deciding whether to trace a request.
 
-The value should between `0.0` and `1.0` where `1.0` is 100% of all requests.
+The must be a value between `0.0` and `1.0`, where `1.0` means 100% of requests
+are traced. The value is rounded to four decimal places of precision (e.g.
+0.0001, 0.3333) to ensure consistency and reasonable size when propagating the
+sampling rate in the `tracestate` header for
+<<distributed-tracing,distributed tracing>>.
 
 [[hostname]]
 ==== `hostname`

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -367,7 +367,7 @@ If the `errorOnAbortedRequests` property is `false`, this property is ignored.
 
 Specify the sampling rate to use when deciding whether to trace a request.
 
-The must be a value between `0.0` and `1.0`, where `1.0` means 100% of requests
+This must be a value between `0.0` and `1.0`, where `1.0` means 100% of requests
 are traced. The value is rounded to four decimal places of precision (e.g.
 0.0001, 0.3333) to ensure consistency and reasonable size when propagating the
 sampling rate in the `tracestate` header for

--- a/lib/config.js
+++ b/lib/config.js
@@ -154,10 +154,6 @@ var CENTRAL_CONFIG = {
   sanitize_field_names: 'sanitizeFieldNames'
 }
 
-var VALIDATORS = {
-  transactionSampleRate: numberBetweenZeroAndOne
-}
-
 var BOOL_OPTS = [
   'active',
   'asyncHooks',
@@ -320,21 +316,16 @@ class Config {
             normalize(conf, agent.logger)
 
             for (const [key, value] of Object.entries(conf)) {
-              const validator = VALIDATORS[key]
-              if (validator ? validator(value) : true) {
-                const oldValue = agent._conf[key]
-                agent._conf[key] = value
-                if (key === 'logLevel' && value !== oldValue && !logging.isLoggerCustom(agent.logger)) {
-                  // If a new log level value was provided, and we aren't
-                  // already using a custom-provided logger (_conf.logger),
-                  // then update the agent logger.
-                  agent.logger = agent._conf.logger = logging.createLogger(value)
-                  agent.logger.info(`Remote config success. Updated logger with new logLevel: ${value}`)
-                }
-                agent.logger.info(`Remote config success. Updated ${key}: ${value}`)
-              } else {
-                agent.logger.warn(`Remote config failure. Invalid value for ${key}: ${value}`)
+              const oldValue = agent._conf[key]
+              agent._conf[key] = value
+              if (key === 'logLevel' && value !== oldValue && !logging.isLoggerCustom(agent.logger)) {
+                // If a new log level value was provided, and we aren't
+                // already using a custom-provided logger (_conf.logger),
+                // then update the agent logger.
+                agent.logger = agent._conf.logger = logging.createLogger(value)
+                agent.logger.info(`Remote config success. Updated logger with new logLevel: ${value}`)
               }
+              agent.logger.info(`Remote config success. Updated ${key}: ${value}`)
             }
           }
         })
@@ -422,7 +413,31 @@ function normalize (opts, logger) {
   normalizeIgnoreOptions(opts)
   normalizeSanitizeFieldNames(opts)
   normalizeCloudProvider(opts, logger)
+  normalizeTransactionSampleRate(opts, logger)
   truncateOptions(opts)
+}
+
+// transactionSampleRate is specified to be:
+// - in the range [0,1]
+// - rounded to 4 decimal places of precision (e.g. 0.0001, 0.5678, 0.9999)
+// - with the special case that a value in the range (0, 0.0001] should be
+//   rounded to 0.0001 -- to avoid a small value being rounded to zero.
+//
+// https://github.com/elastic/apm/blob/master/specs/agents/tracing-sampling.md
+function normalizeTransactionSampleRate (opts, logger) {
+  if ('transactionSampleRate' in opts) {
+    // The value was already run through `Number(...)` in `normalizeNumbers`.
+    const rate = opts.transactionSampleRate
+    if (isNaN(rate) || rate < 0 || rate > 1) {
+      opts.transactionSampleRate = DEFAULTS.transactionSampleRate
+      logger.warn('Invalid "transactionSampleRate" config value %s, falling back to default %s',
+        rate, opts.transactionSampleRate)
+    } else if (rate > 0 && rate < 0.0001) {
+      opts.transactionSampleRate = 0.0001
+    } else {
+      opts.transactionSampleRate = Math.round(rate * 10000) / 10000
+    }
+  }
 }
 
 function normalizeSanitizeFieldNames (opts) {
@@ -616,10 +631,6 @@ function pairsToObject (pairs) {
     object[key] = value
     return object
   }, {})
-}
-
-function numberBetweenZeroAndOne (n) {
-  return n >= 0 && n <= 1
 }
 
 function loadConfigFile (configFile) {

--- a/test/central-config-enabled.js
+++ b/test/central-config-enabled.js
@@ -120,6 +120,23 @@ test('remote config enabled: receives non delimited string', function (t) {
   runTestsWithServer(t, updates, expect)
 })
 
+// Tests for transaction_sample_rate precision from central config.
+;[
+  ['0', 0],
+  ['0.0001', 0.0001],
+  ['0.00002', 0.0001],
+  ['0.300000002', 0.3],
+  ['0.444444', 0.4444],
+  ['0.555555', 0.5556],
+  ['1', 1]
+].forEach(function ([centralVal, expected]) {
+  test(`central transaction_sample_rate precision: "${centralVal}"`, function (t) {
+    runTestsWithServer(t,
+      { transaction_sample_rate: centralVal },
+      { transactionSampleRate: expected })
+  })
+})
+
 // Ensure the logger updates if the central config `log_level` changes.
 test('agent.logger updates for central config `log_level` change', { timeout: 1000 }, function (t) {
   let agent

--- a/test/config.js
+++ b/test/config.js
@@ -959,6 +959,65 @@ test('parsing of ARRAY and KEY_VALUE opts', function (t) {
   t.end()
 })
 
+test('transactionSampleRate precision', function (t) {
+  var cases = [
+    {
+      opts: { transactionSampleRate: 0 },
+      expect: { transactionSampleRate: 0 }
+    },
+    {
+      env: { ELASTIC_APM_TRANSACTION_SAMPLE_RATE: '0' },
+      expect: { transactionSampleRate: 0 }
+    },
+    {
+      opts: { transactionSampleRate: 0.0001 },
+      expect: { transactionSampleRate: 0.0001 }
+    },
+    {
+      opts: { transactionSampleRate: 0.00002 },
+      expect: { transactionSampleRate: 0.0001 }
+    },
+    {
+      env: { ELASTIC_APM_TRANSACTION_SAMPLE_RATE: '0.00002' },
+      expect: { transactionSampleRate: 0.0001 }
+    },
+    {
+      opts: { transactionSampleRate: 0.300000002 },
+      expect: { transactionSampleRate: 0.3 }
+    },
+    {
+      opts: { transactionSampleRate: 0.444444 },
+      expect: { transactionSampleRate: 0.4444 }
+    },
+    {
+      opts: { transactionSampleRate: 0.555555 },
+      expect: { transactionSampleRate: 0.5556 }
+    },
+    {
+      opts: { transactionSampleRate: 1 },
+      expect: { transactionSampleRate: 1 }
+    }
+  ]
+
+  cases.forEach(function testOneCase ({ opts, env, expect }) {
+    var origEnv = process.env
+    try {
+      if (env) {
+        process.env = Object.assign({}, origEnv, env)
+      }
+      var cfg = config(opts)
+      for (var field in expect) {
+        t.deepEqual(cfg[field], expect[field],
+          util.format('opts=%j env=%j -> %j', opts, env, expect))
+      }
+    } finally {
+      process.env = origEnv
+    }
+  })
+
+  t.end()
+})
+
 test('should accept and normalize cloudProvider', function (t) {
   const agentDefault = Agent()
   agentDefault.start()


### PR DESCRIPTION
This implements the transaction_sample_rate precision spec (https://github.com/elastic/apm/blob/master/specs/agents/tracing-sampling.md#transaction_sample_rate-configuration), added in https://github.com/elastic/apm/pull/335.

Fixes: #1817

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
