### PR TITLE
3.12.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,11 +28,9 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-[[release-notes-unreleased]]
-==== Unreleased
+[[release-notes-3.12.0]]
+==== 3.12.0 - 2020/22/21
 
-[float]
-===== Breaking changes
 
 [float]
 ===== Features

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -31,6 +31,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.12.x |2022-08-22 |3.13.0
 |3.11.x |2022-08-08 |3.12.0
 |3.10.x |2022-07-11 |3.11.0
 |3.9.x |2022-05-30 |3.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## 3.12.0 - 2020/22/21

### Features

* feat: set span outcome to success or failure depending on whether an error
  was captured during when the span was active.
  https://github.com/elastic/apm-agent-nodejs/issues/1814

* feat: Adds public `setOutcome` method to span and transaction APIs, and
  adds a top level `setTransactionOutcome` and `setSpanOutcome` to set
  outcome values for the current active transaction or active span.

* Limit the `transactionSampleRate` value to 4 decimal places of precision
  according to the shared https://github.com/elastic/apm/blob/master/specs/agents/tracing-sampling.md#transaction_sample_rate-configuration[APM spec]. This ensures that propagated sampling rate
  in the `tracestate` header is short and consistent. #1979

## Bug fixes

* fix: It was possible for fetching central config to result in the
  `cloudProvider` config value being reset to its default. {issues}1976[#1976]

* fix: fixes bug where tedious could crash the agent on bulk inserts {pull}1935[#1935] +
  Reported https://discuss.elastic.co/t/apm-agent-crashes-nodejs-after-reporting-exception-in-tedious-instrumentation-code/259851[via the forum].
  The error symptom was: `Cannot read property 'statement' of undefined`
