### PR TITLE
chore: drop unused 'nodejs.eventloop.delay.ns' metric

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,22 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Remove the accidental `nodejs.eventloop.delay.ns` metric that was always
+  reporting a zero value. The existing `nodejs.eventloop.delay.avg.ms` is
+  the intended metric. {pull}1993[#1993]
+
+
 [[release-notes-3.12.1]]
 ==== 3.12.1 - 2021/02/25
 

--- a/lib/metrics/runtime.js
+++ b/lib/metrics/runtime.js
@@ -17,7 +17,7 @@ class RuntimeCollector {
     this.stats = {
       'nodejs.handles.active': 0,
       'nodejs.requests.active': 0,
-      'nodejs.eventloop.delay.ns': 0,
+      'nodejs.eventloop.delay.avg.ms': 0,
       'nodejs.memory.heap.allocated.bytes': 0,
       'nodejs.memory.heap.used.bytes': 0,
       'nodejs.memory.external.bytes': 0,

--- a/test/metrics/breakdown.js
+++ b/test/metrics/breakdown.js
@@ -23,7 +23,6 @@ const basicMetrics = [
   'system.process.memory.rss.bytes',
   'nodejs.handles.active',
   'nodejs.requests.active',
-  'nodejs.eventloop.delay.ns',
   'nodejs.memory.heap.allocated.bytes',
   'nodejs.memory.heap.used.bytes',
   'nodejs.eventloop.delay.avg.ms'


### PR DESCRIPTION
The nodejs runtime metrics code define both
    nodejs.eventloop.delay.ns
    nodejs.eventloop.delay.avg.ms
but only the latter is every filled with a value. The former
is initialized to 0 and always reported as 0. This stems from the
original addition in #1021.

The apm-contrib Node.js dashboard only uses the latter.
https://github.com/elastic/apm-contrib/tree/master/apm-agent-nodejs/dashboards/

Refs: #1021
