### PR TITLE
feat: ignore_message_queues configuration

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -933,3 +933,33 @@ During startup the Node.js agent queries the local environment to determine whet
 - `none`: Do not query for any cloud provider information.
 
 If the value is not one of the five listed above, the agent will use the value of `auto`.
+
+[[ignore_message_queues]]
+==== `ignoreMessageQueues`
+* *Type:* Array
+* *Default:* `[]`
+* *Env:* `ELASTIC_IGNORE_MESSAGE_QUEUES`
+
+Array or comma-separated string of wildcard patterns that tell the agent to
+ignore certain queues/topics when instrumenting messaging systems.
+
+When an instrumented messaging system sends or receives a message, the agent
+will test the queue/topic name against each wildcard in this list. If
+the name matches the agent will skip instrumenting the operation.
+
+The `ignoreMessageQueues` property supports simple wildcard (`*`) patterns, and
+may not include commas.  Wildcard matches are case-insensitive by default. You
+may make wildcard searches case-sensitive by using the `(?-i)` prefix.
+
+Example usage:
+
+[source,js]
+----
+require('elastic-apm-node').start({
+  ignoreMessageQueues: [
+    'overnight_jobs',
+    'events_*',
+    '(?-i)/caseSensitiveSearch'
+  ]
+})
+----

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -934,18 +934,19 @@ During startup the Node.js agent queries the local environment to determine whet
 
 If the value is not one of the five listed above, the agent will use the value of `auto`.
 
-[[ignore_message_queues]]
+[[ignore-message-queues]]
 ==== `ignoreMessageQueues`
 * *Type:* Array
 * *Default:* `[]`
 * *Env:* `ELASTIC_IGNORE_MESSAGE_QUEUES`
+* <<dynamic-configuration, image:./images/dynamic-config.svg[] >> *Central config name:* `ignore_message_queues`
 
 Array or comma-separated string of wildcard patterns that tell the agent to
 ignore certain queues/topics when instrumenting messaging systems.
 
 When an instrumented messaging system sends or receives a message, the agent
 will test the queue/topic name against each wildcard in this list. If
-the name matches the agent will skip instrumenting the operation.
+the name matches, the agent will skip instrumenting the operation.
 
 The `ignoreMessageQueues` property supports simple wildcard (`*`) patterns, and
 may not include commas.  Wildcard matches are case-insensitive by default. You
@@ -959,7 +960,7 @@ require('elastic-apm-node').start({
   ignoreMessageQueues: [
     'overnight_jobs',
     'events_*',
-    '(?-i)/caseSensitiveSearch'
+    '(?-i)caseSensitiveSearch'
   ]
 })
 ----

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,7 +211,7 @@ interface AgentConfigOptions {
   frameworkVersion?: string;
   globalLabels?: KeyValueConfig;
   hostname?: string;
-  ignoreMessageQueues: Array<string>;
+  ignoreMessageQueues?: Array<string>;
   ignoreUrls?: Array<string | RegExp>;
   ignoreUserAgents?: Array<string | RegExp>;
   instrument?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,6 +211,7 @@ interface AgentConfigOptions {
   frameworkVersion?: string;
   globalLabels?: KeyValueConfig;
   hostname?: string;
+  ignoreMessageQueues: Array<string>;
   ignoreUrls?: Array<string | RegExp>;
   ignoreUserAgents?: Array<string | RegExp>;
   instrument?: boolean;

--- a/lib/config.js
+++ b/lib/config.js
@@ -497,7 +497,7 @@ function normalizeIgnoreOptions (opts) {
   }
 
   if (opts.ignoreMessageQueues) {
-    if(!opts.ignoreMessageQueuesRegExp) {
+    if (!opts.ignoreMessageQueuesRegExp) {
       opts.ignoreMessageQueuesRegExp = []
     }
     const wildcard = new WildcardMatcher()

--- a/lib/config.js
+++ b/lib/config.js
@@ -225,7 +225,6 @@ class Config {
     this.transactionIgnoreUrlRegExp = []
     this.sanitizeFieldNamesRegExp = []
     this.ignoreMessageQueuesRegExp = []
-
     // If we didn't find a config file on process boot, but a path to one is
     // provided as a config option, let's instead try to load that
     if (confFile === null && opts && opts.configFile) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,6 +58,7 @@ var DEFAULTS = {
   errorOnAbortedRequests: false,
   filterHttpHeaders: true,
   globalLabels: undefined,
+  ignoreMessageQueues: [],
   instrument: true,
   instrumentIncomingHTTPRequests: true,
   kubernetesNamespace: undefined,
@@ -106,6 +107,7 @@ var ENV_TABLE = {
   cloudProvider: 'ELASTIC_APM_CLOUD_PROVIDER',
   disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
   environment: 'ELASTIC_APM_ENVIRONMENT',
+  ignoreMessageQueues: 'ELASTIC_IGNORE_MESSAGE_QUEUES',
   errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
   errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
   filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',
@@ -201,7 +203,8 @@ var MINUS_ONE_EQUAL_INFINITY = [
 var ARRAY_OPTS = [
   'disableInstrumentations',
   'sanitizeFieldNames',
-  'transactionIgnoreUrls'
+  'transactionIgnoreUrls',
+  'ignoreMessageQueues'
 ]
 
 var KEY_VALUE_OPTS = [
@@ -221,6 +224,8 @@ class Config {
     this.ignoreUserAgentRegExp = []
     this.transactionIgnoreUrlRegExp = []
     this.sanitizeFieldNamesRegExp = []
+    this.ignoreMessageQueuesRegExp = []
+
     // If we didn't find a config file on process boot, but a path to one is
     // provided as a config option, let's instead try to load that
     if (confFile === null && opts && opts.configFile) {
@@ -490,6 +495,17 @@ function normalizeIgnoreOptions (opts) {
       else opts.ignoreUserAgentRegExp.push(ptn)
     }
     delete opts.ignoreUserAgents
+  }
+
+  if (opts.ignoreMessageQueues) {
+    if(!opts.ignoreMessageQueuesRegExp) {
+      opts.ignoreMessageQueuesRegExp = []
+    }
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.ignoreMessageQueues) {
+      const re = wildcard.compile(ptn)
+      opts.ignoreMessageQueuesRegExp.push(re)
+    }
   }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -153,7 +153,8 @@ var CENTRAL_CONFIG = {
   transaction_max_spans: 'transactionMaxSpans',
   capture_body: 'captureBody',
   transaction_ignore_urls: 'transactionIgnoreUrls',
-  sanitize_field_names: 'sanitizeFieldNames'
+  sanitize_field_names: 'sanitizeFieldNames',
+  ignore_message_queues: 'ignoreMessageQueues'
 }
 
 var BOOL_OPTS = [

--- a/test/config.js
+++ b/test/config.js
@@ -1062,9 +1062,7 @@ test('should accept and normalize cloudProvider', function (t) {
 })
 
 test('should accept and normalize ignoreMessageQueues', function (suite) {
-
-
-  suite.test('ignoreMessageQueues defaults', function(t){
+  suite.test('ignoreMessageQueues defaults', function (t) {
     const agent = Agent()
     agent.start()
     t.equals(
@@ -1081,9 +1079,9 @@ test('should accept and normalize ignoreMessageQueues', function (suite) {
     t.end()
   })
 
-  suite.test('ignoreMessageQueues via configuration', function(t){
+  suite.test('ignoreMessageQueues via configuration', function (t) {
     const agent = Agent()
-    agent.start({ignoreMessageQueues: ['f*o','bar']})
+    agent.start({ ignoreMessageQueues: ['f*o', 'bar'] })
     t.equals(
       agent._conf.ignoreMessageQueues.length,
       2,
@@ -1103,9 +1101,9 @@ test('should accept and normalize ignoreMessageQueues', function (suite) {
     t.end()
   })
 
-  suite.test('ignoreMessageQueues via env', function(t){
+  suite.test('ignoreMessageQueues via env', function (t) {
     const agent = Agent()
-    process.env['ELASTIC_IGNORE_MESSAGE_QUEUES'] = 'f*o,bar,baz'
+    process.env.ELASTIC_IGNORE_MESSAGE_QUEUES = 'f*o,bar,baz'
     agent.start()
     t.equals(
       agent._conf.ignoreMessageQueues.length,

--- a/test/config.js
+++ b/test/config.js
@@ -1060,6 +1060,75 @@ test('should accept and normalize cloudProvider', function (t) {
   delete process.env.ELASTIC_APM_CLOUD_PROVIDER
   t.end()
 })
+
+test('should accept and normalize ignoreMessageQueues', function (suite) {
+
+
+  suite.test('ignoreMessageQueues defaults', function(t){
+    const agent = Agent()
+    agent.start()
+    t.equals(
+      agent._conf.ignoreMessageQueues.length,
+      0,
+      'ignore message queue defaults empty'
+    )
+
+    t.equals(
+      agent._conf.ignoreMessageQueuesRegExp.length,
+      0,
+      'ignore message queue regex defaults empty'
+    )
+    t.end()
+  })
+
+  suite.test('ignoreMessageQueues via configuration', function(t){
+    const agent = Agent()
+    agent.start({ignoreMessageQueues: ['f*o','bar']})
+    t.equals(
+      agent._conf.ignoreMessageQueues.length,
+      2,
+      'ignore message picks up configured values'
+    )
+
+    t.equals(
+      agent._conf.ignoreMessageQueuesRegExp.length,
+      2,
+      'ignore message queue regex picks up configured values'
+    )
+
+    t.ok(
+      agent._conf.ignoreMessageQueuesRegExp[0].test('faooooo'),
+      'wildcard converted to regular expression'
+    )
+    t.end()
+  })
+
+  suite.test('ignoreMessageQueues via env', function(t){
+    const agent = Agent()
+    process.env['ELASTIC_IGNORE_MESSAGE_QUEUES'] = 'f*o,bar,baz'
+    agent.start()
+    t.equals(
+      agent._conf.ignoreMessageQueues.length,
+      3,
+      'ignore message queue picks up env values'
+    )
+
+    t.equals(
+      agent._conf.ignoreMessageQueuesRegExp.length,
+      3,
+      'ignore message queue regex picks up env values'
+    )
+
+    t.ok(
+      agent._conf.ignoreMessageQueuesRegExp[0].test('faooooo'),
+      'wildcard converted to regular expression'
+    )
+    t.end()
+  })
+
+  suite.end()
+})
+
 function assertEncodedTransaction (t, trans, result) {
   t.comment('transaction')
   t.strictEqual(result.id, trans.id, 'id matches')


### PR DESCRIPTION
Partially implements: https://github.com/elastic/apm-agent-nodejs/issues/1956

This PR adds [the `ignore_message_queues`](https://github.com/elastic/apm/blob/master/specs/agents/tracing-instrumentation-messaging.md#ignore_message_queues-configuration) configuration to the agent.  This is a prerequisite for supporting AWS SQS instrumentation.  This PR does not include a CHANGELOG entry (that will come later, once the first messaging system (SQS) is added)

- [x] Implement code
- [X] Add tests
- [X] Update TypeScript typings
- [X] Update documentation
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
