### PR TITLE
pass a logger to the apmclient and private _getStats for debugging

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -76,6 +76,17 @@ Agent.prototype.destroy = function () {
   if (this._transport) this._transport.destroy()
 }
 
+// These are metrics about the agent itself -- separate from the metrics
+// gathered on behalf of the using app and sent to APM server. Currently these
+// are only useful for internal debugging of the APM agent itself.
+//
+// **These stats are NOT a promised interface.**
+Agent.prototype._getStats = function () {
+  return {
+    apmclient: this._transport._getStats()
+  }
+}
+
 Agent.prototype.addPatch = function (modules, handler) {
   return this._instrumentation.addPatch.apply(this._instrumentation, arguments)
 }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -82,9 +82,11 @@ Agent.prototype.destroy = function () {
 //
 // **These stats are NOT a promised interface.**
 Agent.prototype._getStats = function () {
-  return {
-    apmclient: this._transport._getStats()
+  const stats = {}
+  if (typeof this._transport._getStats === 'function') {
+    stats.apmclient = this._transport._getStats()
   }
+  return stats
 }
 
 Agent.prototype.addPatch = function (modules, handler) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -258,6 +258,11 @@ class Config {
 
     if (typeof this.transport !== 'function') {
       this.transport = function httpTransport (conf, agent) {
+        let clientLogger = null
+        if (!logging.isLoggerCustom(agent.logger)) {
+          // https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-module
+          clientLogger = agent.logger.child({'event.module': 'apmclient'})
+        }
         var transport = new ElasticAPMHttpClient({
           agentName: 'nodejs',
           agentVersion: version,
@@ -291,6 +296,7 @@ class Config {
           time: conf.apiRequestTime * 1000,
 
           // Debugging
+          logger: clientLogger,
           payloadLogFile: conf.payloadLogFile,
 
           // Container conf

--- a/lib/config.js
+++ b/lib/config.js
@@ -261,7 +261,7 @@ class Config {
         let clientLogger = null
         if (!logging.isLoggerCustom(agent.logger)) {
           // https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-module
-          clientLogger = agent.logger.child({'event.module': 'apmclient'})
+          clientLogger = agent.logger.child({ 'event.module': 'apmclient' })
         }
         var transport = new ElasticAPMHttpClient({
           agentName: 'nodejs',


### PR DESCRIPTION
This is a companion to https://github.com/elastic/apm-nodejs-http-client/pull/143 to add a logger to the apm client and a private `agent._getStats()` API for dev/debugging.

* * *

This is pre-support for a coming work to fix https://github.com/elastic/apm-nodejs-http-client/issues/136
I'm trying to separate out some changes to make that change more focused.