### PR TITLE
test: skip testing @elastic/elasticsearch >= 7.12.0 with node 8

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -246,9 +246,16 @@ elasticsearch:
 # @elastic/elasticsearch
 # - Version 7.7.0 included a change that broke usage with Node.js < 10.
 #   Fixed in 7.7.1: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog-client.html#_7_7_1
-#   Note: When Node.js v8 support is dropped, `versions` can be simplified.
+#   Note: When this repo drops Node.js v8 support, `versions` can be simplified.
+# - Version 7.12.0 dropped support for node v8.
+'@elastic/elasticsearch-v7.0-v7.11':
+  name: '@elastic/elasticsearch'
+  versions: '>=7.0.0 <7.7.0 || >7.7.0 <7.12.0'
+  commands: node test/instrumentation/modules/@elastic/elasticsearch.js
 '@elastic/elasticsearch':
-  versions: '>=7.0.0 <7.7.0 || >7.7.0 <8.0.0'
+  name: '@elastic/elasticsearch'
+  versions: '>=7.12.0 <8.0.0'
+  node: '>=10.0.0'
   commands: node test/instrumentation/modules/@elastic/elasticsearch.js
 
 handlebars:

--- a/test/config.js
+++ b/test/config.js
@@ -711,6 +711,7 @@ usePathAsTransactionNameTests.forEach(function (usePathAsTransactionNameTest) {
 test('disableInstrumentations', function (t) {
   var hapiVersion = require('hapi/package.json').version
   var expressGraphqlVersion = require('express-graphql/package.json').version
+  var esVersion = require('@elastic/elasticsearch/package.json').version
 
   var flattenedModules = Instrumentation.modules.reduce((acc, val) => acc.concat(val), [])
   var modules = new Set(flattenedModules)
@@ -722,6 +723,9 @@ test('disableInstrumentations', function (t) {
   }
   if (semver.lt(process.version, '7.6.0') && semver.gte(expressGraphqlVersion, '0.9.0')) {
     modules.delete('express-graphql')
+  }
+  if (semver.lt(process.version, '10.0.0') && semver.gte(esVersion, '7.12.0')) {
+    modules.delete('@elastic/elasticsearch')
   }
 
   function testSlice (t, name, selector) {

--- a/test/instrumentation/modules/@elastic/elasticsearch.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.js
@@ -9,13 +9,21 @@ const agent = require('../../../..').start({
   centralConfig: false
 })
 
+// Skip (exit the process) if this package version doesn't support this version
+// of node.
+const esVersion = require('@elastic/elasticsearch/package.json').version
+const semver = require('semver')
+if (semver.lt(process.version, '10.0.0') && semver.gte(esVersion, '7.12.0')) {
+  console.log(`# SKIP @elastic/elasticsearch@${esVersion} does not support node ${process.version}`)
+  process.exit()
+}
+
 // Silence deprecation warning from @elastic/elasticsearch when using a Node.js
 // version that is *soon* to be EOL'd, but isn't yet.
 process.noDeprecation = true
 const { Client } = require('@elastic/elasticsearch')
 
 const { Readable } = require('stream')
-const semver = require('semver')
 const test = require('tape')
 
 const findObjInArray = require('../../../_utils').findObjInArray


### PR DESCRIPTION
The ES client has dropped support for node v8.

Fixes: #2016
