### PR TITLE
fix: workaround to a git <2.7 issue

### DIFF
--- a/.ci/scripts/docker-test.sh
+++ b/.ci/scripts/docker-test.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
-set -xueo pipefail
+set -ueo pipefail
 
 major_node_version=`node --version | cut -d . -f1 | cut -d v -f2`
 minor_node_version=`node --version | cut -d . -f2`
 
 if [[ $major_node_version -eq 8 ]] && [[ $minor_node_version -lt 8 ]]; then
   export NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS}} --expose-http2"
+fi
+
+# Workaround to git <2.7
+# error fatal: unable to look up current user in the passwd file: no such user
+# see http://git.661346.n2.nabble.com/git-clone-fails-when-current-user-is-not-in-etc-passwd-td7643604.html
+if [ -z "$(grep \"\:$(id -u)\:\" /etc/passwd)" ]; then
+  git config --global user.name foo
+  git config --global user.email foo@exemple.com
+  git config -l
 fi
 
 export


### PR DESCRIPTION
We detected an issue with Node.js Docker images <=10 when we try to close the `apm-nodejs-http-client` repository during the `npm install`, we see a fatal error `unable to look up current user in the passwd file: no such user`. This errors is related to the Git version in those Docker images that is older than 2.7, the workaround is to set the user and email in the git configuration in case the user is not in the `/etc/passwd`.


