### PR TITLE
3.13.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,10 +28,8 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-3.13.0]]
+==== 3.13.0 - 2021/04/06
 
 [float]
 ===== Features
@@ -64,6 +62,10 @@ as they are added over time.
 
 [float]
 ===== Bug fixes
+
+* Lock package dependency "elastic-apm-http-client@9.6.0" to avoid using
+  v9.7.0 for now, because it is breaking tests. A coming release will get back
+  on the latest of this dependency. {issues}2032[#2032]
 
 * Remove the "ancestors" field from a log.trace message on startup. Its info
   is a duplicate of info in the "startTrace" field in the same log record.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -31,6 +31,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.13.x |2022-10-06 |3.14.0
 |3.12.x |2022-08-22 |3.13.0
 |3.11.x |2022-08-08 |3.12.0
 |3.10.x |2022-07-11 |3.11.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.12.1",
+  "version": "3.13.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
@@ -87,7 +87,7 @@
     "basic-auth": "^2.0.1",
     "cookie": "^0.4.0",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "^9.5.1",
+    "elastic-apm-http-client": "9.6.0",
     "end-of-stream": "^1.4.4",
     "error-stack-parser": "^2.0.6",
     "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
This locks to "elastic-apm-http-client@9.6.0" to temporarily fix test
failures and the change in uncaughtException handling behaviour in
a rare case (https://github.com/elastic/apm-nodejs-http-client/issues/150).

Fixes: #2032
