### PR TITLE
fix: fixes crash when accessing values from invalid tracestates

### DIFF
--- a/lib/tracecontext/tracestate.js
+++ b/lib/tracecontext/tracestate.js
@@ -92,7 +92,7 @@ class TraceState {
   getValue (keyToGet) {
     const allValues = this.toObject()
     const rawValue = allValues[this.listMemberNamespace]
-    if(!rawValue) {
+    if (!rawValue) {
       return rawValue
     }
     const values = TraceState._parseValues(rawValue)

--- a/lib/tracecontext/tracestate.js
+++ b/lib/tracecontext/tracestate.js
@@ -92,6 +92,9 @@ class TraceState {
   getValue (keyToGet) {
     const allValues = this.toObject()
     const rawValue = allValues[this.listMemberNamespace]
+    if(!rawValue) {
+      return rawValue
+    }
     const values = TraceState._parseValues(rawValue)
     return values[keyToGet]
   }

--- a/test/tracecontext/tracestate.js
+++ b/test/tracecontext/tracestate.js
@@ -288,7 +288,7 @@ test('TraceState defaultValues', function (t) {
   t.end()
 })
 
-test('TraceState empty or invalid values', function(t) {
+test('TraceState empty or invalid values', function (t) {
   const tracestateEmpty = TraceState.fromStringFormatString('')
   t.ok(undefined === tracestateEmpty.getValue('s'), 'does not crash for empty tracestate')
 

--- a/test/tracecontext/tracestate.js
+++ b/test/tracecontext/tracestate.js
@@ -287,3 +287,13 @@ test('TraceState defaultValues', function (t) {
   t.equals(tracestate2.toW3cString(), 'es=foo:bar2;zip:zap2', 'prefers defautlValues over binary in constructor')
   t.end()
 })
+
+test('TraceState empty or invalid values', function(t) {
+  const tracestateEmpty = TraceState.fromStringFormatString('')
+  t.ok(undefined === tracestateEmpty.getValue('s'), 'does not crash for empty tracestate')
+
+  const tracestateInvalid = TraceState.fromStringFormatString('xxxxxx')
+  t.ok(undefined === tracestateInvalid.getValue('s'), 'does not crash for invalid tracestate')
+
+  t.end()
+})


### PR DESCRIPTION
Part of #2023

This fixes a small bug in the `TraceState` class where

1. Creating an invalid tracestate
2. and then attempting to access a value in that tracestate via `getValue`

resulted in a crash.  This came up during the sample_rate work.

This PR provides a fix, and tests for that fix. The tests fail before the fix but succeed after. 