### PR TITLE
chore: silence a warning from 'docker-compose --no-ansi ...' usage

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -x "$(command -v docker-compose)" ]; then
   docker-compose \
-    --no-ansi \
+    --ansi never \
     --log-level ERROR \
     -f .ci/docker/docker-compose-all.yml \
     pull --quiet --ignore-pull-failures

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -51,7 +51,7 @@ NODE_VERSION=${NODE_VERSION} \
 TAV_VERSIONS=${TAV_VERSIONS} \
 USER_ID="$(id -u):$(id -g)" \
 docker-compose \
-  --no-ansi \
+  --ansi never \
   --log-level ERROR \
   -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
   build >docker-compose.log 2>docker-compose.err
@@ -70,7 +70,7 @@ NODE_VERSION=${NODE_VERSION} \
 TAV_VERSIONS=${TAV_VERSIONS} \
 USER_ID="$(id -u):$(id -g)" \
 docker-compose \
-  --no-ansi \
+  --ansi never \
   --log-level ERROR \
   -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
   up \
@@ -80,7 +80,7 @@ docker-compose \
   node_tests
 
 NODE_VERSION=${NODE_VERSION} docker-compose \
-  --no-ansi \
+  --ansi never \
   --log-level ERROR \
   -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
   down -v

--- a/.ci/scripts/windows/prepare-test.sh
+++ b/.ci/scripts/windows/prepare-test.sh
@@ -6,7 +6,7 @@ NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 NODE_VERSION=${NODE_VERSION} \
 USER_ID="$(id -u):$(id -g)" \
 docker-compose \
-  --no-ansi \
+  --ansi never \
   --log-level ERROR \
   -f .ci/docker/docker-compose-all.yml \
   up \

--- a/.ci/scripts/windows/stop-test.sh
+++ b/.ci/scripts/windows/stop-test.sh
@@ -4,13 +4,13 @@ set -exo pipefail
 NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 
 NODE_VERSION=${NODE_VERSION} docker-compose \
-  --no-ansi \
+  --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   logs \
   --timestamps > docker-compose-logs.txt
 
 NODE_VERSION=${NODE_VERSION} docker-compose \
-  --no-ansi \
+  --ansi never \
   --log-level ERROR \
   -f .ci/docker/docker-compose-all.yml \
   down -v

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /test/babel/out.js
 /test/types/transpile/index.js
 /test-suite-output.tap
+/docker-compose.err
+/docker-compose.log
 
 # Folders to ignore
 /.nyc_output

--- a/test/script/docker/run_tests.sh
+++ b/test/script/docker/run_tests.sh
@@ -24,7 +24,7 @@ else
   CMD='npm test'
 fi
 
-NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml run \
+NODE_VERSION=${1} docker-compose --ansi never --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml run \
   -e NODE_VERSION=${NODE_VERSION} \
   -e TAV=${TAV_VERSIONS} \
   -e JUNIT=${JUNIT} \
@@ -42,4 +42,4 @@ NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-co
       npm --version
       ${CMD}"
 
-NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml down -v
+NODE_VERSION=${1} docker-compose --ansi never --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml down -v


### PR DESCRIPTION
The message is:
    --no-ansi option is deprecated and will be removed in future versions. Use `--ansi never` instead.
