### PR TITLE
chore: drop unused createFilter function

### DIFF
--- a/lib/filters/sanitize-field-names.js
+++ b/lib/filters/sanitize-field-names.js
@@ -51,27 +51,7 @@ function redactKeysFromObject (obj, regexes) {
   return obj
 }
 
-function createFilter (conf) {
-  return sanitizeFieldNames
-
-  function sanitizeFieldNames (obj) {
-    const requestHeaders = obj.context && obj.context.request && obj.context.request.headers
-    const responseHeaders = obj.context && obj.context.response && obj.context.response.headers
-    const body = obj.context && obj.context.request && obj.context.request.body
-
-    redactKeysFromObject(requestHeaders, conf.sanitizeFieldNamesRegExp)
-    redactKeysFromObject(responseHeaders, conf.sanitizeFieldNamesRegExp)
-
-    if (body) {
-      obj.context.request.body = redactKeysFromPostedFormVariables(body, requestHeaders, conf.sanitizeFieldNamesRegExp)
-    }
-
-    return obj
-  }
-}
-
 module.exports = {
-  createFilter,
   redactKeysFromObject,
   redactKeysFromPostedFormVariables
 }


### PR DESCRIPTION
This was added in commit 4cbe2f9e85f3d23808ddbec4e2833205c4550ae8,
likely in early revs of its PR, but never used.
