### PR TITLE
ci: CI docker TAV tests are unnecessarily setting up all services for some modules

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,8 +90,8 @@ pipeline {
                 // parallelTasks["Windows-Node.js-${version}"] = generateStepForWindows(version: version)
               }
 
-              // Only 12 for the time being
-              parallelTasks["Windows-Node.js-12"] = generateStepForWindows(version: '12')
+              // Only 14 for the time being
+              parallelTasks["Windows-Node.js-14"] = generateStepForWindows(version: '14')
 
               // Linting in parallel with the test stage
               parallelTasks['linting'] = linting()

--- a/.ci/docker/docker-compose-node-edge-test.yml
+++ b/.ci/docker/docker-compose-node-edge-test.yml
@@ -25,7 +25,7 @@ services:
       NODE_VERSION: ${NODE_VERSION}
       NVM_NODEJS_ORG_MIRROR: ${NVM_NODEJS_ORG_MIRROR}
       ELASTIC_APM_ASYNC_HOOKS: ${ELASTIC_APM_ASYNC_HOOKS}
-      TAV: ${TAV_VERSIONS}
+      TAV: ${TAV_MODULE}
       HOME: /tmp
     volumes:
       - ${PWD}:/app

--- a/.ci/docker/docker-compose-node-test.yml
+++ b/.ci/docker/docker-compose-node-test.yml
@@ -21,7 +21,7 @@ services:
       PGUSER: 'postgres'
       MEMCACHED_HOST: 'memcached'
       NODE_VERSION: ${NODE_VERSION}
-      TAV: ${TAV_VERSIONS}
+      TAV: ${TAV_MODULE}
       ELASTIC_APM_ASYNC_HOOKS: ${ELASTIC_APM_ASYNC_HOOKS}
       HOME: /tmp
       PATH: /app/node_modules/.bin:./node_modules/.bin:/app/node_modules:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -54,43 +54,48 @@ IS_EDGE=${3:false}
 # Select a config for 'docker-compose build' that sets up (a) the "node_tests"
 # container where the tests are actually run and (b) any services that are
 # needed for this set of tests, if any.
-case ${TAV_MODULE} in
-  redis|ioredis)
-    DOCKER_COMPOSE_FILE=docker-compose-redis.yml
-    ;;
-  tedious)
-    DOCKER_COMPOSE_FILE=docker-compose-mssql.yml
-    ;;
-  mongodb-core)
-    DOCKER_COMPOSE_FILE=docker-compose-mongodb.yml
-    ;;
-  pg|knex)
-    DOCKER_COMPOSE_FILE=docker-compose-postgres.yml
-    ;;
-  cassandra-driver)
-    DOCKER_COMPOSE_FILE=docker-compose-cassandra.yml
-    ;;
-  elasticsearch|@elastic/elasticsearch)
-    DOCKER_COMPOSE_FILE=docker-compose-elasticsearch.yml
-    ;;
-  mysql|mysql2)
-    DOCKER_COMPOSE_FILE=docker-compose-mysql.yml
-    ;;
-  memcached)
-    DOCKER_COMPOSE_FILE=docker-compose-memcached.yml
-    ;;
-  *)
-    # Just the "node_tests" container. No additional services needed for testing.
-    DOCKER_COMPOSE_FILE=docker-compose-node-test.yml
-    ;;
-esac
-
-## This will use RC/nightly node versions. It does NOT support TAV!
-if [ "${IS_EDGE}" = "true" ]; then
+if [[ "${IS_EDGE}" = "true" ]]; then
+  # This will run the regular tests against rc and nightly builds of
+  # node.js. It does NOT support TAV tests.
   if [[ -n "${TAV_MODULE}" ]]; then
     fatal "running TAV tests (TAV_MODULE=${TAV_MODULE}) with IS_EDGE=${IS_EDGE} is not supported"
   fi
   DOCKER_COMPOSE_FILE=docker-compose-edge.yml
+elif [[ -n "${TAV_MODULE}" ]]; then
+  # Run the TAV tests for a particular module.
+  case ${TAV_MODULE} in
+    redis|ioredis)
+      DOCKER_COMPOSE_FILE=docker-compose-redis.yml
+      ;;
+    tedious)
+      DOCKER_COMPOSE_FILE=docker-compose-mssql.yml
+      ;;
+    mongodb-core)
+      DOCKER_COMPOSE_FILE=docker-compose-mongodb.yml
+      ;;
+    pg|knex)
+      DOCKER_COMPOSE_FILE=docker-compose-postgres.yml
+      ;;
+    cassandra-driver)
+      DOCKER_COMPOSE_FILE=docker-compose-cassandra.yml
+      ;;
+    elasticsearch|@elastic/elasticsearch)
+      DOCKER_COMPOSE_FILE=docker-compose-elasticsearch.yml
+      ;;
+    mysql|mysql2)
+      DOCKER_COMPOSE_FILE=docker-compose-mysql.yml
+      ;;
+    memcached)
+      DOCKER_COMPOSE_FILE=docker-compose-memcached.yml
+      ;;
+    *)
+      # Just the "node_tests" container. No additional services needed for testing.
+      DOCKER_COMPOSE_FILE=docker-compose-node-test.yml
+      ;;
+  esac
+else
+  # Run the regular tests against a release build of node.js.
+  DOCKER_COMPOSE_FILE=docker-compose-all.yml
 fi
 
 set +e

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -70,8 +70,7 @@ case ${TAV_MODULE} in
   cassandra-driver)
     DOCKER_COMPOSE_FILE=docker-compose-cassandra.yml
     ;;
-  # XXX elasticsearch|@elastic/elasticsearch)
-  elasticsearch)
+  elasticsearch|@elastic/elasticsearch)
     DOCKER_COMPOSE_FILE=docker-compose-elasticsearch.yml
     ;;
   mysql|mysql2)

--- a/test/script/docker/run_tests.sh
+++ b/test/script/docker/run_tests.sh
@@ -14,7 +14,7 @@ docker_nyc_output="/app/.nyc_output"
 
 NODE_VERSION=$1
 if [[ ! -z $2  ]]; then
-  TAV_VERSIONS=`echo "$2" | sed -e 's/\+/,/g'`
+  TAV_MODULES=`echo "$2" | sed -e 's/\+/,/g'`
   CMD='npm run test:tav'
 elif [[ -n $COVERAGE ]]; then
   CMD='npm run coverage'
@@ -24,7 +24,7 @@ fi
 
 NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml run \
   -e NODE_VERSION=${NODE_VERSION} \
-  -e TAV=${TAV_VERSIONS} \
+  -e TAV=${TAV_MODULES} \
   -e CI=true \
   -v ${npm_cache}:${docker_npm_cache} \
   -v ${nyc_output}:${docker_nyc_output} \


### PR DESCRIPTION
Invert logic of the selection of an appropriate docker-compose config
for *TAV* testing in docker, to default to *not setting up any extra
services* for a test run, unless specifically required for that TAV
module. Before this, TAV tests for `@hapi/hapi`, `@koa/router`, and
`@elastic/elasticsearch` would setup *all* services, which is overkill.

Also document .ci/scripts/test.sh because it subtlely does a few
slightly different things. Also rename the TAV_MODULE var name to be
more accurate.

Also bumps to using node 14 for the windows build which fixes #2061

* * *

Looking at the log for https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/master/864/pipeline/1037
which is step "TAV Test / Node.js-10-@hapi/hapi" of the TAV tests:

```
[2021-04-22T06:05:24.749Z] + .ci/scripts/test.sh 10 @hapi/hapi false
[2021-04-22T06:05:24.749Z] + DOCKER_FOLDER=.ci/docker
[2021-04-22T06:05:24.749Z] + NODE_VERSION=10
[2021-04-22T06:05:24.749Z] + TAV_VERSIONS=@hapi/hapi
[2021-04-22T06:05:24.749Z] + IS_EDGE=false
...
[2021-04-22T06:05:24.749Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
...
```

That is using the docker compose file to setup *all* services for testing, which is overkill. That is a failing of this block that selects an appropriate docker compose config for the test: https://github.com/elastic/apm-agent-nodejs/blob/v3.14.0/.ci/scripts/test.sh#L9-L40

If we grep the full [consoleText of build 864](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/master/864/consoleText) for 'docker-compose ... build' usage (full grep output here: https://gist.github.com/trentm/dd290655f594c6d162453c0ffb15d9a2), we see the following that are using `docker-compose-all.yml` unnecessarily:

```
% rg '.ci/scripts/test.sh|docker-compose .*build$' consoleText-build-864.log
...
275569:[2021-04-22T06:03:03.821Z] + .ci/scripts/test.sh 14 @elastic/elasticsearch false
275585:[2021-04-22T06:03:03.821Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
275645:[2021-04-22T06:03:07.749Z] + .ci/scripts/test.sh 14 @hapi/hapi false
275661:[2021-04-22T06:03:07.749Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
275673:[2021-04-22T06:03:09.194Z] + .ci/scripts/test.sh 14 @koa/router false
275689:[2021-04-22T06:03:09.194Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
279407:[2021-04-22T06:03:56.116Z] + .ci/scripts/test.sh 13 @hapi/hapi false
279423:[2021-04-22T06:03:56.117Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
279639:[2021-04-22T06:03:57.470Z] + .ci/scripts/test.sh 13 @koa/router false
279655:[2021-04-22T06:03:57.470Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
279879:[2021-04-22T06:04:00.097Z] + .ci/scripts/test.sh 13 @elastic/elasticsearch false
279895:[2021-04-22T06:04:00.097Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
286755:[2021-04-22T06:04:46.195Z] + .ci/scripts/test.sh 12 @elastic/elasticsearch false
286771:[2021-04-22T06:04:46.196Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml build
... etc.
```

In other words, what happened is that support for `@hapi/hapi`, `@koa/router`, and `@elastic/elasticsearch` was added, this block in ".ci/scripts/tests.sh" was not updated, and the fallback behaviour of setting up *all* services for a test "worked". So it wasn't noticed that this logic should be updated for a new module instrumentation.

I'd like to invert the logic to setup *no* extra services for a `TAV_VERSIONS` by default. That means that the TAV tests for a newly added module instrumentation (and a matching new ".tav.yml" block) *that requires a service for testing* will **break** until .ci/scripts/test.sh is updated.

