### PR TITLE
chore: don't run GH Actions CI lint and tests for .md and doc file changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,17 @@ on:
   push:
     branches:
     - master
+    paths-ignore:
+    - '*.md'
+    - '*.asciidoc'
+    - 'docs/**'
   pull_request:
     branches:
     - master
+    paths-ignore:
+    - '*.md'
+    - '*.asciidoc'
+    - 'docs/**'
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,17 @@ on:
   push:
     branches:
     - master
+    paths-ignore:
+    - '*.md'
+    - '*.asciidoc'
+    - 'docs/**'
   pull_request:
     branches:
     - master
+    paths-ignore:
+    - '*.md'
+    - '*.asciidoc'
+    - 'docs/**'
 
 jobs:
   test-vers:


### PR DESCRIPTION
The .ci/Jenkinsfile already has a similar skip:

```
            // Skip all the stages except docs for PR's with asciidoc or md changes only
            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
```