### PR TITLE
refactor: clarify func name

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -7,7 +7,7 @@ var path = require('path')
 var afterAll = require('after-all-results')
 var basicAuth = require('basic-auth')
 var getUrlFromRequest = require('original-url')
-var httpHeaders = require('http-headers')
+var parseHttpHeadersFromReqOrRes = require('http-headers')
 var stringify = require('fast-safe-stringify')
 var truncate = require('unicode-byte-truncate')
 var stacktrace = require('error-stack-parser')
@@ -195,7 +195,7 @@ function getContextFromResponse (res, conf, isError) {
   }
 
   if (conf.captureHeaders) {
-    context.headers = res.headers || httpHeaders(res, true)
+    context.headers = res.headers || parseHttpHeadersFromReqOrRes(res, true)
     context.headers = redactKeysFromObject(context.headers, conf.sanitizeFieldNamesRegExp)
   }
 


### PR DESCRIPTION
There is a local 'http-headers' module (in lib/filters) that does
something different.

Possibly a neurotic refactor. When I was walking through code for https://github.com/elastic/apm-agent-nodejs/pull/2072 there were two "things" matching "http-headers" in the agent code that do different things.