### PR TITLE
fix: add 'stringify' arg to TypeScript typings for setLabel and addLabels

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,9 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Update TypeScript typings for `Agent.setLabel` and `Agent.addLabels` to
+  include the `stringify` argument that was added in v3.11.0.
+
 
 [[release-notes-3.14.0]]
 ==== 3.14.0 - 2021/04/19

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,8 +100,8 @@ declare class Agent implements Taggable, StartSpanFn {
   currentSpan: Span | null;
 
   // Context
-  setLabel (name: string, value: LabelValue): boolean;
-  addLabels (labels: Labels): boolean;
+  setLabel (name: string, value: LabelValue, stringify?: boolean): boolean;
+  addLabels (labels: Labels, stringify?: boolean): boolean;
   setUserContext (user: UserObject): void;
   setCustomContext (custom: object): void;
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -87,8 +87,11 @@ agent.startSpan('foo', 'type', 'subtype', 'action', { childOf: 'baz' })
 agent.setLabel('foo', 'bar')
 agent.setLabel('foo', 1)
 agent.setLabel('foo', false)
+agent.setLabel('foo', 1, false)
+agent.setLabel('foo', false, false)
 
 agent.addLabels({ s: 'bar', n: 42, b: false })
+agent.addLabels({ s: 'bar', n: 42, b: false }, false)
 
 agent.setUserContext({
   id: 'foo',


### PR DESCRIPTION
They had been added to GenericSpan, but forgotten on class Agent.

Fixes: #2076

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
