### PR TITLE
3.15.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,10 +28,8 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-3.15.0]]
+==== 3.15.0 - 2021/05/19
 
 [float]
 ===== Features

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -31,6 +31,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.15.x |2022-11-19 |3.16.0
 |3.14.x |2022-10-19 |3.15.0
 |3.13.x |2022-10-06 |3.14.0
 |3.12.x |2022-08-22 |3.13.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
@@ -42,7 +42,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": "^8.6.0 || 10 || 12 || 13 || 14 || 15 || 16"
+    "node": "^8.6.0 || 10 || 12 || 14 || 15 || 16"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
Excerpt from the changelog:

```
[float]
===== Features

* Add support for Node.js v16. (This also drops testing of Node.js v13
  releases.)

[float]
===== Bug fixes

* Update TypeScript typings for `Agent.setLabel` and `Agent.addLabels` to
  include the `stringify` argument that was added in v3.11.0.
```


See the request here for a release: https://github.com/elastic/apm-agent-nodejs/issues/1840#issuecomment-842620858