### PR TITLE
feat: prefer 'traceparent' header over 'elastic-apm-traceparent' header

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,21 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+- Prefer W3C "traceparent" header over "elastic-apm-traceparent" for incoming
+  requests. {pull}2079[#2079]
+
+[float]
+===== Bug fixes
+
+
 [[release-notes-3.15.0]]
 ==== 3.15.0 - 2021/05/19
 
@@ -35,7 +50,7 @@ Notes:
 ===== Features
 
 * Add support for Node.js v16. (This also drops testing of Node.js v13
-  releases.)
+  releases.) {pull}2055[#2055]
 
 [float]
 ===== Bug fixes

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -21,7 +21,7 @@ exports.instrumentRequest = function (agent, moduleName) {
           // don't leak previous transaction
           agent._instrumentation.currentTransaction = null
         } else {
-          var traceparent = req.headers['elastic-apm-traceparent'] || req.headers.traceparent
+          var traceparent = req.headers.traceparent || req.headers['elastic-apm-traceparent']
           var tracestate = req.headers.tracestate
           var trans = agent.startTransaction(null, null, {
             childOf: traceparent,


### PR DESCRIPTION
The w3c traceparent header is standardized and widely used enough now in Elastic tools that we should prefer it over the proprietary 'elastic-apm-traceparent' header.

See similar for [Java](https://github.com/elastic/apm-agent-java/pull/1821), [.NET](https://github.com/elastic/apm-agent-dotnet/pull/1302).

### Checklist

- [x] Implement code
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
