### PR TITLE
test: limit testing of 'edge' node builds (node.js nightly and RC builds) to useful versions

### DIFF
--- a/.ci/.jenkins_nightly_nodejs.yml
+++ b/.ci/.jenkins_nightly_nodejs.yml
@@ -1,6 +1,12 @@
+# The node.js project produces "nightly" builds of the tip of *some*
+# development branches. They get uploaded to:
+# https://nodejs.org/download/nightly/
+#
+# My observation is that nightly builds are only made for the next major
+# version *up to the point there is a release of that version*.  For example,
+# at time of writing, there is not yet a v17 release of node, and
+# "v17.0.0-nightly*" builds are being created. Once a v17.0.0 release has been
+# made, these will stop and there will be no value in testing v17 nightlies.
+#
 NODEJS_VERSION:
-  - "16"
-  - "15"
-  - "14"
-  - "12"
-  - "10"
+  - "17"

--- a/.ci/.jenkins_rc_nodejs.yml
+++ b/.ci/.jenkins_rc_nodejs.yml
@@ -1,6 +1,15 @@
+# The node.js project *sometimes* produces "rc" builds leading up to a new
+# release. They get uploaded to: https://nodejs.org/download/rc/
+#
+# There is only value in testing an RC build, e.g. "v16.0.0-rc.5" before that
+# version, e.g. "v16.0.0", is released. The only versions that should be
+# listed here are active major releases listed at
+# https://nodejs.org/en/about/releases/
+#
+# (Ideally the Jenkins build steps would automatically determine if a given RC
+# build need not be tested.)
 NODEJS_VERSION:
+  - "17"
   - "16"
-  - "15"
   - "14"
   - "12"
-  - "10"

--- a/.ci/.jenkins_rc_nodejs.yml
+++ b/.ci/.jenkins_rc_nodejs.yml
@@ -1,15 +1,11 @@
-# The node.js project *sometimes* produces "rc" builds leading up to a new
-# release. They get uploaded to: https://nodejs.org/download/rc/
-#
-# There is only value in testing an RC build, e.g. "v16.0.0-rc.5" before that
-# version, e.g. "v16.0.0", is released. The only versions that should be
-# listed here are active major releases listed at
+# This should list all active Node.js major versions listed at:
 # https://nodejs.org/en/about/releases/
 #
-# (Ideally the Jenkins build steps would automatically determine if a given RC
-# build need not be tested.)
+# The node.js project *sometimes* produces "rc" builds leading up to a new
+# release. They get uploaded to: https://nodejs.org/download/rc/
 NODEJS_VERSION:
   - "17"
   - "16"
+  - "15"
   - "14"
   - "12"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -179,7 +179,7 @@ pipeline {
                   def node = readYaml(file: '.ci/.jenkins_nightly_nodejs.yml')
                   def parallelTasks = [:]
                   node['NODEJS_VERSION'].each { version ->
-                    parallelTasks["Node.js-${version}-nightly"] = generateStep(version: version, edge: true)
+                    parallelTasks["Node.js-${version}-nightly"] = generateStep(version: version, buildType: 'nightly')
                   }
                   parallel(parallelTasks)
                 }
@@ -201,7 +201,7 @@ pipeline {
                   def node = readYaml(file: '.ci/.jenkins_nightly_nodejs.yml')
                   def parallelTasks = [:]
                   node['NODEJS_VERSION'].each { version ->
-                    parallelTasks["Node.js-${version}-nightly-no-async-hooks"] = generateStep(version: version, edge: true, disableAsyncHooks: true)
+                    parallelTasks["Node.js-${version}-nightly-no-async-hooks"] = generateStep(version: version, buildType: 'nightly', disableAsyncHooks: true)
                   }
                   parallel(parallelTasks)
                 }
@@ -223,7 +223,7 @@ pipeline {
                   def node = readYaml(file: '.ci/.jenkins_rc_nodejs.yml')
                   def parallelTasks = [:]
                   node['NODEJS_VERSION'].each { version ->
-                    parallelTasks["Node.js-${version}-rc"] = generateStep(version: version, edge: true)
+                    parallelTasks["Node.js-${version}-rc"] = generateStep(version: version, buildType: 'rc')
                   }
                   parallel(parallelTasks)
                 }
@@ -245,7 +245,7 @@ pipeline {
                   def node = readYaml(file: '.ci/.jenkins_rc_nodejs.yml')
                   def parallelTasks = [:]
                   node['NODEJS_VERSION'].each { version ->
-                    parallelTasks["Node.js-${version}-rc-no-async-hooks"] = generateStep(version: version, edge: true, disableAsyncHooks: true)
+                    parallelTasks["Node.js-${version}-rc-no-async-hooks"] = generateStep(version: version, buildType: 'rc', disableAsyncHooks: true)
                   }
                   parallel(parallelTasks)
                 }
@@ -362,7 +362,7 @@ pipeline {
 def generateStep(Map params = [:]){
   def version = params?.version
   def tav = params.containsKey('tav') ? params.tav : ''
-  def edge = params.containsKey('edge') ? params.edge : false
+  def buildType = params.containsKey('buildType') ? params.buildType : 'release'
   def disableAsyncHooks = params.get('disableAsyncHooks', false)
   return {
     node('linux && immutable'){
@@ -372,7 +372,7 @@ def generateStep(Map params = [:]){
         dir("${BASE_DIR}"){
           try {
             retryWithSleep(retries: 2, seconds: 5, backoff: true) {
-              sh(label: "Run Tests", script: """.ci/scripts/test.sh "${version}" "${tav}" "${edge}" """)
+              sh(label: "Run Tests", script: """.ci/scripts/test.sh -b "${buildType}" -t "${tav}" "${version}" """)
             }
           } catch(e){
             error(e.toString())

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -145,8 +145,11 @@ pipeline {
         }
       }
     }
+
     /**
-      Run Edge tests.
+      The "Edge Test" is a run of the agent test suite with pre-release builds
+      of node.js, if available and useful. "Pre-release" builds are release
+      candidate (RC) and "nightly" node.js builds.
     */
     stage('Edge Test') {
       options { skipDefaultCheckout() }
@@ -167,9 +170,6 @@ pipeline {
       parallel {
         stage('Nightly Test') {
           agent { label 'linux && immutable' }
-          environment {
-            NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/nightly/"
-          }
           steps {
             withGithubNotify(context: 'Nightly Test', tab: 'tests') {
               deleteDir()
@@ -189,9 +189,6 @@ pipeline {
         }
         stage('Nightly Test - No async hooks') {
           agent { label 'linux && immutable' }
-          environment {
-            NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/nightly/"
-          }
           steps {
             withGithubNotify(context: 'Nightly No Async Hooks Test', tab: 'tests') {
               deleteDir()
@@ -211,9 +208,6 @@ pipeline {
         }
         stage('RC Test') {
           agent { label 'linux && immutable' }
-          environment {
-            NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/rc/"
-          }
           steps {
             withGithubNotify(context: 'RC Test', tab: 'tests') {
               deleteDir()
@@ -233,9 +227,6 @@ pipeline {
         }
         stage('RC Test - No async hooks') {
           agent { label 'linux && immutable' }
-          environment {
-            NVM_NODEJS_ORG_MIRROR = "https://nodejs.org/download/rc/"
-          }
           steps {
             withGithubNotify(context: 'RC No Async Hooks Test', tab: 'tests') {
               deleteDir()

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -152,11 +152,11 @@ fi
 # Select a config for 'docker-compose build' that sets up (a) the "node_tests"
 # container where the tests are actually run and (b) any services that are
 # needed for this set of tests, if any.
-if [[ "${IS_EDGE}" = "true" ]]; then
+if [[ "${BUILD_TYPE}" = "rc" || "${BUILD_TYPE}" = "nightly" ]]; then
   # This will run the regular tests against rc and nightly builds of
   # node.js. It does NOT support TAV tests.
   if [[ -n "${TAV_MODULE}" ]]; then
-    fatal "running TAV tests (TAV_MODULE=${TAV_MODULE}) with IS_EDGE=${IS_EDGE} is not supported"
+    fatal "running TAV tests (TAV_MODULE=${TAV_MODULE}) with BUILD_TYPE=${BUILD_TYPE} is not supported"
   fi
   DOCKER_COMPOSE_FILE=docker-compose-edge.yml
 elif [[ -n "${TAV_MODULE}" ]]; then

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -205,7 +205,7 @@ USER_ID="$(id -u):$(id -g)" \
 docker-compose \
   --no-ansi \
   --log-level ERROR \
-  -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
+  -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   build >docker-compose.log 2>docker-compose.err
 
 if [ $? -gt 0 ] ; then
@@ -224,7 +224,7 @@ USER_ID="$(id -u):$(id -g)" \
 docker-compose \
   --no-ansi \
   --log-level ERROR \
-  -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
+  -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   up \
   --exit-code-from node_tests \
   --remove-orphans \
@@ -234,5 +234,5 @@ docker-compose \
 NODE_VERSION=${NODE_VERSION} docker-compose \
   --no-ansi \
   --log-level ERROR \
-  -f ${DOCKER_FOLDER}/${DOCKER_COMPOSE_FILE} \
+  -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   down -v --remove-orphans


### PR DESCRIPTION
"Edge" builds or "Edge Test" is this repo's name for running the Agent test suite against pre-release (RC or nightly) builds of Node.js.

1. node.js "nightly" builds: It is only useful testing those if there are no current releases for that major branch. For example, a nightly build of "v16.0.0-nightly20210420a0261d231c" (the current latest v16 nightly build) is pointless because there are v16.x node.js releases after that that we already test.  At time of writing only v17 has nightly builds and no releases. Once there is a v17.0.0 release my interpretation of https://nodejs.org/download/nightly/ is that there will be no more v17.x nightly builds -- or at least no v17 nightly builds of a commit past the latest v17 release commit sha. (I'd welcome an authoritative source for that. I couldn't find it. E.g. https://github.com/nodejs/node/blob/master/doc/guides/releases.md#8-produce-a-nightly-build-optional isn't really it.)

2. node.js "RC" builds: Only useful to check for active majors (per https://nodejs.org/en/about/releases/). Similar to the above, if the latest v16 RC build is "v16.0.0-rc.5" (as is the case currently), then there is no point in testing against it because there is a v16.0.0 actual release of node.js.

This PR:
- changes the Node.js versions of "nightly" and "rc" pre-release builds that we consider testing against; and
- makes ".ci/scripts/test.sh" smarter to **skip out** of running the agent test suite against a nightly or RC pre-release build that isn't useful to test against (according to the descriptions above). 


The result is that the execution of "Edge Tests" (currently run daily by Jenkins on a timer) will, at time of writing, only run a test against the latest node v17 nightly build. There aren't currently any RCs for upcoming node.js releases. If one lands in https://nodejs.org/download/nightly/ or https://nodejs.org/download/rc/   then the next "Edge Tests" run will test it.
