### PR TITLE
test: faster TAV runs by reducing the test matrix

### DIFF
--- a/.ci/.jenkins_tav.yml
+++ b/.ci/.jenkins_tav.yml
@@ -3,6 +3,7 @@ TAV:
   - '@hapi/hapi'
   - '@koa/router'
   - apollo-server-express
+  - aws-sdk
   - bluebird
   - cassandra-driver
   - elasticsearch

--- a/.tav.yml
+++ b/.tav.yml
@@ -413,6 +413,13 @@ body-parser:
     - node test/sanitize-field-names/express.js
 
 aws-sdk:
-  versions: '>=2.858 <3'
+  # We want this version range:
+  #   versions: '>=2.858 <3'
+  # However, awk-sdk releases *very* frequently (almost every day) and there
+  # is no need to test *all* those releases. Instead we statically list every
+  # N=5 releases to test.
+  #
+  # Maintenance note: This should be updated periodically.
+  versions: '2.858.0 || 2.863.0 || 2.868.0 || 2.873.0 || 2.878.0 || 2.883.0 || 2.888.0 || 2.893.0 || 2.898.0 || 2.903.0 || 2.908.0 || 2.913.0 || 2.918.0 || >2.918 <3'
   commands:
     - node test/instrumentation/modules/aws-sdk/sqs.js

--- a/.tav.yml
+++ b/.tav.yml
@@ -51,7 +51,12 @@ ioredis-new:
   commands: node test/instrumentation/modules/ioredis.js
 pg-old-node:
   name: pg
-  versions: '>=4 <9'
+  # We want this version range:
+  #   versions: '>=4 <9'
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '4.0.0 || 4.1.1 || 4.2.0 || 4.3.0 || 4.4.6 || 4.5.7 || 5.0.0 || 5.1.0 || 5.2.1 || 6.0.5 || 6.1.6 || 6.2.5 || 6.3.3 || 6.4.2 || 7.0.3 || 7.1.2 || 7.2.0 || 7.3.0 || 7.4.3 || 7.5.0 || 7.6.1 || 7.7.1 || 7.8.2 || 7.9.0 || 7.10.0 || 7.11.0 || 7.12.1 || 7.13.0 || 7.14.0 || 7.15.2 || 7.16.1 || 7.17.1 || 7.18.2 || 8.0.3 || 8.1.0 || 8.2.2 || 8.3.3 || 8.4.2 || 8.5.1 || 8.6.0 || >8.6.0 <9'
   node: '<14'
   peerDependencies:
     - bluebird@^3.0.0
@@ -61,7 +66,12 @@ pg-old-node:
     - node test/instrumentation/modules/pg/knex.js
 pg-new-node:
   name: pg
-  versions: '>=8.0.3 <9' # Prior versions didn't work in Node.js 14
+  # We want this version range:
+  #   versions: '>=8.0.3 <9' # Prior versions didn't work in Node.js 14
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '8.0.3 || 8.1.0 || 8.2.2 || 8.3.3 || 8.4.2 || 8.5.1 || 8.6.0 || >8.6.0 <9'
   node: '>=14'
   peerDependencies:
     - bluebird@^3.0.0

--- a/.tav.yml
+++ b/.tav.yml
@@ -206,22 +206,52 @@ apollo-server-express-2_12:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.12.0
-  versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  # We want this version range:
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_13:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.13.0
-  versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  # We want this version range:
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.js
 apollo-server-express-2_14:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
-  versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  # We want this version range:
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   node: '>=6'
+  commands: node test/instrumentation/modules/apollo-server-express.js
+apollo-server-express-2_15:
+  name: apollo-server-express
+  preinstall: npm uninstall express-graphql
+  peerDependencies: graphql@^15.0.0
+  # We want this version range (2.12.0 was the first release of
+  # apollo-server-express after graphql@15 was released):
+  #   versions: '>= 2.12.0'
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  # Per https://github.com/graphql/graphql-js/releases/tag/v15.0.0
+  # graphql v15 supports node v8 as a minimum.
+  node: '>=8'
   commands: node test/instrumentation/modules/apollo-server-express.js
 
 express-queue:


### PR DESCRIPTION
- apollo-server-express: Only test the latest MAJOR.MINOR.x patch
  releases, reducing from 84 down to 25 releases (currently).
  - Aside: This also *adds* testing of apollo-server-express against
    graphql@15 (released since this test matrix was updated.

Fixes #2084
