### PR TITLE
test: make this test robust for additional capture spans possible with mongodb-core@1.x

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -133,24 +133,24 @@ we can list the slowest ones via:
 npm install -g json  # Re-writing this to use jq is an exercise for the reader.
 
 curl -s https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/.../artifact/steps-info.json \
-    | json -c 'this.displayName==="Run Tests"' -ga durationInMillis displayDescription | sort -n -k1 | tail -20
+    | json -c 'this.displayName==="Run Tests"' -ga durationInMillis state result displayDescription | sort -n -k1 | tail -20
 ```
 
 For example:
 
 ```
 % curl -s https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/master/903/artifact/steps-info.json \
-    | json -c 'this.displayName==="Run Tests"' -ga durationInMillis displayDescription | sort -n -k1 | tail -10
-1940297 .ci/scripts/test.sh "14" "fastify" "false"
-2434461 .ci/scripts/test.sh "15" "apollo-server-express" "false"
-2867593 .ci/scripts/test.sh "16" "apollo-server-express" "false"
-3232404 .ci/scripts/test.sh "8" "pg" "false"
-3233514 .ci/scripts/test.sh "12" "pg" "false"
-3371890 .ci/scripts/test.sh "10" "pg" "false"
-5394174 .ci/scripts/test.sh "12" "apollo-server-express" "false"
-5832066 .ci/scripts/test.sh "10" "apollo-server-express" "false"
-6481178 .ci/scripts/test.sh "14" "apollo-server-express" "false"
-6626799 .ci/scripts/test.sh "8" "apollo-server-express" "false"
+    | json -c 'this.displayName==="Run Tests"' -ga durationInMillis state result displayDescription | sort -n -k1 | tail -10
+1940297 FINISHED SUCCESS .ci/scripts/test.sh "14" "fastify" "false"
+2434461 FINISHED SUCCESS .ci/scripts/test.sh "15" "apollo-server-express" "false"
+2867593 FINISHED SUCCESS .ci/scripts/test.sh "16" "apollo-server-express" "false"
+3232404 FINISHED SUCCESS .ci/scripts/test.sh "8" "pg" "false"
+3233514 FINISHED SUCCESS .ci/scripts/test.sh "12" "pg" "false"
+3371890 FINISHED SUCCESS .ci/scripts/test.sh "10" "pg" "false"
+5394174 FINISHED SUCCESS .ci/scripts/test.sh "12" "apollo-server-express" "false"
+5832066 FINISHED SUCCESS .ci/scripts/test.sh "10" "apollo-server-express" "false"
+6481178 FINISHED SUCCESS .ci/scripts/test.sh "14" "apollo-server-express" "false"
+6626799 FINISHED SUCCESS .ci/scripts/test.sh "8" "apollo-server-express" "false"
 ```
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,6 +123,37 @@ Note that it might likely get out of date:
         deactivate
 
 
+## How to show the slowest TAV tests from a Jenkins build
+
+Jenkins builds of the agent produce a "steps-info.json" artifact that gives
+execution time of each of the build steps. For a build that ran the TAV tests
+we can list the slowest ones via:
+
+```
+npm install -g json  # Re-writing this to use jq is an exercise for the reader.
+
+curl -s https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/.../artifact/steps-info.json \
+    | json -c 'this.displayName==="Run Tests"' -ga durationInMillis displayDescription | sort -n -k1 | tail -20
+```
+
+For example:
+
+```
+% curl -s https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/master/903/artifact/steps-info.json \
+    | json -c 'this.displayName==="Run Tests"' -ga durationInMillis displayDescription | sort -n -k1 | tail -10
+1940297 .ci/scripts/test.sh "14" "fastify" "false"
+2434461 .ci/scripts/test.sh "15" "apollo-server-express" "false"
+2867593 .ci/scripts/test.sh "16" "apollo-server-express" "false"
+3232404 .ci/scripts/test.sh "8" "pg" "false"
+3233514 .ci/scripts/test.sh "12" "pg" "false"
+3371890 .ci/scripts/test.sh "10" "pg" "false"
+5394174 .ci/scripts/test.sh "12" "apollo-server-express" "false"
+5832066 .ci/scripts/test.sh "10" "apollo-server-express" "false"
+6481178 .ci/scripts/test.sh "14" "apollo-server-express" "false"
+6626799 .ci/scripts/test.sh "8" "apollo-server-express" "false"
+```
+
+
 # Other tips
 
 ## How to trigger a benchmark run for a PR

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,3 +145,38 @@ showed PR values.
 and, depending on other conditions, the "TAV Test" step -- both of which are
 long and will run before getting to the Benchmarks run.)
 
+
+## How to test your local agent in Docker
+
+If you are developing on macOS, it can be convenient to test your local
+agent changes in Linux via docker:
+
+1. Optionally start services whose clients the agent instruments (redis, mysql,
+   etc.). These are placed on the `test_default` network.
+
+        npm run docker:start
+
+2. Start Bash in a linux container on that same network, mounting your current
+   dir:
+
+        docker run --rm -ti --network test_default -v $(pwd):/app --workdir /app node:16 /bin/bash
+
+3. When you are done, stop the services:
+
+        npm run docker:stop
+
+For example:
+
+```
+% docker run --rm -ti --network test_default -v $(pwd):/app --workdir /app node:16 /bin/bash
+root@248cddc5b508:/app# ls package.json
+package.json
+
+root@248cddc5b508:/app# ping mongodb
+PING mongodb (172.20.0.3) 56(84) bytes of data.
+64 bytes from test_mongodb_1.test_default (172.20.0.3): icmp_seq=1 ttl=64 time=0.315 ms
+^C
+--- mongodb ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 0.315/0.315/0.315/0.000 ms
+```

--- a/test/instrumentation/modules/mongodb-core.js
+++ b/test/instrumentation/modules/mongodb-core.js
@@ -11,81 +11,65 @@ var agent = require('../../..').start({
 var Server = require('mongodb-core').Server
 var semver = require('semver')
 var test = require('tape')
-var version = require('mongodb-core/package').version
+var mongodbCoreVersion = require('mongodb-core/package').version
 
 var mockClient = require('../../_mock_http_client')
 
 test('instrument simple command', function (t) {
-  const expected = semver.lt(version, '2.0.0')
-    ? (process.platform === 'darwin' ? 11 : 10)
-    : 7
-
-  resetAgent(expected, function (data) {
-    var trans = data.transactions[0]
-    var groups
+  // Because a variable number of events to the APM server is possible (see
+  // the "Note ... additional spans" below), we cannot use the 'expected' arg
+  // to `mockClient` here.
+  resetAgent(function (data) {
+    var expectedSpanNamesInOrder = [
+      'system.$cmd.ismaster',
+      'elasticapm.test.insert',
+      'elasticapm.test.update',
+      'elasticapm.test.remove',
+      'elasticapm.test.find',
+      'system.$cmd.ismaster'
+    ]
 
     t.strictEqual(data.transactions.length, 1)
-
+    var trans = data.transactions[0]
     t.strictEqual(trans.name, 'foo')
     t.strictEqual(trans.type, 'bar')
     t.strictEqual(trans.result, 'success')
 
-    // Ensure spans are sorted by start time
+    // Ensure spans are sorted by start time.
     data.spans = data.spans.sort((a, b) => {
       return a.timestamp - b.timestamp
     })
 
-    if (semver.lt(version, '2.0.0')) {
-      groups = [
-        'system.$cmd.ismaster',
-        'elasticapm.test.insert',
-        'elasticapm.$cmd.command',
-        'elasticapm.test.update',
-        'elasticapm.$cmd.command',
-        'elasticapm.test.remove',
-        'elasticapm.$cmd.command',
-        'elasticapm.test.find',
-        'system.$cmd.ismaster'
-      ]
-
-      if (process.platform === 'darwin') {
-        // mongodb-core v1.x will sometimes perform two `ismaster` queries
-        // towards the admin and/or the system database. This doesn't always
-        // happen, but if it does, we'll accept it.
-        if (data.spans[0].name === 'admin.$cmd.ismaster') {
-          groups.unshift('admin.$cmd.ismaster')
-        } else if (data.spans[1].name === 'system.$cmd.ismaster') {
-          groups.unshift('system.$cmd.ismaster')
+    // Check that the APM server received the expected spans in order.
+    //
+    // Note that there might be some additional spans that we allow and ignore:
+    // - mongodb-core@1.x always does a `admin.$cmd.ismaster` command on
+    //   initial connection. The APM agent captures this if asyncHooks=true.
+    // - mongodb-core@1.x includes `elasticapm.$cmd.command` spans after the
+    //   insert, update, and remove commands.
+    for (var i = 0; i < data.spans.length; i++) {
+      const span = data.spans[i]
+      if (semver.lt(mongodbCoreVersion, '2.0.0')) {
+        if (span.name === 'admin.$cmd.ismaster' && i === 0) {
+          t.comment("ignore 'admin.$cmd.ismaster' captured span")
+          continue
+        } else if (span.name === 'elasticapm.$cmd.command') {
+          t.comment("ignore 'elasticapm.$cmd.command' captured span")
+          continue
         }
       }
-    } else {
-      groups = [
-        'system.$cmd.ismaster',
-        'elasticapm.test.insert',
-        'elasticapm.test.update',
-        'elasticapm.test.remove',
-        'elasticapm.test.find',
-        'system.$cmd.ismaster'
-      ]
-    }
 
-    t.strictEqual(data.spans.length, groups.length)
-
-    // spans are sorted by their end time - we need them sorted by their start time
-    data.spans = data.spans.sort(function (a, b) {
-      return a.timestamp - b.timestamp
-    })
-
-    groups.forEach(function (name, i) {
-      const span = data.spans[i]
-      t.strictEqual(span.name, name)
-      t.strictEqual(span.type, 'db')
-      t.strictEqual(span.subtype, 'mongodb')
-      t.strictEqual(span.action, 'query')
-
+      t.strictEqual(span.name, expectedSpanNamesInOrder[0],
+        'captured span has expected name: ' + expectedSpanNamesInOrder[0])
+      t.strictEqual(span.type, 'db', 'span has expected type')
+      t.strictEqual(span.subtype, 'mongodb', 'span has expected subtype')
+      t.strictEqual(span.action, 'query', 'span has expected action')
       var offset = span.timestamp - trans.timestamp
-      t.ok(offset + span.duration * 1000 < trans.duration * 1000)
-    })
+      t.ok(offset + span.duration * 1000 < trans.duration * 1000,
+        `span ends (${span.timestamp / 1000 + span.duration}ms) before the transaction (${trans.timestamp / 1000 + trans.duration}ms)`)
+
+      expectedSpanNamesInOrder.shift()
+    }
 
     t.end()
   })


### PR DESCRIPTION
With mongodb-core@1.x there are some addition spans that can be
captured. This makes the test not blow up in those cases.

Fixes: #1337
