### PR TITLE
fix: missing typescript defs

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -160,7 +160,7 @@ A boolean specifying if the agent should automatically apply instrumentation to 
 Note that both `active` and `instrument` needs to be `true` for instrumentation to be running.
 
 [[instrument-incoming-http-requests]]
-==== `instrumentIncomingHTTPRequests?:`
+==== `instrumentIncomingHTTPRequests`
 
 * *Type:* Boolean
 * *Default:* `true`

--- a/index.d.ts
+++ b/index.d.ts
@@ -197,11 +197,14 @@ interface AgentConfigOptions {
   apiRequestSize?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
   apiRequestTime?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
   asyncHooks?: boolean;
+  breakdownMetrics?: boolean;
   captureBody?: CaptureBody;
   captureErrorLogStackTraces?: CaptureErrorLogStackTraces;
   captureExceptions?: boolean;
   captureHeaders?: boolean;
   captureSpanStackTraces?: boolean;
+  cloudProvider?: string;
+  configFile?: string;
   containerId?: string;
   disableInstrumentations?: string | string[];
   environment?: string;
@@ -226,6 +229,7 @@ interface AgentConfigOptions {
   logger?: Logger;
   maxQueueSize?: number;
   metricsInterval?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
+  metricsLimit?: number;
   payloadLogFile?: string;
   centralConfig?: boolean;
   sanitizeFieldNames?: Array<string>;
@@ -234,6 +238,7 @@ interface AgentConfigOptions {
   serverTimeout?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
   serverUrl?: string;
   serviceName?: string;
+  serviceNodeName?: string;
   serviceVersion?: string;
   sourceLinesErrorAppFrames?: number;
   sourceLinesErrorLibraryFrames?: number;
@@ -243,6 +248,7 @@ interface AgentConfigOptions {
   transactionIgnoreUrls?: Array<string>;
   transactionMaxSpans?: number;
   transactionSampleRate?: number;
+  useElasticTraceparentHeader?: boolean;
   usePathAsTransactionName?: boolean;
   verifyServerCert?: boolean;
 }


### PR DESCRIPTION
After fixing up a missing type in another PR, I noticed there were a number of configuration values used by `lib/config.js` and documented by `docs/configuration.asciidoc` that were missing from our `index.d.ts` file.   This PR adds them in.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Update TypeScript typings
- [x] Update documentation
