### PR TITLE
bump read-pkg-up from 7.x to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "object-identity-map": "^1.0.2",
     "original-url": "^1.2.3",
     "pino": "^6.11.2",
-    "read-pkg-up": "^7.0.1",
+    "read-pkg-up": "^8.0.0",
     "relative-microtime": "^2.0.0",
     "require-in-the-middle": "^5.0.3",
     "semver": "^6.3.0",


### PR DESCRIPTION
Updates dependencies to not use vulnerability in hosted-git-info https://www.npmjs.com/advisories/1677

Used in elastic-apm-node > read-pkg-up > read-pkg > normalize-package-data > hosted-git-info