### PR TITLE
fix: 'TypeError: lastPrepareStackTrace' crash when used with React v17+

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,9 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix a crash (`TypeError: lastPrepareStackTrace`) in the agent when used with
+  React v17 and later ({issues}1980[#1980]).
+
 * Performance improvements have been made in error and stacktrace capture ({pull}2094[#2094]).
   This also included in two bug fixes:
 +

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "core-util-is": "^1.0.2",
     "elastic-apm-http-client": "^9.8.0",
     "end-of-stream": "^1.4.4",
-    "error-callsites": "^2.0.3",
+    "error-callsites": "^2.0.4",
     "error-stack-parser": "^2.0.6",
     "escape-string-regexp": "^4.0.0",
     "fast-safe-stringify": "^2.0.7",


### PR DESCRIPTION
The root cause was https://github.com/facebook/react/pull/18708
temporarily doing `Error.prepareStackTrace = undefined` to get a stack
string. This wasn't handled correctly by error-callsites
(watson/error-callsites#3).

Fixes: #1980

### Checklist

- [x] Implement code
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
