### PR TITLE
fix: avoid possible circular require bug between this and ecs-pino-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
   "dependencies": {
-    "@elastic/ecs-pino-format": "^1.1.0",
+    "@elastic/ecs-pino-format": "^1.1.2",
     "after-all-results": "^2.0.0",
     "async-cache": "^1.1.0",
     "async-value-promise": "^1.1.1",


### PR DESCRIPTION
https://github.com/elastic/ecs-logging-nodejs/issues/79 was a circular
require issue that could happen between 'elastic-apm-node' and
'@elastic/ecs-pino-format' (versions before 1.1.2) -- if user code
directly used both modules. This bumps the version of the latter to help
avoid that situation in user apps.

Refs: #2110
