### PR TITLE
fix: SQS crashing error with no active transaction

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,7 +46,7 @@ Notes:
   method (e.g. "GET", "PUT", "POST"), rather than "http". ({pull}2075[#2075])
 
 * Fixed error where SQS messages sent without an active transactions could
-  crash the agent.
+  crash the agent. ({issues}2113[#2113])
 
 [[release-notes-x.x.x]]
 ==== 3.16.0 - 2021/06/14

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,8 @@ Notes:
   respectively. As well, <<span-action, `span.action`>> will now be the HTTP
   method (e.g. "GET", "PUT", "POST"), rather than "http". ({pull}2075[#2075])
 
+* Fixed error where SQS messages sent without an active transactions could
+  crash the agent.
 
 [[release-notes-x.x.x]]
 ==== 3.16.0 - 2021/06/14

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -130,7 +130,7 @@ function shouldIgnoreRequest (request, agent) {
     }
   }
 
-  if (!agent.currentTransaction) {
+  if (!agent.currentTransaction || agent.currentTransaction.ended) {
     agent.logger.trace('no active transaction found, skipping sqs instrumentation')
     return true
   }

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -147,7 +147,7 @@ function instrumentationSqs (orig, origArguments, request, AWS, agent, { version
   const action = getActionFromRequest(request)
   const name = getSpanNameFromRequest(request)
   const span = agent.startSpan(name, type, subtype, action)
-  if(span) {
+  if (span) {
     span.setDestinationContext(getMessageDestinationContextFromRequest(request))
     span.setMessageContext(getMessageContextFromRequest(request))
 

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -130,11 +130,6 @@ function shouldIgnoreRequest (request, agent) {
     }
   }
 
-  if (!agent.currentTransaction || agent.currentTransaction.ended) {
-    agent.logger.trace('no active transaction found, skipping sqs instrumentation')
-    return true
-  }
-
   return false
 }
 
@@ -152,28 +147,29 @@ function instrumentationSqs (orig, origArguments, request, AWS, agent, { version
   const action = getActionFromRequest(request)
   const name = getSpanNameFromRequest(request)
   const span = agent.startSpan(name, type, subtype, action)
-  span.setDestinationContext(getMessageDestinationContextFromRequest(request))
-  span.setMessageContext(getMessageContextFromRequest(request))
+  if(span) {
+    span.setDestinationContext(getMessageDestinationContextFromRequest(request))
+    span.setMessageContext(getMessageContextFromRequest(request))
 
-  request.on('complete', function (response) {
-    if (response && response.error) {
-      const errOpts = {
-        skipOutcome: true
+    request.on('complete', function (response) {
+      if (response && response.error) {
+        const errOpts = {
+          skipOutcome: true
+        }
+        agent.captureError(response.error, errOpts)
+        span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
       }
-      agent.captureError(response.error, errOpts)
-      span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
-    }
 
-    // we'll need to manually mark this span as async.  The actual async hop
-    // is captured by the agent's async hooks instrumentation
-    span.sync = false
-    span.end()
+      // we'll need to manually mark this span as async.  The actual async hop
+      // is captured by the agent's async hooks instrumentation
+      span.sync = false
+      span.end()
 
-    if (request.operation === 'receiveMessage' && response && response.data) {
-      recordMetrics(getQueueNameFromRequest(request), response.data, agent)
-    }
-  })
-
+      if (request.operation === 'receiveMessage' && response && response.data) {
+        recordMetrics(getQueueNameFromRequest(request), response.data, agent)
+      }
+    })
+  }
   const origResult = orig.apply(request, origArguments)
 
   return origResult

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -147,32 +147,33 @@ function instrumentationSqs (orig, origArguments, request, AWS, agent, { version
   const action = getActionFromRequest(request)
   const name = getSpanNameFromRequest(request)
   const span = agent.startSpan(name, type, subtype, action)
-  if (span) {
-    span.setDestinationContext(getMessageDestinationContextFromRequest(request))
-    span.setMessageContext(getMessageContextFromRequest(request))
-
-    request.on('complete', function (response) {
-      if (response && response.error) {
-        const errOpts = {
-          skipOutcome: true
-        }
-        agent.captureError(response.error, errOpts)
-        span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
-      }
-
-      // we'll need to manually mark this span as async.  The actual async hop
-      // is captured by the agent's async hooks instrumentation
-      span.sync = false
-      span.end()
-
-      if (request.operation === 'receiveMessage' && response && response.data) {
-        recordMetrics(getQueueNameFromRequest(request), response.data, agent)
-      }
-    })
+  if (!span) {
+    return orig.apply(request, origArguments)
   }
-  const origResult = orig.apply(request, origArguments)
 
-  return origResult
+  span.setDestinationContext(getMessageDestinationContextFromRequest(request))
+  span.setMessageContext(getMessageContextFromRequest(request))
+
+  request.on('complete', function (response) {
+    if (response && response.error) {
+      const errOpts = {
+        skipOutcome: true
+      }
+      agent.captureError(response.error, errOpts)
+      span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
+    }
+
+    // we'll need to manually mark this span as async.  The actual async hop
+    // is captured by the agent's async hooks instrumentation
+    span.sync = false
+    span.end()
+
+    if (request.operation === 'receiveMessage' && response && response.data) {
+      recordMetrics(getQueueNameFromRequest(request), response.data, agent)
+    }
+  })
+
+  return orig.apply(request, origArguments)
 }
 
 module.exports = {

--- a/test/instrumentation/modules/aws-sdk/sqs.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.js
@@ -144,7 +144,6 @@ tape.test('AWS SQS: Unit Test Functions', function (test) {
       },
       logger: logging.createLogger('off')
     }
-    t.equals(shouldIgnoreRequest(request, agent), true)
 
     agent.currentTransaction = { mocked: 'transaction' }
     t.equals(shouldIgnoreRequest(request, agent), false)


### PR DESCRIPTION
Fixes #2113

This PR modifies adds an additional guard clause to the SQS instrumentation that checks to see if a span was actually started or not.  It also removed the old `currentTransaction` guard clause from `shouldIgnoreRequest` and modifies the unit test accordingly. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
