### PR TITLE
docs: improve changelog note on sanitize_field_names

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -274,9 +274,10 @@ slightly to commonalize:
 * feat: Add `log_level` central config support. {pull}1908[#1908] +
   Spec: https://github.com/elastic/apm/blob/master/specs/agents/logging.md
 
-* feat: implemented sanitize_feature_names specification +
+* feat: Add `sanitize_field_names` configuration option. +
   Allows users to configure a list of wildcard patterns to _remove_ items
   from the agent's HTTP header and `application/x-www-form-urlencoded` payloads.
+  {pull}1898[#1898]
   ** https://github.com/elastic/apm/blob/master/specs/agents/sanitization.md[spec]
   ** https://github.com/elastic/apm-agent-nodejs/blob/master/docs/configuration.asciidoc#sanitize-field-names[docs]
 


### PR DESCRIPTION
Minor tweaks to the changelog item for having added `sanitize_field_names`.

Related: I've also updated the relevant cells in https://docs.google.com/spreadsheets/d/1JJjZotapacA3FkHc2sv_0wiChILi3uKnkwLTjtBmxwU/edit#gid=0 for this.
