### PR TITLE
tests: fix docker-compose setup that broke aws-sdk TAV tests in CI

### DIFF
--- a/.ci/docker/docker-compose-localstack.yml
+++ b/.ci/docker/docker-compose-localstack.yml
@@ -12,3 +12,7 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+
+volumes:
+  nodelocalstackdata:
+    driver: local


### PR DESCRIPTION
Fixes: #2129
