### PR TITLE
tests: fix mssql server Docker registry

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       retries: 30
 
   mssql:
-    image: microsoft/mssql-server-linux
+    image: mcr.microsoft.com/mssql/server
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Very(!)Secure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: 1
 
       mssql:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         env:
           ACCEPT_EULA: 'Y'
           SA_PASSWORD: 'Very(!)Secure'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       retries: 30
 
   mssql:
-    image: microsoft/mssql-server-linux
+    image: mcr.microsoft.com/mssql/server
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Very(!)Secure


### PR DESCRIPTION
Very recently MS removed the 'microsoft/mssql-server-linux' images from
Docker Hub in favour of https://hub.docker.com/_/microsoft-mssql-server
This was breaking tests.
