### PR TITLE
ci: tear down docker network to retry explicitly

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -365,8 +365,6 @@ def generateStep(Map params = [:]){
             retryWithSleep(retries: 2, seconds: 5, backoff: true) {
               sh(label: "Run Tests", script: """.ci/scripts/test.sh -b "${buildType}" -t "${tav}" "${version}" """)
             }
-          } catch(e){
-            error(e.toString())
           } finally {
             // TAV tests run 'npm run test:tav' which does *not* produce TAP
             // output.

--- a/.ci/docker/docker-compose-all.yml
+++ b/.ci/docker/docker-compose-all.yml
@@ -76,3 +76,7 @@ volumes:
     driver: local
   nodelocalstackdata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-cassandra.yml
+++ b/.ci/docker/docker-compose-cassandra.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodecassandradata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-edge.yml
+++ b/.ci/docker/docker-compose-edge.yml
@@ -76,3 +76,7 @@ volumes:
     driver: local
   nodecassandradata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-elasticsearch.yml
+++ b/.ci/docker/docker-compose-elasticsearch.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodeesdata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-localstack.yml
+++ b/.ci/docker/docker-compose-localstack.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodelocalstackdata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-memcached.yml
+++ b/.ci/docker/docker-compose-memcached.yml
@@ -12,3 +12,7 @@ services:
     depends_on:
       memcached:
         condition: service_healthy
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-mongodb.yml
+++ b/.ci/docker/docker-compose-mongodb.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodemongodata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-mssql.yml
+++ b/.ci/docker/docker-compose-mssql.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodemssqldata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-mysql.yml
+++ b/.ci/docker/docker-compose-mysql.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodemysqldata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-node-edge-test.yml
+++ b/.ci/docker/docker-compose-node-edge-test.yml
@@ -33,3 +33,7 @@ services:
     user: ${USER_ID}
     networks:
       - apm-agent-nodejs
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-node-edge-test.yml
+++ b/.ci/docker/docker-compose-node-edge-test.yml
@@ -31,3 +31,5 @@ services:
     volumes:
       - ${PWD}:/app
     user: ${USER_ID}
+    networks:
+      - apm-agent-nodejs

--- a/.ci/docker/docker-compose-node-test.yml
+++ b/.ci/docker/docker-compose-node-test.yml
@@ -29,3 +29,5 @@ services:
     volumes:
       - ${PWD}:/app
     user: ${USER_ID}
+    networks:
+      - apm-agent-nodejs

--- a/.ci/docker/docker-compose-node-test.yml
+++ b/.ci/docker/docker-compose-node-test.yml
@@ -31,3 +31,7 @@ services:
     user: ${USER_ID}
     networks:
       - apm-agent-nodejs
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-postgres.yml
+++ b/.ci/docker/docker-compose-postgres.yml
@@ -16,3 +16,7 @@ services:
 volumes:
   nodepgdata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose-redis.yml
+++ b/.ci/docker/docker-compose-redis.yml
@@ -12,3 +12,7 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       interval: 1s
       timeout: 10s
       retries: 30
+    networks:
+      - apm-agent-nodejs
 
   mongodb:
     image: mongo
@@ -29,6 +31,8 @@ services:
       interval: 1s
       timeout: 10s
       retries: 30
+    networks:
+      - apm-agent-nodejs
 
   mssql:
     image: mcr.microsoft.com/mssql/server
@@ -45,6 +49,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    networks:
+      - apm-agent-nodejs
 
   mysql:
     image: mysql:5.7
@@ -59,6 +65,8 @@ services:
       interval: 1s
       timeout: 10s
       retries: 30
+    networks:
+      - apm-agent-nodejs
 
   redis:
     image: redis
@@ -69,6 +77,8 @@ services:
       interval: 1s
       timeout: 10s
       retries: 30
+    networks:
+      - apm-agent-nodejs
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
@@ -87,6 +97,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    networks:
+      - apm-agent-nodejs
 
   cassandra:
     image: cassandra:3
@@ -102,6 +114,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    networks:
+      - apm-agent-nodejs
 
   memcached:
     image: memcached:alpine
@@ -113,6 +127,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    networks:
+      - apm-agent-nodejs
 
   localstack:
     # https://hub.docker.com/r/localstack/localstack/tags
@@ -129,6 +145,8 @@ services:
       retries: 5
     volumes:
       - nodelocalstackdata:/var/lib/localstack
+    networks:
+      - apm-agent-nodejs
 
 volumes:
   nodepgdata:
@@ -145,3 +163,7 @@ volumes:
     driver: local
   nodelocalstackdata:
     driver: local
+
+networks:
+  apm-agent-nodejs:
+    driver: bridge

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -250,6 +250,9 @@ docker-compose \
   --abort-on-container-exit \
   node_tests
 
+echo "Workaround issues with docker-compose down while removing network"
+docker network prune --force || true
+
 NODE_VERSION=${NODE_VERSION} docker-compose \
   --no-ansi \
   --log-level ERROR \

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -250,9 +250,6 @@ docker-compose \
   --abort-on-container-exit \
   node_tests
 
-echo "Workaround issues with docker-compose down while removing network"
-docker network prune --force || true
-
 NODE_VERSION=${NODE_VERSION} docker-compose \
   --no-ansi \
   --log-level ERROR \


### PR DESCRIPTION
### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)


### What

The docker compose environment failed when tearing down the network. Since there is a retry in this particular stage in the CI, it's needed to happen otherwise the next iteration will fail.

Let's run an explicit `docker network prune --force` before running the `docker-compose down` since the later does not support a `force` feature.

### Why

Reduce any environmental flakiness.

Log errors can be seen in https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/master/963/pipeline/#step-600-log-1841


```
[2021-07-05T06:08:58.530Z] + docker-compose --no-ansi --log-level ERROR -f .ci/docker/docker-compose-all.yml down -v --remove-orphans
[2021-07-05T06:08:59.471Z] Stopping docker_mssql_1         ... 
...
[2021-07-05T06:09:10.904Z] Removing docker_mongodb_1       ... done
[2021-07-05T06:09:10.904Z] error while removing network: network docker_default id 8731047bca1c48562f34b7a5016ebcbd46d36fe4b1d1354ddba24ad812af506d has active endpoints

```

### Tests

![image](https://user-images.githubusercontent.com/2871786/124466452-9633be00-dd8e-11eb-84fb-93c0a3c56ef8.png)

