### PR TITLE
ci: use withNode step to allocate unique workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -356,7 +356,7 @@ def generateStep(Map params = [:]){
   def buildType = params.containsKey('buildType') ? params.buildType : 'release'
   def ELASTIC_APM_ASYNC_HOOKS = String.valueOf(!params.get('disableAsyncHooks', false))
   return {
-    node('linux && immutable'){
+    withNode(labels: 'linux && immutable', forceWorspace: true, forceWorker: true) {
       withEnv(["VERSION=${version}", "ELASTIC_APM_ASYNC_HOOKS=${ELASTIC_APM_ASYNC_HOOKS}"]) {
         deleteDir()
         unstash 'source'
@@ -430,7 +430,7 @@ def getSmartTAVContext() {
 
  def linting(){
    return {
-    node('linux && immutable') {
+    withNode(labels: 'linux && immutable', forceWorspace: true, forceWorker: true) {
       catchError(stageResult: 'UNSTABLE', message: 'Linting failures') {
         withGithubNotify(context: 'Linting') {
           deleteDir()
@@ -453,7 +453,7 @@ def generateStepForWindows(Map params = [:]){
   return {
     sh label: 'Prepare services', script: ".ci/scripts/windows/prepare-test.sh ${version}"
     def linuxIp = grabWorkerIP()
-    node('windows-2019-docker-immutable'){
+    withNode(labels: 'windows-2019-docker-immutable', forceWorspace: true, forceWorker: true) {
       // When installing with choco the PATH might not be updated within the already connected worker.
       withEnv(["PATH=${PATH};C:\\Program Files\\nodejs",
                "VERSION=${version}",


### PR DESCRIPTION
### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)

### What 

Ensure a unique CI Worker is allocated.

### Why

There is a known issue with the provisioner that reuses workers for some reason (this is not related to Jenkins itself but the external provisioner). That could somehow be related to the issues when tearing down the tests (see https://github.com/elastic/apm-agent-nodejs/pull/2142)

### Further details

https://github.com/elastic/apm-pipeline-library/blob/master/vars/withNode.txt


