### PR TITLE
fix: rename to .test.js for all tests in TAV

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -272,12 +272,12 @@ koa-router:
   node: '>=6.0.0'
   peerDependencies: koa@2
   versions: '>=5.2.0 <11'
-  commands: node test/instrumentation/modules/koa-router/old-name.js
+  commands: node test/instrumentation/modules/koa-router/old-name.test.js
 '@koa/router':
   node: '>=8.0.0'
   peerDependencies: koa@2
   versions: '>=8 <11'
-  commands: node test/instrumentation/modules/koa-router/new-name.js
+  commands: node test/instrumentation/modules/koa-router/new-name.test.js
 
 elasticsearch:
   versions: '>=8.0.0'

--- a/.tav.yml
+++ b/.tav.yml
@@ -221,7 +221,7 @@ apollo-server-express-2_12:
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_13:
@@ -233,7 +233,7 @@ apollo-server-express-2_13:
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_14:
@@ -245,7 +245,7 @@ apollo-server-express-2_14:
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_15:
@@ -258,7 +258,7 @@ apollo-server-express-2_15:
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   # Per https://github.com/graphql/graphql-js/releases/tag/v15.0.0
   # graphql v15 supports node v8 as a minimum.
   node: '>=8'

--- a/.tav.yml
+++ b/.tav.yml
@@ -124,7 +124,7 @@ express:
     - node test/instrumentation/modules/express/basic.test.js
     - node test/instrumentation/modules/express/capture-exceptions-off.test.js
     - node test/instrumentation/modules/express/capture-exceptions-on.test.js
-    - node test/instrumentation/modules/express/set-framework.js
+    - node test/instrumentation/modules/express/set-framework.test.js
 
 express-graphql-1:
   name: express-graphql
@@ -324,22 +324,22 @@ hapi-v9-v15:
   versions: '>=9.0.1 <16.0.0'
   node: '>=4 <14'
   commands:
-    - node test/instrumentation/modules/hapi/basic-legacy-path.js
-    - node test/instrumentation/modules/hapi/set-framework-hapi.js
+    - node test/instrumentation/modules/hapi/basic-legacy-path.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapi.test.js
 hapi-v16:
   name: hapi
   versions: '>=16.0.0 <17.0.0'
   node: '>=4'
   commands:
-    - node test/instrumentation/modules/hapi/basic-legacy-path.js
-    - node test/instrumentation/modules/hapi/set-framework-hapi.js
+    - node test/instrumentation/modules/hapi/basic-legacy-path.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapi.test.js
 hapi-prenodev15:
   name: hapi
   versions: '>=17.0.0'
   node: '>=8.12.0 <15.0.0'
   commands:
-    - node test/instrumentation/modules/hapi/basic-legacy-path.js
-    - node test/instrumentation/modules/hapi/set-framework-hapi.js
+    - node test/instrumentation/modules/hapi/basic-legacy-path.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapi.test.js
 hapi:
   name: hapi
   # Work around https://github.com/npm/cli/issues/2267 in npm@7.
@@ -349,22 +349,22 @@ hapi:
   node: '>=15.0.0'
   versions: '>=17.0.0'
   commands:
-    - node test/instrumentation/modules/hapi/basic-legacy-path.js
-    - node test/instrumentation/modules/hapi/set-framework-hapi.js
+    - node test/instrumentation/modules/hapi/basic-legacy-path.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapi.test.js
 '@hapi/hapi-v17-v18':
   name: '@hapi/hapi'
   versions: '>=17.0.0 <19.0.0'
   node: '>=8.12.0'
   commands:
-    - node test/instrumentation/modules/hapi/basic.js
-    - node test/instrumentation/modules/hapi/set-framework-hapihapi.js
+    - node test/instrumentation/modules/hapi/basic.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
 '@hapi/hapi':
   name: '@hapi/hapi'
   versions: '>=19.0.0'
   node: '>=12'
   commands:
-    - node test/instrumentation/modules/hapi/basic.js
-    - node test/instrumentation/modules/hapi/set-framework-hapihapi.js
+    - node test/instrumentation/modules/hapi/basic.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
 
 tedious:
   name: tedious
@@ -383,21 +383,21 @@ restify-old:
   versions: '>=5.2.0 <8.0.0'
   commands:
     - node test/instrumentation/modules/restify/basic.test.js
-    - node test/instrumentation/modules/restify/set-framework.js
+    - node test/instrumentation/modules/restify/set-framework.test.js
 restify-new:
   name: restify
   node: '>=8.6.0'
   versions: '>=8.0.0'
   commands:
     - node test/instrumentation/modules/restify/basic.test.js
-    - node test/instrumentation/modules/restify/set-framework.js
+    - node test/instrumentation/modules/restify/set-framework.test.js
 
 fastify:
   versions: '>=0.27.0 <0.29.0 || >0.29.0 <2.4.0 || >2.4.0'
   commands:
     - node test/instrumentation/modules/fastify/fastify.test.js
-    - node test/instrumentation/modules/fastify/async-await.js
-    - node test/instrumentation/modules/fastify/set-framework.js
+    - node test/instrumentation/modules/fastify/async-await.test.js
+    - node test/instrumentation/modules/fastify/set-framework.test.js
 
 finalhandler:
   versions: '*'

--- a/.tav.yml
+++ b/.tav.yml
@@ -217,7 +217,7 @@ apollo-server-express-2_12:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.12.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
@@ -229,7 +229,7 @@ apollo-server-express-2_13:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.13.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
@@ -241,7 +241,7 @@ apollo-server-express-2_14:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
@@ -254,7 +254,7 @@ apollo-server-express-2_15:
   peerDependencies: graphql@^15.0.0
   # We want this version range (2.12.0 was the first release of
   # apollo-server-express after graphql@15 was released):
-  #   versions: '>= 2.12.0'
+  #   versions: '>= 2.12.0 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -60,7 +60,7 @@ These modules override that behavior to give better insights into specialized HT
 |=======================================================================
 |Module |Version |Note
 |https://www.npmjs.com/package/express-graphql[express-graphql] |>=0.6.1 <0.10.0 |Will name all transactions by the GraphQL query name
-|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |^2.0.4 |Will name all transactions by the GraphQL query name
+|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |^2.0.4 <3|Will name all transactions by the GraphQL query name
 |=======================================================================
 
 [float]


### PR DESCRIPTION
The `.tav.yml` didn't have _all_ it's tests renamed.  Specifically

```
test/instrumentation/modules/express/set-framework.js
test/instrumentation/modules/fastify/async-await.js
test/instrumentation/modules/fastify/set-framework.js
test/instrumentation/modules/hapi/basic-legacy-path.js
test/instrumentation/modules/hapi/basic.js
test/instrumentation/modules/hapi/set-framework-hapi.js
test/instrumentation/modules/hapi/set-framework-hapihapi.js
test/instrumentation/modules/restify/set-framework.js
test/instrumentation/modules/koa-router/old-name,js
test/instrumentation/modules/koa-router/new-name.js
```

were still hanging around.  When the TAV runner tried to run these commands, it failed.

This PR renames these files to `.test.js`.