### PR TITLE
fix: get apollo-server-express working @3.x

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -217,11 +217,11 @@ apollo-server-express-2_12:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.12.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_13:
@@ -229,11 +229,11 @@ apollo-server-express-2_13:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.13.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_14:
@@ -241,11 +241,11 @@ apollo-server-express-2_14:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_15:
@@ -254,11 +254,11 @@ apollo-server-express-2_15:
   peerDependencies: graphql@^15.0.0
   # We want this version range (2.12.0 was the first release of
   # apollo-server-express after graphql@15 was released):
-  #   versions: '>= 2.12.0 <3'
+  #   versions: '>= 2.12.0'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
+  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
   # Per https://github.com/graphql/graphql-js/releases/tag/v15.0.0
   # graphql v15 supports node v8 as a minimum.
   node: '>=8'

--- a/.tav.yml
+++ b/.tav.yml
@@ -217,11 +217,11 @@ apollo-server-express-2_12:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.12.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_13:
@@ -229,11 +229,11 @@ apollo-server-express-2_13:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^0.13.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_14:
@@ -241,11 +241,11 @@ apollo-server-express-2_14:
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
   # We want this version range:
-  #   versions: '>=2.0.4 <2.2 || >= 2.3.2'
+  #   versions: '>=2.0.4 <2.2 || >= 2.3.2 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.0.7 || 2.1.0 || 2.3.3 || 2.4.8 || 2.5.1 || 2.6.9 || 2.7.2 || 2.8.2 || 2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 apollo-server-express-2_15:
@@ -254,14 +254,22 @@ apollo-server-express-2_15:
   peerDependencies: graphql@^15.0.0
   # We want this version range (2.12.0 was the first release of
   # apollo-server-express after graphql@15 was released):
-  #   versions: '>= 2.12.0'
+  #   versions: '>= 2.12.0 <3'
   # but only the latest MAJOR.MINOR.x to reduce the test matrix.
   #
   # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x'
+  versions: '2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   # Per https://github.com/graphql/graphql-js/releases/tag/v15.0.0
   # graphql v15 supports node v8 as a minimum.
   node: '>=8'
+  commands: node test/instrumentation/modules/apollo-server-express.test.js
+
+apollo-server-express-3_15:
+  name: apollo-server-express
+  preinstall: npm uninstall express-graphql
+  peerDependencies: graphql@^15.0.0
+  versions: '^3.0.0'
+  node: '>=12'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 
 express-queue:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ Notes:
 
 [float]
 ===== Features
+* The agent now supports the 3.x branch of apollo-server-express. ({pull}2155[#2155])
 
 [float]
 ===== Bug fixes

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -86,7 +86,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 A lot of higher level MongoDB modules use mongodb-core,
 so those should be supported as well.
 |https://www.npmjs.com/package/mongodb[mongodb] |>=2.0.0 <3.3.0 |Supported via mongodb-core
-|https://www.npmjs.com/package/mongodb[mongodb] |^3.3.0 |Will instrument all queries
+|https://www.npmjs.com/package/mongodb[mongodb] |^3.3.0 <5 |Will instrument all queries
 |https://www.npmjs.com/package/mongojs[mongojs] |>=1.0.0 <2.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 <5.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mysql[mysql] |^2.0.0 |Will instrument all queries

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -60,7 +60,7 @@ These modules override that behavior to give better insights into specialized HT
 |=======================================================================
 |Module |Version |Note
 |https://www.npmjs.com/package/express-graphql[express-graphql] |>=0.6.1 <0.10.0 |Will name all transactions by the GraphQL query name
-|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |^2.0.4 <3|Will name all transactions by the GraphQL query name
+|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |^2.0.4 <4|Will name all transactions by the GraphQL query name
 |=======================================================================
 
 [float]
@@ -86,7 +86,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 A lot of higher level MongoDB modules use mongodb-core,
 so those should be supported as well.
 |https://www.npmjs.com/package/mongodb[mongodb] |>=2.0.0 <3.3.0 |Supported via mongodb-core
-|https://www.npmjs.com/package/mongodb[mongodb] |^3.3.0 <5 |Will instrument all queries
+|https://www.npmjs.com/package/mongodb[mongodb] |^3.3.0 |Will instrument all queries
 |https://www.npmjs.com/package/mongojs[mongojs] |>=1.0.0 <2.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 <5.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mysql[mysql] |^2.0.0 |Will instrument all queries

--- a/lib/instrumentation/modules/apollo-server-core.js
+++ b/lib/instrumentation/modules/apollo-server-core.js
@@ -7,7 +7,7 @@ const clone = require('shallow-clone-shim')
 module.exports = function (apolloServerCore, agent, { version, enabled }) {
   if (!enabled) return apolloServerCore
 
-  if (!semver.satisfies(version, '^2.0.2') && !semver.satisfies(version, '^3.0.0')) {
+  if (!semver.satisfies(version, '^2.0.2 || ^3.0.0')) {
     agent.logger.debug('apollo-server-core version %s not supported - aborting...', version)
     return apolloServerCore
   }

--- a/lib/instrumentation/modules/apollo-server-core.js
+++ b/lib/instrumentation/modules/apollo-server-core.js
@@ -7,7 +7,7 @@ const clone = require('shallow-clone-shim')
 module.exports = function (apolloServerCore, agent, { version, enabled }) {
   if (!enabled) return apolloServerCore
 
-  if (!semver.satisfies(version, '^2.0.2')) {
+  if (!semver.satisfies(version, '^2.0.2') && !semver.satisfies(version, '^3.0.0')) {
     agent.logger.debug('apollo-server-core version %s not supported - aborting...', version)
     return apolloServerCore
   }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@koa/router": "^9.0.1",
     "@types/node": "^13.7.4",
     "ajv": "^6.12.6",
-    "apollo-server-express": "^2.10.1",
+    "apollo-server-express": "^3.0.0",
     "aws-sdk": "^2.622.0",
     "backport": "^5.1.2",
     "benchmark": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "dependency-check": "^4.1.0",
     "elasticsearch": "^16.5.0",
     "express": "^4.17.1",
+    "express-graphql": "^0.9.0",
     "express-queue": "^0.0.12",
     "fastify": "^2.12.0",
     "fastify-formbody": "^3.2",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "dependency-check": "^4.1.0",
     "elasticsearch": "^16.5.0",
     "express": "^4.17.1",
-    "express-graphql": "^0.9.0",
     "express-queue": "^0.0.12",
     "fastify": "^2.12.0",
     "fastify-formbody": "^3.2",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@koa/router": "^9.0.1",
     "@types/node": "^13.7.4",
     "ajv": "^6.12.6",
+    "apollo-server-core":"^3.0.0",
     "apollo-server-express": "^3.0.0",
     "aws-sdk": "^2.622.0",
     "backport": "^5.1.2",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -716,7 +716,7 @@ test('disableInstrumentations', function (t) {
   var esVersion = require('@elastic/elasticsearch/package.json').version
 
   // require('apollo-server-core') is a hard crash on nodes < 12.0.0
-  const apolloServerCoreVersion = require('../node_modules/apollo-server-core/package.json').version
+  const apolloServerCoreVersion = require('apollo-server-core/package.json').version
 
   var flattenedModules = Instrumentation.modules.reduce((acc, val) => acc.concat(val), [])
   var modules = new Set(flattenedModules)

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -715,6 +715,9 @@ test('disableInstrumentations', function (t) {
   var expressGraphqlVersion = require('express-graphql/package.json').version
   var esVersion = require('@elastic/elasticsearch/package.json').version
 
+  // require('apollo-server-core') is a hard crash on nodes < 12.0.0
+  const apolloServerCoreVersion = require('../node_modules/apollo-server-core/package.json').version
+
   var flattenedModules = Instrumentation.modules.reduce((acc, val) => acc.concat(val), [])
   var modules = new Set(flattenedModules)
   if (isHapiIncompat('hapi')) {
@@ -733,6 +736,10 @@ test('disableInstrumentations', function (t) {
   const mongodbVersion = require('../node_modules/mongodb/package.json').version
   if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.4.0')) {
     modules.delete('mongodb')
+  }
+
+  if (semver.gte(apolloServerCoreVersion, '3.0.0') && semver.lt(process.version, '12.0.0')) {
+    modules.delete('apollo-server-core')
   }
 
   function testSlice (t, name, selector) {

--- a/test/instrumentation/modules/apollo-server-express.test.js
+++ b/test/instrumentation/modules/apollo-server-express.test.js
@@ -40,7 +40,7 @@ test('POST /graphql', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.start().then(function(){
+  apollo.start().then(function () {
     apollo.applyMiddleware({ app })
     var server = app.listen(function () {
       var port = server.address().port
@@ -86,7 +86,7 @@ test('GET /graphql', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.start().then(function(){
+  apollo.start().then(function () {
     apollo.applyMiddleware({ app })
     var server = app.listen(function () {
       var port = server.address().port
@@ -131,7 +131,7 @@ test('POST /graphql - named query', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.start().then(function(){
+  apollo.start().then(function () {
     apollo.applyMiddleware({ app })
     var server = app.listen(function () {
       var port = server.address().port
@@ -181,7 +181,7 @@ test('POST /graphql - sort multiple queries', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.start().then(function(){
+  apollo.start().then(function () {
     apollo.applyMiddleware({ app })
     var server = app.listen(function () {
       var port = server.address().port
@@ -246,7 +246,7 @@ test('POST /graphql - sub-query', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.start().then(function(){
+  apollo.start().then(function () {
     apollo.applyMiddleware({ app })
     var server = app.listen(function () {
       var port = server.address().port

--- a/test/instrumentation/modules/apollo-server-express.test.js
+++ b/test/instrumentation/modules/apollo-server-express.test.js
@@ -14,6 +14,13 @@ var test = require('tape')
 var http = require('http')
 var express = require('express')
 var querystring = require('querystring')
+const semver = require('semver')
+// require('apollo-server-express') is a hard crash for nodes < 12.0.0
+const apolloServerExpressVersion = require('../../../node_modules/apollo-server-express/package.json').version
+if (semver.gte(apolloServerExpressVersion, '3.0.0') && semver.lt(process.version, '12.0.0')) {
+  console.log(`# SKIP apollo-server-express@${apolloServerExpressVersion} does not support node ${process.version}`)
+  process.exit()
+}
 
 var ApolloServer = require('apollo-server-express').ApolloServer
 var gql = require('apollo-server-express').gql

--- a/test/instrumentation/modules/apollo-server-express.test.js
+++ b/test/instrumentation/modules/apollo-server-express.test.js
@@ -40,27 +40,29 @@ test('POST /graphql', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.applyMiddleware({ app })
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.strictEqual(result, '{"data":{"hello":"Hello world!"}}\n',
-          'client got the expected response body')
-        agent.flush()
+  apollo.start().then(function(){
+    apollo.applyMiddleware({ app })
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path: '/graphql',
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.strictEqual(result, '{"data":{"hello":"Hello world!"}}\n',
+            'client got the expected response body')
+          agent.flush()
+        })
       })
+      req.end(query)
     })
-    req.end(query)
   })
 })
 
@@ -84,26 +86,28 @@ test('GET /graphql', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.applyMiddleware({ app })
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'GET',
-      port: port,
-      path: '/graphql?' + query
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.strictEqual(result, '{"data":{"hello":"Hello world!"}}\n',
-          'client got the expected response body')
-        agent.flush()
+  apollo.start().then(function(){
+    apollo.applyMiddleware({ app })
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'GET',
+        port: port,
+        path: '/graphql?' + query
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.strictEqual(result, '{"data":{"hello":"Hello world!"}}\n',
+            'client got the expected response body')
+          agent.flush()
+        })
       })
+      req.end()
     })
-    req.end()
   })
 })
 
@@ -127,26 +131,28 @@ test('POST /graphql - named query', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.applyMiddleware({ app })
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.strictEqual(result, '{"data":{"hello":"Hello world!"}}\n')
-        agent.flush()
+  apollo.start().then(function(){
+    apollo.applyMiddleware({ app })
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path: '/graphql',
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.strictEqual(result, '{"data":{"hello":"Hello world!"}}\n')
+          agent.flush()
+        })
       })
+      req.end(query)
     })
-    req.end(query)
   })
 })
 
@@ -175,26 +181,28 @@ test('POST /graphql - sort multiple queries', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.applyMiddleware({ app })
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.strictEqual(result, '{"data":{"life":42,"hello":"Hello world!"}}\n')
-        agent.flush()
+  apollo.start().then(function(){
+    apollo.applyMiddleware({ app })
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path: '/graphql',
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.strictEqual(result, '{"data":{"life":42,"hello":"Hello world!"}}\n')
+          agent.flush()
+        })
       })
+      req.end(query)
     })
-    req.end(query)
   })
 })
 
@@ -238,26 +246,28 @@ test('POST /graphql - sub-query', function (t) {
 
   var app = express()
   var apollo = new ApolloServer({ typeDefs, resolvers, uploads: false })
-  apollo.applyMiddleware({ app })
-  var server = app.listen(function () {
-    var port = server.address().port
-    var opts = {
-      method: 'POST',
-      port: port,
-      path: '/graphql',
-      headers: { 'Content-Type': 'application/json' }
-    }
-    var req = http.request(opts, function (res) {
-      var chunks = []
-      res.on('data', chunks.push.bind(chunks))
-      res.on('end', function () {
-        server.close()
-        var result = Buffer.concat(chunks).toString()
-        t.strictEqual(result, JSON.stringify({ data: { books } }) + '\n')
-        agent.flush()
+  apollo.start().then(function(){
+    apollo.applyMiddleware({ app })
+    var server = app.listen(function () {
+      var port = server.address().port
+      var opts = {
+        method: 'POST',
+        port: port,
+        path: '/graphql',
+        headers: { 'Content-Type': 'application/json' }
+      }
+      var req = http.request(opts, function (res) {
+        var chunks = []
+        res.on('data', chunks.push.bind(chunks))
+        res.on('end', function () {
+          server.close()
+          var result = Buffer.concat(chunks).toString()
+          t.strictEqual(result, JSON.stringify({ data: { books } }) + '\n')
+          agent.flush()
+        })
       })
+      req.end(query)
     })
-    req.end(query)
   })
 })
 

--- a/test/instrumentation/modules/apollo-server-express.test.js
+++ b/test/instrumentation/modules/apollo-server-express.test.js
@@ -16,7 +16,7 @@ var express = require('express')
 var querystring = require('querystring')
 const semver = require('semver')
 // require('apollo-server-express') is a hard crash for nodes < 12.0.0
-const apolloServerExpressVersion = require('../../../node_modules/apollo-server-express/package.json').version
+const apolloServerExpressVersion = require('apollo-server-express/package.json').version
 if (semver.gte(apolloServerExpressVersion, '3.0.0') && semver.lt(process.version, '12.0.0')) {
   console.log(`# SKIP apollo-server-express@${apolloServerExpressVersion} does not support node ${process.version}`)
   process.exit()


### PR DESCRIPTION
This PR adds support for the 3.x branch of `apollo-server-express`, and adjusts our tests to ensure apollo server starts correctly. 

Prior to this change, tests were failing with the message

```
TAP version 13
# POST /graphql
/Users/astorm/Documents/github/elastic/apm-agent-nodejs/node_modules/apollo-server-core/dist/ApolloServer.js:273
            throw new Error('You must `await server.start()` before calling `server.' +
            ^
Error: You must `await server.start()` before calling `server.applyMiddleware()`            
```

This PR adjusts the tests to start the server as expected in 3.x.

This PR also adjusts the `semver` constraint to allow version 3.x.

Finally, this PR adjusts the TAV tests to include an entry for apollo server 3.x using a peer dependency of `graphql@^15.0.0` and nodes >12.  These versions are based on 

https://github.com/apollographql/apollo-server/blob/94862a48ff9430d3238f9b456c9a99159fd0aa69/packages/apollo-server-express/package.json#L46

https://github.com/apollographql/apollo-server/blob/94862a48ff9430d3238f9b456c9a99159fd0aa69/packages/apollo-server-express/package.json#L26

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
