### PR TITLE
chore: [ci] Fix parameter to correctly call forceWorkspace

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -356,7 +356,7 @@ def generateStep(Map params = [:]){
   def buildType = params.containsKey('buildType') ? params.buildType : 'release'
   def ELASTIC_APM_ASYNC_HOOKS = String.valueOf(!params.get('disableAsyncHooks', false))
   return {
-    withNode(labels: 'linux && immutable', forceWorspace: true, forceWorker: true) {
+    withNode(labels: 'linux && immutable', forceWorkspace: true, forceWorker: true) {
       withEnv(["VERSION=${version}", "ELASTIC_APM_ASYNC_HOOKS=${ELASTIC_APM_ASYNC_HOOKS}"]) {
         deleteDir()
         unstash 'source'
@@ -430,7 +430,7 @@ def getSmartTAVContext() {
 
  def linting(){
    return {
-    withNode(labels: 'linux && immutable', forceWorspace: true, forceWorker: true) {
+    withNode(labels: 'linux && immutable', forceWorkspace: true, forceWorker: true) {
       catchError(stageResult: 'UNSTABLE', message: 'Linting failures') {
         withGithubNotify(context: 'Linting') {
           deleteDir()
@@ -453,7 +453,7 @@ def generateStepForWindows(Map params = [:]){
   return {
     sh label: 'Prepare services', script: ".ci/scripts/windows/prepare-test.sh ${version}"
     def linuxIp = grabWorkerIP()
-    withNode(labels: 'windows-2019-docker-immutable', forceWorspace: true, forceWorker: true) {
+    withNode(labels: 'windows-2019-docker-immutable', forceWorkspace: true, forceWorker: true) {
       // When installing with choco the PATH might not be updated within the already connected worker.
       withEnv(["PATH=${PATH};C:\\Program Files\\nodejs",
                "VERSION=${version}",


### PR DESCRIPTION
There was a typo in the named parameters for `WithNode` where the forcing of a workspace was never initialized

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
