### PR TITLE
fix: span name should comply with spec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fixed naming for outgoing HTTP spans to comply with the spec.
+  https://github.com/elastic/apm/blob/master/specs/agents/tracing-instrumentation-http.md#http-client-spans
+  Span names no longer include the path portion of the URL. ({pull}2161[#2161])
+
 * Fix a header object re-use bug that prevented propagation of trace-context
   headers (`traceparent` et al) in AWS requests using AWS v4 signature auth.
   ({issues}2134[#2134])

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -180,7 +180,7 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       ins.bindEmitter(req)
 
       span.action = req.method
-      span.name = req.method + ' ' + getSafeHost(req) + parseUrl(req.path).pathname
+      span.name = req.method + ' ' + getSafeHost(req)
 
       // TODO: Research if it's possible to add this to the prototype instead.
       // Or if it's somehow preferable to listen for when a `response` listener

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -225,7 +225,7 @@ module.exports = function (http2, agent, { enabled }) {
       var urlObj = parseUrl(headers[':path'])
       var path = urlObj.pathname
       var url = host + path
-      span.name = method + ' ' + url
+      span.name = method + ' ' + host
 
       var statusCode
       req.on('response', (headers) => {

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -511,7 +511,7 @@ function checkDataAndEnd (t, method, path, dbStatement) {
     t.strictEqual(httpSpan.subtype, 'http')
     t.strictEqual(httpSpan.action, method)
 
-    t.equal(httpSpan.name, method + ' ' + host + path, 'http span should have expected name')
+    t.equal(httpSpan.name, method + ' ' + host, 'http span should have expected name')
     t.equal(esSpan.name, 'Elasticsearch: ' + method + ' ' + path, 'elasticsearch span should have expected name')
 
     t.ok(esSpan.stacktrace.some(function (frame) {

--- a/test/instrumentation/modules/elasticsearch.test.js
+++ b/test/instrumentation/modules/elasticsearch.test.js
@@ -217,7 +217,7 @@ function done (t, method, path, query, abort = false) {
       t.strictEqual(span2.action, action)
     }
 
-    t.strictEqual(span1.name, method + ' ' + host + path)
+    t.strictEqual(span1.name, method + ' ' + host)
     t.strictEqual(span2.name, 'Elasticsearch: ' + method + ' ' + path)
 
     t.ok(span2.stacktrace.some(function (frame) {

--- a/test/instrumentation/modules/http/disabling.test.js
+++ b/test/instrumentation/modules/http/disabling.test.js
@@ -34,7 +34,7 @@ if (cluster.isMaster) {
     }
 
     function assertSpan (t, span) {
-      t.ok(/GET localhost:\d+\//.test(span.name), 'span name')
+      t.ok(/GET localhost:\d*$/.test(span.name), 'span name')
       t.strictEqual(span.type, 'external', 'span type')
       t.strictEqual(span.subtype, 'http', 'span subtype')
       t.strictEqual(span.action, 'GET', 'span action')

--- a/test/instrumentation/modules/http/disabling.test.js
+++ b/test/instrumentation/modules/http/disabling.test.js
@@ -34,7 +34,7 @@ if (cluster.isMaster) {
     }
 
     function assertSpan (t, span) {
-      t.ok(/GET localhost:\d*$/.test(span.name), 'span name')
+      t.ok(/GET localhost:\d+$/.test(span.name), 'span name')
       t.strictEqual(span.type, 'external', 'span type')
       t.strictEqual(span.subtype, 'http', 'span subtype')
       t.strictEqual(span.action, 'GET', 'span action')

--- a/test/instrumentation/modules/http/outgoing.test.js
+++ b/test/instrumentation/modules/http/outgoing.test.js
@@ -167,7 +167,7 @@ function echoTest (type, opts, handler) {
       resetAgent(opts, data => {
         t.strictEqual(data.transactions.length, 1, 'has one transaction')
         t.strictEqual(data.spans.length, 1, 'has one span')
-        t.strictEqual(data.spans[0].name, 'GET localhost:' + port + '/', 'has expected span name')
+        t.strictEqual(data.spans[0].name, 'GET localhost:' + port, 'has expected span name')
         t.strictEqual(data.spans[0].outcome, 'success')
         t.deepEqual(data.spans[0].context.http, {
           method: 'GET',
@@ -230,7 +230,7 @@ function abortTest (type, handler) {
       resetAgent({}, data => {
         t.equal(data.transactions.length, 1, 'has one transaction')
         t.equal(data.spans.length, 1, 'has one span')
-        t.equal(data.spans[0].name, `${req.method} localhost:${port}/`, 'has expected span name')
+        t.equal(data.spans[0].name, `${req.method} localhost:${port}`, 'has expected span name')
         if (typeof httpContext.status_code === 'undefined') {
           t.equal(data.spans[0].outcome, 'unknown')
         } else {

--- a/test/instrumentation/modules/http/request.test.js
+++ b/test/instrumentation/modules/http/request.test.js
@@ -24,7 +24,7 @@ test('request', function (t) {
     t.strictEqual(root.outcome, 'success')
     const span = findObjInArray(data.spans, 'transaction_id', root.id)
     t.strictEqual(span.outcome, 'success')
-    t.strictEqual(span.name, 'GET localhost:' + server.address().port + '/test')
+    t.strictEqual(span.name, 'GET localhost:' + server.address().port)
 
     server.close()
     t.end()
@@ -54,7 +54,7 @@ test('Outcome', function (t) {
     t.strictEqual(root.outcome, 'failure')
     const span = findObjInArray(data.spans, 'transaction_id', root.id)
     t.strictEqual(span.outcome, 'failure')
-    t.strictEqual(span.name, 'GET localhost:' + server.address().port + '/test')
+    t.strictEqual(span.name, 'GET localhost:' + server.address().port)
 
     server.close()
     t.end()

--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -295,7 +295,7 @@ isSecure.forEach(secure => {
       t.strictEqual(span.type, 'external')
       t.strictEqual(span.subtype, 'http')
       t.strictEqual(span.action, 'GET')
-      t.strictEqual(span.name, `GET http${secure ? 's' : ''}://localhost:${port}/sub`)
+      t.strictEqual(span.name, `GET http${secure ? 's' : ''}://localhost:${port}`)
       t.deepEqual(span.context.http, {
         method: 'GET',
         status_code: 200,


### PR DESCRIPTION
Part of https://github.com/elastic/apm-agent-nodejs/issues/2067

This PR changes the behavior of naming outgoing HTTP spans by dropping the path portion of the URL. This is done to comply with the spec and reduce the cardinality of outgoing HTTP span names: https://github.com/elastic/apm/blob/master/specs/agents/tracing-instrumentation-http.md#http-client-spans

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
