### PR TITLE
ci: limit CI builds to explicit branches: master, PRs, and 3.x

### DIFF
--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -12,7 +12,8 @@
         discover-pr-origin: merge-current
         discover-tags: true
         notification-context: 'apm-ci'
-        head-filter-regex: '^(?!greenkeeper).*$'
+        # Run CI builds only on master, PRs, and non-EOL version branches.
+        head-filter-regex: '^(master|PR-.*|3\.x)$'
         repo: apm-agent-nodejs
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
This changes to be an allowlist rather than a denylist. It means that
feature branches that aren't yet PRs will not have CI run on them. This
also effectively drops the 2.x branch because that version is now EOL.

### Motivation

In https://github.com/elastic/observability-robots/discussions/689 and https://github.com/elastic/observability-robots/issues/683 it was raised that we should exclude unsupported branches from CI builds. For the node.js agent: [2.x is EOL as of 2021-03-19](https://www.elastic.co/guide/en/apm/agent/nodejs/current/upgrading.html#end-of-life-dates).

As well, before this change we include feature branches that need not be built:

![Screen Shot 2021-07-27 at 11 07 41 AM](https://user-images.githubusercontent.com/46866/127205632-0d375573-4bb8-420c-8b4f-88733b4a1e09.png)

most of those branch jobs are races against creating a PR job for that feature branch.
