### PR TITLE
fix: adds supports for MongoDB 4.0+

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -86,7 +86,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 A lot of higher level MongoDB modules use mongodb-core,
 so those should be supported as well.
 |https://www.npmjs.com/package/mongodb[mongodb] |>=2.0.0 <3.3.0 |Supported via mongodb-core
-|https://www.npmjs.com/package/mongodb[mongodb] |^3.3.0 |Will instrument all queries
+|https://www.npmjs.com/package/mongodb[mongodb] |^3.3.0 <5 |Will instrument all queries
 |https://www.npmjs.com/package/mongojs[mongojs] |>=1.0.0 <2.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 <5.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mysql[mysql] |^2.0.0 |Will instrument all queries

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -8,34 +8,39 @@ const HOSTNAME_PORT_RE = /^([^:]+):(\d+)$/
 
 module.exports = (mongodb, agent, { version, enabled }) => {
   if (!enabled) return mongodb
-  if (!semver.satisfies(version, '>=3.3')) {
+  if (!semver.satisfies(version, '>=3.3 < 5.0')) {
     agent.logger.debug('mongodb version %s not instrumented (mongodb <3.3 is instrumented via mongodb-core)', version)
     return mongodb
   }
 
   const activeSpans = new Map()
-  if(mongodb.instrument) {
+  if (mongodb.instrument) {
     const listener = mongodb.instrument()
 
     listener.on('started', onStart)
     listener.on('succeeded', onEnd)
     listener.on('failed', onEnd)
-  } else {
+  } else if (mongodb.MongoClient) {
+    // mongo 4.0+ removed the instrument() method in favor of
+    // listeners on the instantiated client objects.
     class MongoClient extends mongodb.MongoClient {
-      constructor(url, options) {
-        super(url, options)
+      constructor () {
+        super(...arguments)
+        this.on('commandStarted', onStart)
+        this.on('commandSucceeded', onEnd)
+        this.on('commandFailed', onEnd)
       }
     }
     Object.defineProperty(
       mongodb,
-      "MongoClient",
+      'MongoClient',
       {
         enumerable: true,
         get: function () {
           return MongoClient
         }
       }
-    );
+    )
   }
   return mongodb
 

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -8,7 +8,7 @@ const HOSTNAME_PORT_RE = /^([^:]+):(\d+)$/
 
 module.exports = (mongodb, agent, { version, enabled }) => {
   if (!enabled) return mongodb
-  if (!semver.satisfies(version, '>=3.3 < 5.0')) {
+  if (!semver.satisfies(version, '>=3.3 <5.0')) {
     agent.logger.debug('mongodb version %s not instrumented (mongodb <3.3 is instrumented via mongodb-core)', version)
     return mongodb
   }

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -13,13 +13,30 @@ module.exports = (mongodb, agent, { version, enabled }) => {
     return mongodb
   }
 
-  const listener = mongodb.instrument()
   const activeSpans = new Map()
+  if(mongodb.instrument) {
+    const listener = mongodb.instrument()
 
-  listener.on('started', onStart)
-  listener.on('succeeded', onEnd)
-  listener.on('failed', onEnd)
-
+    listener.on('started', onStart)
+    listener.on('succeeded', onEnd)
+    listener.on('failed', onEnd)
+  } else {
+    class MongoClient extends mongodb.MongoClient {
+      constructor(url, options) {
+        super(url, options)
+      }
+    }
+    Object.defineProperty(
+      mongodb,
+      "MongoClient",
+      {
+        enumerable: true,
+        get: function () {
+          return MongoClient
+        }
+      }
+    );
+  }
   return mongodb
 
   function onStart (event) {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "memcached": "^2.2.2",
     "mimic-response": "^2.1.0",
     "mkdirp": "^0.5.1",
-    "mongodb": "^4.0.0",
+    "mongodb": "^3.5.3",
     "mongodb-core": "^3.2.7",
     "mysql": "^2.18.1",
     "mysql2": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "memcached": "^2.2.2",
     "mimic-response": "^2.1.0",
     "mkdirp": "^0.5.1",
-    "mongodb": "^3.5.3",
+    "mongodb": "^4.0.0",
     "mongodb-core": "^3.2.7",
     "mysql": "^2.18.1",
     "mysql2": "^2.1.0",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -729,9 +729,9 @@ test('disableInstrumentations', function (t) {
   if (semver.lt(process.version, '10.0.0') && semver.gte(esVersion, '7.12.0')) {
     modules.delete('@elastic/elasticsearch')
   }
-  // require('mongodb') is a hard crash on node 8
+  // require('mongodb') is a hard crash on nodes < 10.4
   const mongodbVersion = require('../node_modules/mongodb/package.json').version
-  if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
+  if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.4.0')) {
     modules.delete('mongodb')
   }
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -729,6 +729,11 @@ test('disableInstrumentations', function (t) {
   if (semver.lt(process.version, '10.0.0') && semver.gte(esVersion, '7.12.0')) {
     modules.delete('@elastic/elasticsearch')
   }
+  // require('mongodb') is a hard crash on node 8
+  const mongodbVersion = require('../node_modules/mongodb/package.json').version
+  if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
+    modules.delete('mongodb')
+  }
 
   function testSlice (t, name, selector) {
     var selection = selector(modules)

--- a/test/instrumentation/modules/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb.test.js
@@ -8,10 +8,10 @@ const agent = require('../../..').start({
   centralConfig: false
 })
 
-// require('mongodb') is a hard crash on node 8
+// require('mongodb') is a hard crash on nodes <10.4
 const mongodbVersion = require('../../../node_modules/mongodb/package.json').version
 const semver = require('semver')
-if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
+if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.4.0')) {
   console.log(`# SKIP mongodb@${mongodbVersion} does not support node ${process.version}`)
   process.exit()
 }

--- a/test/instrumentation/modules/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb.test.js
@@ -11,7 +11,7 @@ const agent = require('../../..').start({
 // require('mongodb') is a hard crash on node 8
 const mongodbVersion = require('./node_modules/mongodb/package.json').version
 const semver = require('semver')
-if(semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
+if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
   console.log(`# SKIP mongodb@${mongodbVersion} does not support node ${process.version}`)
   process.exit()
 }

--- a/test/instrumentation/modules/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb.test.js
@@ -8,6 +8,13 @@ const agent = require('../../..').start({
   centralConfig: false
 })
 
+// require('mongodb') is a hard crash on node 8
+const mongodbVersion = require('./node_modules/mongodb/package.json').version
+const semver = require('semver')
+if(semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
+  console.log(`# SKIP mongodb@${mongodbVersion} does not support node ${process.version}`)
+  process.exit()
+}
 const MongoClient = require('mongodb').MongoClient
 const test = require('tape')
 

--- a/test/instrumentation/modules/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb.test.js
@@ -9,7 +9,7 @@ const agent = require('../../..').start({
 })
 
 // require('mongodb') is a hard crash on node 8
-const mongodbVersion = require('./node_modules/mongodb/package.json').version
+const mongodbVersion = require('../../../node_modules/mongodb/package.json').version
 const semver = require('semver')
 if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.0.0')) {
   console.log(`# SKIP mongodb@${mongodbVersion} does not support node ${process.version}`)


### PR DESCRIPTION
Fixes: https://github.com/elastic/apm-agent-nodejs/issues/2170

This PR adds back support for the recently release MongoDB 4.0+, and adds a `<5` constraint to the version check on the MongoDB instrumentation module. TAV test constraint remains at `>3.3` in order to catch problems with a theoretical 5.0 in the future. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
