### PR TITLE
fix: ensure instrumentation of mongodb >=4.1.0 works

### DIFF
--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -21,10 +21,16 @@ module.exports = (mongodb, agent, { version, enabled }) => {
     listener.on('succeeded', onEnd)
     listener.on('failed', onEnd)
   } else if (mongodb.MongoClient) {
-    // mongo 4.0+ removed the instrument() method in favor of
+    // mongodb 4.0+ removed the instrument() method in favor of
     // listeners on the instantiated client objects.
     class MongoClient extends mongodb.MongoClient {
       constructor () {
+        // The `command*` events are only sent if `monitorCommands: true`.
+        if (!arguments[1]) {
+          arguments[1] = { monitorCommands: true }
+        } else if (arguments[1].monitorCommands !== true) {
+          arguments[1] = Object.assign({}, arguments[1], { monitorCommands: true })
+        }
         super(...arguments)
         this.on('commandStarted', onStart)
         this.on('commandSucceeded', onEnd)

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "memcached": "^2.2.2",
     "mimic-response": "^2.1.0",
     "mkdirp": "^0.5.1",
-    "mongodb": "^4.0.0",
+    "mongodb": "^4.1.0",
     "mongodb-core": "^3.2.7",
     "mysql": "^2.18.1",
     "mysql2": "^2.1.0",

--- a/test/instrumentation/modules/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const agent = require('../../..').start({
-  serviceName: 'test',
-  secretToken: 'test',
+  serviceName: 'test-mongodb',
   captureExceptions: false,
   metricsInterval: 0,
-  centralConfig: false
+  centralConfig: false,
+  cloudProvider: 'none'
 })
 
 // require('mongodb') is a hard crash on nodes <10.4


### PR DESCRIPTION
In mongodb@4.1.0 (https://jira.mongodb.org/browse/NODE-3513) the
monitorCommands option was reverted to defaulting to false. To
instrument we ensure it is true.

Fixes: #2177
