### PR TITLE
feat: add tracestate header when starting lambda transaction

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -87,7 +87,7 @@ module.exports = function elasticApmAwsLambda (agent) {
              * elastic-apm-traceparent if available.
              */
             parentId = value
-          } else if(lowerCaseKey === 'tracestate') {
+          } else if (lowerCaseKey === 'tracestate') {
             tracestate = value
           }
         }

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -74,7 +74,7 @@ module.exports = function elasticApmAwsLambda (agent) {
 
     return function wrappedLambda (payload, context, callback) {
       let parentId
-      let traceState
+      let tracestate
       if (payload.headers !== undefined) {
         for (const [key, value] of Object.entries(payload.headers)) {
           const lowerCaseKey = key.toLowerCase()
@@ -88,7 +88,7 @@ module.exports = function elasticApmAwsLambda (agent) {
              */
             parentId = value
           } else if(lowerCaseKey === 'tracestate') {
-            traceState = value
+            tracestate = value
           }
         }
       }

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -74,6 +74,7 @@ module.exports = function elasticApmAwsLambda (agent) {
 
     return function wrappedLambda (payload, context, callback) {
       let parentId
+      let traceState
       if (payload.headers !== undefined) {
         for (const [key, value] of Object.entries(payload.headers)) {
           const lowerCaseKey = key.toLowerCase()
@@ -86,11 +87,14 @@ module.exports = function elasticApmAwsLambda (agent) {
              * elastic-apm-traceparent if available.
              */
             parentId = value
+          } else if(lowerCaseKey === 'tracestate') {
+            traceState = value
           }
         }
       }
       const trans = agent.startTransaction(context.functionName, type, {
-        childOf: parentId
+        childOf: parentId,
+        tracestate: tracestate
       })
 
       // Wrap context and callback to finish and send transaction

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -76,22 +76,16 @@ module.exports = function elasticApmAwsLambda (agent) {
       let parentId
       let tracestate
       if (payload.headers !== undefined) {
-        for (const [key, value] of Object.entries(payload.headers)) {
+        const normalizedHeaders = {}
+        for (const key of Object.keys(payload.headers)) {
+          const value = payload.headers[key]
           const lowerCaseKey = key.toLowerCase()
-          if (lowerCaseKey === 'elastic-apm-traceparent') {
-            parentId = value
-            break
-          } else if (lowerCaseKey === 'traceparent') {
-            /**
-             * We do not break here because we want to make sure to use
-             * elastic-apm-traceparent if available.
-             */
-            parentId = value
-          } else if (lowerCaseKey === 'tracestate') {
-            tracestate = value
-          }
+          normalizedHeaders[lowerCaseKey] = value
         }
+        parentId = normalizedHeaders.traceparent ? normalizedHeaders.traceparent : normalizedHeaders['elastic-apm-traceparent']
+        tracestate = normalizedHeaders.tracestate
       }
+
       const trans = agent.startTransaction(context.functionName, type, {
         childOf: parentId,
         tracestate: tracestate

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -53,7 +53,7 @@ test('resolve with parent id header present', function (t) {
   const input = {
     name: 'world',
     headers: {
-      'elastic-apm-traceparent':'prefer-w3c',
+      // 'elastic-apm-traceparent':'prefer-w3c',
       traceparent: 'test',
       tracestate: 'test2'
     }
@@ -88,6 +88,118 @@ test('resolve with parent id header present', function (t) {
 
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
+      t.end()
+    }
+  })
+})
+
+test('resolve with elastic-apm-traceparent present', function (t) {
+  const name = 'greet.hello'
+  const input = {
+    name: 'world',
+    headers: {
+      'elastic-apm-traceparent': 'test',
+      tracestate: 'test2'
+    }
+  }
+  const output = 'Hello, world!'
+  let context
+
+  const agent = new AgentMock()
+  const wrap = lambda(agent)
+
+  lambdaLocal.execute({
+    event: input,
+    lambdaFunc: {
+      [name]: wrap((payload, _context) => {
+        context = _context
+        return Promise.resolve(`Hello, ${payload.name}!`)
+      })
+    },
+    lambdaHandler: name,
+    timeoutMs: 3000,
+    verboseLevel: 0,
+    callback: function (err, result) {
+      t.error(err)
+      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      t.strictEqual(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
+      t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
+      t.end()
+    }
+  })
+})
+
+test('resolve with both elastic-apm-traceparent and traceparent present', function (t) {
+  const name = 'greet.hello'
+  const input = {
+    name: 'world',
+    headers: {
+      traceparent: 'test',
+      'elastic-apm-traceparent': 'prefer-w3c',
+      tracestate: 'test2'
+    }
+  }
+  const output = 'Hello, world!'
+  let context
+
+  const agent = new AgentMock()
+  const wrap = lambda(agent)
+
+  lambdaLocal.execute({
+    event: input,
+    lambdaFunc: {
+      [name]: wrap((payload, _context) => {
+        context = _context
+        return Promise.resolve(`Hello, ${payload.name}!`)
+      })
+    },
+    lambdaHandler: name,
+    timeoutMs: 3000,
+    verboseLevel: 0,
+    callback: function (err, result) {
+      t.error(err)
+      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
+      t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
+      t.notEquals(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'prefers traceparent to elastic-apm-traceparent')
+      t.end()
+    }
+  })
+})
+
+test('resolve with both elastic-apm-traceparent before traceparent present', function (t) {
+  const name = 'greet.hello'
+  const input = {
+    name: 'world',
+    headers: {
+      'elastic-apm-traceparent': 'prefer-w3c',
+      traceparent: 'test',
+      tracestate: 'test2'
+    }
+  }
+  const output = 'Hello, world!'
+  let context
+
+  const agent = new AgentMock()
+  const wrap = lambda(agent)
+
+  lambdaLocal.execute({
+    event: input,
+    lambdaFunc: {
+      [name]: wrap((payload, _context) => {
+        context = _context
+        return Promise.resolve(`Hello, ${payload.name}!`)
+      })
+    },
+    lambdaHandler: name,
+    timeoutMs: 3000,
+    verboseLevel: 0,
+    callback: function (err, result) {
+      t.error(err)
+      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
+      t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
+      t.notEquals(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'prefers traceparent to elastic-apm-traceparent')
       t.end()
     }
   })

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -53,7 +53,6 @@ test('resolve with parent id header present', function (t) {
   const input = {
     name: 'world',
     headers: {
-      // 'elastic-apm-traceparent':'prefer-w3c',
       traceparent: 'test',
       tracestate: 'test2'
     }

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -53,6 +53,7 @@ test('resolve with parent id header present', function (t) {
   const input = {
     name: 'world',
     headers: {
+      'elastic-apm-traceparent':'prefer-w3c',
       traceparent: 'test',
       tracestate: 'test2'
     }

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -53,7 +53,8 @@ test('resolve with parent id header present', function (t) {
   const input = {
     name: 'world',
     headers: {
-      traceparent: 'test'
+      traceparent: 'test',
+      tracestate: 'test2'
     }
   }
   const output = 'Hello, world!'
@@ -85,7 +86,7 @@ test('resolve with parent id header present', function (t) {
       assertTransaction(t, agent.transactions[0], name, context, input, output)
 
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
-
+      t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.end()
     }
   })


### PR DESCRIPTION
### Checklist

Part of https://github.com/elastic/apm-agent-nodejs/issues/2156

This PR ensures that if the Lambda function is responding to an API Gateway request (or other request that includes a `tracestate` header) that its transaction will start using that tracestate.  This is needed because our existing lambda instrumentation was written before `tracestate` was a thing.

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
