### PR TITLE
feat: cloud metadata for lambda

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -11,7 +11,7 @@ var connect = require('./middleware/connect')
 const constants = require('./constants')
 var errors = require('./errors')
 var Instrumentation = require('./instrumentation')
-var lambda = require('./lambda')
+var { elasticApmAwsLambda } = require('./lambda')
 var Metrics = require('./metrics')
 var parsers = require('./parsers')
 var symbols = require('./symbols')
@@ -43,7 +43,7 @@ function Agent () {
   this._spanFilters = new Filters()
   this._transport = null
 
-  this.lambda = lambda(this)
+  this.lambda = elasticApmAwsLambda(this)
 }
 
 Object.defineProperty(Agent.prototype, 'currentTransaction', {

--- a/lib/cloud-metadata/index.js
+++ b/lib/cloud-metadata/index.js
@@ -2,7 +2,11 @@
 const { getMetadataAws } = require('./aws')
 const { getMetadataAzure } = require('./azure')
 const { getMetadataGcp } = require('./gcp')
+const { getMetadataAwsLambda } = require('./lambda')
 const { CallbackCoordination } = require('./callback-coordination')
+
+const { isLambdaExecutionEnviornment } = require('../lambda')
+
 const logging = require('../logging')
 
 // we "ping" (in the colloquial sense, not the ICMP sense) the metadata
@@ -25,9 +29,10 @@ const HTTP_TIMEOUT_MS = 1000
 const COORDINATION_TIMEOUT_MS = 3000
 
 class CloudMetadata {
-  constructor (cloudProvider, logger) {
+  constructor (cloudProvider, logger, serviceName) {
     this.cloudProvider = cloudProvider
     this.logger = logger
+    this.serviceName = serviceName
   }
 
   /**
@@ -110,6 +115,12 @@ class CloudMetadata {
       })
     }
 
+    if (this.shouldFetchAwsLambda()) {
+      fetcher.schedule((fetcher) => {
+        fetcher.recordResult(null, getMetadataAwsLambda(this.serviceName))
+      })
+    }
+
     fetcher.on('result', function (result) {
       cb(null, result)
     })
@@ -131,6 +142,10 @@ class CloudMetadata {
 
   shouldFetchAws () {
     return this.cloudProvider === 'auto' || this.cloudProvider === 'aws'
+  }
+
+  shouldFetchAwsLambda () {
+    return isLambdaExecutionEnviornment()
   }
 }
 

--- a/lib/cloud-metadata/lambda.js
+++ b/lib/cloud-metadata/lambda.js
@@ -1,0 +1,13 @@
+function getMetadataAwsLambda (serviceName) {
+  return {
+    provider: 'aws',
+    region: process.env.AWS_REGION,
+    service: {
+      name: serviceName
+    }
+  }
+}
+
+module.exports = {
+  getMetadataAwsLambda
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ var packageName = require('../package').name
 const { WildcardMatcher } = require('./wildcard-matcher')
 const { CloudMetadata } = require('./cloud-metadata')
 const { NoopTransport } = require('./noop-transport')
+const { isLambdaExecutionEnviornment } = require('./lambda')
 
 // Standardize user-agent header. Only use "elasticapm-node" if it matches "elastic-apm-node".
 if (packageName === 'elastic-apm-node') {
@@ -274,58 +275,8 @@ class Config {
       }
     } else if (typeof this.transport !== 'function') {
       this.transport = function httpTransport (conf, agent) {
-        let clientLogger = null
-        if (!logging.isLoggerCustom(agent.logger)) {
-          // https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-module
-          clientLogger = agent.logger.child({ 'event.module': 'apmclient' })
-        }
-        var transport = new ElasticAPMHttpClient({
-          agentName: 'nodejs',
-          agentVersion: version,
-          serviceName: conf.serviceName,
-          serviceNodeName: conf.serviceNodeName,
-          serviceVersion: conf.serviceVersion,
-          frameworkName: conf.frameworkName,
-          frameworkVersion: conf.frameworkVersion,
-          globalLabels: maybePairsToObject(conf.globalLabels),
-          hostname: conf.hostname,
-          environment: conf.environment,
-
-          // Sanitize conf
-          truncateKeywordsAt: config.INTAKE_STRING_MAX_SIZE,
-          truncateErrorMessagesAt: conf.errorMessageMaxLength,
-
-          // HTTP conf
-          secretToken: conf.secretToken,
-          apiKey: conf.apiKey,
-          userAgent: userAgent,
-          serverUrl: conf.serverUrl,
-          serverCaCert: loadServerCaCertFile(conf),
-          rejectUnauthorized: conf.verifyServerCert,
-          serverTimeout: conf.serverTimeout * 1000,
-
-          // APM Agent Configuration via Kibana:
-          centralConfig: conf.centralConfig,
-
-          // Streaming conf
-          size: conf.apiRequestSize,
-          time: conf.apiRequestTime * 1000,
-          maxQueueSize: conf.maxQueueSize,
-
-          // Debugging
-          logger: clientLogger,
-          payloadLogFile: conf.payloadLogFile,
-
-          // Container conf
-          containerId: conf.containerId,
-          kubernetesNodeName: conf.kubernetesNodeName,
-          kubernetesNamespace: conf.kubernetesNamespace,
-          kubernetesPodName: conf.kubernetesPodName,
-          kubernetesPodUID: conf.kubernetesPodUID,
-
-          // Cloud metadata fetching
-          cloudMetadataFetcher: (new CloudMetadata(conf.cloudProvider, conf.logger))
-        })
+        const config = getBaseClientConfig(conf, agent)
+        var transport = new ElasticAPMHttpClient(config)
 
         transport.on('config', remoteConf => {
           const conf = {}
@@ -707,5 +658,65 @@ function loadServerCaCertFile (opts) {
     } catch (err) {
       opts.logger.error('Elastic APM initialization error: Can\'t read server CA cert file %s (%s)', opts.serverCaCertFile, err.message)
     }
+  }
+}
+
+function getBaseClientConfig (conf, agent) {
+  let clientLogger = null
+  if (!logging.isLoggerCustom(agent.logger)) {
+    // https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-module
+    clientLogger = agent.logger.child({ 'event.module': 'apmclient' })
+  }
+
+  let cloudProvider = conf.cloudProvider
+  if (isLambdaExecutionEnviornment()) {
+    cloudProvider = 'none'
+  }
+  return {
+    agentName: 'nodejs',
+    agentVersion: version,
+    serviceName: conf.serviceName,
+    serviceNodeName: conf.serviceNodeName,
+    serviceVersion: conf.serviceVersion,
+    frameworkName: conf.frameworkName,
+    frameworkVersion: conf.frameworkVersion,
+    globalLabels: maybePairsToObject(conf.globalLabels),
+    hostname: conf.hostname,
+    environment: conf.environment,
+
+    // Sanitize conf
+    truncateKeywordsAt: config.INTAKE_STRING_MAX_SIZE,
+    truncateErrorMessagesAt: conf.errorMessageMaxLength,
+
+    // HTTP conf
+    secretToken: conf.secretToken,
+    apiKey: conf.apiKey,
+    userAgent: userAgent,
+    serverUrl: conf.serverUrl,
+    serverCaCert: loadServerCaCertFile(conf),
+    rejectUnauthorized: conf.verifyServerCert,
+    serverTimeout: conf.serverTimeout * 1000,
+
+    // APM Agent Configuration via Kibana:
+    centralConfig: conf.centralConfig,
+
+    // Streaming conf
+    size: conf.apiRequestSize,
+    time: conf.apiRequestTime * 1000,
+    maxQueueSize: conf.maxQueueSize,
+
+    // Debugging
+    logger: clientLogger,
+    payloadLogFile: conf.payloadLogFile,
+
+    // Container conf
+    containerId: conf.containerId,
+    kubernetesNodeName: conf.kubernetesNodeName,
+    kubernetesNamespace: conf.kubernetesNamespace,
+    kubernetesPodName: conf.kubernetesPodName,
+    kubernetesPodUID: conf.kubernetesPodUID,
+
+    // Cloud metadata fetching
+    cloudMetadataFetcher: (new CloudMetadata(cloudProvider, conf.logger, conf.serviceName))
   }
 }

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -2,7 +2,7 @@
 
 const shimmer = require('./instrumentation/shimmer')
 
-module.exports = function elasticApmAwsLambda (agent) {
+function elasticApmAwsLambda (agent) {
   function captureContext (trans, payload, context, result) {
     trans.setCustomContext({
       lambda: {
@@ -100,4 +100,13 @@ module.exports = function elasticApmAwsLambda (agent) {
       return fn.call(this, payload, context, callback)
     }
   }
+}
+
+function isLambdaExecutionEnviornment () {
+  return !!process.env.AWS_LAMBDA_FUNCTION_NAME
+}
+
+module.exports = {
+  isLambdaExecutionEnviornment,
+  elasticApmAwsLambda
 }

--- a/test/cloud-metadata/index.test.js
+++ b/test/cloud-metadata/index.test.js
@@ -551,3 +551,22 @@ tape('aws metadata unified IMDS: if server is not there', function (t) {
     t.ok(err, 'expected unreachable server error')
   })
 })
+
+tape('aws lambda metadata', function (t) {
+  // inject values into env.
+  process.env.AWS_REGION = 'us-west-2'
+  process.env.AWS_LAMBDA_FUNCTION_NAME = 'fixture-function-name'
+
+  const cloudMetadata = new CloudMetadata('none', logger, 'service name')
+  cloudMetadata.getCloudMetadata(
+    providerUrls,
+    function (err, metadata) {
+      t.error(err, 'no errors expected')
+      t.ok(metadata, 'returned data')
+      t.equals(metadata.provider, 'aws', 'cloud metadata provider set')
+      t.equals(metadata.region, 'us-west-2', 'cloud metadata region set')
+      t.equals(metadata.service.name, 'service name', 'cloud metadata service name set')
+      t.end()
+    }
+  )
+})

--- a/test/lambda/callbacks.test.js
+++ b/test/lambda/callbacks.test.js
@@ -3,7 +3,7 @@
 const test = require('tape')
 const lambdaLocal = require('lambda-local')
 
-const lambda = require('../../lib/lambda')
+const { elasticApmAwsLambda } = require('../../lib/lambda')
 const AgentMock = require('./mock/agent')
 const util = require('./_util')
 const assertError = util.assertError
@@ -19,7 +19,7 @@ test('success', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -55,7 +55,7 @@ test('failure', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,

--- a/test/lambda/cloud-metadata.test.js
+++ b/test/lambda/cloud-metadata.test.js
@@ -1,0 +1,34 @@
+// inject env. variables before loading agent
+process.env.AWS_LAMBDA_FUNCTION_NAME = 'fixture-function-name'
+const agent = require('../..').start({
+  serviceName: 'test',
+  secretToken: 'test',
+  cloudProvider: 'auto',
+  captureExceptions: false,
+  metricsInterval: 0,
+  centralConfig: false
+})
+
+const tape = require('tape')
+
+const { isLambdaExecutionEnviornment } = require('../../lib/lambda')
+
+tape.test('ignores cloudProvider:auto in lambda enviornment', function (t) {
+  const fetcher = agent._transport._conf.cloudMetadataFetcher
+  t.strictEquals(fetcher.cloudProvider, 'none', 'config set to none')
+
+  t.strictEquals(fetcher.shouldFetchGcp(), false, 'no gcp metadata')
+  t.strictEquals(fetcher.shouldFetchAws(), false, 'no aws metadata fetcher')
+  t.strictEquals(fetcher.shouldFetchAzure(), false, 'no azure metadata fetcher')
+  t.strictEquals(fetcher.shouldFetchAwsLambda(), true, 'yes to AWS Lambda metadata fetcher')
+  t.end()
+})
+
+tape.test('isLambdaExecutionEnviornment', function (t) {
+  delete process.env.AWS_LAMBDA_FUNCTION_NAME
+  t.strictEquals(isLambdaExecutionEnviornment(), false, 'execution enviornment not detected')
+
+  process.env.AWS_LAMBDA_FUNCTION_NAME = 'fixture-function-name'
+  t.strictEquals(isLambdaExecutionEnviornment(), true, 'execution enviornment detected')
+  t.end()
+})

--- a/test/lambda/context.test.js
+++ b/test/lambda/context.test.js
@@ -3,7 +3,7 @@
 const test = require('tape')
 const lambdaLocal = require('lambda-local')
 
-const lambda = require('../../lib/lambda')
+const { elasticApmAwsLambda } = require('../../lib/lambda')
 const AgentMock = require('./mock/agent')
 const util = require('./_util')
 const assertError = util.assertError
@@ -19,7 +19,7 @@ test('context.succeed', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -55,7 +55,7 @@ test('context.done', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -91,7 +91,7 @@ test('context.fail', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -3,7 +3,7 @@
 const test = require('tape')
 const lambdaLocal = require('lambda-local')
 
-const lambda = require('../../lib/lambda')
+const { elasticApmAwsLambda } = require('../../lib/lambda')
 const AgentMock = require('./mock/agent')
 const util = require('./_util')
 const assertError = util.assertError
@@ -19,7 +19,7 @@ test('resolve', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -61,7 +61,7 @@ test('resolve with parent id header present', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -105,7 +105,7 @@ test('resolve with elastic-apm-traceparent present', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -142,7 +142,7 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -180,7 +180,7 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,
@@ -211,7 +211,7 @@ test('reject', function (t) {
   let context
 
   const agent = new AgentMock()
-  const wrap = lambda(agent)
+  const wrap = elasticApmAwsLambda(agent)
 
   lambdaLocal.execute({
     event: input,


### PR DESCRIPTION
Part of: https://github.com/elastic/apm-agent-nodejs/issues/2156

This PR implements a cloud metadata fetcher for AWS Lambda, and collects the three known cloud metadata fields for Lambda.  [Per the spec](https://github.com/elastic/apm/pull/470/files#diff-f2c63c07259b18f0e99842294455cf6f50fd4b1f415fafd1a2946a56f6086c25R35), when in an AWS Lambda environment the normal cloud metadata HTTP-service checks should be suspended, and we should attempt to collect as much of the cloud metadata from the environment without external service requests. 

This PR also does some small bits of module refactoring to facilitate current/future work

- `lib/lamba.js` now exports multiple functions, to facilitate testing of the new  `isLambdaExecutionEnviornment`

- A `getBaseClientConfig` has been introduced in order to isolate the growing conditional logic for configuring a the APM Server client 

There [are other cloud metadata fields](https://github.com/elastic/apm/pull/470/files#r686397153) we _may_ set in the future for Lambda support -- this PR isn't concerned with them.  We'll set those once the spec settles.  This PR is concerned with setting up the fetcher and disabling the other fetchers. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
