### PR TITLE
fix: ensure the APM agent's own requests to APM server are not traced

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,21 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Ensure the internal HTTP(S) client requests made by the APM agent to APM
+  server are not themselves traced. ({issues}1168[#1168], {issues}1136[#1136])
+
+
 [[release-notes-3.19.0]]
 ==== 3.19.0 2021/08/05
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,15 +36,21 @@ Notes:
 
 [float]
 ===== Features
-[[release-notes-3.20.0]]
-==== 3.20.0 2021/08/12
 
 [float]
 ===== Bug fixes
 
 * Ensure the internal HTTP(S) client requests made by the APM agent to APM
   server are not themselves traced. ({issues}1168[#1168], {issues}1136[#1136])
-- Fix failing tests and a possible runtime crash in
+
+
+[[release-notes-3.20.0]]
+==== 3.20.0 2021/08/12
+
+[float]
+===== Bug fixes
+
+* Fix failing tests and a possible runtime crash in
   `@elastic/elasticsearch@7.14.0` instrumentation. ({issues}2187[#2187])
 
 

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -169,13 +169,8 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
       var req = orig.apply(this, newArgs)
       if (!span) return req
 
-      if (getSafeHost(req) === agent._conf.serverHost) {
-        agent.logger.debug('ignore %s request to intake API %o', moduleName, { id: id })
-        return req
-      } else {
-        var protocol = req.agent && req.agent.protocol
-        agent.logger.debug('request details: %o', { protocol: protocol, host: getSafeHost(req), id: id })
-      }
+      var protocol = req.agent && req.agent.protocol
+      agent.logger.debug('request details: %o', { protocol: protocol, host: getSafeHost(req), id: id })
 
       ins.bindEmitter(req)
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "basic-auth": "^2.0.1",
     "cookie": "^0.4.0",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "^9.8.1",
+    "elastic-apm-http-client": "^9.9.0",
     "end-of-stream": "^1.4.4",
     "error-callsites": "^2.0.4",
     "error-stack-parser": "^2.0.6",

--- a/test/_mock_apm_server.js
+++ b/test/_mock_apm_server.js
@@ -5,6 +5,7 @@
 //    server.start(function (serverUrl) {
 //      // Test code using `serverUrl`...
 //      // - Events received on the intake API will be on `server.events`.
+//      // - Raw request data is on `server.requests`.
 //      // - Call `server.close()` when done.
 //    })
 
@@ -15,6 +16,7 @@ const zlib = require('zlib')
 class MockAPMServer {
   constructor () {
     this.events = []
+    this.requests = []
     this.serverUrl = null // set in .start()
     this._http = http.createServer(this._onRequest.bind(this))
   }
@@ -51,6 +53,12 @@ class MockAPMServer {
       } else {
         res.writeHead(404)
       }
+      this.requests.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: body
+      })
       res.end(resBody)
     })
   }

--- a/test/do-not-trace-self.test.js
+++ b/test/do-not-trace-self.test.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { execFile } = require('child_process')
+const tape = require('tape')
+
+const { MockAPMServer } = require('./_mock_apm_server')
+
+// Exec an APM-using script that makes an APM server intake request while
+// there is a current transaction. Assert that that current transaction does
+// *not* result in tracing of the intake request.
+tape.test('APM server intake request should not be traced', function (t) {
+  const server = new MockAPMServer()
+  server.start(function (serverUrl) {
+    execFile(
+      process.execPath,
+      ['fixtures/do-not-trace-self.js'],
+      {
+        cwd: __dirname,
+        timeout: 10000, // sanity stop, 3s is sometimes too short for CI
+        env: Object.assign({}, process.env, {
+          ELASTIC_APM_SERVER_URL: serverUrl
+        })
+      },
+      function done (err, _stdout, _stderr) {
+        t.error(err, 'fixtures/do-not-trace-self.js did not error out')
+        t.ok(server.events[0].metadata, 'APM server got an event metadata object')
+        t.ok(server.events[1].span, 'APM server got a span event')
+        t.equal(server.events.length, 2, 'APM server got no other events')
+        t.equal(server.requests.length, 1, 'APM server got a single request')
+        const req = server.requests[0]
+        t.equal(req.method, 'POST', 'APM server req was a POST...')
+        t.ok(req.url.startsWith('/intake'), '... to the intake API')
+        t.equal(req.headers.traceparent, undefined, 'APM server req had no traceparent header')
+        t.equal(req.headers.tracestate, undefined, 'APM server req had no tracestate header')
+        t.equal(req.headers['elastic-apm-traceparent'], undefined, 'APM server req had no elastic-apm-traceparent header')
+        server.close()
+        t.end()
+      }
+    )
+  })
+})

--- a/test/fixtures/do-not-trace-self.js
+++ b/test/fixtures/do-not-trace-self.js
@@ -1,0 +1,26 @@
+// A small APM-using script used to test that the APM agent's own HTTP
+// communication with APM server is not traced.
+
+var apm = require('../../').start({ // elastic-apm-node
+  serviceName: 'test-do-not-trace-self',
+  metricsInterval: 0,
+  cloudProvider: 'none',
+  centralConfig: false
+})
+
+// Explicitly require the possible APM server client transport modules so that
+// the agent instruments them.
+require('http')
+require('https')
+
+// Start a transaction and intentionally do not end it. We expect the APM agent
+// end-of-process handling will flush the ended *span*... while there is still
+// this current transaction. This creates the potential for the agent to
+// incorrectly trace its own HTTP request to APM server.
+apm.startTransaction('transactionThatWeDoNotEnd')
+setImmediate(function () {
+  const s = apm.startSpan('s')
+  setImmediate(function () {
+    s.end()
+  })
+})


### PR DESCRIPTION
This fixes a couple of older issues and also ensures these internal
requests do not add noise to internal debug logging for instrumentation
async context tracking.

Fixes: #1168
Fixes: #1136

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
