### PR TITLE
ci: avoid port 8200 for mock apm-server for benchmark runs

### DIFF
--- a/test/benchmarks/scripts/run-benchmarks.sh
+++ b/test/benchmarks/scripts/run-benchmarks.sh
@@ -57,9 +57,10 @@ function teardown() {
 
 function startAPMServer() {
   log "Starting mock APM Server..."
-  node $utils/apm-server.js &
+  node $utils/apm-server.js $apm_server_port &
   pid=$!
-  log "Mock APM Server running as pid $pid"
+  log "Mock APM Server running on port $apm_server_port as pid $pid"
+  export ELASTIC_APM_SERVER_URL=http://localhost:$apm_server_port
 
   sleep 1
 }
@@ -68,6 +69,7 @@ function shutdownAPMServer() {
   log "Shutting down mock APM Server (pid: $pid)..."
   kill -SIGUSR2 $pid
   unset pid
+  unset ELASTIC_APM_SERVER_URL
 }
 
 function runBenchmark() {
@@ -97,6 +99,9 @@ outputdir=$basedir/.tmp
 appout_no_agent=$outputdir/app-no-agent.json
 appout_agent=$outputdir/app-agent.json
 result_file=$2
+# Avoid port 8200 conflicts with others on shared machines in the past
+# (https://github.com/elastic/apm-agent-rum-js/issues/1074).
+apm_server_port=8201
 
 rm -f $result_file # in case it's left over from an old run somehow
 rm -fr $outputdir

--- a/test/benchmarks/utils/apm-server.js
+++ b/test/benchmarks/utils/apm-server.js
@@ -1,3 +1,5 @@
+// A mock APM server that just accepts any request.
+// Usage: node apm-server.js PORT
 'use strict'
 
 process.on('SIGUSR2', function () {
@@ -13,4 +15,8 @@ const server = http.createServer(function (req, res) {
   req.resume()
 })
 
-server.listen(8200)
+const PORT = Number(process.argv[2])
+if (isNaN(PORT)) {
+  throw new Error(`invalid or missing PORT argument: ${process.argv[2]}`)
+}
+server.listen(PORT)


### PR DESCRIPTION
This is to avoid possible port conflict if there is a real APM server
already running on a shared machine.

Fixes: #2131
