### PR TITLE
fix: test crash with mongodb@4.1.1 and node v10

### DIFF
--- a/test/config.test.js
+++ b/test/config.test.js
@@ -734,7 +734,7 @@ test('disableInstrumentations', function (t) {
   }
   // As of mongodb@4 only supports node >=v12.
   const mongodbVersion = require('../node_modules/mongodb/package.json').version
-  if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '11.0.0')) {
+  if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '12.0.0')) {
     modules.delete('mongodb')
   }
 

--- a/test/instrumentation/modules/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb.test.js
@@ -8,10 +8,10 @@ const agent = require('../../..').start({
   cloudProvider: 'none'
 })
 
-// require('mongodb') is a hard crash on nodes <10.4
+// As of mongodb@4 only supports node >=v12.
 const mongodbVersion = require('../../../node_modules/mongodb/package.json').version
 const semver = require('semver')
-if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '10.4.0')) {
+if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '12.0.0')) {
   console.log(`# SKIP mongodb@${mongodbVersion} does not support node ${process.version}`)
   process.exit()
 }


### PR DESCRIPTION
mongodb@4.0.0 dropped support for node v10. However, it wasn't until
v4.1.1 that it failed in usage with the latest node v10.
