### PR TITLE
support `[{ "host": "127.0.0.1", "port": 9200 }]` format from prior `npm elasticsearch` versions

### DIFF
--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -31,7 +31,18 @@ module.exports = function (elasticsearch, agent, { enabled }) {
         const transportConfig = this._config
         let host, port
         if (typeof transportConfig === 'object' && transportConfig.host) {
-          [host, port] = transportConfig.host.split(':')
+          if (Array.isArray(transportConfig.host)) {
+            const first = transportConfig.host[0]
+            if ('host' in first && 'port' in first) {
+              ({host, port} = first)
+            }
+            else if ('host' in first) {
+              [host, port] = first.host.split(':')
+            }
+          }
+          else if ('string' === typeof transportConfig.host) {
+            [host, port] = transportConfig.host.split(':')
+          }
         }
         span.setDestinationContext(getDBDestination(span, host, port))
 


### PR DESCRIPTION
fixes: `UnhandledPromiseRejectionWarning: TypeError:
transportConfig.host.split is not a function or its return value is not
iterable`
