### PR TITLE
fix: 'transportConfig.host.split' error in old elasticsearch client instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix a crash in instrumentation of the old Elasticsearch client
+  (`elasticsearch`) for some rarer cases of client options -- for example
+  passing multiple hosts.
+
 * Ensure the internal HTTP(S) client requests made by the APM agent to APM
   server are not themselves traced. ({issues}1168[#1168], {issues}1136[#1136])
 
@@ -90,7 +94,7 @@ Notes:
 
 * Add instrumentation of the AWS SNS publish method when using the
   https://www.npmjs.com/package/aws-sdk[JavaScript AWS SDK v2] (`aws-sdk`). ({pull}2157[#2157])
-  
+
 [float]
 ===== Bug fixes
 

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -1,8 +1,57 @@
 'use strict'
 
+const URL = require('url').URL
+
 var shimmer = require('../shimmer')
 var { getDBDestination } = require('../context')
 const { setElasticsearchDbContext } = require('../elasticsearch-shared')
+
+const startsWithProtocolRE = /^([a-z]+:)?\/\//;
+const DEFAULT_PORT = 9200
+const DEFAULT_PORT_FROM_PROTO = {
+  'http:': 80,
+  'https:': 443,
+}
+
+// This is an imperfect equivalent of the handling in the Transport
+// constructor and internal Host parsing function.
+function getHostAndPortFromTransportConfig (config) {
+  const transportHosts = config ? config.host || config.hosts : null
+  if (!transportHosts) {
+    return null
+  }
+
+  let firstTransportHost = Array.isArray(transportHosts)
+    ? transportHosts[0] : transportHosts
+  if (!firstTransportHost) {
+    return null
+  }
+
+  if (typeof firstTransportHost === 'string') {
+    // "example.com:42" or "someprotocol://example.com:42" or
+    // "someprotocol://example.com".
+    if (!startsWithProtocolRE.test(firstTransportHost)) {
+      firstTransportHost = 'http://' + firstTransportHost
+    }
+    let u
+    try {
+      u = new URL(firstTransportHost)
+    } catch {
+      return null
+    }
+    if (!u.port) {
+      u.port = DEFAULT_PORT_FROM_PROTO[u.protocol]
+    }
+    return [u.hostname, u.port]
+  } else if (typeof firstTransportHost === 'object') {
+    return [
+      firstTransportHost.hostname || firstTransportHost.host,
+      firstTransportHost.port || DEFAULT_PORT
+    ]
+  }
+
+  return null
+}
 
 module.exports = function (elasticsearch, agent, { enabled }) {
   if (!enabled) return elasticsearch
@@ -28,10 +77,11 @@ module.exports = function (elasticsearch, agent, { enabled }) {
           params && params.body)
 
         // Get the remote host information from elasticsearch Transport options.
-        const transportConfig = this._config
         let host, port
-        if (typeof transportConfig === 'object' && transportConfig.host) {
-          [host, port] = transportConfig.host.split(':')
+        let hostAndPort = getHostAndPortFromTransportConfig(this._config)
+        if (hostAndPort) {
+          host = hostAndPort[0]
+          port = hostAndPort[1]
         }
         span.setDestinationContext(getDBDestination(span, host, port))
 

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -13,8 +13,8 @@ const DEFAULT_PORT_FROM_PROTO = {
   'https:': 443,
 }
 
-// This is an imperfect equivalent of the handling in the Transport
-// constructor and internal Host parsing function.
+// This is an imperfect equivalent of the handling in the `Transport`
+// constructor and internal `Host` parsing function in the ES client.
 function getHostAndPortFromTransportConfig (config) {
   const transportHosts = config ? config.host || config.hosts : null
   if (!transportHosts) {

--- a/test/instrumentation/modules/elasticsearch.test.js
+++ b/test/instrumentation/modules/elasticsearch.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const URL = require('url').URL
+
 const { pathIsAQuery } = require('../../../lib/instrumentation/elasticsearch-shared')
 
 process.env.ELASTIC_APM_TEST = true
@@ -180,6 +182,43 @@ test('client.count with callback', function userLandCode (t) {
 
   var client = new elasticsearch.Client({ host: host })
   client.count(function (err) {
+    t.error(err)
+    agent.endTransaction()
+    agent.flush()
+  })
+})
+
+test('client with host=<array of host:port>', function userLandCode (t) {
+  resetAgent(done(t, 'HEAD', '/'))
+  agent.startTransaction('foo')
+  var client = new elasticsearch.Client({ host: [host] })
+  client.ping(function (err) {
+    t.error(err)
+    agent.endTransaction()
+    agent.flush()
+  })
+})
+
+test('client with hosts=<array of host:port>', function userLandCode (t) {
+  resetAgent(done(t, 'HEAD', '/'))
+  agent.startTransaction('foo')
+  var client = new elasticsearch.Client({ hosts: [host, host] })
+  client.ping(function (err) {
+    t.error(err)
+    agent.endTransaction()
+    agent.flush()
+  })
+})
+
+test('client with hosts="http://host:port"', function userLandCode (t) {
+  resetAgent(done(t, 'HEAD', '/'))
+  agent.startTransaction('foo')
+  let hostWithProto = host
+  if (!hostWithProto.startsWith('http')) {
+    hostWithProto = 'http://' + host
+  }
+  var client = new elasticsearch.Client({ hosts: hostWithProto })
+  client.ping(function (err) {
     t.error(err)
     agent.endTransaction()
     agent.flush()


### PR DESCRIPTION
The instrumentation of the old 'elasticsearch' client could throw `TypeError: transportConfig.host.split is not a function or its return value is not iterable` if multiple hosts were given. This change improves on the parsing of the ES clients `Transport._config` to extract the target Elasticsearch host and port to be more resilient.

Thanks to @ancms2600 for reporting the issue and starting the fix.

Refs: #2306

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
