### PR TITLE
tests: refactor handling of config var type in config.test.js

### DIFF
--- a/test/config.test.js
+++ b/test/config.test.js
@@ -100,11 +100,23 @@ var truthyValues = [true, 'true']
 
 optionFixtures.forEach(function (fixture) {
   if (fixture[1]) {
-    var bool = typeof fixture[2] === 'boolean'
-    var url = fixture[0] === 'serverUrl' // special case for url's so they can be parsed using url.parse()
-    var file = fixture[0] === 'serverCaCertFile' // special case for files, so a temp file can be written
-    var number = typeof fixture[2] === 'number'
-    var array = Array.isArray(fixture[2])
+    var type
+    if (typeof fixture[2] === 'boolean') {
+      type = 'bool'
+    } else if (fixture[0] === 'serverUrl') {
+      // special case for url's so they can be parsed using url.parse()
+      type = 'url'
+    } else if (fixture[0] === 'serverCaCertFile') {
+      // special case for files, so a temp file can be written
+      type = 'file'
+    } else if (typeof fixture[2] === 'number') {
+      type = 'number'
+    } else if (Array.isArray(fixture[2])) {
+      type = 'array'
+    } else {
+      type = 'string'
+    }
+
     var envName = 'ELASTIC_APM_' + fixture[1]
     var existingValue = process.env[envName]
 
@@ -112,28 +124,50 @@ optionFixtures.forEach(function (fixture) {
       var agent = new Agent()
       var value
 
-      if (bool) value = !fixture[2]
-      else if (number) value = 1
-      else if (url) value = 'http://custom-value'
-      else if (file) {
-        var tmpdir = path.join(os.tmpdir(), 'elastic-apm-node-test', String(Date.now()))
-        var tmpfile = path.join(tmpdir, 'custom-file')
-        t.on('end', function () { rimraf.sync(tmpdir) })
-        mkdirp.sync(tmpdir)
-        fs.writeFileSync(tmpfile, tmpfile)
-        value = tmpfile
-      } else value = 'custom-value'
+      switch (type) {
+        case 'bool':
+          value = !fixture[2]
+          break
+        case 'number':
+          value = 1
+          break
+        case 'url':
+          value = 'http://custom-value'
+          break
+        case 'file':
+          var tmpdir = path.join(os.tmpdir(), 'elastic-apm-node-test', String(Date.now()))
+          var tmpfile = path.join(tmpdir, 'custom-file')
+          t.on('end', function () { rimraf.sync(tmpdir) })
+          mkdirp.sync(tmpdir)
+          fs.writeFileSync(tmpfile, tmpfile)
+          value = tmpfile
+          break
+        case 'array':
+          value = ['custom-value']
+          break
+        case 'string':
+          value = 'custom-value'
+          break
+        default:
+          t.fail(`missing handling for config var type "${type}"`)
+      }
 
       process.env[envName] = value.toString()
 
       agent.start(agentOptsNoopTransport)
 
-      if (array) {
-        t.deepEqual(agent._conf[fixture[0]], [value])
-      } else {
-        t.strictEqual(agent._conf[fixture[0]], bool ? !fixture[2] : value)
+      switch (type) {
+        case 'bool':
+          t.strictEqual(agent._conf[fixture[0]], !fixture[2])
+          break
+        case 'array':
+          t.deepEqual(agent._conf[fixture[0]], value)
+          break
+        default:
+          t.strictEqual(agent._conf[fixture[0]], value)
       }
 
+      // Restore process.env state.
       if (existingValue) {
         process.env[envName] = existingValue
       } else {
@@ -149,26 +183,38 @@ optionFixtures.forEach(function (fixture) {
       var opts = {}
       var value1, value2
 
-      if (bool) {
-        value1 = !fixture[2]
-        value2 = fixture[2]
-      } else if (number) {
-        value1 = 2
-        value2 = 1
-      } else if (url) {
-        value1 = 'http://overwriting-value'
-        value2 = 'http://custom-value'
-      } else if (file) {
-        var tmpdir = path.join(os.tmpdir(), 'elastic-apm-node-test', String(Date.now()))
-        var tmpfile = path.join(tmpdir, 'custom-file')
-        t.on('end', function () { rimraf.sync(tmpdir) })
-        mkdirp.sync(tmpdir)
-        fs.writeFileSync(tmpfile, tmpfile)
-        value1 = path.join(tmpdir, 'does-not-exist')
-        value2 = tmpfile
-      } else {
-        value1 = 'overwriting-value'
-        value2 = 'custom-value'
+      switch (type) {
+        case 'bool':
+          value1 = !fixture[2]
+          value2 = fixture[2]
+          break
+        case 'number':
+          value1 = 2
+          value2 = 1
+          break
+        case 'url':
+          value1 = 'http://overwriting-value'
+          value2 = 'http://custom-value'
+          break
+        case 'file':
+          var tmpdir = path.join(os.tmpdir(), 'elastic-apm-node-test', String(Date.now()))
+          var tmpfile = path.join(tmpdir, 'custom-file')
+          t.on('end', function () { rimraf.sync(tmpdir) })
+          mkdirp.sync(tmpdir)
+          fs.writeFileSync(tmpfile, tmpfile)
+          value1 = path.join(tmpdir, 'does-not-exist')
+          value2 = tmpfile
+          break
+        case 'array':
+          value1 = ['overwriting-value']
+          value2 = ['custom-value']
+          break
+        case 'string':
+          value1 = 'overwriting-value'
+          value2 = 'custom-value'
+          break
+        default:
+          t.fail(`missing handling for config var type "${type}"`)
       }
 
       opts[fixture[0]] = value1
@@ -176,10 +222,12 @@ optionFixtures.forEach(function (fixture) {
 
       agent.start(Object.assign({}, agentOptsNoopTransport, opts))
 
-      if (array) {
-        t.deepEqual(agent._conf[fixture[0]], [value2])
-      } else {
-        t.strictEqual(agent._conf[fixture[0]], value2)
+      switch (type) {
+        case 'array':
+          t.deepEqual(agent._conf[fixture[0]], value2)
+          break
+        default:
+          t.strictEqual(agent._conf[fixture[0]], value2)
       }
 
       if (existingValue) {
@@ -203,10 +251,13 @@ optionFixtures.forEach(function (fixture) {
     }
 
     var agent = new Agent().start(opts)
-    if (array) {
-      t.deepEqual(agent._conf[fixture[0]], fixture[2])
-    } else {
-      t.strictEqual(agent._conf[fixture[0]], fixture[2])
+
+    switch (type) {
+      case 'array':
+        t.deepEqual(agent._conf[fixture[0]], fixture[2])
+        break
+      default:
+        t.strictEqual(agent._conf[fixture[0]], fixture[2])
     }
 
     if (existingValue) {


### PR DESCRIPTION
No functional change.

### background on why this change

This is work that came out of earlier work on https://github.com/elastic/apm-agent-nodejs/pull/2193

The `longFieldMaxLength` config var for that PR was *originally* a "strict bytes" type. "Strict bytes" here is a config var type similar to the existing "bytes" type, but per https://github.com/elastic/apm/blob/master/specs/agents/configuration.md#durationsize-config-legacy-considerations all new "bytes" config vars must be *strictly* a string with the units. Our current "bytes" vars are loose (don't require a suffix like "b" or "kb", and allow an integer instead of a string) here, so a separate type on "config.js" will be necessary if/when we add one.

If/when we add a "strict" bytes/size type, then we'll need this refactoring of config.test.js -- or something better than this, to not have this test code get lost in the special overlapping meanings of these vars:

```js
    var bool = typeof fixture[2] === 'boolean'
    var url = fixture[0] === 'serverUrl' // special case for url's so they can be parsed using url.parse()
    var file = fixture[0] === 'serverCaCertFile' // special case for files, so a temp file can be written
    var number = typeof fixture[2] === 'number'
    var array = Array.isArray(fixture[2])
```

A single "type" for the type of the config var, and `switch`es below to handle them is cleaner.
