### PR TITLE
fix: apm.removePatch(name, somethingNotRegistered) would remove last handler

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix a bug in `apm.removePatch(module, aHandler)` that would remove the
+  last registered handler if `aHandler` did not match any currently
+  registered handlers. ({pull}2315[#2315])
+
 * Fix a crash in instrumentation of the old Elasticsearch client
   (`elasticsearch`) for some rarer cases of client options -- for example
   passing multiple hosts. ({pull}2312[#2312])

--- a/lib/instrumentation/named-array.js
+++ b/lib/instrumentation/named-array.js
@@ -34,9 +34,11 @@ class NamedArray {
     const array = this.get(key)
     if (array) {
       const index = array.indexOf(value)
-      array.splice(index, 1)
-      if (!array.length) {
-        this.clear(key)
+      if (index !== -1) {
+        array.splice(index, 1)
+        if (!array.length) {
+          this.clear(key)
+        }
       }
     }
   }


### PR DESCRIPTION
There was a bug in the Instrumentation class's data structure for added
patches where removePatch(name, somethingBogus) would "find" that
handler at index -1 and remove the last handler.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
