### PR TITLE
tests: refactor breakdown metrics tests to not override Agent internals

### DIFF
--- a/lib/metrics/reporter.js
+++ b/lib/metrics/reporter.js
@@ -52,8 +52,10 @@ class MetricsReporter extends Reporter {
         }
       }
 
-      for (const metric of seen.values()) {
-        this._agent._transport.sendMetricSet(metric)
+      if (this._agent._transport) {
+        for (const metric of seen.values()) {
+          this._agent._transport.sendMetricSet(metric)
+        }
       }
     })
 

--- a/test/_capturing_transport.js
+++ b/test/_capturing_transport.js
@@ -1,0 +1,77 @@
+'use strict'
+
+// An Agent transport -- i.e. the APM server client API provided by
+// elastic-apm-http-client -- that just captures all sent events.
+//
+// Usage:
+//    const testAgentOpts = {
+//      // ...
+//      transport () { return new CapturingTransport() }
+//    }
+//
+//    test('something', function (t) {
+//      const agent = new Agent().start(testAgentOpts)
+//      // Use `agent`, then assert that
+//      // `agent._transport.{spans,transactions,errors,metricsets}` are as
+//      // expected.
+//      agent.destroy()
+//      t.end()
+//    })
+//
+// Note: This is similar to _mock_http_client.js, but avoids the testing model
+// of using an expected number of sent APM events to decide when a test should
+// end.
+
+class CapturingTransport {
+  constructor () {
+    this.spans = []
+    this.transactions = []
+    this.errors = []
+    this.metricsets = []
+  }
+
+  config (opts) {}
+
+  addMetadataFilter (fn) {}
+
+  sendSpan (span, cb) {
+    this.spans.push(span)
+    if (cb) {
+      process.nextTick(cb)
+    }
+  }
+
+  sendTransaction (transaction, cb) {
+    this.transactions.push(transaction)
+    if (cb) {
+      process.nextTick(cb)
+    }
+  }
+
+  sendError (error, cb) {
+    this.errors.push(error)
+    if (cb) {
+      process.nextTick(cb)
+    }
+  }
+
+  sendMetricSet (metricset, cb) {
+    this.metricsets.push(metricset)
+    if (cb) {
+      process.nextTick(cb)
+    }
+  }
+
+  flush (cb) {
+    if (cb) {
+      process.nextTick(cb)
+    }
+  }
+
+  // Inherited from Writable, called in agent.js.
+  destroy () {}
+}
+
+module.exports = {
+  CapturingTransport
+}

--- a/test/metrics/breakdown.test.js
+++ b/test/metrics/breakdown.test.js
@@ -310,7 +310,6 @@ test('acceptance', t => {
       agent.destroy()
       t.end()
     })
-
   })
 
   t.test('with single app sub-span', t => {


### PR DESCRIPTION
This refactors breakdown.test.js to not need a `resetAgent(...)` that knows so much about Agent internals. Now that we have a usable `agent.destroy()`, use that and create a new Agent for each test case. 

This also moves away from the test/_mock_http_client.js testing style of waiting for an expected number of sent events to decide when to end a test case. This style is brittle when there is a test failure: either hanging waiting for an event that isn't coming, or crashing with `throw new Error('too many writes')`.