### PR TITLE
fix: ensure metrics collection is actually disabled with metricsInterval=0s

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,24 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Guard against a negative value of `metricsInterval`, which can lead to
+  high CPU usage as metrics are collected as fast as possible. Also ensure
+  no metrics collection can happen if `metricsInterval="0s"` as intended.
+  Before this change it was possible for some metric collection to still
+  happen, even though none would be reported. ({pull}2330[#2330])
+
+
 [[release-notes-3.21.0]]
 ==== 3.21.0 2021/09/15
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,8 +36,6 @@ Notes:
 
 [float]
 ===== Features
-[[release-notes-3.21.1]]
-==== 3.21.1 2021/09/16
 
 [float]
 ===== Bug fixes
@@ -52,6 +50,14 @@ This change also guards against negative and invalid values in the following
 configuration options: `abortedErrorThreshold`, `apiRequestTime`, and
 `serverTimeout`. If an invalid value is given, then will fallback to their
 default value.
+
+
+[[release-notes-3.21.1]]
+==== 3.21.1 2021/09/16
+
+[float]
+===== Bug fixes
+
 * Update types to avoid imports of `@types/...` modules (other than
   `@types/node`), so that TypeScript users of elastic-apm-node need not
   manually `npm install @types/connect @types/pino @types/aws-lambda` to

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,11 @@ Notes:
   no metrics collection can happen if `metricsInterval="0s"` as intended.
   Before this change it was possible for some metric collection to still
   happen, even though none would be reported. ({pull}2330[#2330])
++
+This change also guards against negative and invalid values in the following
+configuration options: `abortedErrorThreshold`, `apiRequestTime`, and
+`serverTimeout`. If an invalid value is given, then will fallback to their
+default value.
 
 
 [[release-notes-3.21.0]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,16 +57,16 @@ Notes:
   Specific transaction/span/error fields (see the list below) will be truncated
   at this number of unicode characters. ({pull}2193[#2193], {issues}1921[#1921])
 +
-  The `errorMessageMaxLength` configuration option is now *deprecated*, but
-  still supported. Users should switch to using `longFieldMaxLength. If
-  `errorMessageMaxLength` is not specified, truncation of error messages will
-  now use the `longFieldMaxLength` value.
+The `errorMessageMaxLength` configuration option is now *deprecated*, but
+still supported. Users should switch to using `longFieldMaxLength`. If
+`errorMessageMaxLength` is not specified, truncation of error messages will
+now use the `longFieldMaxLength` value.
 +
-  Note that ultimately the maximum length of any tracing field is limited by the
-  {apm-server-ref-v}/configuration-process.html#max_event_size[`max_event_size`]
-  configured for the receiving APM server.
+Note that ultimately the maximum length of any tracing field is limited by the
+{apm-server-ref-v}/configuration-process.html#max_event_size[`max_event_size`]
+configured for the receiving APM server.
 +
-  The fields affected by `longFieldMaxLength` are:
+The fields affected by `longFieldMaxLength` are:
 +
 ** `transaction.context.request.body`, `error.context.request.body` - Before
    this change these fields were not truncated.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -948,15 +948,14 @@ it will be parsed out of the `/proc/self/cgroup` file.
 ==== `metricsInterval`
 
 * *Type:* String
-* *Default:* `30s`
+* *Default:* `"30s"`
 * *Env:* `ELASTIC_APM_METRICS_INTERVAL`
 
 Specify the interval for reporting metrics to APM Server.
 The interval should be in seconds,
 or should include a time suffix.
 
-To disable metrics reporting,
-set the interval to `0`.
+To disable metrics reporting, set the interval to `"0s"`.
 
 [[metrics-limit]]
 ==== `metricsLimit`

--- a/lib/config.js
+++ b/lib/config.js
@@ -747,7 +747,7 @@ function getBaseClientConfig (conf, agent) {
     cloudMetadataFetcher: (new CloudMetadata(cloudProvider, conf.logger, conf.serviceName))
   }
 
-  if (conf.errorMessageMaxLength !== undefined) {O
+  if (conf.errorMessageMaxLength !== undefined) {
     // As of v10 of the http client, truncation of error messages will default
     // to `truncateLongFieldsAt` if `truncateErrorMessagesAt` is not specified.
     clientConfig.truncateErrorMessagesAt = conf.errorMessageMaxLength

--- a/lib/config.js
+++ b/lib/config.js
@@ -519,12 +519,12 @@ function normalizeBytes (opts) {
 function normalizePositiveTime (opts, logger) {
   for (const key of POSITIVE_TIME_OPTS) {
     if (key in opts) {
-      let val = toSeconds(String(opts[key]))
+      let val = secondsFromTimeStr(String(opts[key]))
       if (val === null) {
         const def = DEFAULTS[key]
         logger.warn('invalid time value "%s" for "%s" config option: using default "%s"',
           opts[key], key, def)
-        val = toSeconds(def)
+        val = secondsFromTimeStr(def)
       }
       opts[key] = val
     }
@@ -533,7 +533,7 @@ function normalizePositiveTime (opts, logger) {
 
 function normalizeTime (opts) {
   for (const key of TIME_OPTS) {
-    if (key in opts) opts[key] = toSeconds(String(opts[key]), true)
+    if (key in opts) opts[key] = secondsFromTimeStr(String(opts[key]), true)
   }
 }
 
@@ -613,7 +613,7 @@ function bytes (input) {
   }
 }
 
-function toSeconds (value, allowNegative) {
+function secondsFromTimeStr (value, allowNegative) {
   let matches
   if (allowNegative) {
     matches = /^(-?\d+)(m|ms|s)?$/.exec(value)
@@ -747,7 +747,7 @@ function getBaseClientConfig (conf, agent) {
     cloudMetadataFetcher: (new CloudMetadata(cloudProvider, conf.logger, conf.serviceName))
   }
 
-  if (conf.errorMessageMaxLength !== undefined) {
+  if (conf.errorMessageMaxLength !== undefined) {O
     // As of v10 of the http client, truncation of error messages will default
     // to `truncateLongFieldsAt` if `truncateErrorMessagesAt` is not specified.
     clientConfig.truncateErrorMessagesAt = conf.errorMessageMaxLength
@@ -762,4 +762,7 @@ module.exports.INTAKE_STRING_MAX_SIZE = INTAKE_STRING_MAX_SIZE
 module.exports.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER = CAPTURE_ERROR_LOG_STACK_TRACES_NEVER
 module.exports.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES = CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES
 module.exports.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS = CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS
+
+// The following are exported for tests.
 module.exports.DEFAULTS = DEFAULTS
+module.exports.secondsFromTimeStr = secondsFromTimeStr

--- a/lib/config.js
+++ b/lib/config.js
@@ -197,11 +197,14 @@ var NUM_OPTS = [
   'transactionSampleRate'
 ]
 
-var TIME_OPTS = [
+var POSITIVE_TIME_OPTS = [
   'abortedErrorThreshold',
   'apiRequestTime',
   'metricsInterval',
-  'serverTimeout',
+  'serverTimeout'
+]
+// Time options allowing negative values.
+var TIME_OPTS = [
   'spanFramesMinDuration'
 ]
 
@@ -400,6 +403,7 @@ function normalize (opts, logger) {
   normalizeNumbers(opts)
   normalizeBytes(opts)
   normalizeArrays(opts)
+  normalizePositiveTime(opts, logger)
   normalizeTime(opts)
   normalizeBools(opts, logger)
   normalizeIgnoreOptions(opts)
@@ -512,9 +516,24 @@ function normalizeBytes (opts) {
   }
 }
 
+function normalizePositiveTime (opts, logger) {
+  for (const key of POSITIVE_TIME_OPTS) {
+    if (key in opts) {
+      let val = toSeconds(String(opts[key]))
+      if (val === null) {
+        const def = DEFAULTS[key]
+        logger.warn('invalid time value "%s" for "%s" config option: using default "%s"',
+          opts[key], key, def)
+        val = toSeconds(def)
+      }
+      opts[key] = val
+    }
+  }
+}
+
 function normalizeTime (opts) {
   for (const key of TIME_OPTS) {
-    if (key in opts) opts[key] = toSeconds(String(opts[key]))
+    if (key in opts) opts[key] = toSeconds(String(opts[key]), true)
   }
 }
 
@@ -594,14 +613,19 @@ function bytes (input) {
   }
 }
 
-function toSeconds (value) {
-  var matches = /^(-)?(\d+)(m|ms|s)?$/.exec(value)
-  if (!matches) return null
+function toSeconds (value, allowNegative) {
+  let matches
+  if (allowNegative) {
+    matches = /^(-?\d+)(m|ms|s)?$/.exec(value)
+  } else {
+    matches = /^(\d+)(m|ms|s)?$/.exec(value)
+  }
+  if (!matches) {
+    return null
+  }
 
-  var negate = matches[1]
-  var amount = Number(matches[2])
-  if (negate) amount = -amount
-  var scale = matches[3]
+  var amount = Number(matches[1])
+  var scale = matches[2]
 
   if (scale === 'm') {
     amount *= 60

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -92,6 +92,9 @@ function recordMetrics (queueName, data, agent) {
   }
   if (!queueMetrics.get(queueName)) {
     const collector = agent._metrics.createQueueMetricsCollector(queueName)
+    if (!collector) {
+      return
+    }
     queueMetrics.set(queueName, collector)
   }
   const metrics = queueMetrics.get(queueName)

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -24,14 +24,16 @@ class Metrics {
   start (refTimers) {
     const metricsInterval = this[agentSymbol]._conf.metricsInterval
     const enabled = metricsInterval !== 0 && !this[agentSymbol]._conf.disableSend
-    this[registrySymbol] = new MetricsRegistry(this[agentSymbol], {
-      reporterOptions: {
-        defaultReportingIntervalInSeconds: metricsInterval,
-        enabled: enabled,
-        unrefTimers: !refTimers,
-        logger: new NoopLogger()
-      }
-    })
+    if (enabled) {
+      this[registrySymbol] = new MetricsRegistry(this[agentSymbol], {
+        reporterOptions: {
+          defaultReportingIntervalInSeconds: metricsInterval,
+          enabled: enabled,
+          unrefTimers: !refTimers,
+          logger: new NoopLogger()
+        }
+      })
+    }
   }
 
   stop () {


### PR DESCRIPTION
Also guard against:
- `metricsInterval:null` resulting in metrics being enabled without any
  log message, which is perhaps slightly surprising.
- `metricsInterval:-1s` (any negative value) resulting in metrics being
  collected *as fast as possible* via
  `setInterval(collectAllTheMetrics, -1000)`.

An invalid value for this config var, and the other "POSTIVE_TIME_OPTS",
will result in (a) a log.warning and (b) falling back to the default
value.

A slight semantic change on the internal Metrics object means that the
`getOrCreate...()` metric functions now return undefined when metrics
are disabled via `metricsInterval`. This doesn't affect any public API.

### Repro

```js
// no-metrics-please.js

require('./').start({
  serviceName: 'foo',
  metricsInterval: '0s'
})

const http = require('http')

const hostname = '127.0.0.1'
const port = 3000
const server = http.createServer((req, res) => {
  res.end('pong')
})
server.listen(port, hostname, () => {
  console.log(`Server running at http://${hostname}:${port}/`)
})
```

Run the above script, then do at least one request via `curl -i localhost:3000/`.


The agent's internal `Metrics` object will have `enabled === false` and calls:

```
      this[registrySymbol] = new MetricsRegistry(this[agentSymbol], {
        reporterOptions: {
          defaultReportingIntervalInSeconds: 0,
          enabled: false,
          unrefTimers: !refTimers,
          logger: new NoopLogger()
        }
      })
```

The `enabled: false` there is just for our `MetricsRegistry` class.
Internally the `Reporter` from measured-reporting gets the `defaultReportingIntervalInSeconds: 0` and does this:

```js
    this._defaultReportingIntervalInSeconds =
      options.defaultReportingIntervalInSeconds || DEFAULT_REPORTING_INTERVAL_IN_SECONDS;
```

hence defaulting to its internal 10s interval. Then the first time `<reporter>.reportMetricOnInterval(metricKey)` is called (which happens for breakdown metrics on that `curl ...` call above), that `defaultReportingIntervalInSeconds: 10` is used in a `setInterval` to call metrics collectors.

We don't *report* any metrics to APM server because of this in MetricsRegistry:

```js
  _reportMetrics (metrics) {
    if (!this.enabled) return
...
```

However, collection can still be happening, which is work that shouldn't be done.


### Repro metricsInterval=-1s

With a negative value you get approaching 100% CPU usage as system and runtime metrics are collected in a setInterval with a negative delay -- which means run as fast as possible (subject to a JS engine-defined minimum delay).

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
