### PR TITLE
fix: avoid import of any '@types/...' packages in types file

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@ Notes:
 * Update types to avoid imports of `@types/...` modules (other than
   `@types/node`), so that TypeScript users of elastic-apm-node need not
   manually `npm install @types/connect @types/pino @types/aws-lambda` to
-  compile.
+  compile. ({issues}2331[#2331])
 
 
 [[release-notes-3.21.0]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,23 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Update types to avoid imports of `@types/...` modules (other than
+  `@types/node`), so that TypeScript users of elastic-apm-node need not
+  manually `npm install @types/connect @types/pino @types/aws-lambda` to
+  compile.
+
+
 [[release-notes-3.21.0]]
 ==== 3.21.0 2021/09/15
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -123,6 +123,15 @@ you instead have to import the agent like so:
 import * as apm from 'elastic-apm-node/start'
 ----
 
+
+If your "tsconfig.json" sets https://www.typescriptlang.org/tsconfig#skipLibCheck[`skipLibCheck`] false (or excludes it), then you will need to install `@types/node` to avoid compile errors:
+
+[source,bash]
+----
+npm install --save-dev @types/node
+----
+
+
 include::./configuration.asciidoc[]
 
 include::./custom-transactions.asciidoc[]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,11 @@
 /// <reference types="node" />
 
+// Note: We avoid import of any external `@types/...` to avoid TypeScript users
+// needing to manually install them. The only exception is the prerequisite to
+// `npm install -D @types/node`.
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { Logger as PinoLogger } from 'pino';
-import type * as Connect from 'connect';
-import type * as AwsLambda from 'aws-lambda';
+import { Connect } from './types/connect';
+import { AwsLambda } from './types/aws-lambda';
 
 declare namespace apm {
   // Agent API
@@ -236,7 +238,7 @@ declare namespace apm {
     kubernetesPodUID?: string;
     logLevel?: LogLevel;
     logUncaughtExceptions?: boolean;
-    logger?: PinoLogger | Logger;
+    logger?: Logger; // Notably this Logger interface matches the Pino Logger.
     longFieldMaxLength?: number;
     maxQueueSize?: number;
     metricsInterval?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
@@ -295,6 +297,9 @@ declare namespace apm {
   }
 
   interface Logger {
+    // Defining overloaded methods rather than a separate `interface LogFn`
+    // as @types/pino does, because the IDE completion shows these as *methods*
+    // rather than as properties, which is slightly nicer.
     fatal (msg: string, ...args: any[]): void;
     fatal (obj: {}, msg?: string, ...args: any[]): void;
     error (msg: string, ...args: any[]): void;
@@ -307,6 +312,9 @@ declare namespace apm {
     debug (obj: {}, msg?: string, ...args: any[]): void;
     trace (msg: string, ...args: any[]): void;
     trace (obj: {}, msg?: string, ...args: any[]): void;
+    // Allow a passed in Logger that has other properties, as a Pino logger
+    // does. Discussion:
+    // https://github.com/elastic/apm-agent-nodejs/pull/926/files#r266239656
     [propName: string]: any;
   }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "files": [
     "lib",
+    "types",
     "start.js",
     "index.d.ts",
     "start.d.ts"
@@ -120,8 +121,6 @@
     "@elastic/elasticsearch": "^7.14.0",
     "@hapi/hapi": "^20.1.2",
     "@koa/router": "^9.0.1",
-    "@types/aws-lambda": "^8.10.77",
-    "@types/connect": "^3.4.34",
     "@types/node": "^13.7.4",
     "@types/pino": "^6.3.8",
     "ajv": "^6.12.6",

--- a/types/aws-lambda.d.ts
+++ b/types/aws-lambda.d.ts
@@ -1,0 +1,69 @@
+// Inlined from @types/aws-lambda
+//
+// These types are inlined, rather than being used from `@types/aws-lambda`
+// directly, as a trade-off. It avoids needing an additional entry in
+// "dependencies" just for types. It avoids TypeScript users of
+// elastic-apm-node needing to manually `npm install @types/aws-lambda`.
+//
+// https://github.com/elastic/apm-agent-nodejs/issues/2331#issuecomment-921251030
+
+export declare namespace AwsLambda {
+  interface CognitoIdentity {
+    cognitoIdentityId: string;
+    cognitoIdentityPoolId: string;
+  }
+
+  interface ClientContext {
+    client: ClientContextClient;
+    custom?: any;
+    env: ClientContextEnv;
+  }
+
+  interface ClientContextClient {
+    installationId: string;
+    appTitle: string;
+    appVersionName: string;
+    appVersionCode: string;
+    appPackageName: string;
+  }
+
+  interface ClientContextEnv {
+    platformVersion: string;
+    platform: string;
+    make: string;
+    model: string;
+    locale: string;
+  }
+
+  type Callback<TResult = any> = (error?: Error | null | string, result?: TResult) => void;
+
+  interface Context {
+    // Properties
+    callbackWaitsForEmptyEventLoop: boolean;
+    functionName: string;
+    functionVersion: string;
+    invokedFunctionArn: string;
+    memoryLimitInMB: number;
+    awsRequestId: string;
+    logGroupName: string;
+    logStreamName: string;
+    identity?: CognitoIdentity;
+    clientContext?: ClientContext;
+
+    // Functions
+    getRemainingTimeInMillis(): number;
+
+    // Functions for compatibility with earlier Node.js Runtime v0.10.42
+    // For more details see http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-using-old-runtime.html#nodejs-prog-model-oldruntime-context-methods
+    done(error?: Error, result?: any): void;
+    fail(error: Error | string): void;
+    succeed(messageOrObject: any): void;
+    succeed(message: string, object: any): void;
+  }
+
+  type Handler<TEvent = any, TResult = any> = (
+    event: TEvent,
+    context: Context,
+    callback: Callback<TResult>,
+  ) => void | Promise<TResult>;
+}

--- a/types/connect.d.ts
+++ b/types/connect.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="node" />
+
+// Inlined from @types/connect
+//
+// These types are inlined, rather than being used from `@types/connect`
+// directly, as a trade-off. It avoids needing an additional entry in
+// "dependencies" just for types. It avoids TypeScript users of
+// elastic-apm-node needing to manually `npm install @types/connect`.
+//
+// https://github.com/elastic/apm-agent-nodejs/issues/2331#issuecomment-921251030
+
+import type { IncomingMessage, ServerResponse } from 'http';
+
+export declare namespace Connect {
+  type NextFunction = (err?: any) => void;
+  type ErrorHandleFunction = (err: any, req: IncomingMessage, res: ServerResponse, next: NextFunction) => void;
+}


### PR DESCRIPTION
This ensures that TypeScript users do not need to install separate
'@types/...' packages to build -- with the lone exception of
'@types/node'.

We avoid imports by instead inlining the required types. This is a
trade-off. We don't want '@types/...' in "dependencies" because they
can be big and aren't really "official" types for those packages.

Fixes: #2331

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] ~Add tests~  I'm skipping this because it is relatively difficult to test. The only way to simulate the failure is to `npm prune --production` or to install a fully separate `node_modules/...` tree with just the "dependencies" of elastic-apm-node. I don't think it is worth the churn during tests.
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
