### PR TITLE
fix: SpanOptions type should include 'startTime'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -324,6 +324,7 @@ declare namespace apm {
   }
 
   export interface SpanOptions {
+    startTime?: number;
     childOf?: Transaction | Span | string;
   }
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -98,6 +98,7 @@ apm.startSpan('foo', { childOf: 'baz' })
 apm.startSpan('foo', 'type', { childOf: 'baz' })
 apm.startSpan('foo', 'type', 'subtype', { childOf: 'baz' })
 apm.startSpan('foo', 'type', 'subtype', 'action', { childOf: 'baz' })
+apm.startSpan('foo', 'type', 'subtype', 'action', { startTime: 42 })
 
 apm.setLabel('foo', 'bar')
 apm.setLabel('foo', 1)


### PR DESCRIPTION
Noticed by @sqren 

### Checklist

- [x] Add tests
- [x] Update TypeScript typings
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
