### PR TITLE
ci: simplify GitHub commands

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -398,7 +398,7 @@ def getSmartTAVContext() {
    env.TAV_UPDATED=${env.TAV_UPDATED}""".stripIndent()
 
    if (env.GITHUB_COMMENT) {
-     def modules = getModulesFromCommentTrigger(regex: '(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?module\\W+tests\\W+for\\W+(.+)')
+     def modules = getModulesFromCommentTrigger(regex: 'run module tests for (.+)')
      if (modules.isEmpty()) {
        context.ghDescription = 'TAV Test disabled'
        context.tav = readYaml(text: 'TAV:')

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -172,7 +172,7 @@ from the "master" branch. It would be useful to have a separate chart that
 showed PR values.
 
 (Another way to start the "Benchmarks" step is via a GitHub comment
-"jenkins run the benchmark tests". However, that also triggers the "Test" step
+"run benchmark tests". However, that also triggers the "Test" step
 and, depending on other conditions, the "TAV Test" step -- both of which are
 long and will run before getting to the Benchmarks run.)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -140,7 +140,7 @@ have any effect).
 Run the regular test suite:
 
 ```
-jenkins run the tests
+/test
 ```
 
 Run TAV tests for one or more modules, where `<modules>` can be either a
@@ -148,11 +148,11 @@ comma separated list of modules (e.g.  `memcached,redis`) or the
 string literal `ALL` to test _all_ modules:
 
 ```
-jenkins run the module tests for <modules>
+run module tests for <modules>
 ```
 
 Run the benchmark test only:
 
 ```
-jenkins run benchmark tests
+run benchmark tests
 ```


### PR DESCRIPTION
### What

https://github.com/elastic/apm-agent-nodejs/pull/2342 simplified the GItHub commands, though there were some missing changes in the docs that should reflect the supported commands. `Jenkins run the ...` is deprecated in favour of the new `/test` and `^run....` commands.


### Why

Ensure the docs reflect those changes.

### Further details

The new GitHub comment changes now provide those details, that were added in the apm-pipeline-library:

- https://github.com/elastic/apm-pipeline-library/blob/b057084212cbba2df8f3215d3bb00956ef1dcae4/src/co/elastic/NotificationManager.groovy#L479-L483