### PR TITLE
types: add Span.ids and Transaction.ids to types

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Add `Span.ids` and `Transaction.ids` to TypeScript types. ({pull}2347[#2347])
+
 * Improve `span.sync` determination (fixes {issue}1996[#1996]) and stop
   reporting `transaction.sync` which was never used ({issue}2292[#2292]).
   A minor semantic change is that `span.sync` is not set to a final value

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,10 @@ declare namespace apm {
     traceparent: string;
     outcome: Outcome;
     result: string | number;
+    ids: {
+      'trace.id': string;
+      'transaction.id': string;
+    }
 
     setType (type?: string | null, subtype?: string | null, action?: string | null): void;
     setLabel (name: string, value: LabelValue, stringify?: boolean): boolean;
@@ -191,6 +195,10 @@ declare namespace apm {
     action: string | null;
     traceparent: string;
     outcome: Outcome;
+    ids: {
+      'trace.id': string;
+      'span.id': string;
+    }
 
     setType (type?: string | null, subtype?: string | null, action?: string | null): void;
     setLabel (name: string, value: LabelValue, stringify?: boolean): boolean;

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -11,6 +11,7 @@ import apm, {
   TransactionOptions,
   SpanOptions
 } from '../../'
+import assert from 'assert'
 
 const agentOpts: AgentConfigOptions = {
   captureExceptions: false,
@@ -25,9 +26,7 @@ function started (aBool: boolean) {
 started(apm.isStarted())
 
 const trans = apm.currentTransaction
-if (trans) trans.end()
 const span = apm.currentSpan
-if (span) span.end()
 const traceparent = apm.currentTraceparent
 if (traceparent) traceparent.split('-')
 const currentTraceIds = apm.currentTraceIds
@@ -35,6 +34,14 @@ let traceId = currentTraceIds['trace.id'] || ''
 traceId += '-' + (currentTraceIds['transaction.id'] === undefined
   ? currentTraceIds['transaction.id']
   : currentTraceIds['span.id'])
+if (span) {
+  assert('span.id' in span.ids)
+  span.end()
+}
+if (trans) {
+  assert('transaction.id' in trans.ids)
+  trans.end()
+}
 
 apm.setFramework({})
 apm.setFramework({ name: 'foo' })


### PR DESCRIPTION
Back in #1335 the "ids" property was added to Span and Transaction, but
it wasn't added to the TypeScript types.

/cc @mshustov 

### Checklist

- [x] Add tests
- [x] Update TypeScript typings
- [x] Add CHANGELOG.asciidoc entry
