### PR TITLE
deprecate specified format of Span#toString() and Transaction#toString()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* <<span-to-string,`span.toString()`>> and <<transaction-to-string,`transaction.toString()`>>
+  have been *deprecated*. The exact string output may change in v4 of the
+  agent.
+
 * Improve `span.sync` determination (fixes {issue}1996[#1996]) and stop
   reporting `transaction.sync` which was never used ({issue}2292[#2292]).
   A minor semantic change is that `span.sync` is not set to a final value

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -822,7 +822,7 @@ apm.clearPatches(['timers'])
 
 `apm.currentTraceIds` produces an object containing `trace.id` and either `transaction.id` or `span.id` when a current transaction or span is available.
 When no transaction or span is available it will return an empty object.
-This enables log correlation to APM traces with structured loggers.
+This enables <<log-correlation,log correlation>> to APM traces with structured loggers.
 
 [source,js]
 ----
@@ -837,17 +837,6 @@ This enables log correlation to APM traces with structured loggers.
 }
 ----
 
-All current trace id objects,
-including the empty form,
-include a `toString()` implementation.
-This enables log correlation to APM traces with text-only loggers.
-
-[source,js]
-----
-"trace.id=abc123 transaction.id=abc123"
-// or ...
-"trace.id=abc123 span.id=abc123"
-----
 // end::currentTraceIds[]
 
 [[apm-register-custom-metrics]]

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -147,10 +147,12 @@ This enables log correlation to APM traces with structured loggers.
 }
 ----
 
-[[span-to-string]]
-==== `span.toString()`
 
-[small]#Added in: v2.17.0#
+[[span-to-string]]
+==== `span.toString()` (deprecated)
+
+[small]#Added in: v2.17.0# +
+[small]#Deprecated in: v3.23.0#
 
 Produces a string representation of the span to inject in log messages.
 This enables log correlation to APM traces with text-only loggers.
@@ -159,6 +161,18 @@ This enables log correlation to APM traces with text-only loggers.
 ----
 "trace.id=abc123 span.id=abc123"
 ----
+
+Relying on the format of `span.toString()` has been **deprecated** and may
+change in v4 of the agent. Prefer the use of <<span-ids,`span.ids`>> or
+<<apm-current-trace-ids,`apm.currentTraceIds`>>. The v3 format may be reproduced
+via:
+
+[source,js]
+----
+const { stringify } = require('querystring')
+console.log( stringify(span.ids, ' ', '=')) )
+----
+
 
 [[span-end]]
 ==== `span.end([endTime])`

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -210,10 +210,12 @@ This enables log correlation to APM traces with structured loggers.
 }
 ----
 
-[[transaction-to-string]]
-==== `transaction.toString()`
 
-[small]#Added in: v2.17.0#
+[[transaction-to-string]]
+==== `transaction.toString()` (deprecated)
+
+[small]#Added in: v2.17.0# +
+[small]#Deprecated in: v3.23.0#
 
 Produces a string representation of the transaction to inject in log messages.
 This enables log correlation to APM traces with text-only loggers.
@@ -222,6 +224,18 @@ This enables log correlation to APM traces with text-only loggers.
 ----
 "trace.id=abc123 transaction.id=abc123"
 ----
+
+Relying on the format of `transaction.toString()` has been **deprecated** and may
+change in v4 of the agent. Prefer the use of <<transaction-ids,`transaction.ids`>> or
+<<apm-current-trace-ids,`apm.currentTraceIds`>>. The v3 format may be reproduced
+via:
+
+[source,js]
+----
+const { stringify } = require('querystring')
+console.log( stringify(transaction.ids, ' ', '=')) )
+----
+
 
 [[transaction-end]]
 ==== `transaction.end([result][, endTime])`


### PR DESCRIPTION
Refs: #2348

These were added in https://github.com/elastic/apm-agent-nodejs/pull/1335 along with the structured `apm.currentTraceIds`.  I don't think the `.toString()` of Span and Transaction (or really *any* class) should be specified in API docs. At the time of that PR there was [discussion on exactly this](https://github.com/elastic/apm-agent-nodejs/pull/1335#discussion_r322518554).


### Checklist

- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
