### PR TITLE
3.23.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,7 +28,9 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-==== Unreleased
+
+[[release-notes-3.23.0]]
+==== 3.23.0 2021/10/25
 
 [float]
 ===== Breaking changes
@@ -44,9 +46,6 @@ Notes:
 
 * Add initial support for version 8 of `@elastic/elasticsearch`, which is
   still in pre-release. ({pull}2385[#2385])
-
-[float]
-===== Bug fixes
 
 
 [[release-notes-3.22.0]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -31,7 +31,8 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
-|3.22.x |2023-04-31 |3.23.0
+|3.23.x |2023-04-25 |3.24.0
+|3.22.x |2023-04-21 |3.23.0
 |3.21.x |2023-03-15 |3.22.0
 |3.20.x |2023-02-12 |3.21.0
 |3.19.x |2023-02-05 |3.20.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
To get a quick release out with `@elastic/elasticsearch@8` support.