### PR TITLE
chore: stop recording transaction breakdown metrics

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ Notes:
 * Stop collecting transaction breakdown metrics (`transaction.breakdown.count`,
   `transaction.duration.sum.us`, `transaction.duration.count`), as they are not
   being used in APM UI. ({issues}2370[#2370])
+
 * Wrap `fs.realpath.native` when configured with `asyncHooks=false`. This
   fixes using that function (which was undefined before this fix) and a
   crash when importing fs-extra@10. ({issues}2401[#2401])

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Stop collecting transaction breakdown metrics (`transaction.breakdown.count`,
+  `transaction.duration.sum.us`, `transaction.duration.count`), as they are not
+  being used in APM UI. ({issues}2370[#2370])
+
 * A significant change was made to internal run context tracking (a.k.a. async
   context tracking). There are no configuration changes or API changes for
   custom instrumentation. ({pull}2181[#2181])

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -149,49 +149,6 @@ Memory allocated for ArrayBuffers and SharedArrayBuffers, including all Node.js 
 This is also included in the `nodejs.memory.external.bytes` value.
 
 [float]
-[[metrics-transaction.duration.sum]]
-=== `transaction.duration.sum`
-
-* *Type:* Long
-* *Type:* Milliseconds
-
-The sum of all transaction durations in ms since the last report (the delta)
-
-You can filter and group by these dimensions:
-
-* `transaction.name`: The name of the transaction
-* `transaction.type`: The type of the transaction, for example `request`
-
-[float]
-[[metrics-transaction.duration.count]]
-=== `transaction.duration.count`
-
-* *Type:* Long
-* *Type:* Milliseconds
-
-The count of all transactions since the last report (the delta)
-
-You can filter and group by these dimensions:
-
-* `transaction.name`: The name of the transaction
-* `transaction.type`: The type of the transaction, for example `request`
-
-[float]
-[[metrics-transaction.breakdown.count]]
-=== `transaction.breakdown.count`
-
-* *Type:* Long
-* *Format:* Counter
-
-The number of transactions for which breakdown metrics (`span.self_time`) have been created.
-Breakdown metrics are only collected for sampled transactions.
-
-You can filter and group by these dimensions:
-
-* `transaction.name`: The name of the transaction
-* `transaction.type`: The type of the transaction, for example `request`
-
-[float]
 [[metrics-span.self_time.sum]]
 === `span.self_time.sum`
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -303,18 +303,6 @@ Transaction.prototype._captureBreakdown = function (span) {
 
   // Record transaction data
   if (span instanceof Transaction) {
-    const { duration } = this._timer
-    const labels = flattenBreakdown({
-      transaction: transactionBreakdownDetails(this)
-    })
-
-    metrics.incrementCounter('transaction.duration.count', labels)
-    metrics.incrementCounter('transaction.duration.sum.us', labels, duration)
-
-    if (conf.breakdownMetrics) {
-      metrics.incrementCounter('transaction.breakdown.count', labels, this.sampled ? 1 : 0)
-    }
-
     for (const { labels, time, count } of this._breakdownTimings.values()) {
       const flattenedLabels = flattenBreakdown(labels)
       metrics.incrementCounter('span.self_time.count', flattenedLabels, count)


### PR DESCRIPTION
None of `transaction.breakdown.count`, `transaction.duration.sum.us`,
`transaction.duration.count` are or were used by APM UI.

Closes: #2370

### Checklist

- [x] Implement code
- [x] Update tests
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
