### PR TITLE
fix: remove unspec'd custom context for lambda transactions

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -347,24 +347,6 @@ function setLambdaTransactionData (agent, trans, event, context, isColdStart) {
 function elasticApmAwsLambda (agent) {
   const log = agent.logger
 
-  function captureContext (trans, event, context, result) {
-    trans.setCustomContext({
-      lambda: {
-        functionName: context.functionName,
-        functionVersion: context.functionVersion,
-        invokedFunctionArn: context.invokedFunctionArn,
-        memoryLimitInMB: context.memoryLimitInMB,
-        awsRequestId: context.awsRequestId,
-        logGroupName: context.logGroupName,
-        logStreamName: context.logStreamName,
-        executionEnv: process.env.AWS_EXECUTION_ENV,
-        region: process.env.AWS_REGION,
-        input: event,
-        output: result
-      }
-    })
-  }
-
   function wrapContext (trans, event, context) {
     shimmer.wrap(context, 'succeed', (succeed) => {
       return function wrappedSucceed (result) {
@@ -397,7 +379,6 @@ function elasticApmAwsLambda (agent) {
 
   function captureAndMakeCompleter (trans, event, context, result, boundCallback) {
     log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: fn end')
-    captureContext(trans, event, context, result)
     trans.end()
     return () => {
       agent.flush((err) => {

--- a/test/lambda/_util.js
+++ b/test/lambda/_util.js
@@ -1,34 +1,15 @@
 'use strict'
 
-function assertContext (t, name, received, expected, input, output) {
-  t.ok(received)
-  const lambda = received.lambda
-  t.ok(lambda, 'context data has lambda object')
-  t.strictEqual(lambda.functionName, name, 'function name matches')
-  t.strictEqual(lambda.functionVersion, expected.functionVersion, 'function version matches')
-  t.strictEqual(lambda.invokedFunctionArn, expected.invokedFunctionArn, 'function ARN matches')
-  t.strictEqual(lambda.memoryLimitInMB, expected.memoryLimitInMB, 'memory limit matches')
-  t.strictEqual(lambda.awsRequestId, expected.awsRequestId, 'AWS request ID matches')
-  t.strictEqual(lambda.logGroupName, expected.logGroupName, 'log group name matches')
-  t.strictEqual(lambda.logStreamName, expected.logStreamName, 'log group name matches')
-  t.strictEqual(lambda.executionEnv, process.env.AWS_EXECUTION_ENV, 'execution env matches')
-  t.strictEqual(lambda.region, process.env.AWS_REGION, 'region matches')
-  t.deepEqual(lambda.input, input, 'input matches')
-  t.deepEqual(lambda.output, output, 'output matches')
-}
-
 function assertError (t, received, expected) {
   t.strictEqual(received, expected)
 }
 
-function assertTransaction (t, trans, name, context, input, output) {
+function assertTransaction (t, trans, name) {
   t.strictEqual(trans.name, name)
   t.ok(trans.ended)
-  assertContext(t, name, trans.customContext, context, input, output)
 }
 
 module.exports = {
-  assertContext,
   assertError,
   assertTransaction
 }

--- a/test/lambda/context.test.js
+++ b/test/lambda/context.test.js
@@ -41,7 +41,7 @@ test('context.succeed', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }
@@ -52,7 +52,6 @@ test('context.done', function (t) {
   const name = 'greet.hello'
   const input = { name: 'world' }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -60,8 +59,7 @@ test('context.done', function (t) {
   lambdaLocal.execute({
     event: input,
     lambdaFunc: {
-      [name]: wrap((payload, _context) => {
-        context = _context
+      [name]: wrap((payload, context) => {
         context.done(null, `Hello, ${payload.name}!`)
       })
     },
@@ -77,7 +75,7 @@ test('context.done', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }
@@ -88,7 +86,6 @@ test('context.fail', function (t) {
   const name = 'fn.fail'
   const input = {}
   const error = new Error('fail')
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -96,8 +93,7 @@ test('context.fail', function (t) {
   lambdaLocal.execute({
     event: input,
     lambdaFunc: {
-      [name]: wrap((payload, _context) => {
-        context = _context
+      [name]: wrap((payload, context) => {
         context.fail(error)
       })
     },
@@ -114,7 +110,7 @@ test('context.fail', function (t) {
       assertError(t, agent.errors[0], error)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -97,7 +97,6 @@ test('resolve with elastic-apm-traceparent present', function (t) {
       tracestate: 'test2'
     }
   }
-  const output = 'Hello, world!'
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -132,7 +131,6 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
       tracestate: 'test2'
     }
   }
-  const output = 'Hello, world!'
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -168,7 +166,6 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
       tracestate: 'test2'
     }
   }
-  const output = 'Hello, world!'
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -16,7 +16,6 @@ test('resolve', function (t) {
   const name = 'greet.hello'
   const input = { name: 'world' }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -25,7 +24,6 @@ test('resolve', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -41,7 +39,7 @@ test('resolve', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }
@@ -58,7 +56,6 @@ test('resolve with parent id header present', function (t) {
     }
   }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -67,7 +64,6 @@ test('resolve with parent id header present', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -83,7 +79,7 @@ test('resolve with parent id header present', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
@@ -102,7 +98,6 @@ test('resolve with elastic-apm-traceparent present', function (t) {
     }
   }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -111,7 +106,6 @@ test('resolve with elastic-apm-traceparent present', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -120,7 +114,7 @@ test('resolve with elastic-apm-traceparent present', function (t) {
     verboseLevel: 0,
     callback: function (err, result) {
       t.error(err)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
       t.strictEqual(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.end()
@@ -139,7 +133,6 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
     }
   }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -148,7 +141,6 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -157,7 +149,7 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
     verboseLevel: 0,
     callback: function (err, result) {
       t.error(err)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.notEquals(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'prefers traceparent to elastic-apm-traceparent')
@@ -177,7 +169,6 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
     }
   }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -186,7 +177,6 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -195,7 +185,7 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
     verboseLevel: 0,
     callback: function (err, result) {
       t.error(err)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.notEquals(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'prefers traceparent to elastic-apm-traceparent')
@@ -208,7 +198,6 @@ test('reject', function (t) {
   const name = 'fn.fail'
   const input = {}
   const error = new Error('fail')
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -217,7 +206,6 @@ test('reject', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.reject(error)
       })
     },
@@ -234,7 +222,7 @@ test('reject', function (t) {
       assertError(t, agent.errors[0], error)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }


### PR DESCRIPTION
Closes: #2417

Skipping changelog entry, because if this is in the same release as the recent Lambda transaction data work, then it falls under the same changelog entry.

### Checklist

- [x] Implement code
- [x] Add tests
