### PR TITLE
fix: lambda transaction data fixes

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -313,24 +313,6 @@ function isS3SingleEvent (event) {
   return records.length === 1 && records[0].eventSource === 'aws:s3'
 }
 
-function setTransactionResultFromApiGatewayResponse (trans, result, event) {
-  if (!result) {
-    return
-  }
-  const statusCode = result.statusCode ? result.statusCode : result.statuscode
-  if (statusCode >= 500 && isApiGatewayEvent(event)) {
-    trans.result = 'HTTP ' + statusCode.toString()[0] + 'xx'
-  }
-}
-
-function setTransactionFailure (trans, event) {
-  if (isApiGatewayEvent(event)) {
-    trans.result = 'HTTP 5xx'
-  } else {
-    trans.result = constants.RESULT_FAILURE
-  }
-}
-
 function setLambdaTransactionData (agent, trans, event, context, isColdStart) {
   setGenericData(trans, event, context, isColdStart)
   if (isApiGatewayEvent(event)) {
@@ -347,85 +329,70 @@ function setLambdaTransactionData (agent, trans, event, context, isColdStart) {
 function elasticApmAwsLambda (agent) {
   const log = agent.logger
 
-  function captureContext (trans, event, context, result) {
-    trans.setCustomContext({
-      lambda: {
-        functionName: context.functionName,
-        functionVersion: context.functionVersion,
-        invokedFunctionArn: context.invokedFunctionArn,
-        memoryLimitInMB: context.memoryLimitInMB,
-        awsRequestId: context.awsRequestId,
-        logGroupName: context.logGroupName,
-        logStreamName: context.logStreamName,
-        executionEnv: process.env.AWS_EXECUTION_ENV,
-        region: process.env.AWS_REGION,
-        input: event,
-        output: result
+  function endAndFlushTransaction (err, result, trans, event, context, cb) {
+    log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: fn end')
+
+    const isApiGatewayTriggered = isApiGatewayEvent(event)
+    if (err) {
+      // Capture the error before trans.end() so it associates with the
+      // current trans.  `skipOutcome` to avoid setting outcome on a possible
+      // currentSpan, because this error applies to the transaction, not any
+      // sub-span.
+      agent.captureError(err, { skipOutcome: true })
+      trans.setOutcome(constants.OUTCOME_FAILURE)
+      if (isApiGatewayTriggered) {
+        trans.result = 'HTTP 5xx'
+      } else {
+        trans.result = constants.RESULT_FAILURE
       }
+    } else {
+      trans.setOutcome(constants.OUTCOME_SUCCESS)
+      if (isApiGatewayTriggered && result && result.statusCode) {
+        trans.result = 'HTTP ' + result.statusCode.toString()[0] + 'xx'
+      } else {
+        trans.result = constants.RESULT_SUCCESS
+      }
+    }
+
+    trans.end()
+
+    agent.flush(flushErr => {
+      if (flushErr) {
+        log.error({ flushErr, awsRequestId: context && context.awsRequestId }, 'lambda: flush error')
+      } else {
+        log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: flushed')
+      }
+      cb()
     })
   }
 
   function wrapContext (trans, event, context) {
-    shimmer.wrap(context, 'succeed', (succeed) => {
+    shimmer.wrap(context, 'succeed', (origSucceed) => {
       return function wrappedSucceed (result) {
-        setTransactionResultFromApiGatewayResponse(trans, result, event)
-        const bound = succeed.bind(this, result)
-        const done = captureAndMakeCompleter(trans, event, context, result, bound)
-        done()
+        endAndFlushTransaction(null, result, trans, event, context, function () {
+          origSucceed(result)
+        })
       }
     })
 
-    shimmer.wrap(context, 'fail', (fail) => {
+    shimmer.wrap(context, 'fail', (origFail) => {
       return function wrappedFail (err) {
-        // Capture the error before trans.end() so it associates with the
-        // current trans.  `skipOutcome` to avoid setting outcome on a possible
-        // currentSpan, because this error applies to the transaction, not any
-        // sub-span.
-        agent.captureError(err, { skipOutcome: true })
-        trans.setOutcome(constants.OUTCOME_FAILURE)
-        setTransactionFailure(trans, event)
-        const bound = fail.bind(this, err)
-        const finish = captureAndMakeCompleter(trans, event, context, undefined, bound)
-        finish()
+        endAndFlushTransaction(err, null, trans, event, context, function () {
+          origFail(err)
+        })
       }
     })
 
-    shimmer.wrap(context, 'done', (done) => {
-      return wrapLambdaCallback(trans, event, context, done)
+    shimmer.wrap(context, 'done', (origDone) => {
+      return wrapLambdaCallback(trans, event, context, origDone)
     })
-  }
-
-  function captureAndMakeCompleter (trans, event, context, result, boundCallback) {
-    log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: fn end')
-    captureContext(trans, event, context, result)
-    trans.end()
-    return () => {
-      agent.flush((err) => {
-        if (err) {
-          log.error({ err, awsRequestId: context && context.awsRequestId }, 'lambda: flush error')
-        } else {
-          log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: flushed')
-        }
-        boundCallback()
-      })
-    }
   }
 
   function wrapLambdaCallback (trans, event, context, callback) {
     return function wrappedLambdaCallback (err, result) {
-      if (err) {
-        // Capture the error before trans.end() so it associates with the
-        // current trans.  `skipOutcome` to avoid setting outcome on a possible
-        // currentSpan, because this error applies to the transaction, not any
-        // sub-span.
-        agent.captureError(err, { skipOutcome: true })
-        trans.setOutcome(constants.OUTCOME_FAILURE)
-        setTransactionFailure(trans, event)
-      }
-      const bound = callback.bind(this, err, result)
-      const finish = captureAndMakeCompleter(trans, event, context, result, bound)
-      setTransactionResultFromApiGatewayResponse(trans, result, event)
-      finish()
+      endAndFlushTransaction(err, result, trans, event, context, () => {
+        callback(err, result)
+      })
     }
   }
 

--- a/test/lambda/_util.js
+++ b/test/lambda/_util.js
@@ -1,34 +1,15 @@
 'use strict'
 
-function assertContext (t, name, received, expected, input, output) {
-  t.ok(received)
-  const lambda = received.lambda
-  t.ok(lambda, 'context data has lambda object')
-  t.strictEqual(lambda.functionName, name, 'function name matches')
-  t.strictEqual(lambda.functionVersion, expected.functionVersion, 'function version matches')
-  t.strictEqual(lambda.invokedFunctionArn, expected.invokedFunctionArn, 'function ARN matches')
-  t.strictEqual(lambda.memoryLimitInMB, expected.memoryLimitInMB, 'memory limit matches')
-  t.strictEqual(lambda.awsRequestId, expected.awsRequestId, 'AWS request ID matches')
-  t.strictEqual(lambda.logGroupName, expected.logGroupName, 'log group name matches')
-  t.strictEqual(lambda.logStreamName, expected.logStreamName, 'log group name matches')
-  t.strictEqual(lambda.executionEnv, process.env.AWS_EXECUTION_ENV, 'execution env matches')
-  t.strictEqual(lambda.region, process.env.AWS_REGION, 'region matches')
-  t.deepEqual(lambda.input, input, 'input matches')
-  t.deepEqual(lambda.output, output, 'output matches')
-}
-
 function assertError (t, received, expected) {
   t.strictEqual(received, expected)
 }
 
-function assertTransaction (t, trans, name, context, input, output) {
+function assertTransaction (t, trans, name) {
   t.strictEqual(trans.name, name)
   t.ok(trans.ended)
-  assertContext(t, name, trans.customContext, context, input, output)
 }
 
 module.exports = {
-  assertContext,
   assertError,
   assertTransaction
 }

--- a/test/lambda/context.test.js
+++ b/test/lambda/context.test.js
@@ -41,7 +41,7 @@ test('context.succeed', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }
@@ -52,7 +52,6 @@ test('context.done', function (t) {
   const name = 'greet.hello'
   const input = { name: 'world' }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -60,8 +59,7 @@ test('context.done', function (t) {
   lambdaLocal.execute({
     event: input,
     lambdaFunc: {
-      [name]: wrap((payload, _context) => {
-        context = _context
+      [name]: wrap((payload, context) => {
         context.done(null, `Hello, ${payload.name}!`)
       })
     },
@@ -77,7 +75,7 @@ test('context.done', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }
@@ -88,7 +86,6 @@ test('context.fail', function (t) {
   const name = 'fn.fail'
   const input = {}
   const error = new Error('fail')
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -96,8 +93,7 @@ test('context.fail', function (t) {
   lambdaLocal.execute({
     event: input,
     lambdaFunc: {
-      [name]: wrap((payload, _context) => {
-        context = _context
+      [name]: wrap((payload, context) => {
         context.fail(error)
       })
     },
@@ -114,7 +110,7 @@ test('context.fail', function (t) {
       assertError(t, agent.errors[0], error)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }

--- a/test/lambda/fixtures/aws_api_http_test_data.json
+++ b/test/lambda/fixtures/aws_api_http_test_data.json
@@ -14,7 +14,7 @@
       "x-forwarded-proto": "https"
     },
     "requestContext": {
-      "accountId": "XXXXXXXXXXXX",
+      "accountId": "000000000000",
       "apiId": "21mj4tsk90",
       "domainName": "21mj4tsk90.execute-api.us-west-2.amazonaws.com",
       "domainPrefix": "21mj4tsk90",

--- a/test/lambda/fixtures/context.json
+++ b/test/lambda/fixtures/context.json
@@ -5,6 +5,6 @@
   "memoryLimitInMB": "128",
   "logGroupName": "/aws/lambda/the-function-name",
   "logStreamName": "2021/08/13/[$LATEST]08834acf4e4f463b95b7b99aa8b34aff",
-  "invokedFunctionArn": "arn:aws:lambda:us-west-2:XXXXXXXXXXXX:function:the-function-name",
+  "invokedFunctionArn": "arn:aws:lambda:us-west-2:000000000000:function:the-function-name",
   "awsRequestId": "649bf7d0-c6ae-432d-899d-da44ccd7ee95"
 }

--- a/test/lambda/mock/transaction.js
+++ b/test/lambda/mock/transaction.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const constants = require('../../../lib/constants')
+
 module.exports = class TransactionMock {
   constructor (name, type, opts) {
     this.name = name
@@ -11,7 +13,7 @@ module.exports = class TransactionMock {
     this._cloud = undefined
     this._message = undefined
     this._service = undefined
-    this.outcome = 'success'
+    this.outcome = constants.OUTCOME_UNKNOWN
     this.opts = opts
   }
 

--- a/test/lambda/promises.test.js
+++ b/test/lambda/promises.test.js
@@ -16,7 +16,6 @@ test('resolve', function (t) {
   const name = 'greet.hello'
   const input = { name: 'world' }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -25,7 +24,6 @@ test('resolve', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -41,7 +39,7 @@ test('resolve', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }
@@ -58,7 +56,6 @@ test('resolve with parent id header present', function (t) {
     }
   }
   const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -67,7 +64,6 @@ test('resolve with parent id header present', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -83,7 +79,7 @@ test('resolve with parent id header present', function (t) {
       t.strictEqual(agent.errors.length, 0)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
@@ -101,8 +97,6 @@ test('resolve with elastic-apm-traceparent present', function (t) {
       tracestate: 'test2'
     }
   }
-  const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -111,7 +105,6 @@ test('resolve with elastic-apm-traceparent present', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -120,7 +113,7 @@ test('resolve with elastic-apm-traceparent present', function (t) {
     verboseLevel: 0,
     callback: function (err, result) {
       t.error(err)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
       t.strictEqual(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.end()
@@ -138,8 +131,6 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
       tracestate: 'test2'
     }
   }
-  const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -148,7 +139,6 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -157,7 +147,7 @@ test('resolve with both elastic-apm-traceparent and traceparent present', functi
     verboseLevel: 0,
     callback: function (err, result) {
       t.error(err)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.notEquals(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'prefers traceparent to elastic-apm-traceparent')
@@ -176,8 +166,6 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
       tracestate: 'test2'
     }
   }
-  const output = 'Hello, world!'
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -186,7 +174,6 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.resolve(`Hello, ${payload.name}!`)
       })
     },
@@ -195,7 +182,7 @@ test('resolve with both elastic-apm-traceparent before traceparent present', fun
     verboseLevel: 0,
     callback: function (err, result) {
       t.error(err)
-      assertTransaction(t, agent.transactions[0], name, context, input, output)
+      assertTransaction(t, agent.transactions[0], name)
       t.strictEqual(input.headers.traceparent, agent.transactions[0].opts.childOf, 'context trace id matches parent trace id')
       t.strictEqual(input.headers.tracestate, agent.transactions[0].opts.tracestate, 'input tracestate pased on to transaction ')
       t.notEquals(input.headers['elastic-apm-traceparent'], agent.transactions[0].opts.childOf, 'prefers traceparent to elastic-apm-traceparent')
@@ -208,7 +195,6 @@ test('reject', function (t) {
   const name = 'fn.fail'
   const input = {}
   const error = new Error('fail')
-  let context
 
   const agent = new AgentMock()
   const wrap = elasticApmAwsLambda(agent)
@@ -217,7 +203,6 @@ test('reject', function (t) {
     event: input,
     lambdaFunc: {
       [name]: wrap((payload, _context) => {
-        context = _context
         return Promise.reject(error)
       })
     },
@@ -234,7 +219,7 @@ test('reject', function (t) {
       assertError(t, agent.errors[0], error)
 
       t.strictEqual(agent.transactions.length, 1)
-      assertTransaction(t, agent.transactions[0], name, context, input)
+      assertTransaction(t, agent.transactions[0], name)
 
       t.end()
     }

--- a/test/lambda/transaction.test.js
+++ b/test/lambda/transaction.test.js
@@ -9,12 +9,12 @@ function loadFixture (file) {
 }
 
 tape.test('cold start tests', function (t) {
-  function mockLambda () {
+  function myHandler () {
 
   }
   const mockAgent = new AgentMock()
   const wrapLambda = elasticApmAwsLambda(mockAgent)
-  const wrappedMockLambda = wrapLambda(mockLambda)
+  const wrappedMockLambda = wrapLambda(myHandler)
   const mockEvent = {}
   const mockContext = {}
 
@@ -30,7 +30,7 @@ tape.test('cold start tests', function (t) {
   t.end()
 })
 
-tape.test('setLambdaTransactionData aws_api_http_test_data tests', function (t) {
+tape.test('setLambdaTransactionData aws_api_http_test_data tests', async function (t) {
   const mockAgent = new AgentMock()
   const wrapLambda = elasticApmAwsLambda(mockAgent)
   const wrappedMockLambda = wrapLambda(function () {})
@@ -40,11 +40,10 @@ tape.test('setLambdaTransactionData aws_api_http_test_data tests', function (t) 
   wrappedMockLambda(event, context)
   const transaction = mockAgent.transactions.shift()
 
-  t.strictEquals(transaction._faas.coldstart, false, 'colstart value set')
+  t.strictEquals(typeof transaction._faas.coldstart, 'boolean', 'coldstart value set')
   t.strictEquals(transaction._faas.execution, context.awsRequestId, 'execution value set')
   t.strictEquals(transaction._faas.trigger.type, 'http', 'execution value set')
   t.strictEquals(transaction._faas.trigger.request_id, event.requestContext.requestId, 'execution value set')
-  t.strictEquals(transaction.outcome, 'success', 'outcome set')
   t.strictEquals(transaction.type, 'request', 'transaction type set')
   t.strictEquals(transaction.name, 'GET the-function-name', 'transaction named correctly')
   t.strictEquals(transaction._cloud.origin.provider, 'aws', 'cloud origin provider set correctly')
@@ -52,7 +51,7 @@ tape.test('setLambdaTransactionData aws_api_http_test_data tests', function (t) 
   t.strictEquals(transaction._service.origin.id, '21mj4tsk90', 'service origin id set correctly')
   t.strictEquals(transaction._service.origin.version, '2.0', 'service origin version set correctly')
   t.strictEquals(transaction._cloud.origin.service.name, 'api gateway', 'cloud origin service name set correctly')
-  t.strictEquals(transaction._cloud.origin.account.id, 'XXXXXXXXXXXX', 'cloud origin service name set correctly')
+  t.strictEquals(transaction._cloud.origin.account.id, '000000000000', 'cloud origin service name set correctly')
   t.end()
 })
 
@@ -70,7 +69,6 @@ tape.test('setLambdaTransactionData aws_api_rest_test_data.json tests', function
   t.strictEquals(transaction._faas.execution, context.awsRequestId, 'execution value set')
   t.strictEquals(transaction._faas.trigger.type, 'http', 'trigger type set')
   t.strictEquals(transaction._faas.trigger.request_id, event.requestContext.requestId, 'execution value set')
-  t.strictEquals(transaction.outcome, 'success', 'outcome set')
   t.strictEquals(transaction.type, 'request', 'transaction type set')
   t.strictEquals(transaction.name, 'GET the-function-name', 'transaction named correctly')
   t.strictEquals(transaction._service.origin.name, 'GET /fetch_all/dev', 'service origin name set correctly')
@@ -204,8 +202,6 @@ tape.test('setLambdaTransactionData generic tests', function (t) {
 
     t.strictEquals(transaction.type, 'request', 'transaction type set')
     t.strictEquals(transaction.name, 'the-function-name', 'transaction named correctly')
-    t.strictEquals(transaction.outcome, 'success', 'transaction outcome correct')
-    t.strictEquals(transaction.result, 'success', 'transaction outcome correct')
     t.strictEquals(transaction._cloud.origin.provider, 'aws', 'cloud origin provider set correctly')
   }
   t.end()


### PR DESCRIPTION
- Only accept exact 'statusCode' case on API Gateway triggered
  results, not 'statuscode'. AWS docs require that exact case, e.g.:
  https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
- Set `transaction.outcome = 'success'` when the invocation succeeds.
- Set `transaction.result = 'HTTP Nxx'` for API Gateway triggered
  invocations for any statusCode value, not just >=500.


### Checklist

- [ ] Wait for https://github.com/elastic/apm-agent-nodejs/pull/2422 to go in first, and merge.
- [x] Implement code
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
