### PR TITLE
docs: new lambda docs for Node.js agent

### DIFF
--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -7,9 +7,7 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs/current/lambda.html[elastic.co]
 endif::[]
 
-=== Get started with Lambda (Deprecated)
-
-WARNING: *Lambda functions are no longer supported by the Elastic APM Node.js Agent.*
+=== Get started with Lambda (Beta)
 
 Getting Elastic APM set up for your lambda functions is easy,
 and there are various ways you can tweak it to fit your needs.
@@ -19,6 +17,20 @@ check out the <<api,API Reference>>.
 [float]
 [[lambda-installation]]
 ==== Installation
+Setting up your Lambda function is a two step process. First, you’ll
+need to install https://github.com/elastic/apm-aws-lambda/[the Elastic
+APM Lambda extension] into your Lambda environment. Elastic uses a
+Lambda extension to forward data on to APM Server in a way that does not
+interfere with the execution of your Lambda function. You can
+https://github.com/elastic/apm-aws-lambda/blob/main/apm-lambda-extension/docs/aws-lambda-extension.asciidoc[read
+more about installing and using this extension here].
+
+Once you have the extension installed in your environment, you’ll need
+to configure your Lambda handler to instrument your function.
+
+[float]
+[[lambda-instrumenting]]
+==== Instrumenting your Lambda Handler
 
 Add the `elastic-apm-node` module as a dependency to your application:
 
@@ -37,21 +49,8 @@ Here's a simple lambda example with the Elastic APM agent installed:
 
 [source,js]
 ----
-// Add this to the VERY top of the first file loaded in your app
-const apm = require('elastic-apm-node').start({
-  // Override service name from package.json
-  // Allowed characters: a-z, A-Z, 0-9, -, _, and space
-  serviceName: '',
-
-  // Use if APM Server requires a token
-  secretToken: '',
-
-  // Use if APM Server uses API keys for authentication
-  apiKey: '',
-
-  // Set custom APM Server URL (default: http://localhost:8200)
-  serverUrl: '',
-})
+// Add this to the VERY top of your lambda handler module
+const apm = require('elastic-apm-node').start({})
 
 exports.handler = apm.lambda(function handler (payload, context, callback) {
   callback(null, `Hello, ${payload.name}!`)
@@ -59,6 +58,8 @@ exports.handler = apm.lambda(function handler (payload, context, callback) {
 ----
 
 The agent will now monitor the performance of your lambda function.
+
+*IMPORTANT*: During installation of the Lambda extension you'll have set a number of environmental variables for configuring the agent.  We recommend relying on these environmental variables -- while it's possible to set configuration values via the configuration object passed to `start`, doing so may interfere with the configuration required by the Lambda extension.
 
 [float]
 [[lambda-full-documentation]]
@@ -71,7 +72,7 @@ The agent will now monitor the performance of your lambda function.
 [[lambda-performance-monitoring]]
 ==== Performance monitoring
 
-Elastic APM automatically measures the performance of everything within your lambda function executions.
+Elastic APM automatically measures the performance of your lambda function executions.
 It records traces for database queries,
 external HTTP requests,
 and other slow operations that happen during execution.

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -17,16 +17,28 @@ check out the <<api,API Reference>>.
 [float]
 [[lambda-installation]]
 ==== Installation
-Setting up your Lambda function is a two step process. First, you’ll
-need to install https://github.com/elastic/apm-aws-lambda/[the Elastic
-APM Lambda extension] into your Lambda environment. Elastic uses a
-Lambda extension to forward data to APM Server in a way that does not
-interfere with the execution of your Lambda function. You can
-https://github.com/elastic/apm-aws-lambda/blob/main/apm-lambda-extension/docs/aws-lambda-extension.asciidoc[read
-more about installing and using this extension here].
 
-Once you have the extension installed in your environment, you’ll need
-to configure your Lambda handler to instrument your function.
+Setting up your Lambda function is a two-step process.
+
+1. <<lambda-extension>>
+2. <<lambda-instrumenting>>
+
+First, https://github.com/elastic/apm-aws-lambda/blob/main/apm-lambda-extension/docs/aws-lambda-extension.asciidoc[install the Elastic
+APM Lambda extension] into your Lambda environment. Elastic uses a Lambda
+extension to forward data to APM Server in a way that does not interfere with the
+execution of your Lambda function.
+
+[float]
+[[lambda-extension]]
+==== Install the Elastic APM Lambda extension
+
+Elastic uses a Lambda extension to forward data to APM Server in a way that does not interfere with the
+execution of your Lambda function.
+
+See the https://github.com/elastic/apm-aws-lambda/blob/main/apm-lambda-extension/docs/aws-lambda-extension.asciidoc[installation documentation] to get started.
+
+Once you have the extension installed in your environment, you can
+configure your Lambda handler to instrument your function.
 
 [float]
 [[lambda-instrumenting]]
@@ -59,7 +71,7 @@ exports.handler = apm.lambda(function handler (payload, context, callback) {
 
 The agent will now monitor the performance of your lambda function.
 
-*IMPORTANT*: During installation of the Lambda extension you'll have set a number of environmental variables for configuring the agent.  We recommend relying on these environmental variables -- while it's possible to set configuration values via the configuration object passed to `start`, doing so may interfere with the configuration required by the Lambda extension.
+*IMPORTANT*: During installation of the Lambda extension you'll have set a number of environment variables for configuring the agent.  We recommend relying on these environment variables -- while it's possible to set configuration values via the configuration object passed to `start`, doing so may interfere with the configuration required by the Lambda extension.
 
 [float]
 [[lambda-full-documentation]]

--- a/docs/lambda.asciidoc
+++ b/docs/lambda.asciidoc
@@ -20,7 +20,7 @@ check out the <<api,API Reference>>.
 Setting up your Lambda function is a two step process. First, you’ll
 need to install https://github.com/elastic/apm-aws-lambda/[the Elastic
 APM Lambda extension] into your Lambda environment. Elastic uses a
-Lambda extension to forward data on to APM Server in a way that does not
+Lambda extension to forward data to APM Server in a way that does not
 interfere with the execution of your Lambda function. You can
 https://github.com/elastic/apm-aws-lambda/blob/main/apm-lambda-extension/docs/aws-lambda-extension.asciidoc[read
 more about installing and using this extension here].

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -11,7 +11,7 @@ To get you off the ground, we've prepared guides for setting up the Agent with a
 * <<koa>>
 * <<restify>>
 * <<fastify>>
-// * <<lambda>>
+* <<lambda>>
 // end::web-frameworks-list[]
 
 Alternatively, you can <<custom-stack>>.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -47,6 +47,7 @@ router information for full support. We currently support the most popular Koa r
 https://github.com/alexmingoia/koa-router[koa-router].
 |<<restify,Restify>> |>=5.2.0
 |<<fastify,Fastify>> |>=1.0.0; see also https://www.fastify.io/docs/latest/LTS/[Fastify's own LTS documentation]
+|<<lambda,AWS Lambda>> |N/A
 |=======================================================================
 
 [float]


### PR DESCRIPTION
Updates Lambda docs to undeprecate Lambda and provide information on installing with [the Lambda extension](https://github.com/elastic/apm-aws-lambda/)

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Update documentation
