### PR TITLE
fix: apm.startTransaction() crash if agent not yet started

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -29,7 +29,10 @@ function Agent () {
   // Early configuration to ensure `agent.logger` works before `agent.start()`.
   this.logger = config.configLogger()
 
-  this._conf = null
+  // Get an initial pre-.start() configuration of agent defaults. This is a
+  // crutch for Agent APIs that depend on `agent._conf`.
+  this._conf = config.initialConfig(this.logger)
+
   this._httpClient = null
   this._uncaughtExceptionListener = null
   this._inflightEvents = new InflightEventSet()

--- a/lib/config.js
+++ b/lib/config.js
@@ -246,6 +246,26 @@ function configLogger (opts) {
   return logging.createLogger(logLevel, customLogger)
 }
 
+// Create an initial configuration from DEFAULTS. This is used as a stand-in
+// for Agent configuration until `agent.start(...)` is called.
+function initialConfig () {
+  const cfg = Object.assign({}, DEFAULTS)
+
+  // Reproduce the generated properties for `Config`.
+  cfg.ignoreUrlStr = []
+  cfg.ignoreUrlRegExp = []
+  cfg.ignoreUserAgentStr = []
+  cfg.ignoreUserAgentRegExp = []
+  cfg.transactionIgnoreUrlRegExp = []
+  cfg.sanitizeFieldNamesRegExp = []
+  cfg.ignoreMessageQueuesRegExp = []
+  normalize(cfg)
+
+  cfg.transport = new NoopTransport()
+
+  return cfg
+}
+
 function createConfig (opts, logger) {
   return new Config(opts, logger)
 }
@@ -930,6 +950,7 @@ function getBaseClientConfig (conf, agent) {
 // Exports.
 module.exports = {
   configLogger,
+  initialConfig,
   createConfig,
   INTAKE_STRING_MAX_SIZE,
   CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -146,6 +146,13 @@ test('#setFramework()', function (t) {
 })
 
 test('#startTransaction()', function (t) {
+  t.test('agent not yet started: startTransaction() should not crash', function (t) {
+    const agent = new Agent() // do not start the agent
+    agent.startTransaction('foo')
+    agent.destroy()
+    t.end()
+  })
+
   t.test('name, type, subtype and action', function (t) {
     const agent = new Agent().start(agentOptsNoopTransport)
     var trans = agent.startTransaction('foo', 'type', 'subtype', 'action')


### PR DESCRIPTION
This restores the internal `apm._conf` as a crutch for
apm.startTransaction() -- and possibly other Agent API methods -- to
function without crashing before `apm.start()` is called. `apm._conf`
is set to a config object holding the agent's defaults.

Fixes: #2425


### Checklist

- [x] Implement code
- [x] Add tests
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
