### PR TITLE
fix: do not set 'tracestate' header to the empty string

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Avoid setting the `tracestate` header for outgoing HTTP requests to the empty
+  string. This can happen for non-trace-root transactions. While the HTTP spec
+  allows empty header values, some servers do not. ({issues}2405[#2405])
+
 - Deprecate `transaction.subtype` and `transaction.action`. These fields
   were never used by APM server. This also deprecates the
   `apm.startTransaction(...)` call signatures that take `subtype` and `action`

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -159,7 +159,11 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
 
         const newHeaders = Object.assign({}, options.headers)
         newHeaders.traceparent = headerValue
-        newHeaders.tracestate = traceStateValue
+        if (traceStateValue) {
+          // Do not set the header to the empty string. Though RFC 7230 allows
+          // empty header values, some servers apparently do not.
+          newHeaders.tracestate = traceStateValue
+        }
         if (agent._conf.useElasticTraceparentHeader) {
           newHeaders['elastic-apm-traceparent'] = headerValue
         }


### PR DESCRIPTION
To be nice for servers that balk at empty header values.

Fixes: #2405


### Checklist

- [x] Implement code
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
