### PR TITLE
tests: fix failing restify tests with latest node v18.0.0 nightly

### DIFF
--- a/test/config.test.js
+++ b/test/config.test.js
@@ -849,9 +849,13 @@ test('disableInstrumentations', function (t) {
   if (semver.gte(mongodbVersion, '4.0.0') && semver.lt(process.version, '12.0.0')) {
     modules.delete('mongodb')
   }
-
   if (semver.gte(apolloServerCoreVersion, '3.0.0') && semver.lt(process.version, '12.0.0')) {
     modules.delete('apollo-server-core')
+  }
+  if (semver.satisfies(process.version, '>17.x', { includePrerelease: true })) {
+    // Restify (as of 8.6.0) is completely broken with latest node v18 nightly.
+    // https://github.com/restify/node-restify/issues/1888
+    modules.delete('restify')
   }
 
   function testSlice (t, name, selector) {

--- a/test/instrumentation/modules/fastify/set-framework.test.js
+++ b/test/instrumentation/modules/fastify/set-framework.test.js
@@ -8,7 +8,7 @@ const agent = require('../../../..').start({
 
 const tape = require('tape')
 
-tape('restify set-framework test', function (t) {
+tape('fastify set-framework test', function (t) {
   let asserts = 0
 
   agent.setFramework = function ({ name, version, overwrite }) {

--- a/test/instrumentation/modules/restify/basic.test.js
+++ b/test/instrumentation/modules/restify/basic.test.js
@@ -1,5 +1,13 @@
 'use strict'
 
+// Restify is broken on latest node v18 nightlies.
+// https://github.com/restify/node-restify/issues/1888
+const semver = require('semver')
+if (semver.satisfies(process.version, '>17.x', { includePrerelease: true })) {
+  console.log(`# SKIP restify does not support node ${process.version}`)
+  process.exit()
+}
+
 const agent = require('../../../..').start({
   serviceName: 'test',
   secretToken: 'test',

--- a/test/instrumentation/modules/restify/set-framework.test.js
+++ b/test/instrumentation/modules/restify/set-framework.test.js
@@ -1,5 +1,13 @@
 'use strict'
 
+// Restify is broken on latest node v18 nightlies.
+// https://github.com/restify/node-restify/issues/1888
+const semver = require('semver')
+if (semver.satisfies(process.version, '>17.x', { includePrerelease: true })) {
+  console.log(`# SKIP restify does not support node ${process.version}`)
+  process.exit()
+}
+
 const agent = require('../../../..').start({
   captureExceptions: true,
   metricsInterval: 0,

--- a/test/sanitize-field-names/restify.test.js
+++ b/test/sanitize-field-names/restify.test.js
@@ -1,4 +1,13 @@
 'use strict'
+
+// Restify is broken on latest node v18 nightlies.
+// https://github.com/restify/node-restify/issues/1888
+const semver = require('semver')
+if (semver.satisfies(process.version, '>17.x', { includePrerelease: true })) {
+  console.log(`# SKIP restify does not support node ${process.version}`)
+  process.exit()
+}
+
 const { createAgentConfig } = require('./_shared')
 const agent = require('../..').start(createAgentConfig())
 const {


### PR DESCRIPTION
Restify currently does not work with the latest v18.0.0 nightly.
See https://github.com/restify/node-restify/issues/1888

"Edge" nightly tests recently started failing on this. E.g.:
https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/master/1178/pipeline/6508

```
[2021-11-15T07:16:33.458Z] node_tests_1     | # disableInstrumentations
[2021-11-15T07:16:33.458Z] node_tests_1     | # individual modules -> @elastic/elasticsearch
[2021-11-15T07:16:43.490Z] node_tests_1     | /app/node_modules/restify/lib/request.js:848
[2021-11-15T07:16:43.490Z] node_tests_1     |     Request.prototype.closed = function closed() {
[2021-11-15T07:16:43.490Z] node_tests_1     |                              ^
[2021-11-15T07:16:43.490Z] node_tests_1     | 
[2021-11-15T07:16:43.490Z] node_tests_1     | TypeError: Cannot set property closed of #<Readable> which has only a getter
[2021-11-15T07:16:43.490Z] node_tests_1     |     at patch (/app/node_modules/restify/lib/request.js:848:30)
[2021-11-15T07:16:43.490Z] node_tests_1     |     at Object.<anonymous> (/app/node_modules/restify/lib/server.js:33:1)
[2021-11-15T07:16:43.490Z] node_tests_1     |     at Module._compile (node:internal/modules/cjs/loader:1097:14)
[2021-11-15T07:16:43.490Z] node_tests_1     |     at Module.replacementCompile (/app/node_modules/append-transform/index.js:60:13)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module._extensions..js (node:internal/modules/cjs/loader:1149:10)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Object.<anonymous> (/app/node_modules/append-transform/index.js:64:4)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.load (node:internal/modules/cjs/loader:975:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.require (node:internal/modules/cjs/loader:999:19)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at require (node:internal/modules/cjs/helpers:102:18)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Object.<anonymous> (/app/node_modules/restify/lib/index.js:10:14)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module._compile (node:internal/modules/cjs/loader:1097:14)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.replacementCompile (/app/node_modules/append-transform/index.js:60:13)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module._extensions..js (node:internal/modules/cjs/loader:1149:10)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Object.<anonymous> (/app/node_modules/append-transform/index.js:64:4)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.load (node:internal/modules/cjs/loader:975:32
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.require (node:internal/modules/cjs/loader:999:19)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Module.Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:80:39)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at require (node:internal/modules/cjs/helpers:102:18)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.<anonymous> (/app/test/config.test.js:877:9)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.bound [as _cb] (/app/node_modules/tape/lib/test.js:96:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.run (/app/node_modules/tape/lib/test.js:114:31)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.bound [as run] (/app/node_modules/tape/lib/test.js:96:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test._end (/app/node_modules/tape/lib/test.js:217:11)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.bound [as _end] (/app/node_modules/tape/lib/test.js:96:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.end (/app/node_modules/tape/lib/test.js:196:10)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.bound [as end] (/app/node_modules/tape/lib/test.js:96:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.<anonymous> (/app/test/config.test.js:899:5)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.bound [as _cb] (/app/node_modules/tape/lib/test.js:96:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.run (/app/node_modules/tape/lib/test.js:114:31)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Test.bound [as run] (/app/node_modules/tape/lib/test.js:96:32)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at Immediate.next (/app/node_modules/tape/lib/results.js:88:19)
[2021-11-15T07:16:43.491Z] node_tests_1     |     at processImmediate (node:internal/timers:464:21)
[2021-11-15T07:16:43.491Z] node_tests_1     | 
[2021-11-15T07:16:43.491Z] node_tests_1     | Node.js v18.0.0-nightly20211114cf56abe6bb
```

### Checklist

- [x] Implement code
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
