### PR TITLE
ci: support modules github comments

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run (module|benchmark) tests)")
+    issueCommentTrigger("(${obltGitHubComments()}|^run (module|benchmark) tests.*)")
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ please post them on the [Discuss forum](https://discuss.elastic.co/c/apm).
 
 [![npm](https://img.shields.io/npm/v/elastic-apm-node.svg)](https://www.npmjs.com/package/elastic-apm-node)
 [![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-nodejs%2Fapm-agent-nodejs-mbp%2F3.x)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/3.x/)
-[![Build status](https://travis-ci.org/elastic/apm-agent-nodejs.svg?branch=3.x)](https://travis-ci.org/elastic/apm-agent-nodejs)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/standard/standard)
 
 ## Installation


### PR DESCRIPTION
### What

Fixes the github command for module, see https://github.com/elastic/apm-agent-nodejs/pull/2444#issuecomment-970935406

Remove travis references