### PR TITLE
fix: no need to escape chars in serviceName for User-Agent

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -845,15 +845,19 @@ function loadServerCaCertFile (opts) {
 // The format of User-Agent is governed by https://datatracker.ietf.org/doc/html/rfc7231.
 //    User-Agent = product *( RWS ( product / comment ) )
 // We do not expect `$repoName` and `$version` to have surprise/invalid values.
-// However, `$serviceName` and `$serviceVersion` are provided by the user
-// and could have invalid characters. `comment` is defined by
+// From `validateServiceName` above, we know that `$serviceName` is null or a
+// string limited to `/^[a-zA-Z0-9 _-]+$/`. However, `$serviceVersion` is
+// provided by the user and could have invalid characters.
+//
+// `comment` is defined by
 // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6 as:
 //    comment        = "(" *( ctext / quoted-pair / comment ) ")"
 //    obs-text       = %x80-FF
 //    ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
 //    quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
+//
 // `commentBadChar` below *approximates* these rules, and is used to replace
-// invalid characters with '_' in the generated User-Agent string.  This
+// invalid characters with '_' in the generated User-Agent string. This
 // replacement isn't part of the APM spec.
 function userAgentFromConf (conf) {
   let userAgent = `apm-agent-nodejs/${version}`
@@ -863,7 +867,7 @@ function userAgentFromConf (conf) {
   const commentBadChar = /[^\t \x21-\x27\x2a-\x5b\x5d-\x7e\x80-\xff]/g
   const commentParts = []
   if (conf.serviceName) {
-    commentParts.push(conf.serviceName.replace(commentBadChar, '_'))
+    commentParts.push(conf.serviceName)
   }
   if (conf.serviceVersion) {
     commentParts.push(conf.serviceVersion.replace(commentBadChar, '_'))

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1304,8 +1304,7 @@ test('userAgentFromConf', t => {
   t.equal(config.userAgentFromConf({ serviceName: 'party', serviceVersion: '2021-été' }),
     `apm-agent-nodejs/${apmVersion} (party 2021-été)`)
   // Higher code points are replaced with `_`.
-  t.equal(config.userAgentFromConf({ serviceName: 'freeze', serviceVersion: 'do you want to build a ☃ in my 🏰'
- }),
+  t.equal(config.userAgentFromConf({ serviceName: 'freeze', serviceVersion: 'do you want to build a ☃ in my 🏰' }),
     `apm-agent-nodejs/${apmVersion} (freeze do you want to build a _ in my __)`)
 
   t.end()

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1301,11 +1301,12 @@ test('userAgentFromConf', t => {
   t.equal(config.userAgentFromConf({ serviceName: 'foo', serviceVersion: '1.0.0' }),
     `apm-agent-nodejs/${apmVersion} (foo 1.0.0)`)
   // ISO-8859-1 characters are generally allowed.
-  t.equal(config.userAgentFromConf({ serviceName: 'fête', serviceVersion: '2021-été' }),
-    `apm-agent-nodejs/${apmVersion} (fête 2021-été)`)
+  t.equal(config.userAgentFromConf({ serviceName: 'party', serviceVersion: '2021-été' }),
+    `apm-agent-nodejs/${apmVersion} (party 2021-été)`)
   // Higher code points are replaced with `_`.
-  t.equal(config.userAgentFromConf({ serviceName: 'myhomeismy🏰', serviceVersion: 'do you want to build a ☃' }),
-    `apm-agent-nodejs/${apmVersion} (myhomeismy__ do you want to build a _)`)
+  t.equal(config.userAgentFromConf({ serviceName: 'freeze', serviceVersion: 'do you want to build a ☃ in my 🏰'
+ }),
+    `apm-agent-nodejs/${apmVersion} (freeze do you want to build a _ in my __)`)
 
   t.end()
 })


### PR DESCRIPTION
When creating the User-Agent, there is no need to escape chars in
serviceName, because it is already limited to legal User-Agent chars.

(From some private chat on escaping for User-Agent: https://elastic.slack.com/archives/C9A6ANR5Y/p1637163729166800)

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
