### PR TITLE
fix: the error captured for an erroring redis span should be the span

### DIFF
--- a/lib/instrumentation/modules/redis.js
+++ b/lib/instrumentation/modules/redis.js
@@ -40,8 +40,8 @@ module.exports = function (redis, agent, { version, enabled }) {
 
   return redis
 
-  function makeWrappedCallback (span, origCb) {
-    const wrappedCallback = ins.bindFunction(function (err, _reply) {
+  function makeWrappedCallback (spanRunContext, span, origCb) {
+    const wrappedCallback = ins.bindFunctionToRunContext(spanRunContext, function (err, _reply) {
       if (err) {
         span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
         agent.captureError(err, { skipOutcome: true })
@@ -78,8 +78,8 @@ module.exports = function (redis, agent, { version, enabled }) {
       const connOpts = connOptsFromRedisClient(this)
       span.setDestinationContext(getDBDestination(span, connOpts.host, connOpts.port))
 
-      commandObj.callback = makeWrappedCallback(span, commandObj.callback)
       const spanRunContext = ins.currRunContext().enterSpan(span)
+      commandObj.callback = makeWrappedCallback(spanRunContext, span, commandObj.callback)
       return ins.withRunContext(spanRunContext, original, this, ...arguments)
     }
   }
@@ -110,7 +110,8 @@ module.exports = function (redis, agent, { version, enabled }) {
       const connOpts = connOptsFromRedisClient(this)
       span.setDestinationContext(getDBDestination(span, connOpts.host, connOpts.port))
 
-      const wrappedCb = makeWrappedCallback(span, origCb)
+      const spanRunContext = ins.currRunContext().enterSpan(span)
+      const wrappedCb = makeWrappedCallback(spanRunContext, span, origCb)
       if (cb) {
         cb = wrappedCb
       } else if (origCb) {
@@ -118,7 +119,6 @@ module.exports = function (redis, agent, { version, enabled }) {
       } else {
         cb = wrappedCb
       }
-      const spanRunContext = ins.currRunContext().enterSpan(span)
       return ins.withRunContext(spanRunContext, original, this, command, args, cb)
     }
   }

--- a/test/instrumentation/modules/redis.test.js
+++ b/test/instrumentation/modules/redis.test.js
@@ -138,6 +138,7 @@ if (semver.satisfies(redisVersion, '>=3.0.0')) {
       t.equal(data.spans[0].parent_id, data.transactions[0].id, 'span.parent_id')
       t.equal(data.spans[0].outcome, 'failure', 'span.outcome')
       t.equal(data.errors[0].transaction_id, data.transactions[0].id, 'error.transaction_id')
+      t.equal(data.errors[0].parent_id, data.spans[0].id, 'error.parent_id, error is a child of the failing span')
       t.equal(data.errors[0].exception.type, 'AbortError', 'error.exception.type')
       t.end()
     })


### PR DESCRIPTION
Before this the error.parent_id was set to the transaction.id, rather
than span.id.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
