### PR TITLE
fix: ensure run-context for mysql span does not spill into user code

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -59,6 +59,10 @@ Notes:
   arguments. In the next major version these two fields will be removed.
   ({issues}2356[#2356])
 
+* Fix run-context handling for 'mysql' instrumentation to avoid accidental
+  creation of *child* spans of the automatic 'mysql' spans.
+  ({issues}2430[#2430]})
+
 
 [[release-notes-3.24.0]]
 ==== 3.24.0 2021/11/09

--- a/examples/trace-mysql.js
+++ b/examples/trace-mysql.js
@@ -26,14 +26,14 @@ client.connect(function (err) {
 // requests to a Node.js server. However, because this script is not running
 // an HTTP server, we manually start a transaction. More details at:
 // https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
-apm.startTransaction('t1')
+const t1 = apm.startTransaction('t1')
 client.query('SELECT 1 + 1 AS solution', (err, res) => {
   if (err) {
     console.log('[t1] Failure: err is', err)
   } else {
     console.log('[t1] Success: solution is %s', res[0].solution)
   }
-  apm.endTransaction()
+  t1.end()
 })
 
 // 2. Event emitter style

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -98,59 +98,61 @@ function wrapQueryable (connection, objType, agent) {
 
   function wrapQuery (original) {
     return function wrappedQuery (sql, values, cb) {
-      var span = agent.startSpan(null, 'db', 'mysql', 'query')
-      var id = span && span.transaction.id
+      agent.logger.debug('intercepted call to mysql %s.query', objType)
+
+      var span = ins.createSpan(null, 'db', 'mysql', 'query')
+      if (!span) {
+        return original.apply(this, arguments)
+      }
+
       var hasCallback = false
       var sqlStr
 
-      agent.logger.debug('intercepted call to mysql %s.query %o', objType, { id: id })
-
-      if (span) {
-        if (this[symbols.knexStackObj]) {
-          span.customStackTrace(this[symbols.knexStackObj])
-          this[symbols.knexStackObj] = null
-        }
-
-        const wrapCallback = function (origCallback) {
-          hasCallback = true
-          return ins.bindFunction(function wrappedCallback (_err) {
-            span.end()
-            return origCallback.apply(this, arguments)
-          })
-        }
-
-        switch (typeof sql) {
-          case 'string':
-            sqlStr = sql
-            break
-          case 'object':
-            if (typeof sql._callback === 'function') {
-              sql._callback = wrapCallback(sql._callback)
-            }
-            sqlStr = sql.sql
-            break
-          case 'function':
-            arguments[0] = wrapCallback(sql)
-            break
-        }
-
-        if (sqlStr) {
-          agent.logger.debug('extracted sql from mysql query %o', { id: id, sql: sqlStr })
-          span.setDbContext({ statement: sqlStr, type: 'sql' })
-          span.name = sqlSummary(sqlStr)
-        }
-        span.setDestinationContext(getDBDestination(span, host, port))
-
-        if (typeof values === 'function') {
-          arguments[1] = wrapCallback(values)
-        } else if (typeof cb === 'function') {
-          arguments[2] = wrapCallback(cb)
-        }
+      if (this[symbols.knexStackObj]) {
+        span.customStackTrace(this[symbols.knexStackObj])
+        this[symbols.knexStackObj] = null
       }
 
-      var result = original.apply(this, arguments)
+      const wrapCallback = function (origCallback) {
+        hasCallback = true
+        return ins.bindFunction(function wrappedCallback (_err) {
+          span.end()
+          return origCallback.apply(this, arguments)
+        })
+      }
 
-      if (span && !hasCallback && result instanceof EventEmitter) {
+      switch (typeof sql) {
+        case 'string':
+          sqlStr = sql
+          break
+        case 'object':
+          if (typeof sql._callback === 'function') {
+            sql._callback = wrapCallback(sql._callback)
+          }
+          sqlStr = sql.sql
+          break
+        case 'function':
+          arguments[0] = wrapCallback(sql)
+          break
+      }
+
+      if (sqlStr) {
+        agent.logger.debug({ sql: sqlStr }, 'extracted sql from mysql query')
+        span.setDbContext({ statement: sqlStr, type: 'sql' })
+        span.name = sqlSummary(sqlStr)
+      }
+      span.setDestinationContext(getDBDestination(span, host, port))
+
+      if (typeof values === 'function') {
+        arguments[1] = wrapCallback(values)
+      } else if (typeof cb === 'function') {
+        arguments[2] = wrapCallback(cb)
+      }
+
+      const spanRunContext = ins.currRunContext().enterSpan(span)
+      const result = ins.withRunContext(spanRunContext, original, this, ...arguments)
+
+      if (!hasCallback && result instanceof EventEmitter) {
         // Wrap `result.emit` instead of `result.once('error', ...)` to avoid
         // changing app behaviour by possibly setting the only 'error' handler.
         shimmer.wrap(result, 'emit', function (origEmit) {
@@ -166,7 +168,7 @@ function wrapQueryable (connection, objType, agent) {
             return origEmit.apply(this, arguments)
           }
         })
-        // Ensure event handlers execute in this run context.
+        // Ensure event handlers execute in the caller run context.
         ins.bindEmitter(result)
       }
 


### PR DESCRIPTION
This fixes the 'mysql' instrumentation to not have the mysql span
context be active in user code. This ensures that user code cannot
create a child span of the mysql span, which would (a) be misleading
and (b) cause problems for coming exit span and compressed span work.

Refs: #2430

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
