### PR TITLE
3.25.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,13 +29,8 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
+[[release-notes-3.25.0]]
+==== 3.25.0 2021/11/24
 
 [float]
 ===== Bug fixes

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -31,6 +31,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.25.x |2023-05-24 |3.26.0
 |3.24.x |2023-05-09 |3.25.0
 |3.23.x |2023-04-25 |3.24.0
 |3.22.x |2023-04-21 |3.23.0

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
     "@elastic/elasticsearch": "^7.15.0",
-    "@elastic/elasticsearch-canary": "^8.0.0-canary.35",
+    "@elastic/elasticsearch-canary": "^8.0.0-canary.37",
     "@hapi/hapi": "^20.1.2",
     "@koa/router": "^9.0.1",
     "@types/node": "^13.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.24.0",
+  "version": "3.25.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -209,10 +209,12 @@ if (semver.gte(process.version, '10.0.0')) {
       sort: 'myField:asc'
     }
     let statement
-    // ES client version 8 merges options for *most* APIs into a single body
-    // object, instead of separate query params and body.
+    // ES client version 8 merges options into `body` differently from earlier
+    // versions.
     if (semver.satisfies(esVersion, '>=8', { includePrerelease: true })) {
-      statement = '{"query":{"match":{"request":"bar"}},"size":2,"sort":"myField:asc"}'
+      statement = `sort=myField%3Aasc
+
+{"query":{"match":{"request":"bar"}},"size":2}`
     } else {
       statement = `size=2&sort=myField%3Aasc
 


### PR DESCRIPTION
We have some improvements to release and this will allow us to get a fix for a broken link in the "current" published version of the docs (see https://github.com/elastic/apm-agent-nodejs/pull/2465#issuecomment-977254161).