### PR TITLE
tests: reduce the number of versions of jade being tested

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -326,11 +326,19 @@ elasticsearch:
 handlebars:
   versions: '*'
   commands: node test/instrumentation/modules/handlebars.test.js
+# jade is a dead package. It was renamed to 'pug' in 2015 and hasn't had a
+# release since. Testing all 144 releases that match '>0.5.5' (the first
+# release APM supported) is a waste of time.
 jade:
-  versions: '>0.5.5'
+  versions: '0.5.5 || 1.11.0 || >1.11.0'
   commands: node test/instrumentation/modules/jade.test.js
+# Pug v3 dropped node v8 support (https://github.com/pugjs/pug/releases/tag/pug%403.0.0).
+pug-v2:
+  versions: '0.1.0 || >2.0.0 <3.0.0'
+  commands: node test/instrumentation/modules/pug.test.js
 pug:
-  versions: '0.1.0 || >2.0.0'
+  versions: '>=3.0.0'
+  node: '>8'
   commands: node test/instrumentation/modules/pug.test.js
 
 # hapi and @hapi/hapi

--- a/.tav.yml
+++ b/.tav.yml
@@ -328,9 +328,10 @@ handlebars:
   commands: node test/instrumentation/modules/handlebars.test.js
 # jade is a dead package. It was renamed to 'pug' in 2015 and hasn't had a
 # release since. Testing all 144 releases that match '>0.5.5' (the first
-# release APM supported) is a waste of time.
+# release APM supported) is a waste of time. Instead we will test the first
+# supported and the last released versions.
 jade:
-  versions: '0.5.5 || 1.11.0 || >1.11.0'
+  versions: '0.5.6 || 1.11.0 || >1.11.0'
   commands: node test/instrumentation/modules/jade.test.js
 # Pug v3 dropped node v8 support (https://github.com/pugjs/pug/releases/tag/pug%403.0.0).
 pug-v2:

--- a/examples/trace-handlebars.js
+++ b/examples/trace-handlebars.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// A small example showing Elastic APM tracing the 'handlebars' package.
+
+const apm = require('../').start({ // elastic-apm-node
+  serviceName: 'example-trace-handlebars'
+})
+
+const handlebars = require('handlebars')
+
+// For tracing spans to be created, there must be an active transaction.
+// Typically, a transaction is automatically started for incoming HTTP
+// requests to a Node.js server. However, because this script is not running
+// an HTTP server, we manually start a transaction. More details at:
+// https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
+const t1 = apm.startTransaction('t1')
+
+var template = handlebars.compile('Hello, {{name}}!')
+console.log(template({ name: 'world' }))
+console.log(template({ name: 'Bob' }))
+
+t1.end()

--- a/examples/trace-pug.js
+++ b/examples/trace-pug.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// A small example showing Elastic APM tracing the 'pug' package.
+
+const apm = require('../').start({ // elastic-apm-node
+  serviceName: 'example-trace-pug'
+})
+
+const pug = require('pug')
+
+// For tracing spans to be created, there must be an active transaction.
+// Typically, a transaction is automatically started for incoming HTTP
+// requests to a Node.js server. However, because this script is not running
+// an HTTP server, we manually start a transaction. More details at:
+// https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
+const t1 = apm.startTransaction('t1')
+
+var template = pug.compile('p Hello, #{name}!')
+console.log(template({ name: 'world' }))
+console.log(template({ name: 'Bob' }))
+
+t1.end()


### PR DESCRIPTION
Jade was renamed to pug and hasn't had a release since 2015. Testing
114 releases of jade for every commit is unnecessary.

This also adds examples for the other two templating libs.


- [x] run TAV=pug,handlebars,jade tests

