### PR TITLE
fix: ensure correct run-context for 'memcached' instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ Notes:
 * Fix run-context handling for 'memcached' instrumentation so that the
   automatically created Memcached span is never the `currentSpan` in user
   code.
+
 * Fix 'http' and 'https' instrumentation for outgoing requests to not have the
   'http' span context be active in user code. ({pull}2470[#2470])
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix run-context handling for 'memcached' instrumentation so that the
+  automatically created Memcached span is never the `currentSpan` in user
+  code.
+
 * Fixes for 'ioredis' instrumentation ({pull}2460[#2460]):
 +
 **  Fix run-context so that a span created in the same tick as an ioredis

--- a/lib/instrumentation/modules/memcached.js
+++ b/lib/instrumentation/modules/memcached.js
@@ -13,6 +13,9 @@ module.exports = function (memcached, agent, { version, enabled }) {
     agent.logger.debug('Memcached version %s not supported - aborting...', version)
     return memcached
   }
+
+  const ins = agent._instrumentation
+
   agent.logger.debug('shimming memcached.prototype.command')
   shimmer.wrap(memcached.prototype, 'command', wrapCommand)
   shimmer.wrap(memcached.prototype, 'connect', wrapConnect)
@@ -20,7 +23,7 @@ module.exports = function (memcached, agent, { version, enabled }) {
 
   function wrapConnect (original) {
     return function wrappedConnect () {
-      const currentSpan = agent._instrumentation.currSpan()
+      const currentSpan = ins.currSpan()
       const server = arguments[0]
       agent.logger.debug('intercepted call to memcached.prototype.connect %o', { server })
 
@@ -34,28 +37,37 @@ module.exports = function (memcached, agent, { version, enabled }) {
 
   // Wrap the generic command that is used to build touch, get, gets etc
   function wrapCommand (original) {
-    return function wrappedCommand () {
-      if (typeof arguments[0] === 'function') {
-        var query = arguments[0]()
-        // If the callback is not a function the user doesn't care about result
-        if (query && typeof query.callback === 'function') {
-          var span = agent.startSpan(`memcached.${query.type}`, 'db', 'memcached', query.type)
-          agent.logger.debug('intercepted call to memcached.prototype.command %o', { id: span && span.id, type: query.type })
-          if (span) {
-            span.setDbContext({ statement: `${query.type} ${query.key}`, type: 'memcached' })
-            const origCallback = query.callback
-            query.callback = agent._instrumentation.bindFunction(function tracedCallback () {
-              span.end()
-              return origCallback.apply(this, arguments)
-            })
-            // Rewrite the query compiler with the wrapped callback
-            arguments[0] = function queryCompiler () {
-              return query
-            }
-          }
-        }
+    return function wrappedCommand (queryCompiler, _server) {
+      if (typeof queryCompiler !== 'function') {
+        return original.apply(this, arguments)
       }
-      return original.apply(this, arguments)
+
+      var query = queryCompiler()
+      // Replace the queryCompiler function so it isn't called a second time.
+      arguments[0] = function prerunQueryCompiler () {
+        return query
+      }
+
+      // If the callback is not a function the user doesn't care about result.
+      if (!query && typeof query.callback !== 'function') {
+        return original.apply(this, arguments)
+      }
+
+      const span = ins.createSpan(`memcached.${query.type}`, 'db', 'memcached', query.type)
+      if (!span) {
+        return original.apply(this, arguments)
+      }
+
+      agent.logger.debug('intercepted call to memcached.prototype.command %o', { id: span.id, type: query.type })
+      span.setDbContext({ statement: `${query.type} ${query.key}`, type: 'memcached' })
+
+      const spanRunContext = ins.currRunContext().enterSpan(span)
+      const origCallback = query.callback
+      query.callback = ins.bindFunctionToRunContext(spanRunContext, function tracedCallback () {
+        span.end()
+        return origCallback.apply(this, arguments)
+      })
+      return ins.withRunContext(spanRunContext, original, this, ...arguments)
     }
   }
 }


### PR DESCRIPTION
This ensures that a created 'memcached' span is not the currentSpan
in user code after the call.

Refs: #2430

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] TAV=memcached run
