### PR TITLE
fix: crash in Transaction serialization if req.socket is null

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix a possible crash when serializing a Transaction if the incoming
+  `req.socket` is null (possible if the socket has been destroyed).
+  {issues}2479[#2479]}
+
 * Fixes for 'ioredis' instrumentation ({pull}2460[#2460]):
 +
 **  Fix run-context so that a span created in the same tick as an ioredis

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ Notes:
 * Fix a possible crash when serializing a Transaction if the incoming
   `req.socket` is null (possible if the socket has been destroyed).
   {issues}2479[#2479]}
+
 * Fix 'http' and 'https' instrumentation for outgoing requests to not have the
   'http' span context be active in user code. ({pull}2470[#2470])
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -19,10 +19,12 @@ function getContextFromRequest (req, conf, type) {
     http_version: req.httpVersion,
     method: req.method,
     url: getUrlFromRequest(req),
-    socket: {
-      remote_address: req.socket.remoteAddress
-    },
     headers: undefined
+  }
+  if (req.socket && req.socket.remoteAddress) {
+    context.socket = {
+      remote_address: req.socket.remoteAddress
+    }
   }
 
   if (conf.captureHeaders) {

--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -490,13 +490,12 @@ function assertPath (t, trans, secure, port, path, httpVersion) {
     t.ok(trans.context.request.socket.remote_address === '::ffff:127.0.0.1' || trans.context.request.socket.remote_address === '::1',
       'transaction.context.request.socket.remote_address is as expected: ' + trans.context.request.socket.remote_address)
   }
-  delete trans.context.request.socket.remote_address
+  delete trans.context.request.socket
 
   t.deepEqual(trans.context.request, {
     http_version: httpVersion,
     method: 'GET',
     url: expectedUrl,
-    socket: {},
     headers: expectedReqHeaders
   }, 'trans.context.request is as expected')
 


### PR DESCRIPTION
Fixes: #2479

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests: pending being able to repro
- [x] Add CHANGELOG.asciidoc entry
