### PR TITLE
docs: Fix broken link to 7.16 docs

### DIFF
--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -18,5 +18,10 @@ Using your favorite logging framework, you'd then need to inject this informatio
 
 When your logs contain the appropriate identifiers, the final step is to ingest them into the same
 Elasticsearch instance that contains your APM data. See
+ifeval::["{branch}"=="7.16"]
+{apm-overview-ref-v}/log-correlation.html#_ingest_your_logs_into_elasticsearch[Ingest your logs into Elasticsearch]
+endif::[]
+ifeval::["{branch}"!="7.16"]
 {apm-overview-ref-v}/observability-integrations.html#_ingest_your_logs_into_elasticsearch[Ingest your logs into Elasticsearch]
+endif::[]
 for more information.


### PR DESCRIPTION
The docs PR to upgrade to 7.16 (https://github.com/elastic/docs/pull/2299) is failing due to a broken link in the apm-agent-nodejs repo. This link exists in `master`, `3.x`, and `2.x`:

```
14:29:51 INFO:build_docs:Bad cross-document links:
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/2.x/log-correlation.html contains broken links to:
14:29:51 INFO:build_docs:   - en/apm/guide/7.16/observability-integrations.html#_ingest_your_logs_into_elasticsearch
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/3.x/log-correlation.html contains broken links to:
14:29:51 INFO:build_docs:   - en/apm/guide/7.16/observability-integrations.html#_ingest_your_logs_into_elasticsearch
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/current/log-correlation.html contains broken links to:
14:29:51 INFO:build_docs:   - en/apm/guide/7.16/observability-integrations.html#_ingest_your_logs_into_elasticsearch
14:29:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/master/log-correlation.html contains broken links to:
14:29:51 INFO:build_docs:   - en/apm/guide/7.16/observability-integrations.html#_ingest_your_logs_into_elasticsearch
```

This PR adds an asciidoctor `ifeval` that changes the documentation link based on the`{branch}` attribute specified in [this](https://github.com/elastic/docs/blob/master/shared/versions/stack/current.asciidoc) file. After the 7.16 release, this ifeval can be removed as only the `{apm-overview-ref-v}/log-correlation.html#_ingest_your_logs_into_elasticsearch` link we be valid.

This PR needs to be backported to the `3.x` and `2.x` branches.