### PR TITLE
docs: pin 2.x to 7.15

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/7.15.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :type-string: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type[<string>]


### PR DESCRIPTION
Pins APM agent Node.js version 2.x to stack version 7.15 to avoid future broken links.