### PR TITLE
perf, docs: avoid calculating breakdown metrics if not sending

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -994,7 +994,8 @@ Specify the interval for reporting metrics to APM Server.
 The interval should be in seconds,
 or should include a time suffix.
 
-To disable metrics reporting, set the interval to `"0s"`.
+To disable all metrics reporting, including breakdown metrics, set the interval
+to `"0s"`.
 
 [[metrics-limit]]
 ==== `metricsLimit`
@@ -1066,7 +1067,14 @@ module.exports = {
 * *Default:* `true`
 * *Env:* `ELASTIC_APM_BREAKDOWN_METRICS`
 
-Used to disable reporting of breakdown metrics which records self time spent in each unique type of span.
+Set `breakdownMetrics: false` to disable reporting of breakdown metrics. Note
+that if `metricsInterval: 0`, then breakdown metrics will not be reported.
+
+Breakdown metrics (<<metrics-span.self_time.sum, `span.self_time.*`>>) record
+the self-time spent in each unique type of span. This data drives the
+{kibana-ref}/service-overview.html#service-span-duration[Time spent by span type]
+chart in the APM app.
+
 
 [[cloud-provider]]
 ==== `cloudProvider`

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -155,7 +155,8 @@ This is also included in the `nodejs.memory.external.bytes` value.
 * *Type:* Long
 * *Format:* Milliseconds
 
-The sum of all span self-times in milliseconds since the last report (the delta)
+The sum of all span self-times in milliseconds since the last report (the delta).
+The `span.self_time.*` metrics are referred to as "breakdown metrics".
 
 You can filter and group by these dimensions:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -341,6 +341,9 @@ class Config {
       this.logger.trace('disable metricsInterval (%d -> 0) in lambda environment', this.metricsInterval)
       this.metricsInterval = 0
     }
+    if (this.metricsInterval === 0) {
+      this.breakdownMetrics = false
+    }
 
     if (this.disableSend || this.contextPropagationOnly) {
       this.transport = function createNoopTransport (conf, agent) {


### PR DESCRIPTION
Also add some doc clarifications for the `breakdownMetrics` config var.

Fixes: #2502


### Checklist

- [x] Implement code
- [x] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
