### PR TITLE
fix: run context handling for aws-sdk DynamoDB instrumentation

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -479,6 +479,8 @@ aws-sdk:
   # Test v2.858.0, every N=31 of 159 releases, and current latest.
   versions: '2.858.0 || 2.889.0 || 2.920.0 || 2.951.0 || 2.982.0 || 2.1013.0 || 2.1016.0 || >2.1016.0 <3'
   commands:
+    - node test/instrumentation/modules/aws-sdk/aws4-retries.test.js
     - node test/instrumentation/modules/aws-sdk/s3.test.js
+    - node test/instrumentation/modules/aws-sdk/sns.test.js
     - node test/instrumentation/modules/aws-sdk/sqs.test.js
     - node test/instrumentation/modules/aws-sdk/dynamodb.test.js

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,23 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fixes for run context handling for DynamoDB instrumentation ('aws-sdk'
+  package) so that a span created after an AWS client command (in the same
+  tick, in the command callback, or promise) is not a child of the automatic
+  AWS span. This change also ensures captured errors from failing client
+  commands are a child of the AWS span. ({issues}2430[#2430])
+
 
 [[release-notes-3.26.0]]
 ==== 3.26.0 2021/12/07
@@ -56,12 +73,6 @@ Notes:
 
 [float]
 ===== Bug fixes
-
-* Fixes for run context handling for DynamoDB instrumentation ('aws-sdk'
-  package) so that a span created after an AWS client command (in the same
-  tick, in the command callback, or promise) is not a child of the automatic
-  AWS span. This change also ensures captured errors from failing client
-  commands are a child of the AWS span. ({issues}2430[#2430])
 
 * Fix run-context handling for 'tedious' instrumentation so that automatically
   created 'mssql' spans are never the `currentSpan` in user code.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,12 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fixes for run context handling for DynamoDB instrumentation ('aws-sdk'
+  package) so that a span created after an AWS client command (in the same
+  tick, in the command callback, or promise) is not a child of the automatic
+  AWS span. This change also ensures captured errors from failing client
+  commands are a child of the AWS span. ({issues}2430[#2430])
+
 * Fix run-context handling for 'tedious' instrumentation so that automatically
   created 'mssql' spans are never the `currentSpan` in user code.
   ({issues}2430[#2430])

--- a/lib/instrumentation/modules/aws-sdk/dynamodb.js
+++ b/lib/instrumentation/modules/aws-sdk/dynamodb.js
@@ -1,5 +1,5 @@
 'use strict'
-const constants = require('../../../constants')
+
 const TYPE = 'db'
 const SUBTYPE = 'dynamodb'
 const ACTION = 'query'

--- a/lib/instrumentation/modules/aws-sdk/dynamodb.js
+++ b/lib/instrumentation/modules/aws-sdk/dynamodb.js
@@ -63,12 +63,9 @@ function instrumentationDynamoDb (orig, origArguments, request, AWS, agent, { ve
     return orig.apply(request, origArguments)
   }
 
-  const type = TYPE
-  const subtype = SUBTYPE
-  const action = ACTION
-
+  const ins = agent._instrumentation
   const name = getSpanNameFromRequest(request)
-  const span = agent.startSpan(name, type, subtype, action)
+  const span = ins.createSpan(name, TYPE, SUBTYPE, ACTION)
   if (!span) {
     return orig.apply(request, origArguments)
   }
@@ -91,19 +88,23 @@ function instrumentationDynamoDb (orig, origArguments, request, AWS, agent, { ve
     }
   })
 
-  request.on('complete', function (response) {
+  const onComplete = function (response) {
     if (response && response.error) {
-      const errOpts = {
-        skipOutcome: true
-      }
-      agent.captureError(response.error, errOpts)
-      span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
+      agent.captureError(response.error)
     }
-
     span.end()
-  })
+  }
+  // Bind onComplete to the span's run context so that `captureError` picks
+  // up the correct currentSpan.
+  const parentRunContext = ins.currRunContext()
+  const spanRunContext = parentRunContext.enterSpan(span)
+  request.on('complete', ins.bindFunctionToRunContext(spanRunContext, onComplete))
 
-  return orig.apply(request, origArguments)
+  const cb = origArguments[origArguments.length - 1]
+  if (typeof cb === 'function') {
+    origArguments[origArguments.length - 1] = ins.bindFunctionToRunContext(parentRunContext, cb)
+  }
+  return ins.withRunContext(spanRunContext, orig, request, ...origArguments)
 }
 
 module.exports = {


### PR DESCRIPTION
This also adds a couple aws-sdk-related tests to the TAV=aws-sdk tests.

Refs: #2430

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
