### PR TITLE
tests: fix TAV=got test failures with got@12

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,26 +1,32 @@
 generic-pool:
   versions: ^2.0.0 || ^3.1.0
   commands: node test/instrumentation/modules/generic-pool.test.js
+
 mimic-response:
   versions: ^1.0.0
   commands:
     - node test/instrumentation/modules/mimic-response.test.js
     - node test/instrumentation/modules/http/github-179.test.js
-got-very-old:
+# Versions of `got` are only tested to check a bug in mimic-response@1.0.0
+# (fixed in mimic-response@1.0.1). Got@11 dropped usage of mimic-response,
+# so testing it no longer has a point. Got@12 is pure ESM, so cannot be tested
+# with the current test script.
+got-4:
   name: got
   versions: '>=4.0.0 <9.0.0'
   node: '>=5'
   commands: node test/instrumentation/modules/http/github-423.test.js
-got-old:
+got-9:
   name: got
   versions: ^9.0.0
   node: '>=8.3'
   commands: node test/instrumentation/modules/http/github-423.test.js
-got-new:
+got-10:
   name: got
-  versions: '>=10.0.0 <10.5.1 || >10.5.1' # v10.5.1 is broken
+  versions: '>=10.0.0 <10.5.1 || >10.5.1 <11' # v10.5.1 is broken
   node: '>=10'
   commands: node test/instrumentation/modules/http/github-423.test.js
+
 mysql:
   versions: ^2.0.0
   commands:


### PR DESCRIPTION
got@12 went pure ESM, so we cannot test it with the current test file.
However, since got@11, got doesn't use mimic-response, which was the
point of testing got. This change drops testing with got >=11.


Recent TAV test failure with node v10: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/master/31/pipeline/1363 

```
[2021-12-13T06:54:13.943Z] node_tests_1  | > tav --quiet
[2021-12-13T06:54:13.944Z] node_tests_1  | 
[2021-12-13T06:54:14.514Z] node_tests_1  | -- required packages ["got@12.0.0"]
[2021-12-13T06:54:14.514Z] node_tests_1  | -- installing ["got@12.0.0"]
[2021-12-13T06:54:24.528Z] node_tests_1  | -- running test "node test/instrumentation/modules/http/github-423.test.js" with got
[2021-12-13T06:54:24.528Z] node_tests_1  | internal/modules/cjs/loader.js:638
[2021-12-13T06:54:24.528Z] node_tests_1  |     throw err;
[2021-12-13T06:54:24.528Z] node_tests_1  |     ^
[2021-12-13T06:54:24.528Z] node_tests_1  | 
[2021-12-13T06:54:24.528Z] node_tests_1  | Error: Cannot find module 'got'
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Module.Hook._require.Module.require (/app/node_modules/require-in-the-middle/index.js:61:29)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at require (internal/modules/cjs/helpers.js:25:18)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Object.<anonymous> (/app/test/instrumentation/modules/http/github-423.test.js:14:11)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Module._compile (internal/modules/cjs/loader.js:778:30)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Module.load (internal/modules/cjs/loader.js:653:32)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
[2021-12-13T06:54:24.528Z] node_tests_1  |     at startup (internal/bootstrap/node.js:283:19)
[2021-12-13T06:54:24.529Z] node_tests_1  |     at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
[2021-12-13T06:54:24.529Z] node_tests_1  | -- fatal: Test exited with code 1
```

Or manually with node v16:

```
% node test/instrumentation/modules/http/github-423.test.js
/Users/trentm/el/apm-agent-nodejs13/test/instrumentation/modules/http/github-423.test.js:80
undefined
                                      ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/trentm/el/apm-agent-nodejs13/node_modules/got/dist/source/index.js from /Users/trentm/el/apm-agent-nodejs13/test/instrumentation/modules/http/github-423.test.js not supported.
Instead change the require of index.js in /Users/trentm/el/apm-agent-nodejs13/test/instrumentation/modules/http/github-423.test.js to a dynamic import() which is available in all CommonJS modules.
    at Module.Hook._require.Module.require (/Users/trentm/el/apm-agent-nodejs13/node_modules/require-in-the-middle/index.js:80:39)
    at Object.<anonymous> (/Users/trentm/el/apm-agent-nodejs13/test/instrumentation/modules/http/github-423.test.js:14:11) {
  code: 'ERR_REQUIRE_ESM'
}
```
