### PR TITLE
tests: use www.google.com rather than httpstat.us for an HTTP test

### DIFF
--- a/test/instrumentation/modules/http/fixtures/make-http-request.js
+++ b/test/instrumentation/modules/http/fixtures/make-http-request.js
@@ -24,7 +24,7 @@ function makeARequest (opts, cb) {
     apm.startSpan('span-in-http.request-callback').end()
 
     const chunks = []
-    clientRes.on('data', function (chunk) {
+    clientRes.once('data', function (chunk) {
       assert(apm.currentSpan === null)
       apm.startSpan('span-in-clientRes-on-data').end()
       chunks.push(chunk)
@@ -34,7 +34,7 @@ function makeARequest (opts, cb) {
       assert(apm.currentSpan === null)
       apm.startSpan('span-in-clientRes-on-end').end()
       const body = chunks.join('')
-      console.log('client response body: %j', body)
+      console.log('start of client response body: %j', body.slice(0, 50))
       cb()
     })
   })
@@ -63,9 +63,9 @@ function makeARequest (opts, cb) {
 const t0 = apm.startTransaction('t0')
 makeARequest(
   {
-    // 'http://httpstat.us/200'
-    host: 'httpstat.us',
-    path: '/200',
+    // 'http://wwww.google.com/'
+    host: 'www.google.com',
+    path: '/',
     headers: { accept: '*/*' }
   },
   function () {

--- a/test/instrumentation/modules/http/http-run-context.test.js
+++ b/test/instrumentation/modules/http/http-run-context.test.js
@@ -21,7 +21,7 @@ const cases = [
   {
     // Expect:
     //   transaction "t0"
-    //   `- span "GET httpstat.us"
+    //   `- span "GET www.google.com"
     //   `- span "span-sync-after-http.request"
     //   `- span "span-in-clientReq-on-socket"
     //   `- span "span-in-clientReq-on-finish"
@@ -49,7 +49,7 @@ const cases = [
         t.equal(e.span.parent_id, trans.id, `span ${e.span.name} is a child of the transaction`)
       })
       const spanGet = events.shift().span
-      t.equal(spanGet.name, 'GET httpstat.us')
+      t.equal(spanGet.name, 'GET www.google.com')
     }
   },
   {


### PR DESCRIPTION
This fixes a failing test due to a recent change in 'http://httpstat.us'
to no longer support http -- other than a redirect to https.


This change to `httpstat.us` https://github.com/Readify/httpstatus/commit/c23fb576fe17afbee2035a0b1cd4c735dc1e3cc9#diff-7aab2c6ec5099ca78c72cbed4417e12ea493ba35a898fbbf82faf930a49fd089R33
made it so that an *HTTP* request (rather than HTTPS) now just redirects to HTTPS rather than returning a response. This commit was made Dec 15th, and auto-deploys.

```
% curl -i http://httpstat.us/200
HTTP/1.1 301 Moved Permanently
Content-Type: text/html; charset=UTF-8
Location: https://httpstat.us/200
Date: Fri, 17 Dec 2021 18:14:22 GMT
Content-Length: 0

```

The test/instrumentation/modules/http/http-run-context.test.js test was using `http://httpstat.us/200` as a test endpoint. The new response has no body, so the expected spans has changed -- now no longer get a span for the 'data' event.

Switch to `http://www.google.com/` instead, which at least currently still returns an HTTP response with a body.