### PR TITLE
ci: avoid retagging official node images

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -17,7 +17,6 @@ if [ -x "$(command -v docker)" ]; then
       imageName="apm-agent-nodejs"
       registryImageName="docker.elastic.co/observability-ci/${imageName}:${transformedVersion}"
       (retry 2 docker pull "${registryImageName}")
-      docker tag "${registryImageName}" "node:${transformedVersion}"
   done
 fi
 


### PR DESCRIPTION
### What

No more tagging `apm-agent-nodejs` specific docker images to the official docker `node:version` images.

### Why

Since `node:X` can be consumed by different pipelines, we cannot use the retagging as long as the CI workers are not specific per project but per CI controller.

OTOH, https://github.com/elastic/apm-agent-nodejs/pull/1383 simplified the docker images and [`.ci/docker/node-container/Dockerfile`](https://github.com/elastic/apm-agent-nodejs/blob/master/.ci/docker/node-container/Dockerfile) is pretty much similar to the `node:X` version with the extra layer for the `node version` command.

### Issues

Relates https://github.com/elastic/ecs-logging-nodejs/issues/112


