### PR TITLE
tests: fix test failure due to os.freemem() behaviour change in node v18

### DIFF
--- a/test/metrics/index.test.js
+++ b/test/metrics/index.test.js
@@ -2,6 +2,7 @@
 
 const os = require('os')
 
+const semver = require('semver')
 const test = require('tape')
 
 const Metrics = require('../../lib/metrics')
@@ -73,10 +74,14 @@ test('reports expected metrics', function (t) {
       },
       'system.memory.actual.free': (value) => {
         const free = os.freemem()
-        if (os.type() === 'Linux') {
-          // On Linux we use MemAvailable from /proc/meminfo as the value for this metric
-          // The Node.js API os.freemem() is reporting MemFree from the same file
-          t.ok(value > free, `is larger than os.freemem() (value: ${value}, free: ${free})`)
+        if (os.type() === 'Linux' && semver.lt(process.version, '18.0.0-nightly20220107')) {
+          // On Linux we use "MemAvailable" from /proc/meminfo as the value for
+          // this metric. In versions of Node.js before v18.0.0, `os.freemem()`
+          // reports "MemFree" from /proc/meminfo. (This changed in
+          // v18.0.0-nightly20220107b6b6510187 when node upgraded to libuv
+          // 1.43.0 to include https://github.com/libuv/libuv/pull/3351.)
+          t.ok(value > free, `is larger than os.freemem() (value: ${value},
+          free: ${free})`)
         } else {
           t.ok(isRoughly(value, free, 0.1), `is close to current free memory (value: ${value}, free: ${free})`)
         }


### PR DESCRIPTION
Recent node v18 nightly builds changed the behaviour of os.freemem()
on Linux to report "MemAvailable" from /proc/meminfo rather than
"MemFree". This broke our tests.

The nightly "edge" tests started failing ~6-7 days ago with:

```
running test: cd . && node --unhandled-rejections=strict test/metrics/index.test.js > test_output/test-metrics-index.test.js.tap 2&>1
...
[2022-01-14T19:31:11.076Z] node_tests_1     | # system.memory.actual.free
[2022-01-14T19:31:11.076Z] node_tests_1     | ok 11 is present
[2022-01-14T19:31:11.076Z] node_tests_1     | ok 12 is a number
[2022-01-14T19:31:11.076Z] node_tests_1     | ok 13 is finite (was: 10925056000)
[2022-01-14T19:31:11.076Z] node_tests_1     | not ok 14 is larger than os.freemem() (value: 10925056000, free: 10925056000)
[2022-01-14T19:31:11.076Z] node_tests_1     |   ---
[2022-01-14T19:31:11.076Z] node_tests_1     |     operator: ok
[2022-01-14T19:31:11.076Z] node_tests_1     |     expected: true
[2022-01-14T19:31:11.076Z] node_tests_1     |     actual:   false
[2022-01-14T19:31:11.076Z] node_tests_1     |     at: Object.system.memory.actual.free (/app/test/metrics/index.test.js:79:13)
[2022-01-14T19:31:11.076Z] node_tests_1     |     stack: |-
[2022-01-14T19:31:11.076Z] node_tests_1     |       Error: is larger than os.freemem() (value: 10925056000, free: 10925056000)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at Test.assert [as _assert] (/app/node_modules/tape/lib/test.js:311:54)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at Test.bound [as _assert] (/app/node_modules/tape/lib/test.js:96:32)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at Test.assert (/app/node_modules/tape/lib/test.js:430:10)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at Test.bound [as ok] (/app/node_modules/tape/lib/test.js:96:32)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at Object.system.memory.actual.free (/app/test/metrics/index.test.js:79:13)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at Object.sendMetricSet (/app/test/metrics/index.test.js:137:20)
[2022-01-14T19:31:11.077Z] node_tests_1     |           at /app/lib/metrics/reporter.js:4:1202
[2022-01-14T19:31:11.077Z] node_tests_1     |           at /app/node_modules/after-all-results/index.js:20:25
[2022-01-14T19:31:11.077Z] node_tests_1     |           at processTicksAndRejections (node:internal/process/task_queues:78:11)
[2022-01-14T19:31:11.077Z] node_tests_1     |   ...
```

The breakage started in node nightly build "v18.0.0-nightly20220107b6b6510187".
The culprit node change was https://github.com/nodejs/node/pull/41398, which upgrades libuv, which brought in a change to `os.freemem()` on Linux: https://github.com/libuv/libuv/pull/3351

This broke an assumption in our tests.

