### PR TITLE
feat: align on 'unknown-{service.agent.name}-service' default service_name

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,25 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+* The default <<service-name, `serviceName`>> string (when it is not configured
+  and cannot be inferred from a "package.json" file) has been changed from
+  "nodejs_service" to "unknown-nodejs-service". This is a standardized pattern
+  used across Elastic APM agents to allow the Kibana APM app to recognize when
+  to provide help to the user on configuring the service name.
+  ({issues}2491[#2491])
+
+[float]
+===== Bug fixes
+
+
 [[release-notes-3.28.0]]
 ==== 3.27.0 2022/01/17
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -20,17 +20,17 @@ the agent will use the `name` from `package.json` by default if available.
 ==== `serviceName`
 
 * *Type:* String
-* *Default:* `name` field of `package.json`, or "nodejs_service"
+* *Default:* `name` field of `package.json`, or "unknown-nodejs-service"
 * *Env:* `ELASTIC_APM_SERVICE_NAME`
 
 The name to identify this service in Elastic APM. Multiple instances of the
 same service should use the same name.
 Allowed characters: `a-z`, `A-Z`, `0-9`, `-`, `_`, and space.
 
-If serviceName is not provided, the agent will attempt to use the "name" field
+If `serviceName` is not provided, the agent will attempt to use the "name" field
 from "package.json" -- looking up from the current working directory. The name
 will be normalized to the allowed characters. If the name cannot be inferred
-from package.json, then a fallback value of "nodejs_service" is used.
+from package.json, then a fallback value of "unknown-nodejs-service" is used.
 
 
 [float]

--- a/lib/config.js
+++ b/lib/config.js
@@ -315,14 +315,15 @@ class Config {
         this.serviceName = null
       }
     } else {
-      // Zero-conf support: use package.json#name, else // "nodejs_service".
+      // Zero-conf support: use package.json#name, else
+      // `unknown-${service.agent.name}-service`.
       try {
         this.serviceName = serviceNameFromPackageJson()
       } catch (err) {
         this.logger.warn(err.message)
       }
       if (!this.serviceName) {
-        this.serviceName = 'nodejs_service'
+        this.serviceName = 'unknown-nodejs-service'
       }
     }
     if (!this.serviceVersion) {
@@ -525,7 +526,8 @@ function serviceNameFromPackageJson () {
   serviceName = serviceName.replace(SERVICE_NAME_BAD_CHARS, '_')
 
   // Disallow some weird sanitized values. For example, it is better to
-  // have the fallback "nodejs_service" than "_" or "____" or " ".
+  // have the fallback "unknown-{service.agent.name}-service" than "_" or
+  // "____" or " ".
   const ALL_NON_ALPHANUMERIC = /^[ _-]*$/
   if (ALL_NON_ALPHANUMERIC.test(serviceName)) {
     serviceName = null

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -644,7 +644,8 @@ test('serviceName/serviceVersion zero-conf: no package.json to find', function (
     t.equal(stderr, '', 'no stderr')
     const lines = stdout.trim().split('\n')
     const conf = JSON.parse(lines[lines.length - 1])
-    t.equal(conf.serviceName, 'nodejs_service', 'serviceName is the "nodejs_service" zero-conf fallback')
+    t.equal(conf.serviceName, 'unknown-nodejs-service',
+      'serviceName is the `unknown-{service.agent.name}-service` zero-conf fallback')
     t.equal(conf.serviceVersion, undefined, 'serviceVersion is undefined')
     t.end()
   })
@@ -659,7 +660,8 @@ test('serviceName/serviceVersion zero-conf: no "name" in package.json', function
     t.equal(stderr, '', 'no stderr')
     const lines = stdout.trim().split('\n')
     const conf = JSON.parse(lines[lines.length - 1])
-    t.equal(conf.serviceName, 'nodejs_service', 'serviceName is the "nodejs_service" zero-conf fallback')
+    t.equal(conf.serviceName, 'unknown-nodejs-service',
+      'serviceName is the `unknown-{service.agent.name}-service` zero-conf fallback')
     t.equal(conf.serviceVersion, '1.2.3', 'serviceVersion was inferred from package.json')
     t.end()
   })
@@ -714,7 +716,8 @@ test('serviceName/serviceVersion zero-conf: weird "name" in package.json', funct
     t.ok(logWarn['log.level'] === 'warn' && logWarn.message.indexOf('serviceName') !== -1,
       'there is a log.warn about "serviceName"')
     const conf = JSON.parse(lines[lines.length - 1])
-    t.equal(conf.serviceName, 'nodejs_service', 'serviceName is the "nodejs_service" zero-conf fallback')
+    t.equal(conf.serviceName, 'unknown-nodejs-service',
+      'serviceName is the `unknown-{service.agent.name}-service` zero-conf fallback')
     t.equal(conf.serviceVersion, '1.2.3', 'serviceVersion was inferred from package.json')
     t.end()
   })


### PR DESCRIPTION
This updates the default `serviceName` value per APM spec -- allowing
APM UI to recognize when a service name wasn't configured for a given
service.

Closes: #2491

### Checklist

- [x] Implement code
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/master/CONTRIBUTING.md#commit-message-guidelines)
