### PR TITLE
feat: add error.transaction.name

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -146,6 +146,7 @@ function createAPMError (args, cb) {
   if (args.trans) {
     error.transaction_id = args.trans.id
     error.transaction = {
+      name: args.trans.name,
       type: args.trans.type,
       sampled: args.trans.sampled
     }

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -1523,13 +1523,16 @@ test('#captureError()', function (t) {
         t.equal(apmServer.events.length, 2, 'APM server got 2 events')
         assertMetadata(t, apmServer.events[0].metadata)
         const data = apmServer.events[1].error
-        t.strictEqual(data.exception.message, 'with callback')
-        t.strictEqual(data.id.length, 32, 'id is 32 characters')
-        t.strictEqual(data.parent_id, span.id, 'parent_id matches span id')
-        t.strictEqual(data.trace_id, trans.traceId, 'trace_id matches transaction trace id')
-        t.strictEqual(data.transaction_id, trans.id, 'transaction_id matches transaction id')
-        t.strictEqual(data.transaction.type, trans.type, 'transaction.type matches transaction type')
-        t.strictEqual(data.transaction.sampled, true, 'is sampled')
+        t.strictEqual(data.exception.message, 'with callback', 'error.exception.message')
+        t.strictEqual(data.id.length, 32, 'error.id is 32 characters')
+        t.strictEqual(data.parent_id, span.id, 'error.parent_id matches span id')
+        t.strictEqual(data.trace_id, trans.traceId, 'error.trace_id matches transaction trace id')
+        t.strictEqual(data.transaction_id, trans.id, 'error.transaction_id matches transaction id')
+        t.deepEqual(data.transaction, {
+          name: trans.name,
+          type: trans.type,
+          sampled: true
+        }, 'error.transaction.*')
 
         apmServer.clear()
         agent.destroy()


### PR DESCRIPTION
Add `transaction.name` to errors captured in the context of a
transaction. This allows APM UI to have fields used for transaction
grouping, which allows correlating error groups to transaction groups.

Closes: #2456

### Checklist

- [x] Implement code
- [x] Add tests
- [ ] Add CHANGELOG.asciidoc entry (I'm waiting for https://github.com/elastic/apm-agent-nodejs/pull/2538 to get merged first to avoid a merge conflict.)
- [ ] Sanity check that we don't need to only add `error.transaction.name` for recent APM Server versions. This was [added](https://github.com/elastic/apm-server/pull/6539) in APM Server 8.0.
