### PR TITLE
tests: fix test failure due to os.freemem() behaviour change in node v17.4.0

### DIFF
--- a/test/metrics/index.test.js
+++ b/test/metrics/index.test.js
@@ -74,12 +74,14 @@ test('reports expected metrics', function (t) {
       },
       'system.memory.actual.free': (value) => {
         const free = os.freemem()
-        if (os.type() === 'Linux' && semver.lt(process.version, '18.0.0-nightly20220107')) {
+        if (os.type() === 'Linux' &&
+          semver.lt(process.version, '18.0.0-nightly20220107') &&
+          semver.lt(process.version, '17.4.0')) {
           // On Linux we use "MemAvailable" from /proc/meminfo as the value for
-          // this metric. In versions of Node.js before v18.0.0, `os.freemem()`
-          // reports "MemFree" from /proc/meminfo. (This changed in
-          // v18.0.0-nightly20220107b6b6510187 when node upgraded to libuv
-          // 1.43.0 to include https://github.com/libuv/libuv/pull/3351.)
+          // this metric. In versions of Node.js before v17.4.0 and v18.0.0,
+          // `os.freemem()` reports "MemFree" from /proc/meminfo. (This changed
+          // in v17.4.0 and v18.0.0-nightly20220107b6b6510187 when node upgraded
+          // to libuv 1.43.0 to include https://github.com/libuv/libuv/pull/3351.)
           t.ok(value > free, `is larger than os.freemem() (value: ${value},
           free: ${free})`)
         } else {


### PR DESCRIPTION
The update to libuv 1.43.0 changed the behaviour of os.freemem() on
Linux to report "MemAvailable" from /proc/meminfo rather than "MemFree".

Refs: #2530


(Most test runs for all PRs will fail when testing against node v17 until this is merged in.)