### PR TITLE
[3.x] Doc link fixes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -354,7 +354,7 @@ still supported. Users should switch to using `longFieldMaxLength`. If
 now use the `longFieldMaxLength` value.
 +
 Note that ultimately the maximum length of any tracing field is limited by the
-{apm-guide-ref-v}/configuration-process.html#max_event_size[`max_event_size`]
+{apm-guide-ref}/configuration-process.html#max_event_size[`max_event_size`]
 configured for the receiving APM server.
 +
 The fields affected by `longFieldMaxLength` are:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -354,7 +354,7 @@ still supported. Users should switch to using `longFieldMaxLength`. If
 now use the `longFieldMaxLength` value.
 +
 Note that ultimately the maximum length of any tracing field is limited by the
-{apm-server-ref-v}/configuration-process.html#max_event_size[`max_event_size`]
+{apm-guide-ref-v}/configuration-process.html#max_event_size[`max_event_size`]
 configured for the receiving APM server.
 +
 The fields affected by `longFieldMaxLength` are:

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -104,7 +104,7 @@ containing the data about to be sent to the APM Server.
 
 The format of the payload depends on the event type being sent.
 For details about the different formats,
-see the {apm-server-ref-v}/intake-api.html[APM Server intake API documentation].
+see the {apm-guide-ref-v}/intake-api.html[APM Server intake API documentation].
 
 The filter function is synchronous and should return the manipulated payload object.
 If a filter function doesn't return any value or returns a falsy value,
@@ -164,7 +164,7 @@ but the `fn` will only be called with span payloads.
 [small]#Added in: v3.14.0#
 
 Use `addMetadataFilter(fn)` to supply a filter function for the
-{apm-server-ref-v}/metadata-api.html[metadata object]
+{apm-guide-ref-v}/metadata-api.html[metadata object]
 sent to the APM Server. This will allow you to manipulate the data being
 sent, for instance to remove possibly sensitive information.
 
@@ -184,7 +184,7 @@ apm.addMetadataFilter(function dropArgv(metadata) {
 
 Warning: It is the responsibility of the author to ensure the returned object
 conforms to the
-{apm-server-ref-v}/metadata-api.html#metadata-schema[metadata schema]
+{apm-guide-ref-v}/metadata-api.html#metadata-schema[metadata schema]
 otherwise all APM data injest will fail. A metadata filter that breaks the
 metadata will result in error logging from the agent, something like:
 
@@ -403,7 +403,7 @@ To ease debugging it's possible to send some extra data with each error you send
 The APM Server intake API supports a lot of different metadata fields,
 most of which are automatically managed by the Elastic APM Node.js Agent.
 But if you wish you can supply some extra details using `user` or `custom`.
-For more details on the properties accepted by the events intake API see the {apm-server-ref-v}/events-api.html[events intake API docs].
+For more details on the properties accepted by the events intake API see the {apm-guide-ref-v}/events-api.html[events intake API docs].
 
 To supply any of these extra fields,
 use the optional options argument when calling `apm.captureError()`.

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -104,7 +104,7 @@ containing the data about to be sent to the APM Server.
 
 The format of the payload depends on the event type being sent.
 For details about the different formats,
-see the {apm-guide-ref-v}/intake-api.html[APM Server intake API documentation].
+see the {apm-guide-ref}/intake-api.html[APM Server intake API documentation].
 
 The filter function is synchronous and should return the manipulated payload object.
 If a filter function doesn't return any value or returns a falsy value,
@@ -164,7 +164,7 @@ but the `fn` will only be called with span payloads.
 [small]#Added in: v3.14.0#
 
 Use `addMetadataFilter(fn)` to supply a filter function for the
-{apm-guide-ref-v}/metadata-api.html[metadata object]
+{apm-guide-ref}/metadata-api.html[metadata object]
 sent to the APM Server. This will allow you to manipulate the data being
 sent, for instance to remove possibly sensitive information.
 
@@ -184,7 +184,7 @@ apm.addMetadataFilter(function dropArgv(metadata) {
 
 Warning: It is the responsibility of the author to ensure the returned object
 conforms to the
-{apm-guide-ref-v}/metadata-api.html#metadata-schema[metadata schema]
+{apm-guide-ref}/metadata-api.html#metadata-schema[metadata schema]
 otherwise all APM data injest will fail. A metadata filter that breaks the
 metadata will result in error logging from the agent, something like:
 
@@ -403,7 +403,7 @@ To ease debugging it's possible to send some extra data with each error you send
 The APM Server intake API supports a lot of different metadata fields,
 most of which are automatically managed by the Elastic APM Node.js Agent.
 But if you wish you can supply some extra details using `user` or `custom`.
-For more details on the properties accepted by the events intake API see the {apm-guide-ref-v}/events-api.html[events intake API docs].
+For more details on the properties accepted by the events intake API see the {apm-guide-ref}/events-api.html[events intake API docs].
 
 To supply any of these extra fields,
 use the optional options argument when calling `apm.captureError()`.

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -250,7 +250,7 @@ the context from the active transaction is used as context for the captured erro
 and any custom context given as the 2nd argument to <<apm-capture-error,`apm.captureError`>> takes precedence and is shallow merged on top.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 [[apm-set-label]]
 ==== `apm.setLabel(name, value[, stringify = true])`
@@ -275,7 +275,7 @@ it will also get tagged with the same label.
 TIP: Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable
 (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
@@ -305,7 +305,7 @@ it will also get tagged with the same labels.
 TIP: Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable
 (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -63,7 +63,7 @@ The secret token optionally expected by the APM Server.
 
 The API key optionally expected by the APM Server. This is an alternative to `secretToken`.
 
-This base64-encoded string is used to ensure that only your agents can send data to your APM server. You must have created the API key using the APM server command line tool. Please see the {apm-server-ref}/api-key.html[APM server documentation] for details on how to do that.
+This base64-encoded string is used to ensure that only your agents can send data to your APM server. You must have created the API key using the APM server command line tool. Please see the {apm-guide-ref}/api-key.html[APM server documentation] for details on how to do that.
 
 NOTE: This feature is fully supported in the APM Server versions >= 7.6.
 
@@ -752,7 +752,7 @@ number of unicode characters before being sent to APM server:
   value takes precedence for these error message fields.
 
 Note that tracing data is limited at the upstream APM server to
-{apm-server-ref-v}/configuration-process.html#max_event_size[`max_event_size`],
+{apm-guide-ref-v}/configuration-process.html#max_event_size[`max_event_size`],
 which defaults to 300kB. If you configure `longFieldMaxLength` too large, it
 could result in transactions, spans, or errors that are rejected by APM server.
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -752,7 +752,7 @@ number of unicode characters before being sent to APM server:
   value takes precedence for these error message fields.
 
 Note that tracing data is limited at the upstream APM server to
-{apm-guide-ref-v}/configuration-process.html#max_event_size[`max_event_size`],
+{apm-guide-ref}/configuration-process.html#max_event_size[`max_event_size`],
 which defaults to 300kB. If you configure `longFieldMaxLength` too large, it
 could result in transactions, spans, or errors that are rejected by APM server.
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -30,6 +30,6 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,5 +31,5 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 === Additional Components
 
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -30,6 +30,6 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
 The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -19,9 +19,9 @@ Using your favorite logging framework, you'd then need to inject this informatio
 When your logs contain the appropriate identifiers, the final step is to ingest them into the same
 Elasticsearch instance that contains your APM data. See
 ifeval::["{branch}"=="7.16"]
-{apm-overview-ref-v}/log-correlation.html#_ingest_your_logs_into_elasticsearch[Ingest your logs into Elasticsearch]
+{apm-guide-ref}/log-correlation.html#_ingest_your_logs_into_elasticsearch[Ingest your logs into Elasticsearch]
 endif::[]
 ifeval::["{branch}"!="7.16"]
-{apm-overview-ref-v}/observability-integrations.html#_ingest_your_logs_into_elasticsearch[Ingest your logs into Elasticsearch]
+{apm-guide-ref}/observability-integrations.html#_ingest_your_logs_into_elasticsearch[Ingest your logs into Elasticsearch]
 endif::[]
 for more information.

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -33,7 +33,7 @@ npm install elastic-apm-node elastic-apm-node-opentracing --save
 [[ot-terminologies]]
 === OpenTracing vs Elastic APM terminologies
 
-Elastic APM differentiates between {apm-overview-ref-v}/transactions.html[transactions] and {apm-overview-ref-v}/transaction-spans.html[spans].
+Elastic APM differentiates between {apm-guide-ref}/transactions.html[transactions] and {apm-guide-ref}/transaction-spans.html[spans].
 In the context of OpenTracing, a transaction can be thought of as a special kind of span.
 
 Because OpenTracing natively only has the concept of spans,
@@ -163,7 +163,7 @@ Baggage items are silently dropped.
 
 Only error logging is supported.
 Logging an Error object on the OpenTracing span will create an Elastic APM
-{apm-overview-ref-v}/errors.html[error].
+{apm-guide-ref}/errors.html[error].
 Example:
 
 [source,js]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -22,7 +22,7 @@ that not all core Node.js API's can be instrumented without the use of Async Hoo
 [[elastic-stack-compatibility]]
 === Elastic Stack Compatibility
 
-This agent is compatible with {apm-server-ref-v}[APM Server] v6.5 and above.
+This agent is compatible with {apm-guide-ref-v}[APM Server] v6.5 and above.
 For support for previous releases of the APM Server,
 use version {apm-node-ref-1x}[1.x] of the agent.
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -22,7 +22,7 @@ that not all core Node.js API's can be instrumented without the use of Async Hoo
 [[elastic-stack-compatibility]]
 === Elastic Stack Compatibility
 
-This agent is compatible with {apm-guide-ref-v}[APM Server] v6.5 and above.
+This agent is compatible with {apm-guide-ref}[APM Server] v6.5 and above.
 For support for previous releases of the APM Server,
 use version {apm-node-ref-1x}[1.x] of the agent.
 


### PR DESCRIPTION
Backports the relevant changes in https://github.com/elastic/apm-agent-nodejs/pull/2541 to 3.x.