### PR TITLE
feat: Drop unsampled transactions when connected to APM Server 8.0+

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,8 @@ Notes:
 [float]
 ===== Features
 
+* Drop unsampled transactions when sending to APM Server v8.0+. ({issues}2455[#2455])
+
 * The default <<service-name, `serviceName`>> string (when it is not configured
   and cannot be inferred from a "package.json" file) has been changed from
   "nodejs_service" to "unknown-nodejs-service". This is a standardized pattern

--- a/lib/config.js
+++ b/lib/config.js
@@ -925,9 +925,10 @@ function getBaseClientConfig (conf, agent) {
     time: conf.apiRequestTime * 1000,
     maxQueueSize: conf.maxQueueSize,
 
-    // Debugging
+    // Debugging/testing options
     logger: clientLogger,
     payloadLogFile: conf.payloadLogFile,
+    apmServerVersion: conf.apmServerVersion,
 
     // Container conf
     containerId: conf.containerId,

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -281,6 +281,11 @@ Instrumentation.prototype.addEndedTransaction = function (transaction) {
     return
   }
 
+  // https://github.com/elastic/apm/blob/main/specs/agents/tracing-sampling.md#non-sampled-transactions
+  if (!transaction.sampled && !agent._transport.supportsKeepingUnsampledTransaction()) {
+    return
+  }
+
   var payload = agent._transactionFilters.process(transaction._encode())
   if (!payload) {
     agent.logger.debug('transaction ignored by filter %o', { trans: transaction.id, trace: transaction.traceId })

--- a/lib/noop-transport.js
+++ b/lib/noop-transport.js
@@ -43,6 +43,10 @@ class NoopTransport {
     }
   }
 
+  supportsKeepingUnsampledTransaction () {
+    return false // Default to the behavior for APM Server >=8.0.
+  }
+
   // Inherited from Writable, called in agent.js.
   destroy () {}
 }

--- a/lib/noop-transport.js
+++ b/lib/noop-transport.js
@@ -44,7 +44,7 @@ class NoopTransport {
   }
 
   supportsKeepingUnsampledTransaction () {
-    return false // Default to the behavior for APM Server >=8.0.
+    return true
   }
 
   // Inherited from Writable, called in agent.js.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "url": "https://github.com/elastic/apm-agent-nodejs/issues"
   },
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
+  "XXX elastic-apm-http-client": "^10.4.0",
   "dependencies": {
     "@elastic/ecs-pino-format": "^1.2.0",
     "after-all-results": "^2.0.0",
@@ -86,7 +87,7 @@
     "basic-auth": "^2.0.1",
     "cookie": "^0.4.0",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "^10.3.0",
+    "elastic-apm-http-client": "file:../apm-nodejs-http-client4",
     "end-of-stream": "^1.4.4",
     "error-callsites": "^2.0.4",
     "error-stack-parser": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "basic-auth": "^2.0.1",
     "cookie": "^0.4.0",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "file:../apm-nodejs-http-client4",
+    "elastic-apm-http-client": "elastic/apm-nodejs-http-client#trentm/issue2455-drop-unsampled-trans",
     "end-of-stream": "^1.4.4",
     "error-callsites": "^2.0.4",
     "error-stack-parser": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "url": "https://github.com/elastic/apm-agent-nodejs/issues"
   },
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
-  "XXX elastic-apm-http-client": "^10.4.0",
   "dependencies": {
     "@elastic/ecs-pino-format": "^1.2.0",
     "after-all-results": "^2.0.0",
@@ -87,7 +86,7 @@
     "basic-auth": "^2.0.1",
     "cookie": "^0.4.0",
     "core-util-is": "^1.0.2",
-    "elastic-apm-http-client": "elastic/apm-nodejs-http-client#trentm/issue2455-drop-unsampled-trans",
+    "elastic-apm-http-client": "^10.4.0",
     "end-of-stream": "^1.4.4",
     "error-callsites": "^2.0.4",
     "error-stack-parser": "^2.0.6",

--- a/test/_capturing_transport.js
+++ b/test/_capturing_transport.js
@@ -78,7 +78,7 @@ class CapturingTransport {
   }
 
   supportsKeepingUnsampledTransaction () {
-    return false
+    return true
   }
 
   // Inherited from Writable, called in agent.js.

--- a/test/_capturing_transport.js
+++ b/test/_capturing_transport.js
@@ -77,6 +77,10 @@ class CapturingTransport {
     }
   }
 
+  supportsKeepingUnsampledTransaction () {
+    return false
+  }
+
   // Inherited from Writable, called in agent.js.
   destroy () {}
 }

--- a/test/_mock_http_client.js
+++ b/test/_mock_http_client.js
@@ -56,7 +56,7 @@ module.exports = function (expected, done) {
       if (cb) process.nextTick(cb)
     },
     supportsKeepingUnsampledTransaction () {
-      return false
+      return true
     }
   }
 

--- a/test/_mock_http_client.js
+++ b/test/_mock_http_client.js
@@ -54,6 +54,9 @@ module.exports = function (expected, done) {
     },
     flush (cb) {
       if (cb) process.nextTick(cb)
+    },
+    supportsKeepingUnsampledTransaction () {
+      return false
     }
   }
 

--- a/test/_mock_http_client_states.js
+++ b/test/_mock_http_client_states.js
@@ -35,6 +35,9 @@ module.exports = function (expectations = [], done) {
     },
     flush (cb) {
       if (cb) process.nextTick(cb)
+    },
+    supportsKeepingUnsampledTransaction () {
+      return false
     }
   }
 }

--- a/test/_mock_http_client_states.js
+++ b/test/_mock_http_client_states.js
@@ -37,7 +37,7 @@ module.exports = function (expectations = [], done) {
       if (cb) process.nextTick(cb)
     },
     supportsKeepingUnsampledTransaction () {
-      return false
+      return true
     }
   }
 }

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -553,7 +553,12 @@ test('filters', function (t) {
       filterAgentOpts = Object.assign(
         {},
         agentOpts,
-        { serverUrl }
+        {
+          serverUrl,
+          // Ensure the APM client's `GET /` requests do not get in the way of
+          // the test asserts below.
+          apmServerVersion: '8.0.0'
+        }
       )
       t.end()
     })

--- a/test/central-config-enabled.test.js
+++ b/test/central-config-enabled.test.js
@@ -46,6 +46,7 @@ const runTestsWithServer = (t, updates, expect) => {
       serviceName: 'test',
       logLevel: 'off', // silence for cleaner test output
       captureExceptions: false,
+      apmServerVersion: '8.0.0',
       metricsInterval: 0,
       centralConfig: true
     })
@@ -159,6 +160,7 @@ test('agent.logger updates for central config `log_level` change', { timeout: 10
       serverUrl: 'http://localhost:' + server.address().port,
       serviceName: 'test',
       captureExceptions: false,
+      apmServerVersion: '8.0.0',
       metricsInterval: 0,
       centralConfig: true,
       logLevel: 'warn'
@@ -207,6 +209,7 @@ test('central config change does not erroneously update cloudProvider', { timeou
       cloudProvider: 'aws',
       // These settings to reduce some agent activity:
       captureExceptions: false,
+      apmServerVersion: '8.0.0',
       metricsInterval: 0
     })
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -934,6 +934,10 @@ test('custom transport', function (t) {
     flush (cb) {
       if (cb) setImmediate(cb)
     }
+
+    supportsKeepingUnsampledTransaction () {
+      return false
+    }
   }
   const myTransport = new MyTransport()
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -936,7 +936,7 @@ test('custom transport', function (t) {
     }
 
     supportsKeepingUnsampledTransaction () {
-      return false
+      return true
     }
   }
   const myTransport = new MyTransport()

--- a/test/fixtures/do-not-trace-self.js
+++ b/test/fixtures/do-not-trace-self.js
@@ -4,6 +4,7 @@
 var apm = require('../../').start({ // elastic-apm-node
   serviceName: 'test-do-not-trace-self',
   metricsInterval: 0,
+  apmServerVersion: '8.0.0',
   cloudProvider: 'none',
   centralConfig: false
 })

--- a/test/instrumentation/index.test.js
+++ b/test/instrumentation/index.test.js
@@ -15,9 +15,7 @@ var http = require('http')
 
 var test = require('tape')
 
-const logging = require('../../lib/logging')
 var mockClient = require('../_mock_http_client')
-var Instrumentation = require('../../lib/instrumentation')
 var findObjInArray = require('../_utils').findObjInArray
 
 var origCaptureError = agent.captureError
@@ -248,87 +246,6 @@ test('captureError should handle opts.captureAttributes', function (t) {
   var ex2 = new Error('ex2')
   ex2.theProperty = 'this is the property'
   agent.captureError(ex2, { captureAttributes: false })
-})
-
-test('sampling', function (t) {
-  function generateSamples (rate, count) {
-    count = count || 1000
-    var agent = {
-      _conf: {
-        transactionSampleRate: rate
-      },
-      logger: logging.createLogger('off')
-    }
-    var ins = new Instrumentation(agent)
-    agent._instrumentation = ins
-
-    var results = {
-      count: count,
-      sampled: 0,
-      unsampled: 0
-    }
-    for (var i = 0; i < count; i++) {
-      var trans = ins.startTransaction()
-      if (trans && trans.sampled) {
-        results.sampled++
-      } else {
-        results.unsampled++
-      }
-    }
-
-    return results
-  }
-
-  function toRatios (samples) {
-    return {
-      count: samples.count,
-      sampled: samples.sampled / samples.count,
-      unsampled: samples.unsampled / samples.count
-    }
-  }
-
-  var high = generateSamples(1.0)
-  t.ok(high.sampled > high.unsampled)
-
-  var low = generateSamples(0.1)
-  t.ok(low.sampled < low.unsampled)
-
-  var mid = toRatios(generateSamples(0.5))
-  t.ok(mid.sampled > 0.4 && mid.sampled < 0.6)
-  t.ok(mid.unsampled > 0.4 && mid.unsampled < 0.6)
-
-  t.end()
-})
-
-test('unsampled transactions do not include spans', function (t) {
-  resetAgent(1, function (data, cb) {
-    t.strictEqual(data.transactions.length, 1)
-
-    data.transactions.forEach(function (trans) {
-      t.ok(/^[\da-f]{16}$/.test(trans.id))
-      t.ok(/^[\da-f]{32}$/.test(trans.trace_id))
-      t.ok(trans.duration > 0, 'duration should be >0ms')
-      t.ok(trans.duration < 100, 'duration should be <100ms')
-      t.notOk(Number.isNaN((new Date(trans.timestamp)).getTime()))
-      t.strictEqual(trans.sampled, false)
-    })
-
-    t.end()
-  })
-
-  agent._conf.transactionSampleRate = 0.0
-  var ins = agent._instrumentation
-
-  var trans = ins.startTransaction()
-  var span = ins.startSpan('span 0', 'type')
-  process.nextTick(function () {
-    if (span) span.end()
-    span = ins.startSpan('span 1', 'type')
-    process.nextTick(function () {
-      if (span) span.end()
-      trans.end()
-    })
-  })
 })
 
 test('unsampled request transactions should have the correct result', function (t) {

--- a/test/instrumentation/index.test.js
+++ b/test/instrumentation/index.test.js
@@ -249,6 +249,8 @@ test('captureError should handle opts.captureAttributes', function (t) {
 })
 
 test('unsampled request transactions should have the correct result', function (t) {
+  // This test is relying on `resetAgent` creating an `agent._transaction`
+  // that returns true from `.supportsKeepingUnsampledTransaction()`.
   resetAgent(1, function (data) {
     t.strictEqual(data.transactions.length, 1)
 

--- a/test/integration/allow-invalid-cert.test.js
+++ b/test/integration/allow-invalid-cert.test.js
@@ -10,6 +10,7 @@ getPort().then(function (port) {
     metricsInterval: 0,
     centralConfig: false,
     apmServerVersion: '8.0.0',
+    disableInstrumentations: ['https'], // avoid the agent instrumenting the mock APM Server
     verifyServerCert: false
   })
 

--- a/test/integration/allow-invalid-cert.test.js
+++ b/test/integration/allow-invalid-cert.test.js
@@ -4,12 +4,12 @@ var getPort = require('get-port')
 
 getPort().then(function (port) {
   var agent = require('../../').start({
-    serviceName: 'test',
+    serviceName: 'test-allow-invalid-cert',
     serverUrl: 'https://localhost:' + port,
     captureExceptions: false,
     metricsInterval: 0,
     centralConfig: false,
-    disableInstrumentations: ['https'], // avoid the agent instrumenting the mock APM Server
+    apmServerVersion: '8.0.0',
     verifyServerCert: false
   })
 
@@ -27,7 +27,7 @@ getPort().then(function (port) {
 
     server.listen(port, function () {
       agent.captureError(new Error('boom!'), function (err) {
-        t.error(err)
+        t.error(err, 'no error in captureError')
         t.pass('agent.captureError callback called')
         server.close()
         agent.destroy()

--- a/test/integration/api-schema/basic.test.js
+++ b/test/integration/api-schema/basic.test.js
@@ -244,6 +244,7 @@ function newAgent (server) {
     serverUrl: 'http://localhost:' + server.address().port,
     captureExceptions: false,
     disableInstrumentations: ['http'],
+    apmServerVersion: '8.0.0',
     metricsInterval: 0,
     centralConfig: false
   })

--- a/test/integration/api-schema/capture-error-log-stack-traces.test.js
+++ b/test/integration/api-schema/capture-error-log-stack-traces.test.js
@@ -73,6 +73,7 @@ function newAgent (server) {
     disableInstrumentations: ['http'],
     captureErrorLogStackTraces: true,
     metricsInterval: 0,
+    apmServerVersion: '8.0.0',
     centralConfig: false
   })
 }

--- a/test/integration/api-schema/capture-span-stack-traces.test.js
+++ b/test/integration/api-schema/capture-span-stack-traces.test.js
@@ -69,6 +69,7 @@ function newAgent (server) {
     captureExceptions: false,
     disableInstrumentations: ['http'],
     captureSpanStackTraces: false,
+    apmServerVersion: '8.0.0',
     metricsInterval: 0,
     centralConfig: false
   })

--- a/test/integration/api-schema/source-lines-error-frames.test.js
+++ b/test/integration/api-schema/source-lines-error-frames.test.js
@@ -73,6 +73,7 @@ function newAgent (server) {
     disableInstrumentations: ['http'],
     sourceLinesErrorAppFrames: 0,
     sourceLinesErrorLibraryFrames: 0,
+    apmServerVersion: '8.0.0',
     metricsInterval: 0,
     centralConfig: false
   })

--- a/test/integration/api-schema/source-lines-span-frames.test.js
+++ b/test/integration/api-schema/source-lines-span-frames.test.js
@@ -70,6 +70,7 @@ function newAgent (server) {
     disableInstrumentations: ['http'],
     sourceLinesSpanAppFrames: 5,
     sourceLinesSpanLibraryFrames: 5,
+    apmServerVersion: '8.0.0',
     metricsInterval: 0,
     centralConfig: false
   })

--- a/test/integration/no-sampling.test.js
+++ b/test/integration/no-sampling.test.js
@@ -5,12 +5,12 @@ var ndjson = require('ndjson')
 
 getPort().then(function (port) {
   var agent = require('../../').start({
-    serviceName: 'test',
+    serviceName: 'test-no-sampling',
     serverUrl: 'http://localhost:' + port,
     captureExceptions: false,
     metricsInterval: 0,
     centralConfig: false,
-    disableInstrumentations: ['http'], // avoid the agent instrumenting the mock APM Server
+    apmServerVersion: '8.0.0',
     apiRequestTime: '1s'
   })
 

--- a/test/integration/no-sampling.test.js
+++ b/test/integration/no-sampling.test.js
@@ -11,6 +11,7 @@ getPort().then(function (port) {
     metricsInterval: 0,
     centralConfig: false,
     apmServerVersion: '8.0.0',
+    disableInstrumentations: ['http'], // avoid the agent instrumenting the mock APM Server
     apiRequestTime: '1s'
   })
 

--- a/test/integration/server-url-path.test.js
+++ b/test/integration/server-url-path.test.js
@@ -9,6 +9,7 @@ getPort().then(function (port) {
     captureExceptions: false,
     metricsInterval: 0,
     centralConfig: false,
+    apmServerVersion: '8.0.0',
     disableInstrumentations: ['http'] // avoid the agent instrumenting the mock APM Server
   })
 

--- a/test/integration/skip-internal-http-spans.test.js
+++ b/test/integration/skip-internal-http-spans.test.js
@@ -10,6 +10,7 @@ getPort().then(port => {
     serverUrl: 'http://localhost:' + port,
     captureExceptions: false,
     metricsInterval: 0,
+    apmServerVersion: '8.0.0',
     centralConfig: false
   })
 

--- a/test/integration/socket-close.test.js
+++ b/test/integration/socket-close.test.js
@@ -9,6 +9,7 @@ getPort().then(function (port) {
     captureExceptions: false,
     metricsInterval: 0,
     centralConfig: false,
+    apmServerVersion: '8.0.0',
     disableInstrumentations: ['http'] // avoid the agent instrumenting the mock APM Server
   })
 

--- a/test/integration/verify-server-ca-cert.test.js
+++ b/test/integration/verify-server-ca-cert.test.js
@@ -12,6 +12,7 @@ getPort().then(function (port) {
     captureExceptions: false,
     metricsInterval: 0,
     centralConfig: false,
+    apmServerVersion: '8.0.0',
     disableInstrumentations: ['https'], // avoid the agent instrumenting the mock APM Server
     serverCaCertFile: path.join(__dirname, 'cert.pem') // self-signed certificate
   })

--- a/test/outcome.test.js
+++ b/test/outcome.test.js
@@ -14,7 +14,7 @@ const noOpClient = {
   sendError () {},
   sendMetricSet () {},
   flush () {},
-  supportsKeepingUnsampledTransaction () { return false }
+  supportsKeepingUnsampledTransaction () { return true }
 }
 agent._transport = noOpClient
 

--- a/test/outcome.test.js
+++ b/test/outcome.test.js
@@ -13,7 +13,8 @@ const noOpClient = {
   sendTransaction () {},
   sendError () {},
   sendMetricSet () {},
-  flush () {}
+  flush () {},
+  supportsKeepingUnsampledTransaction () { return false }
 }
 agent._transport = noOpClient
 

--- a/test/transaction-sampling.test.js
+++ b/test/transaction-sampling.test.js
@@ -1,0 +1,189 @@
+'use strict'
+
+// Test agent behavior with Transaction sampling.
+
+const tape = require('tape')
+
+const Agent = require('../lib/agent')
+const { MockAPMServer } = require('./_mock_apm_server')
+
+const testAgentOpts = {
+  serviceName: 'test-transaction-sampling',
+  cloudProvider: 'none',
+  centralConfig: false,
+  captureExceptions: false,
+  captureSpanStackTraces: false,
+  metricsInterval: '0s',
+  logLevel: 'off'
+}
+
+// ---- tests
+
+tape.test('various transactionSampleRate values', function (t) {
+  function startNTransactions (rate, count) {
+    const agent = new Agent().start(Object.assign(
+      {},
+      testAgentOpts,
+      {
+        disableSend: true,
+        transactionSampleRate: rate
+      }
+    ))
+
+    var results = {
+      count: count,
+      numSampled: 0,
+      numUnsampled: 0
+    }
+    for (var i = 0; i < count; i++) {
+      var trans = agent.startTransaction('myTrans')
+      if (trans && trans.sampled) {
+        results.numSampled++
+      } else {
+        results.numUnsampled++
+      }
+      trans.end()
+    }
+
+    agent.destroy()
+    return results
+  }
+
+  let results = startNTransactions(1.0, 1000)
+  t.equal(results.numSampled, results.count,
+    'with transactionSampleRate=1.0, all transactions were sampled')
+  t.equal(results.numUnsampled, 0)
+
+  results = startNTransactions(0.1, 1000)
+  t.ok(Math.abs(results.numSampled / results.count - 0.1) < 0.1, // within 10% of expected 10%
+    'with transactionSampleRate=0.1, ~10% transactions were sampled: ' + JSON.stringify(results))
+
+  results = startNTransactions(0.5, 1000)
+  t.ok(Math.abs(results.numSampled / results.count - 0.5) < 0.1, // within 10% of expected 50%
+    'with transactionSampleRate=0.5, ~50% of transactions were sampled: ' + JSON.stringify(results))
+
+  t.end()
+})
+
+tape.test('APM Server <v8.0 (which requires unsampled transactions)', function (suite) {
+  let apmServer
+  let serverUrl
+
+  suite.test('setup mock APM server', function (t) {
+    apmServer = new MockAPMServer({ apmServerVersion: '7.15.0' })
+    apmServer.start(function (serverUrl_) {
+      serverUrl = serverUrl_
+      t.comment('mock APM serverUrl: ' + serverUrl)
+      t.end()
+    })
+  })
+
+  suite.test('unsampled transactions do not include spans', function (t) {
+    apmServer.clear()
+    const agent = new Agent().start(Object.assign(
+      {},
+      testAgentOpts,
+      {
+        serverUrl,
+        transactionSampleRate: 0
+      }
+    ))
+
+    // Start and end a transaction with some spans.
+    var t0 = agent.startTransaction('t0')
+    var s0 = agent.startSpan('s0', 'type')
+    process.nextTick(function () {
+      if (s0) s0.end()
+      var s1 = agent.startSpan('s1', 'type')
+      t.ok(s1 === null, 'no span should be started for an unsampled transaction')
+      process.nextTick(function () {
+        if (s1) s1.end()
+        t0.end()
+
+        agent.flush(function () {
+          // Assert that the transaction was sent, but no spans.
+          t.equal(apmServer.events.length, 2)
+          var trans = apmServer.events[1].transaction
+          t.equal(trans.name, 't0')
+          t.equal(trans.sampled, false, 'trans.sampled is false')
+          t.equal(trans.sample_rate, 0, 'trans.sample_rate')
+          t.equal(trans.context, undefined, 'no trans.context')
+
+          agent.destroy()
+          t.end()
+        })
+      })
+    })
+  })
+
+  suite.test('teardown mock APM server', function (t) {
+    apmServer.close()
+    t.end()
+  })
+
+  suite.end()
+})
+
+tape.test('APM Server >=v8.0 (which does not want unsampled transactions)', function (suite) {
+  let agent
+  let apmServer
+  let serverUrl
+
+  suite.test('setup mock APM server', function (t) {
+    apmServer = new MockAPMServer({ apmServerVersion: '8.0.0' })
+    apmServer.start(function (serverUrl_) {
+      serverUrl = serverUrl_
+      t.comment('mock APM serverUrl: ' + serverUrl)
+      t.end()
+    })
+  })
+
+  suite.test('setup agent and wait for APM Server version fetch', function (t) {
+    agent = new Agent().start(Object.assign(
+      {},
+      testAgentOpts,
+      {
+        serverUrl,
+        transactionSampleRate: 0
+      }
+    ))
+
+    // The agent's internal usage of client.supportsKeepingUnsampledTransaction()
+    // is the behavior being tested. That depends on the APM client having time
+    // to fetch the APM Server version before processing our test transaction.
+    // There isn't a mechanism exposed to wait for this, so we just wait a short
+    // while and poke into the internal APM client props.
+    setTimeout(function () {
+      t.ok(agent._transport._apmServerVersion, 'the agent APM client has fetched the APM Server version')
+      t.end()
+    }, 1000)
+  })
+
+  suite.test('unsampled transactions are not sent', function (t) {
+    // Start and end a transaction with some spans.
+    var t0 = agent.startTransaction('t0')
+    var s0 = agent.startSpan('s0', 'type')
+    process.nextTick(function () {
+      if (s0) s0.end()
+      var s1 = agent.startSpan('s1', 'type')
+      t.ok(s1 === null, 'no span should be started for an unsampled transaction')
+      process.nextTick(function () {
+        if (s1) s1.end()
+        t0.end()
+
+        agent.flush(function () {
+          t.equal(apmServer.events.length, 0, 'no events were set to APM Server')
+          t.end()
+        })
+      })
+    })
+  })
+
+  suite.test('teardown mock APM server', function (t) {
+    agent.destroy()
+    apmServer.close()
+    t.end()
+  })
+
+  suite.end()
+})


### PR DESCRIPTION
This updates to an elastic-apm-http-client that calls the APM Server
Information API on creation to get the APM Server version.

Closes: #2455


### Checklist

- [x] Update to `"elastic-apm-http-client": "^10.4.0"` when https://github.com/elastic/apm-nodejs-http-client/pull/176 is merged and published.
- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
