### PR TITLE
feat, docs: support mongoose >=5.7.0 <7

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -157,6 +157,7 @@ so those should be supported as well.
 |https://www.npmjs.com/package/mongodb[mongodb] |>=3.3.0 <6 |Will instrument all queries
 |https://www.npmjs.com/package/mongojs[mongojs] |>=1.0.0 <2.7.0 |Supported via mongodb-core
 |https://www.npmjs.com/package/mongoose[mongoose] |>=4.0.0 <5.7.0 |Supported via mongodb-core
+|https://www.npmjs.com/package/mongoose[mongoose] |>=5.7.0 <7 |Supported via mongodb
 |https://www.npmjs.com/package/mysql[mysql] |^2.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <4.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries

--- a/examples/trace-mongoose.js
+++ b/examples/trace-mongoose.js
@@ -1,0 +1,54 @@
+// A small example showing Elastic APM tracing the 'mongoose' package.
+//
+// This assumes a MongoDB server running on localhost. You can use:
+//    npm run docker:start mongodb
+// to start a MongoDB docker container. Then `npm run docker:stop` to stop it.
+//
+// Some of the following code is adapted from
+// https://github.com/Automattic/mongoose/tree/master/examples/statics
+
+const apm = require('../').start({ // elastic-apm-node
+  serviceName: 'example-trace-mongoose',
+  logUncaughtExceptions: true
+})
+
+const mongoose = require('mongoose')
+
+const DB_URL = 'mongodb://localhost:27017/example-trace-mongoose'
+
+// Define a schema.
+const PersonSchema = new mongoose.Schema({
+  name: String,
+  age: Number,
+  birthday: Date
+})
+mongoose.model('Person', PersonSchema)
+
+async function run () {
+  // For tracing spans to be created, there must be an active transaction.
+  // Typically, a transaction is automatically started for incoming HTTP
+  // requests to a Node.js server. However, because this script is not running
+  // an HTTP server, we manually start a transaction. More details at:
+  // https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
+  const t1 = apm.startTransaction('t1')
+
+  const Person = mongoose.model('Person')
+  await mongoose.connect(DB_URL)
+
+  const bill = await Person.create({
+    name: 'bill',
+    age: 25,
+    birthday: new Date().setFullYear((new Date().getFullYear() - 25))
+  })
+  console.log('Person added to db: %s', bill)
+
+  const result = await Person.find({})
+  console.log('find result:', result)
+
+  // Cleanup.
+  await Person.deleteMany()
+  await mongoose.disconnect()
+  t1.end()
+}
+
+run()

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "mkdirp": "^0.5.1",
         "mongodb": "^5.1.0",
         "mongodb-core": "^3.2.7",
+        "mongoose": "^7.2.2",
         "mysql": "^2.18.1",
         "mysql2": "^3.2.4",
         "ndjson": "^1.5.0",
@@ -6796,9 +6797,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
-      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
       "dev": true,
       "engines": {
         "node": ">=14.20.1"
@@ -11638,6 +11639,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -12394,12 +12404,12 @@
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
     "node_modules/mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.5.0.tgz",
+      "integrity": "sha512-XgrkUgAAdfnZKQfk5AsYL8j7O99WHd4YXPxYxnh8dZxD+ekYWFRA3JktUsBnfg+455Smf75/+asoU/YLwNGoQQ==",
       "dev": true,
       "dependencies": {
-        "bson": "^5.0.1",
+        "bson": "^5.3.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -12411,7 +12421,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
-        "mongodb-client-encryption": "^2.3.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
@@ -12493,10 +12503,59 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/mongoose": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.2.tgz",
+      "integrity": "sha512-JPBMTF+oYfLGVFWbHSZ/H+f1GajNanGLYH6c/P0nE3bNJfwGhX573vieGR0kNlNhj3cZk8WCPrnVsTNeUmFUag==",
+      "dev": true,
+      "dependencies": {
+        "bson": "^5.3.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.5.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
     "node_modules/monitor-event-loop-delay": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz",
       "integrity": "sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q=="
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -15253,6 +15312,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
+      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -22581,9 +22646,9 @@
       }
     },
     "bson": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
-      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
       "dev": true
     },
     "buffer": {
@@ -26316,6 +26381,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "dev": true
+    },
     "keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -26921,12 +26992,12 @@
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
     "mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.5.0.tgz",
+      "integrity": "sha512-XgrkUgAAdfnZKQfk5AsYL8j7O99WHd4YXPxYxnh8dZxD+ekYWFRA3JktUsBnfg+455Smf75/+asoU/YLwNGoQQ==",
       "dev": true,
       "requires": {
-        "bson": "^5.0.1",
+        "bson": "^5.3.0",
         "mongodb-connection-string-url": "^2.6.0",
         "saslprep": "^1.0.3",
         "socks": "^2.7.1"
@@ -26989,10 +27060,48 @@
         }
       }
     },
+    "mongoose": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.2.tgz",
+      "integrity": "sha512-JPBMTF+oYfLGVFWbHSZ/H+f1GajNanGLYH6c/P0nE3bNJfwGhX573vieGR0kNlNhj3cZk8WCPrnVsTNeUmFUag==",
+      "dev": true,
+      "requires": {
+        "bson": "^5.3.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.5.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
     "monitor-event-loop-delay": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz",
       "integrity": "sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q=="
+    },
+    "mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "dev": true
+    },
+    "mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "dev": true,
+      "requires": {
+        "debug": "4.x"
+      }
     },
     "ms": {
       "version": "2.1.2",
@@ -29184,6 +29293,12 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "mkdirp": "^0.5.1",
     "mongodb": "^5.1.0",
     "mongodb-core": "^3.2.7",
+    "mongoose": "^6.1.8",
     "mysql": "^2.18.1",
     "mysql2": "^3.2.4",
     "ndjson": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "mkdirp": "^0.5.1",
     "mongodb": "^5.1.0",
     "mongodb-core": "^3.2.7",
-    "mongoose": "^6.1.8",
+    "mongoose": "^7.2.2",
     "mysql": "^2.18.1",
     "mysql2": "^3.2.4",
     "ndjson": "^1.5.0",


### PR DESCRIPTION
Starting with mongoose 5.7.0, it uses "mongodb" (rather than
"mongodb-core") as a backend.

### Checklist

- [ ] Figure out why no ".find" spans with mongoose >=5.7.0 (see comment below).
- [ ] Decide if we want to have explicit mongoose tests. Currently we rely on the mongodb-core tests, which I think should still suffice.
- [x] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
