### PR TITLE
fix: ensure correct run context for '@elastic/elasticsearch' instrumentation

### DIFF
--- a/.ci/.jenkins_tav.yml
+++ b/.ci/.jenkins_tav.yml
@@ -1,5 +1,6 @@
 TAV:
   - '@elastic/elasticsearch'
+  - '@elastic/elasticsearch-canary'
   - '@hapi/hapi'
   - '@koa/router'
   - apollo-server-express

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -204,7 +204,7 @@ elif [[ -n "${TAV_MODULE}" ]]; then
     cassandra-driver)
       DOCKER_COMPOSE_FILE=docker-compose-cassandra.yml
       ;;
-    elasticsearch|@elastic/elasticsearch)
+    elasticsearch|@elastic/elasticsearch|@elastic/elasticsearch-canary)
       DOCKER_COMPOSE_FILE=docker-compose-elasticsearch.yml
       ;;
     mysql|mysql2)

--- a/.tav.yml
+++ b/.tav.yml
@@ -367,7 +367,7 @@ elasticsearch:
   commands: node test/instrumentation/modules/@elastic/elasticsearch.test.js
 '@elastic/elasticsearch-canary':
   name: '@elastic/elasticsearch-canary'
-  versions: '^8.0.0-canary.35'
+  versions: '>=8.0.0-canary.35 || >=8.1.0-canary.2'
   node: '>=12'
   commands: node test/instrumentation/modules/@elastic/elasticsearch-canary.test.js
 

--- a/.tav.yml
+++ b/.tav.yml
@@ -367,7 +367,7 @@ elasticsearch:
   commands: node test/instrumentation/modules/@elastic/elasticsearch.test.js
 '@elastic/elasticsearch-canary':
   name: '@elastic/elasticsearch-canary'
-  versions: '>=8.0.0-canary.35 || >=8.1.0-canary.2'
+  versions: '>=8.0.0-canary.36 || >=8.1.0-canary.2'
   node: '>=12'
   commands: node test/instrumentation/modules/@elastic/elasticsearch-canary.test.js
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,9 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fixes for run context handling for '@elastic/elasticsearch' instrumentation.
+  ({issues}2430[#2430])
+
 * Fixes for run context handling for 'cassandra-driver' instrumentation.
   ({issues}2430[#2430])
 

--- a/lib/instrumentation/elasticsearch-shared.js
+++ b/lib/instrumentation/elasticsearch-shared.js
@@ -28,20 +28,13 @@ exports.pathIsAQuery = pathIsAQuery
 //    {"query":{"query_string":{"query":"pants"}}}
 //
 // `path`, `query`, and `body` can all be null or undefined.
-exports.setElasticsearchDbContext = function (span, path, query, body, isLegacy) {
+exports.setElasticsearchDbContext = function (span, path, query, body) {
   if (path && pathIsAQuery.test(path)) {
-    // From @elastic/elasticsearch: A read of Transport.js suggests query and
-    // body will always be serialized strings, however the documented
-    // `TransportRequestParams` (`ConnectionRequestParams` in version 8)
-    // allows for non-strings, so we will be defensive.
-    //
-    // From legacy elasticsearch: query will be an object and body will be an
-    // object, or an array of objects, e.g. for bulk endpoints.
     const parts = []
     if (query) {
       if (typeof (query) === 'string') {
         parts.push(query)
-      } else if (isLegacy && typeof (query) === 'object') {
+      } else if (typeof (query) === 'object') {
         const encodedQuery = querystring.encode(query)
         if (encodedQuery) {
           parts.push(encodedQuery)
@@ -51,12 +44,12 @@ exports.setElasticsearchDbContext = function (span, path, query, body, isLegacy)
     if (body) {
       if (typeof (body) === 'string') {
         parts.push(body)
-      } else if (isLegacy) {
-        if (Array.isArray(body)) {
-          parts.push(body.map(JSON.stringify).join('\n')) // ndjson
-        } else if (typeof (body) === 'object') {
-          parts.push(JSON.stringify(body))
-        }
+      } else if (Buffer.isBuffer(body)) {
+        // Never serialize a Buffer.
+      } else if (Array.isArray(body)) {
+        parts.push(body.map(JSON.stringify).join('\n') + '\n') // ndjson
+      } else if (typeof (body) === 'object') {
+        parts.push(JSON.stringify(body))
       }
     }
 

--- a/lib/instrumentation/elasticsearch-shared.js
+++ b/lib/instrumentation/elasticsearch-shared.js
@@ -44,12 +44,18 @@ exports.setElasticsearchDbContext = function (span, path, query, body) {
     if (body) {
       if (typeof (body) === 'string') {
         parts.push(body)
-      } else if (Buffer.isBuffer(body)) {
-        // Never serialize a Buffer.
+      } else if (Buffer.isBuffer(body) || typeof body.pipe === 'function') {
+        // Never serialize a Buffer or a Readable. These guards mirror
+        // `shouldSerialize()` in the ES client, e.g.:
+        // https://github.com/elastic/elastic-transport-js/blob/069172506d1fcd544b23747d8c2d497bab053038/src/Transport.ts#L614-L618
       } else if (Array.isArray(body)) {
-        parts.push(body.map(JSON.stringify).join('\n') + '\n') // ndjson
+        try {
+          parts.push(body.map(JSON.stringify).join('\n') + '\n') // ndjson
+        } catch {}
       } else if (typeof (body) === 'object') {
-        parts.push(JSON.stringify(body))
+        try {
+          parts.push(JSON.stringify(body))
+        } catch {}
       }
     }
 

--- a/lib/instrumentation/elasticsearch-shared.js
+++ b/lib/instrumentation/elasticsearch-shared.js
@@ -51,11 +51,11 @@ exports.setElasticsearchDbContext = function (span, path, query, body) {
       } else if (Array.isArray(body)) {
         try {
           parts.push(body.map(JSON.stringify).join('\n') + '\n') // ndjson
-        } catch {}
+        } catch (_ignoredErr) {}
       } else if (typeof (body) === 'object') {
         try {
           parts.push(JSON.stringify(body))
-        } catch {}
+        } catch (_ignoredErr) {}
       }
     }
 

--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -25,6 +25,8 @@
 //   initial "HTTP span (GET /...)". Currently the APM agent is not patching
 //   for this.
 
+const semver = require('semver')
+
 const { getDBDestination } = require('../../context')
 const { setElasticsearchDbContext } = require('../../elasticsearch-shared')
 const shimmer = require('../../shimmer')
@@ -38,6 +40,9 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
     return elasticsearch
   }
 
+  // Before v7.7.0 the Transport#request() implementation's Promises support
+  // would re-call `this.request(...)` inside a Promise.
+  const doubleCallsRequestIfNoCb = semver.lt(version, '7.7.0')
   const ins = agent._instrumentation
 
   agent.logger.debug('shimming elasticsearch.Transport.prototype.{request,getConnection}')
@@ -78,6 +83,10 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
       if (typeof options === 'function') {
         cb = options
         options = {}
+      }
+
+      if (typeof cb !== 'function' && doubleCallsRequestIfNoCb) {
+        return origRequest.apply(this, arguments)
       }
 
       const method = (params && params.method) || '<UnknownMethod>'

--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -5,12 +5,29 @@
 // This uses to 'request' and 'response' events from the Client (documented at
 // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html)
 // to hook into all ES server interactions.
-
-const semver = require('semver')
+//
+// Limitations:
+// - In @elastic/elasticsearch >=7.14 <8, the HTTP span for ES spans made before
+//   the product-check is finished will have an incorrect parent.
+//
+//   An Elasticsearch (ES) request typically results in a single HTTP request to
+//   the server. The APM agent creates an HTTP span that is a child of the ES
+//   span. For some of the later 7.x versions of @elastic/elasticsearch there is
+//   a product-check "GET /" that blocks the *first* request to the server. This
+//   results in:
+//      ES span
+//      |- ES span (the product check)
+//      |  `- HTTP span (GET /)
+//      `- HTTP span (GET /...)
+//   This is fine so far. However, if any ES requests are made before that
+//   product-check completes, then their HTTP requests are effectively queued.
+//   When they *do* run, the async context of each HTTP request is that of the
+//   initial "HTTP span (GET /...)". Currently the APM agent is not patching
+//   for this.
 
 const { getDBDestination } = require('../../context')
 const { setElasticsearchDbContext } = require('../../elasticsearch-shared')
-const constants = require('../../../constants')
+const shimmer = require('../../shimmer')
 
 module.exports = function (elasticsearch, agent, { version, enabled }) {
   if (!enabled) {
@@ -21,82 +38,84 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
     return elasticsearch
   }
 
-  const isGteV8 = semver.satisfies(version, '>=8', { includePrerelease: true })
+  const ins = agent._instrumentation
 
-  class ApmClient extends elasticsearch.Client {
-    constructor (...args) {
-      super(...args)
+  agent.logger.debug('shimming elasticsearch.Transport.prototype.{request,getConnection}')
+  shimmer.wrap(elasticsearch.Transport && elasticsearch.Transport.prototype, 'request', wrapRequest)
+  shimmer.wrap(elasticsearch.Transport && elasticsearch.Transport.prototype, 'getConnection', wrapGetConnection)
 
-      // The thing with the `.on()` method for getting observability events.
-      const diagnostic = isGteV8 ? this.diagnostic : this
+  // Mapping an ES client Connection object to its active span.
+  // - Use WeakMap to avoid a leak from possible spans that don't end.
+  // - WeakMap allows us to key off the ES client `request` object itself,
+  //   which means we don't need to rely on `request.id`, which might be
+  //   unreliable because it is user-settable (see `generateRequestId` at
+  //   https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html)
+  const connFromSpan = new WeakMap()
 
-      // Mapping an ES client event `result` to its active span.
-      // - Use WeakMap to avoid a leak from possible spans that don't end.
-      // - WeakMap allows us to key off the ES client `request` object itself,
-      //   which means we don't need to rely on `request.id`, which might be
-      //   unreliable because it is user-settable (see `generateRequestId` at
-      //   https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html)
-      const spanFromEsResult = new WeakMap()
+  return elasticsearch
 
-      diagnostic.on('request', (err, result) => {
-        let request = null
-        let connection = null
-        if (result && result.meta) {
-          request = result.meta.request
-          connection = result.meta.connection
+  // Transport#request() calls Transport#getConnection() when it is ready to
+  // make the HTTP request. This returns the actual connection to be used for
+  // the request. This is limited, however:
+  // - `getConnection()` is not called if the request was aborted early.
+  // - If all connections are marked dead, then this returns null.
+  // - We are assuming this is called with the correct async context. See
+  //   "Limitations" above.
+  function wrapGetConnection (origGetConnection) {
+    return function wrappedGetConnection (opts) {
+      const conn = origGetConnection.apply(this, arguments)
+      const currSpan = ins.currSpan()
+      if (conn && currSpan) {
+        connFromSpan[currSpan] = conn
+      }
+      return conn
+    }
+  }
+
+  function wrapRequest (origRequest) {
+    return function wrappedRequest (params, options, cb) {
+      options = options || {}
+      if (typeof options === 'function') {
+        cb = options
+        options = {}
+      }
+
+      const method = (params && params.method) || '<UnknownMethod>'
+      const path = (params && params.path) || '<UnknownPath>'
+      agent.logger.debug({ method, path }, 'intercepted call to @elastic/elasticsearch.Transport.prototype.request')
+      const span = ins.createSpan(`Elasticsearch: ${method} ${path}`, 'db', 'elasticsearch', 'request')
+      if (!span) {
+        return origRequest.apply(this, arguments)
+      }
+
+      const parentRunContext = ins.currRunContext()
+      const spanRunContext = parentRunContext.enterSpan(span)
+      const finish = ins.bindFunctionToRunContext(spanRunContext, (err, _result) => {
+        // Set DB context.
+        // In @elastic/elasticsearch@7, `Transport#request` encodes
+        // `params.{querystring,body}` in-place; use it. In >=8 this encoding is
+        // no longer in-place. A better eventual solution would be to wrap
+        // `Connection.request` to capture the serialized params.
+        setElasticsearchDbContext(
+          span,
+          params && params.path,
+          params && params.querystring,
+          params && (params.body || params.bulkBody))
+
+        // Set destination context.
+        // Use the connection from wrappedGetConnection() above, if that worked.
+        // Otherwise, fallback to using the first connection on
+        // `Transport#connectionPool`, if any.  (This is the best parsed
+        // representation of connection options passed to the Client ctor.)
+        let conn = connFromSpan[span]
+        if (conn) {
+          connFromSpan.delete(span)
+        } else if (this.connectionPool && this.connectionPool.connections) {
+          conn = this.connectionPool.connections[0]
         }
-        let paramMethod = null
-        let paramPath = null
-        let paramQueryString = null
-        let paramBody = null
-        if (request && request.params) {
-          // request.params can be null with ProductNotSupportedError and
-          // DeserializationError.
-          paramMethod = request.params.method
-          paramPath = request.params.path
-          paramQueryString = request.params.querystring
-          paramBody = request.params.body
-        }
-        agent.logger.debug('intercepted call to @elastic/elasticsearch "request" event %o',
-          { id: request && request.id, method: paramMethod, path: paramPath })
-
-        let span = spanFromEsResult.get(result)
-
-        if (err) {
-          agent.captureError(err)
-          if (span !== undefined) {
-            span.end()
-            spanFromEsResult.delete(result)
-          }
-          return
-        }
-
-        // With retries (see `makeRequest` in Transport.js) each attempt will
-        // emit this "request" event using the same `result` object. The
-        // intent is to have one Elasticsearch span plus an HTTP span for each
-        // attempt.
-        if (!span) {
-          const spanName = `Elasticsearch: ${paramMethod || '<UnknownMethod>'} ${paramPath || '<UnknownPath>'}`
-          span = agent.startSpan(spanName, 'db', 'elasticsearch', 'request')
-          if (span) {
-            spanFromEsResult.set(result, span)
-          }
-        }
-        if (!span) {
-          return
-        }
-
-        setElasticsearchDbContext(span, paramPath, paramQueryString, paramBody, false)
-
-        if (connection && connection.url) {
-          const { hostname, port } = connection.url
-          span.setDestinationContext(
-            getDBDestination(span, hostname, port))
-        }
-      })
-
-      diagnostic.on('response', (err, result) => {
-        const span = spanFromEsResult.get(result)
+        const connUrl = conn && conn.url
+        span.setDestinationContext(getDBDestination(span,
+          connUrl && connUrl.hostname, connUrl && connUrl.port))
 
         if (err) {
           // Error properties are specified here:
@@ -108,8 +127,7 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
           //   grabbing potentially large and sensitive properties like
           //   `err.data` on DeserializationError.
           const errOpts = {
-            captureAttributes: false,
-            skipOutcome: true
+            captureAttributes: false
           }
           if (err.name === 'ResponseError' && err.body && err.body.error) {
             // Include some data from the Elasticsearch API response body:
@@ -123,27 +141,31 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
               errOpts.custom.caused_by = err.body.error.caused_by
             }
           }
-
-          // The capture error method normally sets an outcome on the
-          // active span.  However, the Elasticsearch client span (the span
-          // we're concerned with here) is no longer the active span.
-          // Therefore, we manully set an outcome here, and also set
-          // errOpts.skipOutcome above. The errOpts.skipOutcome options
-          // instructs captureError to _not_ set the outcome on the active span
-          if (span !== undefined) {
-            span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
-          }
           agent.captureError(err, errOpts)
         }
 
-        if (span !== undefined) {
-          span.end()
-          spanFromEsResult.delete(result)
-        }
+        span.end()
       })
+
+      if (typeof cb === 'function') {
+        const wrappedCb = (err, result) => {
+          finish(err, result)
+          ins.withRunContext(parentRunContext, cb, this, err, result)
+        }
+        return ins.withRunContext(spanRunContext, origRequest, this, params, options, wrappedCb)
+      } else {
+        const origPromise = ins.withRunContext(spanRunContext, origRequest, this, ...arguments)
+        origPromise.then(
+          function onResolve (result) {
+            finish(null, result)
+          },
+          function onReject (err) {
+            finish(err, null)
+          }
+        )
+
+        return origPromise
+      }
     }
   }
-
-  agent.logger.debug('subclassing @elastic/elasticsearch.Client')
-  return Object.assign(elasticsearch, { Client: ApmClient })
 }

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -74,7 +74,7 @@ module.exports = function (elasticsearch, agent, { enabled }) {
         span.name = `Elasticsearch: ${method} ${path}`
 
         setElasticsearchDbContext(span, path, params && params.query,
-          params && params.body, true)
+          params && params.body)
 
         // Get the remote host information from elasticsearch Transport options.
         let host, port

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
     "@elastic/elasticsearch": "^7.15.0",
-    "@elastic/elasticsearch-canary": "^8.0.0-canary.37",
+    "@elastic/elasticsearch-canary": "^8.1.0-canary.2",
     "@hapi/hapi": "^20.1.2",
     "@koa/router": "^9.0.1",
     "@types/node": "^13.7.4",

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -541,17 +541,11 @@ ${body.map(JSON.stringify).join('\n')}
 
           const err = data.errors
             .filter((e) => e.exception.type === 'RequestAbortedError')[0]
-          if (semver.satisfies(esVersion, '7.14.x')) {
-            // https://github.com/elastic/elasticsearch-js/issues/1517 was fixed
-            // for 7.15 and later.
-            t.ok(!err, 'no APM error reported for abort with v7.14.x of the client because elastic/elasticsearch-js#1517')
-          } else {
-            t.ok(err, 'sent an error to APM server')
-            t.ok(err.id, 'err.id')
-            t.equal(err.exception.message, 'Request aborted', 'err.exception.message')
-            t.equal(err.exception.type, 'RequestAbortedError',
-              'err.exception.type is RequestAbortedError')
-          }
+          t.ok(err, 'sent an error to APM server')
+          t.ok(err.id, 'err.id')
+          t.equal(err.exception.message, 'Request aborted', 'err.exception.message')
+          t.equal(err.exception.type, 'RequestAbortedError',
+            'err.exception.type is RequestAbortedError')
 
           t.end()
         }
@@ -601,17 +595,11 @@ ${body.map(JSON.stringify).join('\n')}
 
           const err = data.errors
             .filter((e) => e.exception.type === 'RequestAbortedError')[0]
-          if (semver.satisfies(esVersion, '7.14.x')) {
-            // https://github.com/elastic/elasticsearch-js/issues/1517 was fixed
-            // for 7.15 and later.
-            t.ok(!err, 'no APM error reported for abort with v7.14.x of the client because elastic/elasticsearch-js#1517')
-          } else {
-            t.ok(err, 'sent an error to APM server')
-            t.ok(err.id, 'err.id')
-            t.ok(err.exception.message, 'err.exception.message')
-            t.equal(err.exception.type, 'RequestAbortedError',
-              'err.exception.type is RequestAbortedError')
-          }
+          t.ok(err, 'sent an error to APM server')
+          t.ok(err.id, 'err.id')
+          t.ok(err.exception.message, 'err.exception.message')
+          t.equal(err.exception.type, 'RequestAbortedError',
+            'err.exception.type is RequestAbortedError')
 
           t.end()
         }

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -6,6 +6,7 @@ const agent = require('../../../..').start({
   captureExceptions: false,
   metricsInterval: 0,
   centralConfig: false,
+  apmServerVersion: '8.0.0',
   spanFramesMinDuration: -1 // always capture stack traces with spans
 })
 

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -63,6 +63,7 @@ test('client.ping with promise', function (t) {
     agent.endTransaction()
     agent.flush()
   }).catch(t.error)
+  t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
 })
 
 // Callback-style was dropped in ES client v8.
@@ -78,6 +79,7 @@ if (!semver.satisfies(esVersion, '>=8', { includePrerelease: true })) {
       agent.endTransaction()
       agent.flush()
     })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 }
 
@@ -96,6 +98,7 @@ test('client.search with promise', function (t) {
       agent.flush()
     })
     .catch(t.error)
+  t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
 })
 
 // Tests below this point use `<promise>.finally(...)` for test control.
@@ -118,6 +121,7 @@ if (semver.gte(process.version, '10.0.0')) {
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   test('client.search with queryparam', function (t) {
@@ -134,6 +138,7 @@ if (semver.gte(process.version, '10.0.0')) {
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   test('client.search with body', function (t) {
@@ -160,6 +165,7 @@ if (semver.gte(process.version, '10.0.0')) {
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   // ES client version 8 no longer requires body fields to be in a "body" param.
@@ -188,6 +194,7 @@ if (semver.gte(process.version, '10.0.0')) {
           agent.endTransaction()
           agent.flush()
         })
+      t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
     })
   }
 
@@ -231,6 +238,7 @@ ${JSON.stringify(body)}`
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   test('client.searchTemplate', function (t) {
@@ -258,6 +266,7 @@ ${JSON.stringify(body)}`
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   test('client.msearch', function (t) {
@@ -292,6 +301,7 @@ ${body.map(JSON.stringify).join('\n')}
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   test('client.msearchTempate', function (t) {
@@ -323,6 +333,7 @@ ${body.map(JSON.stringify).join('\n')}
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   // Test some error scenarios.
@@ -378,6 +389,7 @@ ${body.map(JSON.stringify).join('\n')}
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   if (semver.satisfies(esVersion, '<8', { includePrerelease: true })) {
@@ -419,6 +431,7 @@ ${body.map(JSON.stringify).join('\n')}
         agent.endTransaction()
         agent.flush()
       })
+      t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
     })
   }
 
@@ -473,6 +486,7 @@ ${body.map(JSON.stringify).join('\n')}
             client.close()
             esServer.close()
           })
+        t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
       })
     })
   }
@@ -523,6 +537,7 @@ ${body.map(JSON.stringify).join('\n')}
           agent.flush()
           client.close()
         })
+      t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
     })
   }
 
@@ -577,6 +592,7 @@ ${body.map(JSON.stringify).join('\n')}
           agent.flush()
         }
       })
+      t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
       setImmediate(function () {
         req.abort()
       })
@@ -620,6 +636,7 @@ ${body.map(JSON.stringify).join('\n')}
       })
       const client = new es.Client(clientOpts)
       const promise = client.search({ body: slowBody })
+      t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
       promise
         .then(_result => {})
         .catch(err => {
@@ -646,6 +663,7 @@ ${body.map(JSON.stringify).join('\n')}
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
   test('outcome=failure on both spans', function (t) {
@@ -664,6 +682,7 @@ ${body.map(JSON.stringify).join('\n')}
         agent.endTransaction()
         agent.flush()
       })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 }
 

--- a/test/instrumentation/modules/elasticsearch.test.js
+++ b/test/instrumentation/modules/elasticsearch.test.js
@@ -11,6 +11,7 @@ var agent = require('../../..').start({
   captureExceptions: false,
   metricsInterval: 0,
   centralConfig: false,
+  apmServerVersion: '8.0.0',
   spanFramesMinDuration: -1 // always capture stack traces with spans
 })
 

--- a/test/instrumentation/modules/elasticsearch.test.js
+++ b/test/instrumentation/modules/elasticsearch.test.js
@@ -125,7 +125,7 @@ if (semver.satisfies(pkg.version, '>= 13')) {
       }
     ]
 
-    var statement = body.map(JSON.stringify).join('\n')
+    var statement = body.map(JSON.stringify).join('\n') + '\n'
 
     resetAgent(done(t, 'POST', '/_msearch', statement))
 
@@ -157,7 +157,7 @@ if (semver.satisfies(pkg.version, '>= 13')) {
       }
     ]
 
-    var statement = body.map(JSON.stringify).join('\n')
+    var statement = body.map(JSON.stringify).join('\n') + '\n'
 
     resetAgent(done(t, 'POST', '/_msearch/template', statement))
 


### PR DESCRIPTION
This is a re-write of the @elastic/elasticsearch instrumentation that
stops using the ES client observability events
    https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html
and switches to patching Transport#request() instead. This is necessary
to be able to bind that `request()` invocation to the RunContext for the
Span we've created; without using `apm.startSpan(...)`, which bleeds the
RunContext out to user code. (Patching Transport#request() is what the
legacy 'elasticsearch' instrumentation is also doing.)

Refs: #2430

### Checklist

- [x] Implement code
- [x] Add tests
- [x] ensure TAV tests pass
- [x] Add CHANGELOG.asciidoc entry
