### PR TITLE
feat: add traceContinuationStrategy=restart_always config option

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1124,3 +1124,28 @@ require('elastic-apm-node').start({
   ]
 })
 ----
+
+
+[[trace-continuation-strategy]]
+==== `traceContinuationStrategy`
+* *Type:* String
+* *Default:* `'continue_always'`
+* *Env:* `ELASTIC_APM_TRACE_CONTINUATION_STRATEGY`
+
+Warning: This configuration option is **experimental** and may change in
+non-major versions of the agent.
+
+This option allows some control on how the APM agent handles W3C trace-context
+headers on incoming requests. By default, the `traceparent` and `tracestate`
+headers are used per W3C spec for distributed tracing. However, in certain cases
+(typically where an Elastic-monitored service is receiving requests with
+`traceparent` headers from *unmonitored* services) it can be helpful to *not*
+use the incoming `traceparent` header.
+
+Valid values are:
+
+- `'continue_always'` - The current and default behavior. Every incoming
+  `traceparent` header determines the sampling decision and the trace-id.
+- `'restart_always'` - Always ignores the `traceparent` header of incoming
+  requests. A new trace-id will be generated and the sampling decision will be
+  made based on <<transaction-sample-rate,`transactionSampleRate`>>.

--- a/index.d.ts
+++ b/index.d.ts
@@ -280,6 +280,7 @@ declare namespace apm {
     sourceLinesSpanLibraryFrames?: number;
     spanFramesMinDuration?: string;
     stackTraceLimit?: number;
+    traceContinuationStrategy?: TraceContinuationStrategy;
     transactionIgnoreUrls?: Array<string>;
     transactionMaxSpans?: number;
     transactionSampleRate?: number;
@@ -353,6 +354,7 @@ declare namespace apm {
   type CaptureBody = 'off' | 'errors' | 'transactions' | 'all';
   type CaptureErrorLogStackTraces = 'never' | 'messages' | 'always';
   type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'warning' | 'error' | 'fatal' | 'critical' | 'off';
+  type TraceContinuationStrategy = 'continue_always' | 'restart_always';
 
   type CaptureErrorCallback = (err: Error | null, id: string) => void;
   type FilterFn = (payload: Payload) => Payload | boolean | void;

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,8 @@ const INTAKE_STRING_MAX_SIZE = 1024
 const CAPTURE_ERROR_LOG_STACK_TRACES_NEVER = 'never'
 const CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES = 'messages'
 const CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS = 'always'
+const TRACE_CONTINUATION_STRATEGY_CONTINUE_ALWAYS = 'continue_always'
+const TRACE_CONTINUATION_STRATEGY_RESTART_ALWAYS = 'restart_always'
 
 var DEFAULTS = {
   abortedErrorThreshold: '25s',
@@ -73,6 +75,7 @@ var DEFAULTS = {
   sourceLinesSpanLibraryFrames: 0,
   spanFramesMinDuration: '10ms',
   stackTraceLimit: 50,
+  traceContinuationStrategy: TRACE_CONTINUATION_STRATEGY_CONTINUE_ALWAYS,
   transactionIgnoreUrls: [],
   transactionMaxSpans: 500,
   transactionSampleRate: 1.0,
@@ -137,6 +140,7 @@ var ENV_TABLE = {
   sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
   spanFramesMinDuration: 'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION',
   stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
+  traceContinuationStrategy: 'ELASTIC_APM_TRACE_CONTINUATION_STRATEGY',
   transactionIgnoreUrls: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
   transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
   transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
@@ -565,7 +569,21 @@ function normalize (opts, logger) {
   normalizeSanitizeFieldNames(opts)
   normalizeCloudProvider(opts, logger)
   normalizeTransactionSampleRate(opts, logger)
+  normalizeTraceContinuationStrategy(opts, logger)
   truncateOptions(opts)
+}
+
+const ALLOWED_TRACE_CONTINUATION_STRATEGY = {
+  [TRACE_CONTINUATION_STRATEGY_CONTINUE_ALWAYS]: true,
+  [TRACE_CONTINUATION_STRATEGY_RESTART_ALWAYS]: true
+}
+function normalizeTraceContinuationStrategy (opts, logger) {
+  if ('traceContinuationStrategy' in opts &&
+      !(opts.traceContinuationStrategy in ALLOWED_TRACE_CONTINUATION_STRATEGY)) {
+    logger.warn('Invalid "traceContinuationStrategy" config value %j, falling back to default %j',
+      opts.traceContinuationStrategy, DEFAULTS.traceContinuationStrategy)
+    opts.traceContinuationStrategy = DEFAULTS.traceContinuationStrategy
+  }
 }
 
 // transactionSampleRate is specified to be:

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -21,8 +21,22 @@ exports.instrumentRequest = function (agent, moduleName) {
           // Don't leak previous transaction.
           agent._instrumentation.supersedeWithEmptyRunContext()
         } else {
-          var traceparent = req.headers.traceparent || req.headers['elastic-apm-traceparent']
-          var tracestate = req.headers.tracestate
+          // Decide whether to use trace-context headers, if any, for a
+          // distributed trace.
+          let traceparent = req.headers.traceparent || req.headers['elastic-apm-traceparent']
+          let tracestate = req.headers.tracestate
+          switch (agent._conf.traceContinuationStrategy) {
+            case 'continue_always':
+              break
+            case 'restart_always':
+              // Ignore any trace-context headers in the request.
+              traceparent = undefined
+              tracestate = undefined
+              break
+            default:
+              agent.logger.warn(`invalid value for "traceContinuationStrategy": "${agent._conf.traceContinuationStrategy}"`)
+          }
+
           var trans = agent.startTransaction(null, null, {
             childOf: traceparent,
             tracestate: tracestate

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -91,6 +91,7 @@ var optionFixtures = [
   ['sourceLinesSpanAppFrames', 'SOURCE_LINES_SPAN_APP_FRAMES', 0],
   ['sourceLinesSpanLibraryFrames', 'SOURCE_LINES_SPAN_LIBRARY_FRAMES', 0],
   ['stackTraceLimit', 'STACK_TRACE_LIMIT', 50],
+  ['traceContinuationStrategy', 'TRACE_CONTINUATION_STRATEGY', 'continue_always'],
   ['transactionMaxSpans', 'TRANSACTION_MAX_SPANS', 500],
   ['transactionSampleRate', 'TRANSACTION_SAMPLE_RATE', 1.0],
   ['usePathAsTransactionName', 'USE_PATH_AS_TRANSACTION_NAME', false],
@@ -111,6 +112,8 @@ optionFixtures.forEach(function (fixture) {
     } else if (fixture[0] === 'serverCaCertFile') {
       // special case for files, so a temp file can be written
       type = 'file'
+    } else if (fixture[0] === 'traceContinuationStrategy') {
+      type = 'traceContinuationStrategy'
     } else if (typeof fixture[2] === 'number' || fixture[0] === 'errorMessageMaxLength') {
       type = 'number'
     } else if (Array.isArray(fixture[2])) {
@@ -143,6 +146,9 @@ optionFixtures.forEach(function (fixture) {
           mkdirp.sync(tmpdir)
           fs.writeFileSync(tmpfile, tmpfile)
           value = tmpfile
+          break
+        case 'traceContinuationStrategy':
+          value = 'restart_always' // a valid non-default value
           break
         case 'array':
           value = ['custom-value']
@@ -210,6 +216,10 @@ optionFixtures.forEach(function (fixture) {
         case 'array':
           value1 = ['overwriting-value']
           value2 = ['custom-value']
+          break
+        case 'traceContinuationStrategy':
+          value1 = 'restart_always'
+          value2 = 'continue_always'
           break
         case 'string':
           value1 = 'overwriting-value'

--- a/test/trace-continuation-strategy.test.js
+++ b/test/trace-continuation-strategy.test.js
@@ -1,0 +1,100 @@
+'use strict'
+
+// Test the behaviour of the `traceContinuationStrategy` config var.
+
+const apm = require('../').start({
+  serviceName: 'test-traceContinuationStrategy',
+  logLevel: 'off',
+  captureExceptions: false,
+  metricsInterval: '0s',
+  disableSend: true
+})
+
+const http = require('http')
+const tape = require('tape')
+
+// Ensure that, by default, an HTTP request with a valid traceparent to an
+// instrumented HTTP server *uses* that traceparent.
+tape.test('traceContinuationStrategy default is continue_always', t => {
+  const server = http.createServer(function (_req, res) {
+    const currTrans = apm.currentTransaction
+    t.ok(currTrans, 'have a currentTransaction')
+    t.equal(currTrans.traceId, '12345678901234567890123456789012', `currentTransaction.traceId (${currTrans.traceId})`)
+    t.equal(currTrans.parentId, '1234567890123456', `currentTransaction.parentId (${currTrans.parentId})`)
+    res.end('pong')
+  })
+  server.listen(function () {
+    const url = 'http://localhost:' + server.address().port
+    http.get(url, {
+      headers: {
+        traceparent: '00-12345678901234567890123456789012-1234567890123456-01'
+      }
+    }, function (res) {
+      t.equal(res.statusCode, 200, 'client got HTTP 200 response')
+      res.resume()
+      res.on('end', function () {
+        server.close()
+        t.end()
+      })
+    })
+  })
+})
+
+tape.test('traceContinuationStrategy=continue_always', t => {
+  // Hack in the traceContinuationStrategy value. This is equiv to having
+  // started the agent with this setting.
+  apm._conf.traceContinuationStrategy = 'continue_always'
+
+  const server = http.createServer(function (_req, res) {
+    const currTrans = apm.currentTransaction
+    t.ok(currTrans, 'have a currentTransaction')
+    t.equal(currTrans.traceId, '12345678901234567890123456789012', `currentTransaction.traceId (${currTrans.traceId})`)
+    t.equal(currTrans.parentId, '1234567890123456', `currentTransaction.parentId (${currTrans.parentId})`)
+    res.end('pong')
+  })
+  server.listen(function () {
+    const url = 'http://localhost:' + server.address().port
+    http.get(url, {
+      headers: {
+        traceparent: '00-12345678901234567890123456789012-1234567890123456-01'
+      }
+    }, function (res) {
+      t.equal(res.statusCode, 200, 'client got HTTP 200 response')
+      res.resume()
+      res.on('end', function () {
+        server.close()
+        t.end()
+      })
+    })
+  })
+})
+
+// With restart_always the incoming traceparent should be ignored.
+tape.test('traceContinuationStrategy=restart_always', t => {
+  // Hack in the traceContinuationStrategy value. This is equiv to having
+  // started the agent with this setting.
+  apm._conf.traceContinuationStrategy = 'restart_always'
+
+  const server = http.createServer(function (_req, res) {
+    const currTrans = apm.currentTransaction
+    t.ok(currTrans, 'have a currentTransaction')
+    t.not(currTrans.traceId, '12345678901234567890123456789012', `currentTransaction.traceId (${currTrans.traceId})`)
+    t.not(currTrans.parentId, '1234567890123456', `currentTransaction.parentId (${currTrans.parentId})`)
+    res.end('pong')
+  })
+  server.listen(function () {
+    const url = 'http://localhost:' + server.address().port
+    http.get(url, {
+      headers: {
+        traceparent: '00-12345678901234567890123456789012-1234567890123456-01'
+      }
+    }, function (res) {
+      t.equal(res.statusCode, 200, 'client got HTTP 200 response')
+      res.resume()
+      res.on('end', function () {
+        server.close()
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds a `traceContinutationStrategy` configuration option to allow
some control over how the APM Agent uses incoming trace-context headers
for context propagation. The default 'continue_always' value results in
the current behaviour of using 'traceparent' and 'tracestate' per the
W3C spec. A value of 'restart_always' will result in incoming
'traceparent' and 'tracestate' headers being *ignored*. This can be
useful for a service that is receiving problematic tracing headers from
an upstream service that is unmonitored (without root transactions in
ES, the APM UI has limitations) or otherwise out of the user's control
(sampling rate may not be what the user wants).

This is currently *experimental* while a design for
`trace_continuation_strategy` is being discussed at
https://github.com/elastic/apm/issues/286. This currently implements a
*subset* of the proposed design there -- `restart_external` is not yet
implemented.

Closes: #2554
Refs: https://github.com/elastic/apm/issues/286

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [ ] Update for agreed-upon APM Agents spec (per https://github.com/elastic/apm/issues/286) 
- [ ] Add CHANGELOG.asciidoc entry
