### PR TITLE
feat: mark Elasticsearch spans as exit spans; HTTP child spans are now elided

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,8 +47,9 @@ Notes:
   to provide awareness in case some users have custom analysis of APM trace
   data that expects those HTTP spans.
 
-  Per https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans.md#exit-spans[the APM Agent spec for exit spans], Elasticsearch spans are now marked as exit spans and as
-  a result, HTTP child spans are suppressed. ({issues}2000[#2000])
+  Per https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans.md#exit-spans[the APM Agent spec for exit spans],
+  Elasticsearch spans are now marked as exit spans and as a result, HTTP child
+  spans are suppressed. ({issues}2000[#2000])
 
   As part of this change, some HTTP context has been added to Elasticsearch
   spans, when available: the HTTP response `status_code`, and the size of the

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,19 @@ Notes:
   run-context of callbacks.  See {issues}2498[#2498] and the
   <<release-notes-3.26.0,v3.26.0 release notes>> which has a similar change.
 
+* Elasticsearch spans (from `elasticsearch`, `@elastic/elasticsearch`, and
+  `@elastic/elasticsearch-canary` instrumentation) will no longer have an HTTP
+  child span(s) for the underlying HTTP request. This is listed in this section
+  to provide awareness in case some users have custom analysis of APM trace
+  data that expects those HTTP spans.
+
+  Per https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans.md#exit-spans[the APM Agent spec for exit spans], Elasticsearch spans are now marked as exit spans and as
+  a result, HTTP child spans are suppressed. ({issues}2000[#2000])
+
+  As part of this change, some HTTP context has been added to Elasticsearch
+  spans, when available: the HTTP response `status_code`, and the size of the
+  response body (`encoded_body_size`). ({issues}2484[#2484])
+
 [float]
 ===== Features
 

--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -19,6 +19,13 @@
 //   of the initial ES span. This means that `apm.currentSpan` inside an ES
 //   client diagnostic event for these queued ES requests will be wrong.
 //   Currently the APM agent is not patching for this.
+//
+// - When using the non-default `asyncHooks=false` APM Agent option with
+//   @elastic/elasticsearch >=8 instrumentation, the diagnostic events do not
+//   have the async run context of the current span. There are two impacts:
+//   1. Elasticsearch tracing spans will not have additional "http" context
+//      about the underlying HTTP request.
+//   2. Users cannot access `apm.currentSpan` inside a diagnostic event handler.
 
 const semver = require('semver')
 

--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -7,23 +7,18 @@
 // to hook into all ES server interactions.
 //
 // Limitations:
-// - In @elastic/elasticsearch >=7.14 <8, the HTTP span for ES spans made before
-//   the product-check is finished will have an incorrect parent.
+// - In @elastic/elasticsearch >=7.14 <8, the diagnostic events sent for ES
+//   spans started before the product-check is finished will have an incorrect
+//   `currentSpan`.
 //
 //   An Elasticsearch (ES) request typically results in a single HTTP request to
-//   the server. The APM agent creates an HTTP span that is a child of the ES
-//   span. For some of the later 7.x versions of @elastic/elasticsearch there is
-//   a product-check "GET /" that blocks the *first* request to the server. This
-//   results in:
-//      ES span
-//      |- ES span (the product check)
-//      |  `- HTTP span (GET /)
-//      `- HTTP span (GET /...)
-//   This is fine so far. However, if any ES requests are made before that
-//   product-check completes, then their HTTP requests are effectively queued.
-//   When they *do* run, the async context of each HTTP request is that of the
-//   initial "HTTP span (GET /...)". Currently the APM agent is not patching
-//   for this.
+//   the server. For some of the later 7.x versions of @elastic/elasticsearch
+//   there is a product-check "GET /" that blocks the *first* request to the
+//   server. The handling of ES requests are effectively queued until that
+//   product-check is complete. When they *do* run, the async context is that
+//   of the initial ES span. This means that `apm.currentSpan` inside an ES
+//   client diagnostic event for these queued ES requests will be wrong.
+//   Currently the APM agent is not patching for this.
 
 const semver = require('semver')
 
@@ -44,20 +39,38 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
   // would re-call `this.request(...)` inside a Promise.
   const doubleCallsRequestIfNoCb = semver.lt(version, '7.7.0')
   const ins = agent._instrumentation
+  const isGteV8 = semver.satisfies(version, '>=8', { includePrerelease: true })
 
   agent.logger.debug('shimming elasticsearch.Transport.prototype.{request,getConnection}')
   shimmer.wrap(elasticsearch.Transport && elasticsearch.Transport.prototype, 'request', wrapRequest)
   shimmer.wrap(elasticsearch.Transport && elasticsearch.Transport.prototype, 'getConnection', wrapGetConnection)
+  shimmer.wrap(elasticsearch, 'Client', wrapClient)
 
-  // Mapping an ES client Connection object to its active span.
-  // - Use WeakMap to avoid a leak from possible spans that don't end.
-  // - WeakMap allows us to key off the ES client `request` object itself,
-  //   which means we don't need to rely on `request.id`, which might be
-  //   unreliable because it is user-settable (see `generateRequestId` at
-  //   https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html)
+  // Tracking the ES client Connection object and DiagnosticResult for each
+  // active span. Use WeakMap to avoid a leak from possible spans that don't
+  // end.
   const connFromSpan = new WeakMap()
+  const diagResultFromSpan = new WeakMap()
 
   return elasticsearch
+
+  function wrapClient (OrigClient) {
+    class ClientTraced extends OrigClient {
+      constructor (...args) {
+        super(...args)
+        const diagnostic = isGteV8 ? this.diagnostic : this
+        diagnostic.on('response', (_err, result) => {
+          if (result) {
+            const currSpan = ins.currSpan()
+            if (currSpan) {
+              diagResultFromSpan[currSpan] = result
+            }
+          }
+        })
+      }
+    }
+    return ClientTraced
+  }
 
   // Transport#request() calls Transport#getConnection() when it is ready to
   // make the HTTP request. This returns the actual connection to be used for
@@ -92,14 +105,14 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
       const method = (params && params.method) || '<UnknownMethod>'
       const path = (params && params.path) || '<UnknownPath>'
       agent.logger.debug({ method, path }, 'intercepted call to @elastic/elasticsearch.Transport.prototype.request')
-      const span = ins.createSpan(`Elasticsearch: ${method} ${path}`, 'db', 'elasticsearch', 'request')
+      const span = ins.createSpan(`Elasticsearch: ${method} ${path}`, 'db', 'elasticsearch', 'request', { exitSpan: true })
       if (!span) {
         return origRequest.apply(this, arguments)
       }
 
       const parentRunContext = ins.currRunContext()
       const spanRunContext = parentRunContext.enterSpan(span)
-      const finish = ins.bindFunctionToRunContext(spanRunContext, (err, _result) => {
+      const finish = ins.bindFunctionToRunContext(spanRunContext, (err, result) => {
         // Set DB context.
         // In @elastic/elasticsearch@7, `Transport#request` encodes
         // `params.{querystring,body}` in-place; use it. In >=8 this encoding is
@@ -125,6 +138,51 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
         const connUrl = conn && conn.url
         span.setDestinationContext(getDBDestination(span,
           connUrl && connUrl.hostname, connUrl && connUrl.port))
+
+        // Gather some HTTP context from the "DiagnosticResult" object.
+        // We are *not* including the response headers b/c they are boring:
+        //
+        //    X-elastic-product: Elasticsearch
+        //    content-type: application/json
+        //    content-length: ...
+        //
+        // Getting the ES client request "DiagnosticResult" object has some edge cases:
+        // - In v7 using a callback, we always get `result`.
+        // - In v7 using a Promise, if the promise is rejected, then `result` is
+        //   not passed.
+        // - In v8, `result` only includes HTTP response info if `options.meta`
+        //   is true. We use the diagnostic 'response' event instead.
+        // - In v7, see the limitation note above for the rare start case where
+        //   the diagnostic 'response' event may have the wrong currentSpan.
+        // The result is that with Promise usage of v7, ES client requests that
+        // are queued behind the "product-check" and that reject, won't have a
+        // `diagResult`.
+        let diagResult = isGteV8 ? null : result
+        if (!diagResult) {
+          diagResult = diagResultFromSpan[span]
+          if (diagResult) {
+            diagResultFromSpan.delete(span)
+          }
+        }
+        if (diagResult) {
+          const httpContext = {}
+          let haveHttpContext = false
+          if (diagResult.statusCode) {
+            haveHttpContext = true
+            httpContext.status_code = diagResult.statusCode
+          }
+          // *Not* currently adding headers because
+          if (diagResult.headers && 'content-length' in diagResult.headers) {
+            const contentLength = Number(diagResult.headers['content-length'])
+            if (!isNaN(contentLength)) {
+              haveHttpContext = true
+              httpContext.response = { encoded_body_size: contentLength }
+            }
+          }
+          if (haveHttpContext) {
+            span.setHttpContext(httpContext)
+          }
+        }
 
         if (err) {
           // Error properties are specified here:

--- a/lib/instrumentation/modules/elasticsearch.js
+++ b/lib/instrumentation/modules/elasticsearch.js
@@ -65,7 +65,7 @@ module.exports = function (elasticsearch, agent, { enabled }) {
 
   function wrapRequest (original) {
     return function wrappedRequest (params, cb) {
-      var span = ins.createSpan(null, 'db', 'elasticsearch', 'request')
+      var span = ins.createSpan(null, 'db', 'elasticsearch', 'request', { exitSpan: true })
       var id = span && span.transaction.id
       var method = params && params.method
       var path = params && params.path

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -142,16 +142,16 @@ Transaction.prototype.createSpan = function (...args) {
     return null
   }
 
-  // Exit spans must not have child spans. The spec allows child spans "that
-  // have the same type and subtype", but this agent currently has no use for
-  // this case.
+  // Exit spans must not have child spans (unless of the same type and subtype).
   // https://github.com/elastic/apm/blob/master/specs/agents/tracing-spans.md#child-spans-of-exit-spans
   const opts = typeof args[args.length - 1] === 'object'
     ? (args.pop() || {})
     : {}
+  const [_name, type, subtype] = args // eslint-disable-line no-unused-vars
   opts.childOf = opts.childOf || this._agent._instrumentation.currSpan() || this
   const childOf = opts.childOf
-  if (childOf instanceof Span && childOf._exitSpan) {
+  if (childOf instanceof Span && childOf._exitSpan &&
+      !(childOf.type === type && childOf.subtype === subtype)) {
     this._agent.logger.trace({ exitSpanId: childOf.id, newSpanArgs: args },
       'createSpan: drop child span of exit span')
     return null

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
-    "@elastic/elasticsearch": "^7.11.0",
+    "@elastic/elasticsearch": "^7.15.0",
     "@elastic/elasticsearch-canary": "^8.1.0-canary.2",
     "@hapi/hapi": "^20.1.2",
     "@koa/router": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
-    "@elastic/elasticsearch": "^7.15.0",
+    "@elastic/elasticsearch": "^7.11.0",
     "@elastic/elasticsearch-canary": "^8.1.0-canary.2",
     "@hapi/hapi": "^20.1.2",
     "@koa/router": "^9.0.1",

--- a/test/instrumentation/modules/@elastic/_mock_es.js
+++ b/test/instrumentation/modules/@elastic/_mock_es.js
@@ -13,6 +13,7 @@
 //    })
 //    server.start(function (serverUrl) {
 //      // - Test code using `serverUrl`.
+//      // - Use `server.requests` to see the requests the ES server received
 //      // - Call `server.close()` when done.
 //    })
 
@@ -26,6 +27,7 @@ class MockES {
     this._responses = opts.responses
     this._reqCount = 0
     this.serverUrl = null // set in .start()
+    this.requests = []
     this._http = http.createServer(this._onRequest.bind(this))
   }
 
@@ -33,6 +35,11 @@ class MockES {
     const response = this._responses[this._reqCount % this._responses.length]
     this._reqCount++
     req.on('end', () => {
+      this.requests.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers
+      })
       res.writeHead(response.statusCode, response.headers || {})
       res.end(response.body)
     })

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -687,8 +687,8 @@ ${body.map(JSON.stringify).join('\n')}
     t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
   })
 
-  // Ensure that even without HTTP child spans, that trace-context propagation
-  // to Elasticsearch still works.
+  // Ensure that even without HTTP child spans, trace-context propagation to
+  // Elasticsearch still works.
   test('context-propagation works', function (t) {
     const mockResponses = [
       {

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -36,6 +36,7 @@ const es = require(esClientPkgName)
 
 const { Readable } = require('stream')
 const test = require('tape')
+const TraceParent = require('traceparent')
 
 const findObjInArray = require('../../../_utils').findObjInArray
 const mockClient = require('../../../_mock_http_client')
@@ -55,7 +56,7 @@ if (semver.satisfies(esVersion, '>=8', { includePrerelease: true })) {
 }
 
 test('client.ping with promise', function (t) {
-  resetAgent(checkDataAndEnd(t, 'HEAD', '/', null))
+  resetAgent(checkDataAndEnd(t, 'HEAD', '/', null, 200))
 
   agent.startTransaction('myTrans')
 
@@ -70,7 +71,7 @@ test('client.ping with promise', function (t) {
 // Callback-style was dropped in ES client v8.
 if (!semver.satisfies(esVersion, '>=8', { includePrerelease: true })) {
   test('client.ping with callback', function (t) {
-    resetAgent(checkDataAndEnd(t, 'HEAD', '/', null))
+    resetAgent(checkDataAndEnd(t, 'HEAD', '/', null, 200))
 
     agent.startTransaction('myTrans')
 
@@ -87,7 +88,7 @@ if (!semver.satisfies(esVersion, '>=8', { includePrerelease: true })) {
 test('client.search with promise', function (t) {
   const searchOpts = { q: 'pants' }
 
-  resetAgent(checkDataAndEnd(t, 'GET', '/_search', 'q=pants'))
+  resetAgent(checkDataAndEnd(t, 'GET', '/_search', 'q=pants', 200))
 
   agent.startTransaction('myTrans')
 
@@ -108,7 +109,7 @@ if (semver.gte(process.version, '10.0.0')) {
   test('client.child', function (t) {
     const searchOpts = { q: 'pants' }
 
-    resetAgent(checkDataAndEnd(t, 'GET', '/_search', 'q=pants'))
+    resetAgent(checkDataAndEnd(t, 'GET', '/_search', 'q=pants', 200))
 
     agent.startTransaction('myTrans')
 
@@ -128,7 +129,7 @@ if (semver.gte(process.version, '10.0.0')) {
   test('client.search with queryparam', function (t) {
     const searchOpts = { q: 'pants' }
 
-    resetAgent(checkDataAndEnd(t, 'GET', '/_search', 'q=pants'))
+    resetAgent(checkDataAndEnd(t, 'GET', '/_search', 'q=pants', 200))
 
     agent.startTransaction('myTrans')
 
@@ -155,7 +156,7 @@ if (semver.gte(process.version, '10.0.0')) {
       body: body
     }
 
-    resetAgent(checkDataAndEnd(t, 'POST', `/${searchOpts.index}/_search`, JSON.stringify(body)))
+    resetAgent(checkDataAndEnd(t, 'POST', `/${searchOpts.index}/_search`, JSON.stringify(body), 200))
 
     agent.startTransaction('myTrans')
 
@@ -184,7 +185,7 @@ if (semver.gte(process.version, '10.0.0')) {
       let expectedDbStatement = Object.assign({}, searchOpts)
       delete expectedDbStatement.index
       expectedDbStatement = JSON.stringify(expectedDbStatement)
-      resetAgent(checkDataAndEnd(t, 'POST', `/${searchOpts.index}/_search`, expectedDbStatement))
+      resetAgent(checkDataAndEnd(t, 'POST', `/${searchOpts.index}/_search`, expectedDbStatement, 200))
 
       agent.startTransaction('myTrans')
 
@@ -228,7 +229,7 @@ if (semver.gte(process.version, '10.0.0')) {
 ${JSON.stringify(body)}`
     }
 
-    resetAgent(checkDataAndEnd(t, 'POST', `/${searchOpts.index}/_search`, statement))
+    resetAgent(checkDataAndEnd(t, 'POST', `/${searchOpts.index}/_search`, statement, 200))
 
     agent.startTransaction('myTrans')
 
@@ -256,7 +257,7 @@ ${JSON.stringify(body)}`
       }
     }
 
-    resetAgent(checkDataAndEnd(t, 'POST', '/_search/template', JSON.stringify(body)))
+    resetAgent(checkDataAndEnd(t, 'POST', '/_search/template', JSON.stringify(body), 200))
 
     agent.startTransaction('myTrans')
 
@@ -291,7 +292,7 @@ ${JSON.stringify(body)}`
 ${body.map(JSON.stringify).join('\n')}
 `
 
-    resetAgent(checkDataAndEnd(t, 'POST', '/_msearch', statement))
+    resetAgent(checkDataAndEnd(t, 'POST', '/_msearch', statement, 200))
 
     agent.startTransaction('myTrans')
 
@@ -323,7 +324,7 @@ ${body.map(JSON.stringify).join('\n')}
     ]
     const statement = body.map(JSON.stringify).join('\n') + '\n'
 
-    resetAgent(checkDataAndEnd(t, 'POST', '/_msearch/template', statement))
+    resetAgent(checkDataAndEnd(t, 'POST', '/_msearch/template', statement, 200))
 
     agent.startTransaction('myTrans')
 
@@ -687,6 +688,73 @@ ${body.map(JSON.stringify).join('\n')}
   })
 }
 
+// Ensure that even without HTTP child spans, that trace-context propagation
+// to Elasticsearch still works.
+test('context-propagation works', function (t) {
+  const mockResponses = [
+    {
+      statusCode: 200,
+      headers: {
+        'X-elastic-product': 'Elasticsearch',
+        'content-type': 'application/json'
+      },
+      body: '{"took":0,"timed_out":false,"_shards":{"total":0,"successful":0,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":0,"hits":[]}}'
+    }
+  ]
+  if (semver.gte(esVersion, '7.14.0') && semver.satisfies(esVersion, '7.x')) {
+    // First request will be "GET /" for a product check.
+    mockResponses.unshift({
+      statusCode: 200,
+      headers: {
+        'X-elastic-product': 'Elasticsearch',
+        'content-type': 'application/json'
+      },
+      body: '{"name":"645a066f9b52","cluster_name":"docker-cluster","cluster_uuid":"1pR-cy9dSLWO7TNxI3kodA","version":{"number":"8.0.0-beta1","build_flavor":"default","build_type":"docker","build_hash":"ba1f616138a589f12eb0c6f678aee96377525b8f","build_date":"2021-11-04T12:35:26.989068569Z","build_snapshot":false,"lucene_version":"9.0.0","minimum_wire_compatibility_version":"7.16.0","minimum_index_compatibility_version":"7.0.0"},"tagline":"You Know, for Search"}'
+    })
+  }
+  const esServer = new MockES({ responses: mockResponses })
+  esServer.start(function (esUrl) {
+    resetAgent(
+      function done (data) {
+        // Assert that the ES server request for the `client.search()` is as
+        // expected.
+        const searchSpan = data.spans[data.spans.length - 1]
+        const esServerReq = esServer.requests[esServer.requests.length - 1]
+        const tracestate = esServerReq.headers.tracestate
+        t.equal(tracestate, 'es=s:1', 'esServer request included the expected tracestate header')
+        t.ok(esServerReq.headers.traceparent, 'esServer request included a traceparent header')
+        const traceparent = TraceParent.fromString(esServerReq.headers.traceparent)
+        t.equal(traceparent.traceId, myTrans.traceId, 'traceparent.traceId')
+        // node-traceparent erroneously (IMHO) calls this field `id` instead
+        // of `parentId`.
+        t.equal(traceparent.id, searchSpan.id, 'traceparent.id')
+        t.end()
+      }
+    )
+
+    const myTrans = agent.startTransaction('myTrans')
+    const client = new es.Client(Object.assign(
+      {},
+      clientOpts,
+      { node: esUrl }
+    ))
+    client.search({ q: 'pants' })
+      .then(() => {
+        t.ok('client.search succeeded')
+      })
+      .catch((err) => {
+        t.error(err, 'no error from client.search')
+      })
+      .finally(() => {
+        myTrans.end()
+        agent.flush()
+        client.close()
+        esServer.close()
+      })
+    t.ok(agent.currentSpan === null, 'no currentSpan in sync code after @elastic/elasticsearch client command')
+  })
+})
+
 // Utility functions.
 
 function checkSpanOutcomesFailures (t) {
@@ -719,7 +787,7 @@ function checkSpanOutcomesSuccess (t) {
   }
 }
 
-function checkDataAndEnd (t, method, path, dbStatement) {
+function checkDataAndEnd (t, method, path, dbStatement, statusCode) {
   return function (data) {
     t.equal(data.transactions.length, 1, 'should have 1 transaction')
     const trans = data.transactions[0]
@@ -734,30 +802,17 @@ function checkDataAndEnd (t, method, path, dbStatement) {
       const prodCheckEsSpan = data.spans[1]
       t.ok(prodCheckEsSpan, 'have >=7.14.0 product check ES span')
       t.equal(prodCheckEsSpan.name, 'Elasticsearch: GET /', 'product check ES span name')
-      const prodCheckHttpSpan = data.spans[2]
-      t.ok(prodCheckHttpSpan, 'have >=7.14.0 product check HTTP span')
-      t.equal(prodCheckHttpSpan.name, `GET ${host}`, 'product check HTTP span name')
-      // Remove the product check spans for subsequent assertions.
-      data.spans = data.spans.slice(0, 1).concat(data.spans.slice(3))
+      // Remove the product check span for subsequent assertions.
+      data.spans = data.spans.slice(0, 1)
     }
 
-    t.equal(data.spans.length, 2, 'should have 2 spans (excluding product check spans in >=7.14.0)')
-
-    const esSpan = findObjInArray(data.spans, 'subtype', 'elasticsearch')
+    t.equal(data.spans.length, 1, 'should have 1 span (excluding product check spans in >=7.14.0)')
+    const esSpan = data.spans[0]
     t.ok(esSpan, 'have an elasticsearch span')
     t.strictEqual(esSpan.type, 'db')
     t.strictEqual(esSpan.subtype, 'elasticsearch')
     t.strictEqual(esSpan.action, 'request')
     t.strictEqual(esSpan.sync, false, 'span.sync=false')
-
-    const httpSpan = findObjInArray(data.spans, 'subtype', 'http')
-    t.ok(httpSpan, 'have an http span')
-    t.strictEqual(httpSpan.type, 'external')
-    t.strictEqual(httpSpan.subtype, 'http')
-    t.strictEqual(httpSpan.action, method)
-    t.strictEqual(httpSpan.sync, false, 'span.sync=false')
-
-    t.equal(httpSpan.name, method + ' ' + host, 'http span should have expected name')
     t.equal(esSpan.name, 'Elasticsearch: ' + method + ' ' + path, 'elasticsearch span should have expected name')
 
     // Iff the test case provided a `dbStatement`, then we expect `.context.db`.
@@ -773,10 +828,12 @@ function checkDataAndEnd (t, method, path, dbStatement) {
     t.equal(esSpan.context.destination.service.name, 'elasticsearch',
       'elasticsearch span.context.destination.service.name=="elasticsearch"')
 
-    t.ok(httpSpan.timestamp > esSpan.timestamp,
-      'http span should start after elasticsearch span')
-    t.ok(httpSpan.timestamp + httpSpan.duration * 1000 < esSpan.timestamp + esSpan.duration * 1000,
-      'http span should end before elasticsearch span')
+    // Iff the test case provided an expected `statusCode`, then we expect
+    // `.context.http`.
+    if (statusCode !== undefined) {
+      t.equal(esSpan.context.http.status_code, statusCode, 'context.http.status_code')
+      t.ok(esSpan.context.http.response.encoded_body_size, 'context.http.response.encoded_body_size is present')
+    }
 
     t.end()
   }

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -829,10 +829,17 @@ function checkDataAndEnd (t, method, path, dbStatement, statusCode) {
       'elasticsearch span.context.destination.service.name=="elasticsearch"')
 
     // Iff the test case provided an expected `statusCode`, then we expect
-    // `.context.http`.
+    // `.context.http`. The exception is with @elastic/elasticsearch >=8
+    // and `asyncHooks=false` (see "Limitations" section in the instrumentation
+    // code).
     if (statusCode !== undefined) {
-      t.equal(esSpan.context.http.status_code, statusCode, 'context.http.status_code')
-      t.ok(esSpan.context.http.response.encoded_body_size, 'context.http.response.encoded_body_size is present')
+      if (semver.satisfies(esVersion, '>=8', { includePrerelease: true }) &&
+          agent._conf.asyncHooks === false) {
+        t.comment('skip span.context.http check because of asyncHooks=false + esVersion>=8 limitation')
+      } else {
+        t.equal(esSpan.context.http.status_code, statusCode, 'context.http.status_code')
+        t.ok(esSpan.context.http.response.encoded_body_size, 'context.http.response.encoded_body_size is present')
+      }
     }
 
     t.end()

--- a/test/instrumentation/modules/elasticsearch.test.js
+++ b/test/instrumentation/modules/elasticsearch.test.js
@@ -71,7 +71,7 @@ test('client.search with callback', function userLandCode (t) {
 })
 
 test('client.search with abort', function userLandCode (t) {
-  resetAgent(3, done(t, 'POST', '/_search', 'q=pants', true))
+  resetAgent(done(t, 'POST', '/_search', 'q=pants'))
 
   agent.startTransaction('foo')
 
@@ -235,65 +235,45 @@ test('client with hosts="http://host:port"', function userLandCode (t) {
   t.ok(agent.currentSpan === null, 'no currentSpan in sync code after elasticsearch client command')
 })
 
-function done (t, method, path, query, abort = false) {
+function done (t, method, path, query) {
   return function (data, cb) {
     t.strictEqual(data.transactions.length, 1, 'should have 1 transaction')
-    t.strictEqual(data.spans.length, 2, 'should have 2 spans')
+    t.strictEqual(data.spans.length, 1, 'should have 1 span')
 
     var trans = data.transactions[0]
 
     t.strictEqual(trans.name, 'foo', 'transaction name should be "foo"')
     t.strictEqual(trans.type, 'custom', 'transaction type should be "custom"')
 
-    let span1, span2
-    {
-      const type = 'external'
-      const subtype = 'http'
-      const action = method
-      span1 = findObjInArray(data.spans, 'type', type)
-      t.ok(span1, 'should have span with type ' + type)
-      t.strictEqual(span1.type, type)
-      t.strictEqual(span1.subtype, subtype)
-      t.strictEqual(span1.action, action)
-    } {
-      const type = 'db'
-      const subtype = 'elasticsearch'
-      const action = 'request'
-      span2 = findObjInArray(data.spans, 'subtype', subtype)
-      t.ok(span2, 'should have span with subtype ' + subtype)
-      t.strictEqual(span2.type, type)
-      t.strictEqual(span2.subtype, subtype)
-      t.strictEqual(span2.action, action)
-    }
+    const type = 'db'
+    const subtype = 'elasticsearch'
+    const action = 'request'
+    const span = findObjInArray(data.spans, 'subtype', subtype)
+    t.ok(span, 'should have span with subtype ' + subtype)
+    t.strictEqual(span.type, type)
+    t.strictEqual(span.subtype, subtype)
+    t.strictEqual(span.action, action)
 
-    t.strictEqual(span1.name, method + ' ' + host)
-    t.strictEqual(span2.name, 'Elasticsearch: ' + method + ' ' + path)
+    t.strictEqual(span.name, 'Elasticsearch: ' + method + ' ' + path)
 
-    t.ok(span2.stacktrace.some(function (frame) {
+    t.ok(span.stacktrace.some(function (frame) {
       return frame.function === 'userLandCode'
     }), 'include user-land code frame')
 
     if (pathIsAQuery.test(path)) {
-      t.deepEqual(span2.context.db, { statement: query, type: 'elasticsearch' })
+      t.deepEqual(span.context.db, { statement: query, type: 'elasticsearch' })
     } else {
-      t.notOk(span2.context.db, 'span2 should not have "context.db"')
+      t.notOk(span.context.db, 'span should not have "context.db"')
     }
 
     const [address, port] = host.split(':')
-    t.deepEqual(span2.context.destination, {
+    t.deepEqual(span.context.destination, {
       service: {
         name: 'elasticsearch', resource: 'elasticsearch', type: 'db'
       },
       port: Number(port),
       address
     })
-
-    t.ok(span1.timestamp > span2.timestamp, 'http span should start after elasticsearch span')
-    if (abort) {
-      t.ok(span1.timestamp + span1.duration * 1000 > span2.timestamp + span2.duration * 1000, 'http span should end after elasticsearch span when req is aborted')
-    } else {
-      t.ok(span1.timestamp + span1.duration * 1000 < span2.timestamp + span2.duration * 1000, 'http span should end before elasticsearch span')
-    }
 
     t.end()
   }
@@ -302,7 +282,7 @@ function done (t, method, path, query, abort = false) {
 function resetAgent (expected, cb) {
   if (typeof expected === 'function') {
     cb = expected
-    expected = 3
+    expected = 2
   }
   agent._instrumentation.testReset()
   agent._transport = mockClient(expected, cb)


### PR DESCRIPTION
Elasticsearch (ES) client spans are no marked as exit spans, so their HTTP
child spans are now no longer generated per spec:
https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans.md#exit-spans

Some HTTP context has been added to ES spans:
- span.context.http.status_code
- span.context.http.response.encoded_body_size

Closes: #2000
Closes: #2484


### Limitation

```
// - When using the non-default `asyncHooks=false` option with
//   @elastic/elasticsearch >=8 instrumentation, the diagnostic events do not
//   have the async run context of the current span. There are two impacts:
//   1. Elasticsearch tracing spans will not have additional "http" context
//      about the underlying HTTP request.
//   2. Users cannot access `apm.currentSpan` inside a diagnostic event handler.
```

I am currently inclined to *not* deal with this for `asyncHooks=false`. It is a minor degradation on generated ES spans (no `span.context.http`) and we never had a guarantee of the `currentSpan` being correct in the [diagnostic events of the ES client](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html) before anyway.  @astorm, please let me know if you disagree.


### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
