### PR TITLE
test: synchronizing json spec

### DIFF
--- a/test/fixtures/json-specs/span_types.json
+++ b/test/fixtures/json-specs/span_types.json
@@ -225,7 +225,13 @@
           "ruby",
           "java"
         ]
-      }
+      },
+       "ldap": {
+         "__description": "LDAP client",
+         "__used_by": [
+           "java"
+         ]
+       }
     }
   },
   "json": {


### PR DESCRIPTION
### What
  APM agent specs automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm/commit/b3f5827 Add ldap to external subtypes (https://github.com/elastic/apm/pull/588)