### PR TITLE
fix: `apm.createSpan()` with no args would create bogus span.name

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -16,10 +16,16 @@ module.exports = Span
 
 util.inherits(Span, GenericSpan)
 
-function Span (transaction, name, ...args) {
+// new Span(transaction)
+// new Span(transaction, name?, opts?)
+// new Span(transaction, name?, type?, opts?)
+// new Span(transaction, name?, type?, subtype?, opts?)
+// new Span(transaction, name?, type?, subtype?, action?, opts?)
+function Span (transaction, ...args) {
   const opts = typeof args[args.length - 1] === 'object'
     ? (args.pop() || {})
     : {}
+  const [name, ...tsaArgs] = args // "tsa" === Type, Subtype, Action
 
   if (!opts.childOf) {
     const defaultChildOf = transaction._agent._instrumentation.currSpan() || transaction
@@ -32,7 +38,7 @@ function Span (transaction, name, ...args) {
   this._exitSpan = !!opts.exitSpan
   delete opts.exitSpan
 
-  GenericSpan.call(this, transaction._agent, ...args, opts)
+  GenericSpan.call(this, transaction._agent, ...tsaArgs, opts)
 
   this._db = null
   this._http = null

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -403,6 +403,19 @@ test('#startSpan()', function (t) {
     t.end()
   })
 
+  t.test('startSpan with no name results in span.name="unnamed"', function (t) {
+    const agent = new Agent().start(agentOptsNoopTransport)
+    agent.startTransaction()
+    var span = agent.startSpan()
+    t.ok(span, 'should return a span')
+    t.strictEqual(span.name, 'unnamed')
+    t.strictEqual(span.type, null)
+    t.strictEqual(span.subtype, null)
+    t.strictEqual(span.action, null)
+    agent.destroy()
+    t.end()
+  })
+
   t.test('options.startTime', function (t) {
     const agent = new Agent().start(agentOptsNoopTransport)
     agent.startTransaction()


### PR DESCRIPTION
This fixes a bug recently introduced in commit 520a90113a5 where
`apm.createSpan()` with no args would result in a span with span.name
set to a SpanOptions value (and the options would not be applied).

### the issue

commit 520a90113a56e6df0485b16ba067934dd243a33b (#2552) introduced a subtle
bug with `apm.createSpan()` -- specifically when called with no args. In this
case we expect a Span with the default name 'unnamed'. Instead what we get
is a Span with `name` set to a Span *options* object, which when serialized
(I'm shocked it got this far), results in badness:

```
{
    "span": {
        "name": {
            "childOf": {
                "_timer": null,
                "_context": {
                    "traceparent": {
                        "recorded": true,
                        "version": "00",
                        "traceId": "5ea066a3c66fa7bfe12f727e49588dc1",
                        "id": "f8177cad6679a3d2",
                        "flags": "01"
                    },
                    "tracestate": {
                        "buffer": {},
                        "listMemberNamespace": "es",
                        "values": {
                            "s": 1
                        }
                    }
                },
                "_agent": {
                    "logger": {
                        "levels": {
                            "labels": {
                                "10": "trace",
                                "20": "debug",
                                "30": "info",
                                "40": "warn",
                                "50": "error",
                                "60": "fatal"
                            },
                            "values": {
                                "trace": 10,
                                "debug": 20,
                                "info": 30,
                                "warn": 40,
                                "error": 50,
                                "fatal": 60
                            }
                        }
                    },
                    "_conf": {
                        "ignoreUrlStr": [],
...
                        "serverPort": 8200
                    },
                    "_httpClient": null,
                    "_inflightEvents": {},
                    "_instrumentation": {
                        "_agent": "[Circular]",
                        "_hook": {
                            "cache": {},
                            "_unhooked": false
                        },
                        "_started": true,
                        "_runCtxMgr": {
                            "_log": "[Circular]",
                            "_root": {
                                "_trans": null,
                                "_spans": []
                            },
                            "_stack": [],
                            "_runContextFromAsyncId": {},
                            "_asyncHook": {}
                        },
                        "_log": "[Circular]",
                        "_patches": {}
                    },
                    "_metrics": {},
                    "_errorFilters": [
                        null
                    ],
                    "_transactionFilters": [
                        null
                    ],
                    "_spanFilters": [
                        null
                    ],
                    "_transport": {
                        "_writableState": {
                            "objectMode": true,
                            "highWaterMark": 16,
                            "finalCalled": false,
                            "needDrain": false,
                            "ending": false,
                            "ended": false,
                            "finished": false,
                            "destroyed": false,
                            "decodeStrings": true,
                            "defaultEncoding": "utf8",
                            "length": 2,
                            "writing": true,
                            "corked": 0,
                            "sync": true,
                            "bufferProcessing": true,
                            "writelen": 2,
                            "bufferedRequest": {
                                "chunk": {
                                    "transaction": {
                                        "id": "f8177cad6679a3d2",
                                        "trace_id": "5ea066a3c66fa7bfe12f727e49588dc1",
                                        "name": "unnamed",
                                        "type": "custom",
                                        "duration": 7.685,
                                        "timestamp": 1644012311769031,
                                        "result": "success",
...
```

Good thing we don't have a release of this.

The issue is that `Transaction.prototype.createSpan` changed to attempting to
call `new Span(transaction, opts)` when `.createSpan()` was called with no
args; and the signature of Span is `function Span (transaction, name, ...args)`.

### related

Currently (and with the released v3.27.0), despite this interface (in index.d.ts):

```ts
    startSpan(
      name?: string | null,
      options?: SpanOptions
    ): Span | null;
```

it is impossible to create a span with options, but no name. Attempting:

```js
var s = apm.startSpan({ startTime: 42 })
```

Results in this span:

```json
{
    "span": {
        "name": {
            "startTime": 42
        },
        "type": "custom",
        "id": "a3da635a50ffae41",
        "transaction_id": "8b8f078c6dd1e599",
        "parent_id": "8b8f078c6dd1e599",
        "trace_id": "eb21939f42c86ac94c5683e9e395ad11",
        "subtype": null,
        "action": null,
        "timestamp": 1644014275188294,
        "duration": 0.426,
        "sync": true,
        "outcome": "success",
        "sample_rate": 1
    }
}
```

This is effectively the issue that the changed `Transaction.prototype.createSpan` hit.


### Checklist

- [x] Implement code
- [x] Add tests

I'm skipping a changelog entry because we haven't had a release with this bug.