### PR TITLE
perf: fix benchmark 003 to actually have span.stacktrace

### DIFF
--- a/test/benchmarks/003-transaction-and-span-with-stack-trace.js
+++ b/test/benchmarks/003-transaction-and-span-with-stack-trace.js
@@ -6,7 +6,8 @@ const bench = require('./utils/bench')
 
 bench('transaction-and-span-with-stack-trace', {
   agentConf: {
-    captureSpanStackTraces: false
+    captureSpanStackTraces: true,
+    spanFramesMinDuration: '-1ms'
   },
   setup () {
     var agent = this.benchmark.agent


### PR DESCRIPTION
This benchmark is named 'transaction-and-span-with-stack-trace'
but since inception incorrectly has span stacktrace collection
*disabled*.

