### PR TITLE
tests: fix test failure due to os.freemem() behaviour change in node v16.14.0

### DIFF
--- a/test/metrics/index.test.js
+++ b/test/metrics/index.test.js
@@ -76,15 +76,18 @@ test('reports expected metrics', function (t) {
         const free = os.freemem()
         if (os.type() === 'Linux' &&
           semver.lt(process.version, '18.0.0-nightly20220107') &&
-          semver.lt(process.version, '17.4.0')) {
+          semver.lt(process.version, '17.4.0') &&
+          semver.lt(process.version, '16.14.0')) {
           // On Linux we use "MemAvailable" from /proc/meminfo as the value for
-          // this metric. In versions of Node.js before v17.4.0 and v18.0.0,
-          // `os.freemem()` reports "MemFree" from /proc/meminfo. (This changed
-          // in v17.4.0 and v18.0.0-nightly20220107b6b6510187 when node upgraded
-          // to libuv 1.43.0 to include https://github.com/libuv/libuv/pull/3351.)
+          // this metric. In older versions of Node.js on Linus, `os.freemem()`
+          // reports "MemFree" from /proc/meminfo. This changed when dev-lines
+          // of node upgraded to libuv 1.43.0 to include
+          // https://github.com/libuv/libuv/pull/3351.
           t.ok(value > free, `is larger than os.freemem() (value: ${value},
           free: ${free})`)
         } else {
+          // `isRoughly` because we are comparing free memory queried at
+          // near but separate times, so we expect some variance.
           t.ok(isRoughly(value, free, 0.1), `is close to current free memory (value: ${value}, free: ${free})`)
         }
       },


### PR DESCRIPTION
The update to libuv 1.43.0 changed the behaviour of os.freemem() on
Linux to report "MemAvailable" from /proc/meminfo rather than "MemFree".

Refs: #2530, #2540

This is the same thing as we have already done for node v18 and v17, respectively, in the two linked PRs. The recently released node v16.14.0 (https://nodejs.org/en/blog/release/v16.14.0/) updated to the libuv with this `os.freemem()` behaviour change:

> - [[af6f1d512d](https://github.com/nodejs/node/commit/af6f1d512d)] - deps: upgrade to libuv 1.43.0 (Colin Ihrig) [#41398](https://github.com/nodejs/node/pull/41398)

