### PR TITLE
fix: memory leak in @elastic/elasticsearch instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,9 +28,27 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix a bug in instrumentation of `@elastic/elasticsearch` that caused a
+  memory leak. ({issues}2569[#2569])
+
 
 [[release-notes-3.28.0]]
 ==== 3.28.0 2022/02/08
+
+Known issue: This release includes a memory leak in instrumentation of the
+`@elastic/elasticsearch` package. If you use that package, you should not
+use v3.28.0 of this APM agent. ({issues}2569[#2569])
 
 [float]
 ===== Breaking changes

--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -70,7 +70,7 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
           if (result) {
             const currSpan = ins.currSpan()
             if (currSpan) {
-              diagResultFromSpan[currSpan] = result
+              diagResultFromSpan.set(currSpan, result)
             }
           }
         })
@@ -91,7 +91,7 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
       const conn = origGetConnection.apply(this, arguments)
       const currSpan = ins.currSpan()
       if (conn && currSpan) {
-        connFromSpan[currSpan] = conn
+        connFromSpan.set(currSpan, conn)
       }
       return conn
     }

--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -136,7 +136,7 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
         // Otherwise, fallback to using the first connection on
         // `Transport#connectionPool`, if any.  (This is the best parsed
         // representation of connection options passed to the Client ctor.)
-        let conn = connFromSpan[span]
+        let conn = connFromSpan.get(span)
         if (conn) {
           connFromSpan.delete(span)
         } else if (this.connectionPool && this.connectionPool.connections) {
@@ -154,7 +154,7 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
         //    content-length: ...
         //
         // Getting the ES client request "DiagnosticResult" object has some edge cases:
-        // - In v7 using a callback, we always get `result`.
+        // - In v7 using a callback, we always get it as `result`.
         // - In v7 using a Promise, if the promise is rejected, then `result` is
         //   not passed.
         // - In v8, `result` only includes HTTP response info if `options.meta`
@@ -166,7 +166,7 @@ module.exports = function (elasticsearch, agent, { version, enabled }) {
         // `diagResult`.
         let diagResult = isGteV8 ? null : result
         if (!diagResult) {
-          diagResult = diagResultFromSpan[span]
+          diagResult = diagResultFromSpan.get(span)
           if (diagResult) {
             diagResultFromSpan.delete(span)
           }


### PR DESCRIPTION
tl;dr: Use a WeakMap as a WeakMap, not as an Object.
This leak was introduced in #2484.

Fixes: #2569

### Checklist

- [x] Implement code
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
