### PR TITLE
3.30.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,7 +29,8 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
+[[release-notes-3.30.0]]
+==== 3.30.0 2022/03/10
 
 [float]
 ===== Breaking changes

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -36,6 +36,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.30.x |2023-09-10 |3.31.0
 |3.29.x |2023-08-10 |3.30.0
 |3.28.x |2023-08-08 |3.29.0
 |3.27.x |2023-07-17 |3.28.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Release version 3.30.0.  It has been a month. This one has a couple significant changes:

- The capturing of span stacktraces is now *disabled* by default for perf reasons. The `spanFramesMinDuration` config var obsoletes `captureSpanStackTraces` and `spanStackTraceMinDuration` (the old ones still work). https://github.com/elastic/apm-agent-nodejs/pull/2565 for details.
- Instrumentating Lambda functions:
    - One must use [v0.0.4](https://github.com/elastic/apm-aws-lambda/releases/tag/v0.0.4) of the Elastic APM Lambda extension or later, because new functionality in this version of the APM agent tickles a crash bug in older versions of the extension.
    - Instrumenting your Lambda functions is now easier: 1. add the Node.js APM agent layer to your lambda functions, 2. set the `NODE_OPTIONS=-r elastic-apm-node/start` environment variable, and then the manual `apm.lambda(...)` wrapping of your handler function is no longer necessary!
   