### PR TITLE
ci: enable tags and run the release stage only for tags

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,6 +73,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
+          not { tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP' }
           expression { return env.ONLY_DOCS == "false" }
           expression { return params.tests_ci }
         }
@@ -115,9 +116,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
-          not {
-            branch '^greenkeeper/.*'
-          }
+          not { tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP' }
           anyOf {
             expression { return params.Run_As_Main_Branch }
             triggeredBy 'TimerTrigger'
@@ -161,6 +160,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
+          not { tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP' }
           anyOf {
             expression { return params.Run_As_Main_Branch }
             triggeredBy 'TimerTrigger'
@@ -253,6 +253,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
+          not { tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP' }
           expression { return env.ONLY_DOCS == "false" }
           anyOf {
             changeRequest()
@@ -373,7 +374,6 @@ pipeline {
         allOf {
           anyOf {
             branch 'main'
-            tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
             expression { return params.Run_As_Main_Branch }
             expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
           }

--- a/.ci/jobs/apm-agent-nodejs-mbp.yml
+++ b/.ci/jobs/apm-agent-nodejs-mbp.yml
@@ -12,8 +12,8 @@
         discover-pr-origin: merge-current
         discover-tags: true
         notification-context: 'apm-ci'
-        # Run CI builds only on main, PRs, and non-EOL version branches.
-        head-filter-regex: '^(main|PR-.*|3\.x)$'
+        # Run CI builds only on main, PRs, non-EOL version branches, and tags.
+        head-filter-regex: '^(main|PR-.*|3\.x|v[3-9].*)$'
         repo: apm-agent-nodejs
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
### What

* Enable tags in the Jenkins Multibranch Pipeline.
* Disable all the stages in the CI Pipeline for a tag build, but only the `release` stage will be the enabled one.

### Why

Run releases in the CI for tags, since they were disabled in https://github.com/elastic/apm-agent-nodejs/pull/2169

### Issues

Notifies #2607 #2574