### PR TITLE
test: use newer ubuntu for node.js edge tests for GLIBC_2.28 req

### DIFF
--- a/.ci/docker/node-edge-container/Dockerfile
+++ b/.ci/docker/node-edge-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # - nvm dependencies: build-essential, libssl-dev, curl
 # - git is installed for usage in tests using this image


### PR DESCRIPTION
Fixes: #2612

