### PR TITLE
feat: add 'captureBody' support for Hapi

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,8 @@ Notes:
 [float]
 ===== Features
 
+* Add `captureBody` support for Hapi. ({issues}1905[#1905])
+
 * If a SNS or SQS single event trigger to an instrumented Lambda function
   includes message attributes with the name "traceparent" (and "tracestate"),
   case-insensitive, then those are used to continue the trace. This was already

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -40,7 +40,7 @@ These are the frameworks that we officially support:
 |Framework |Version
 |<<express,Express>> |^4.0.0
 |<<hapi,hapi>> |>=9.0.0 <19.0.0
-|<<hapi,@hapi/hapi>> |>=17.9.0 <20.0.0
+|<<hapi,@hapi/hapi>> |>=17.9.0 <=20.0.0
 |<<koa,Koa>> via koa-router or @koa/router |>=5.2.0 <10.0.0
 2+|Koa doesn't have a built in router, so we can't support Koa directly since we rely on
 router information for full support. We currently support the most popular Koa router called

--- a/lib/instrumentation/modules/hapi.js
+++ b/lib/instrumentation/modules/hapi.js
@@ -15,10 +15,11 @@ module.exports = function (hapi, agent, { version, enabled }) {
     agent.logger.debug('hapi version %s not supported - aborting...', version)
     return hapi
   }
+  const isHapiGte17 = semver.satisfies(version, '>=17')
 
   agent.logger.debug('shimming hapi.Server.prototype.initialize')
 
-  if (semver.satisfies(version, '>=17')) {
+  if (isHapiGte17) {
     shimmer.massWrap(hapi, ['Server', 'server'], function (orig) {
       return function (options) {
         var res = orig.apply(this, arguments)
@@ -60,13 +61,16 @@ module.exports = function (hapi, agent, { version, enabled }) {
     if (typeof server.ext === 'function') {
       server.ext('onPreAuth', onPreAuth)
       server.ext('onPreResponse', onPreResponse)
+      if (agent._conf.captureBody !== 'off') {
+        server.ext('onPostAuth', onPostAuth)
+      }
     } else {
       agent.logger.debug('unable to enable automatic hapi transaction naming')
     }
   }
 
   function attachEvents (emitter) {
-    if (semver.satisfies(version, '<17')) {
+    if (!isHapiGte17) {
       emitter.on('request-error', function (request, error) {
         agent.captureError(error, {
           request: request.raw && request.raw.req
@@ -137,9 +141,15 @@ module.exports = function (hapi, agent, { version, enabled }) {
       }
     }
 
-    return semver.satisfies(version, '>=17')
-      ? reply.continue
-      : reply.continue()
+    return (isHapiGte17 ? reply.continue : reply.continue())
+  }
+
+  function onPostAuth (request, reply) {
+    if (request.payload && request.raw && request.raw.req) {
+      // Save the parsed req body to be picked up by getContextFromRequest().
+      request.raw.req.payload = request.payload
+    }
+    return (isHapiGte17 ? reply.continue : reply.continue())
   }
 
   function onPreResponse (request, reply) {
@@ -158,9 +168,7 @@ module.exports = function (hapi, agent, { version, enabled }) {
       agent._instrumentation.setDefaultTransactionName('CORS preflight')
     }
 
-    return semver.satisfies(version, '>=17')
-      ? reply.continue
-      : reply.continue()
+    return (isHapiGte17 ? reply.continue : reply.continue())
   }
 
   return hapi

--- a/test/_is_hapi_incompat.js
+++ b/test/_is_hapi_incompat.js
@@ -12,14 +12,16 @@ function isHapiIncompat (moduleName) {
   if (semver.lt(process.version, '8.9.0') && semver.gte(hapiVersion, '17.0.0')) {
     return true
   }
-  // hapi 18.1.0 (the last hapi 18.x) was released before node v12 was released,
-  // and tests with hapi@18 and node >=16 is known to hang.  (Also, hapi <20 is
-  // deprecated, https://github.com/hapijs/hapi/issues/4114.)
-  if (semver.gte(process.version, '16.0.0') && semver.lt(hapiVersion, '19.0.0')) {
-    return true
-  }
   // hapi 19+ requires Node.js 12 or higher
   if (semver.lt(process.version, '12.0.0') && semver.gte(hapiVersion, '19.0.0')) {
+    return true
+  }
+  // - hapi 18.1.0 (the last hapi 18.x) was released before node v12 was released,
+  //   and tests with hapi@18 and node >=16 is known to hang.
+  // - @hapi/hapi@20.1.2 fixed an issue (https://github.com/hapijs/hapi/pull/4225)
+  //   need to work with node >=16. Earlier versions of Hapi will crash when
+  //   handling a POST.
+  if (semver.gte(process.version, '16.0.0') && semver.lt(hapiVersion, '20.1.2')) {
     return true
   }
 

--- a/test/_is_hapi_incompat.js
+++ b/test/_is_hapi_incompat.js
@@ -12,6 +12,12 @@ function isHapiIncompat (moduleName) {
   if (semver.lt(process.version, '8.9.0') && semver.gte(hapiVersion, '17.0.0')) {
     return true
   }
+  // hapi 18.1.0 (the last hapi 18.x) was released before node v12 was released,
+  // and tests with hapi@18 and node >=16 is known to hang.  (Also, hapi <20 is
+  // deprecated, https://github.com/hapijs/hapi/issues/4114.)
+  if (semver.gte(process.version, '16.0.0') && semver.lt(hapiVersion, '19.0.0')) {
+    return true
+  }
   // hapi 19+ requires Node.js 12 or higher
   if (semver.lt(process.version, '12.0.0') && semver.gte(hapiVersion, '19.0.0')) {
     return true

--- a/test/instrumentation/modules/hapi/shared.js
+++ b/test/instrumentation/modules/hapi/shared.js
@@ -14,6 +14,7 @@ module.exports = (moduleName) => {
   var isHapiIncompat = require('../../../_is_hapi_incompat')
   if (isHapiIncompat(moduleName)) {
     // Skip out of this test.
+    console.log(`# SKIP this version of ${moduleName} is incompatible with node ${process.version}`)
     process.exit()
   }
 

--- a/test/instrumentation/modules/hapi/shared.js
+++ b/test/instrumentation/modules/hapi/shared.js
@@ -77,16 +77,19 @@ module.exports = (moduleName) => {
   })
 
   test('captureBody', function (t) {
-    t.plan(8)
+    t.plan(9)
+
+    const postData = JSON.stringify({ foo: 'bar' })
 
     resetAgent(1, function (data) {
       assert(t, data, { name: 'POST /postSomeData', method: 'POST' })
+      t.equal(data.transactions[0].context.request.body, postData,
+        'body was captured to trans.context.request.body')
       server.stop(noop)
     })
 
     var server = startServer(function (err, port) {
       t.error(err)
-      const postData = JSON.stringify({ foo: 'bar' })
       const cReq = http.request(
         'http://localhost:' + port + '/postSomeData',
         {

--- a/test/sanitize-field-names/hapi.test.js
+++ b/test/sanitize-field-names/hapi.test.js
@@ -3,6 +3,7 @@
 const {
   assertRequestHeadersWithFixture,
   assertResponseHeadersWithFixture,
+  assertFormsWithFixture,
   createAgentConfig,
   resetAgent
 } = require('./_shared')
@@ -60,9 +61,7 @@ async function runTest (
     const transaction = data.transactions.pop()
     assertRequestHeadersWithFixture(transaction, expected, t)
     assertResponseHeadersWithFixture(transaction, expected, t)
-    // TODO: uncomment once we fix
-    // https://github.com/elastic/apm-agent-nodejs/issues/1905
-    // assertFormsWithFixture(transaction, expected, t)
+    assertFormsWithFixture(transaction, expected, t)
   })
 
   // register request handler


### PR DESCRIPTION
The body of incoming requests to an HTTP server using the Hapi
framework will be recorded in relevant APM transaction and error
objects depending on the `captureBody` config var setting.

Closes: #1905

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
