### PR TITLE
feat: exit spans across all module instrumentations

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,10 @@ Notes:
 * Adds initial implementaion of
   https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md[span compression]. To enable, set the `spanCompressionEnabled` configuration field to `true`.  ({issues}2100[#2100])
 
+* Marks spans as "exit spans" across all instrumentations, preventing additional
+  child spans from being added to the exit spans.  See issue for a full list of
+  spans types that will be treated as exit spans. ({issues}2601[#2601])
+
 [float]
 ===== Bug fixes
 

--- a/lib/instrumentation/modules/aws-sdk/dynamodb.js
+++ b/lib/instrumentation/modules/aws-sdk/dynamodb.js
@@ -65,7 +65,7 @@ function instrumentationDynamoDb (orig, origArguments, request, AWS, agent, { ve
 
   const ins = agent._instrumentation
   const name = getSpanNameFromRequest(request)
-  const span = ins.createSpan(name, TYPE, SUBTYPE, ACTION)
+  const span = ins.createSpan(name, TYPE, SUBTYPE, ACTION, { exitSpan: true })
   if (!span) {
     return orig.apply(request, origArguments)
   }

--- a/lib/instrumentation/modules/aws-sdk/sns.js
+++ b/lib/instrumentation/modules/aws-sdk/sns.js
@@ -111,7 +111,7 @@ function instrumentationSns (orig, origArguments, request, AWS, agent, { version
 
   const ins = agent._instrumentation
   const name = getSpanNameFromRequest(request)
-  const span = ins.createSpan(name, TYPE, SUBTYPE, ACTION)
+  const span = ins.createSpan(name, TYPE, SUBTYPE, ACTION, { exitSpan: true })
   if (!span) {
     return orig.apply(request, origArguments)
   }

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -149,7 +149,7 @@ function instrumentationSqs (orig, origArguments, request, AWS, agent, { version
   const ins = agent._instrumentation
   const action = getActionFromRequest(request)
   const name = getSpanNameFromRequest(request)
-  const span = ins.createSpan(name, TYPE, SUBTYPE, action)
+  const span = ins.createSpan(name, TYPE, SUBTYPE, action, { exitSpan: true })
   if (!span) {
     return orig.apply(request, origArguments)
   }

--- a/lib/instrumentation/modules/cassandra-driver.js
+++ b/lib/instrumentation/modules/cassandra-driver.js
@@ -33,7 +33,7 @@ module.exports = function (cassandra, agent, { version, enabled }) {
 
   function wrapAsyncConnect (original) {
     return async function wrappedAsyncConnect () {
-      const span = ins.createSpan('Cassandra: Connect', 'db', 'cassandra', 'connect')
+      const span = ins.createSpan('Cassandra: Connect', 'db', 'cassandra', 'connect', { exitSpan: true })
       try {
         return await original.apply(this, arguments)
       } finally {
@@ -44,7 +44,7 @@ module.exports = function (cassandra, agent, { version, enabled }) {
 
   function wrapConnect (original) {
     return function wrappedConnect (callback) {
-      const span = ins.createSpan('Cassandra: Connect', 'db', 'cassandra', 'connect')
+      const span = ins.createSpan('Cassandra: Connect', 'db', 'cassandra', 'connect', { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }
@@ -82,7 +82,7 @@ module.exports = function (cassandra, agent, { version, enabled }) {
 
   function wrapBatch (original) {
     return function wrappedBatch (queries, options, callback) {
-      const span = ins.createSpan('Cassandra: Batch query', 'db', 'cassandra', 'query')
+      const span = ins.createSpan('Cassandra: Batch query', 'db', 'cassandra', 'query', { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }
@@ -126,7 +126,7 @@ module.exports = function (cassandra, agent, { version, enabled }) {
 
   function wrapExecute (original) {
     return function wrappedExecute (query, params, options, callback) {
-      const span = ins.createSpan(null, 'db', 'cassandra', 'query')
+      const span = ins.createSpan(null, 'db', 'cassandra', 'query', { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }
@@ -165,7 +165,7 @@ module.exports = function (cassandra, agent, { version, enabled }) {
 
   function wrapEachRow (original) {
     return function wrappedEachRow (query, params, options, rowCallback, callback) {
-      const span = ins.createSpan(null, 'db', 'cassandra', 'query')
+      const span = ins.createSpan(null, 'db', 'cassandra', 'query', { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -218,7 +218,7 @@ module.exports = function (http2, agent, { enabled }) {
     return function (headers) {
       agent.logger.debug('intercepted call to http2.request')
       var method = headers[':method'] || 'GET'
-      const span = ins.createSpan(null, 'external', 'http', method)
+      const span = ins.createSpan(null, 'external', 'http', method, { exitSpan: true })
       if (!span) {
         return orig.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/ioredis.js
+++ b/lib/instrumentation/modules/ioredis.js
@@ -42,7 +42,7 @@ module.exports = function (ioredis, agent, { version, enabled }) {
       }
 
       agent.logger.debug({ command: command.name }, 'intercepted call to ioredis.prototype.sendCommand')
-      const span = ins.createSpan(command.name.toUpperCase(), TYPE, SUBTYPE)
+      const span = ins.createSpan(command.name.toUpperCase(), TYPE, SUBTYPE, { exitSpan: true })
       if (!span) {
         return origSendCommand.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/memcached.js
+++ b/lib/instrumentation/modules/memcached.js
@@ -53,7 +53,7 @@ module.exports = function (memcached, agent, { version, enabled }) {
         return original.apply(this, arguments)
       }
 
-      const span = ins.createSpan(`memcached.${query.type}`, 'db', 'memcached', query.type)
+      const span = ins.createSpan(`memcached.${query.type}`, 'db', 'memcached', query.type, { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/mongodb-core.js
+++ b/lib/instrumentation/modules/mongodb-core.js
@@ -51,7 +51,7 @@ module.exports = function (mongodb, agent, { version, enabled }) {
           else if (cmd.count) type = 'count'
           else type = 'command'
 
-          span = ins.createSpan(ns + '.' + type, 'db', 'mongodb', 'query')
+          span = ins.createSpan(ns + '.' + type, 'db', 'mongodb', 'query', { exitSpan: true })
           if (span) {
             arguments[index] = ins.bindFunctionToRunContext(ins.currRunContext(), wrappedCallback)
           }
@@ -80,7 +80,7 @@ module.exports = function (mongodb, agent, { version, enabled }) {
         var index = arguments.length - 1
         var cb = arguments[index]
         if (typeof cb === 'function') {
-          span = ins.createSpan(ns + '.' + name, 'db', 'mongodb', 'query')
+          span = ins.createSpan(ns + '.' + name, 'db', 'mongodb', 'query', { exitSpan: true })
           if (span) {
             arguments[index] = ins.bindFunctionToRunContext(ins.currRunContext(), wrappedCallback)
           }
@@ -109,7 +109,7 @@ module.exports = function (mongodb, agent, { version, enabled }) {
         if (typeof cb === 'function') {
           if (name !== 'next' || !this[firstSpan]) {
             var spanName = `${this.ns}.${this.cmd.find ? 'find' : name}`
-            span = ins.createSpan(spanName, 'db', 'mongodb', 'query')
+            span = ins.createSpan(spanName, 'db', 'mongodb', 'query', { exitSpan: true })
           }
           if (span) {
             arguments[0] = ins.bindFunctionToRunContext(ins.currRunContext(), wrappedCallback)

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -117,7 +117,7 @@ module.exports = (mongodb, agent, { version, enabled }) => {
       event.commandName
     ].join('.')
 
-    const span = ins.createSpan(name, 'db', 'mongodb', 'query')
+    const span = ins.createSpan(name, 'db', 'mongodb', 'query', { exitSpan: true })
     if (span) {
       activeSpans.set(event.requestId, span)
 

--- a/lib/instrumentation/modules/mysql.js
+++ b/lib/instrumentation/modules/mysql.js
@@ -101,7 +101,7 @@ function wrapQueryable (connection, objType, agent) {
     return function wrappedQuery (sql, values, cb) {
       agent.logger.debug('intercepted call to mysql %s.query', objType)
 
-      var span = ins.createSpan(null, 'db', 'mysql', 'query')
+      var span = ins.createSpan(null, 'db', 'mysql', 'query', { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/mysql2.js
+++ b/lib/instrumentation/modules/mysql2.js
@@ -27,7 +27,7 @@ module.exports = function (mysql2, agent, { version, enabled }) {
     return function wrappedQuery (sql, values, cb) {
       agent.logger.debug('intercepted call to mysql2.%s', original.name)
 
-      var span = ins.createSpan(null, 'db', 'mysql', 'query')
+      var span = ins.createSpan(null, 'db', 'mysql', 'query', { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/pg.js
+++ b/lib/instrumentation/modules/pg.js
@@ -49,7 +49,7 @@ function patchClient (Client, klass, agent) {
     return function wrappedFunction (sql) {
       agent.logger.debug('intercepted call to %s.prototype.%s', klass, name)
       const ins = agent._instrumentation
-      const span = ins.createSpan('SQL', 'db', 'postgresql', 'query')
+      const span = ins.createSpan('SQL', 'db', 'postgresql', 'query', { exitSpan: true })
       if (!span) {
         return orig.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/redis.js
+++ b/lib/instrumentation/modules/redis.js
@@ -73,7 +73,7 @@ module.exports = function (redis, agent, { version, enabled }) {
 
       const command = commandObj.command
       agent.logger.debug({ command: command }, 'intercepted call to RedisClient.prototype.internal_send_command')
-      const span = ins.createSpan(command.toUpperCase(), TYPE, SUBTYPE)
+      const span = ins.createSpan(command.toUpperCase(), TYPE, SUBTYPE, { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }
@@ -105,7 +105,7 @@ module.exports = function (redis, agent, { version, enabled }) {
       }
 
       agent.logger.debug({ command: command }, 'intercepted call to RedisClient.prototype.send_command')
-      var span = ins.createSpan(command.toUpperCase(), TYPE, SUBTYPE)
+      var span = ins.createSpan(command.toUpperCase(), TYPE, SUBTYPE, { exitSpan: true })
       if (!span) {
         return original.apply(this, arguments)
       }

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -69,7 +69,7 @@ module.exports = function (tedious, agent, { version, enabled }) {
         if (!request.parametersByName) {
           return super.makeRequest(...arguments)
         }
-        const span = ins.createSpan(null, 'db', 'mssql', 'query')
+        const span = ins.createSpan(null, 'db', 'mssql', 'query', { exitSpan: true })
         if (!span) {
           return super.makeRequest(...arguments)
         }

--- a/lib/instrumentation/modules/ws.js
+++ b/lib/instrumentation/modules/ws.js
@@ -21,7 +21,7 @@ module.exports = function (ws, agent, { version, enabled }) {
   function wrapSend (orig) {
     return function wrappedSend () {
       agent.logger.debug('intercepted call to ws.prototype.send')
-      const span = ins.createSpan('Send WebSocket Message', 'websocket', 'send')
+      const span = ins.createSpan('Send WebSocket Message', 'websocket', 'send', { exitSpan: true })
       if (!span) {
         return orig.apply(this, arguments)
       }

--- a/test/instrumentation/modules/aws-sdk/sqs.test.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.test.js
@@ -195,7 +195,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS SEND to our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -204,7 +205,6 @@ tape.test('AWS SQS: End to End Tests', function (test) {
         t.equals(spanSqs.context.destination.service.type, 'messaging', 'messaging context set')
         t.equals(spanSqs.context.message.queue.name, 'our-queue', 'queue name context set')
 
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
         t.end()
       })
       agent.startTransaction('myTransaction')
@@ -225,9 +225,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
-
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS SEND_BATCH to our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -255,7 +254,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS DELETE from our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -263,8 +263,6 @@ tape.test('AWS SQS: End to End Tests', function (test) {
         t.equals(spanSqs.action, 'delete', 'span action matches API method called')
         t.equals(spanSqs.context.destination.service.type, 'messaging', 'messaging context set')
         t.equals(spanSqs.context.message.queue.name, 'our-queue', 'queue name context set')
-
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
 
         t.end()
       })
@@ -285,9 +283,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
-
-        t.equals(spanHttp.type, 'external', 'second span is for HTTP request')
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS DELETE_BATCH from our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -315,9 +312,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
-
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS POLL from our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -400,7 +396,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS SEND to our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -409,7 +406,6 @@ tape.test('AWS SQS: End to End Tests', function (test) {
         t.equals(spanSqs.context.destination.service.type, 'messaging', 'messaging context set')
         t.equals(spanSqs.context.message.queue.name, 'our-queue', 'queue name context set')
 
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
         t.end()
       })
       agent.startTransaction('myTransaction')
@@ -438,9 +434,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
-
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS SEND_BATCH to our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -472,7 +467,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS DELETE from our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -480,8 +476,6 @@ tape.test('AWS SQS: End to End Tests', function (test) {
         t.equals(spanSqs.action, 'delete', 'span action matches API method called')
         t.equals(spanSqs.context.destination.service.type, 'messaging', 'messaging context set')
         t.equals(spanSqs.context.message.queue.name, 'our-queue', 'queue name context set')
-
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
 
         t.end()
       })
@@ -507,9 +501,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
-
-        t.equals(spanHttp.type, 'external', 'second span is for HTTP request')
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS DELETE_BATCH from our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -542,9 +535,8 @@ tape.test('AWS SQS: End to End Tests', function (test) {
     )
     const listener = app.listen(0, function () {
       resetAgent(function (data) {
-        const [spanSqs, spanHttp] = getSqsAndOtherSpanFromData(data, t)
-
-        t.equals(spanHttp.type, 'external', 'other span is for HTTP request')
+        t.equals(data.spans.length, 1, 'generated one span')
+        const spanSqs = data.spans[0]
 
         t.equals(spanSqs.name, 'SQS POLL from our-queue', 'SQS span named correctly')
         t.equals(spanSqs.type, 'messaging', 'span type set to messaging')
@@ -628,24 +620,6 @@ function initializeAwsSdk () {
   // credentials as though it was on an EC2 instance
   process.env.AWS_ACCESS_KEY_ID = 'fake-1'
   process.env.AWS_SECRET_ACCESS_KEY = 'fake-2'
-}
-
-// extracts the SQS and "other" (so far just HTTP) span
-// from resetAgent's data. The order the agent will
-// write spans is not deterministic and is subject to
-// network latency in the mock server.
-function getSqsAndOtherSpanFromData (data, t) {
-  t.equals(data.spans.length, 2, 'generated two spans')
-  const values = []
-  if (data.spans[0].name.indexOf('SQS') === 0) {
-    values.push(data.spans[0])
-    values.push(data.spans[1])
-  } else {
-    values.push(data.spans[1])
-    values.push(data.spans[0])
-  }
-
-  return values
 }
 
 function resetAgent (cb) {


### PR DESCRIPTION
Implements: https://github.com/elastic/apm-agent-nodejs/issues/2601

Marks database/datastore style spans and outgoing service request spans as exit spans, adjusts SQS tests to reflect that lack of an HTTP span. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
