### PR TITLE
test: add some context to test failure to help with debugging it

### DIFF
--- a/test/instrumentation/span-compression.test.js
+++ b/test/instrumentation/span-compression.test.js
@@ -73,7 +73,7 @@ tape.test('integration/end-to-end span compression tests', function (suite) {
       t.equals(span.name, 'Calls to foo')
       t.equals(span.composite.compression_strategy, constants.STRATEGY_SAME_KIND)
       t.equals(span.composite.count, 3)
-      t.true(span.composite.sum > 30)
+      t.true(span.composite.sum > 30, `span.composite.sum > 30: ${span.composite.sum}`)
       t.equals(span.duration, (finalSpan._endTimestamp - firstSpan.timestamp) / 1000)
       t.end()
     })


### PR DESCRIPTION
A tweak to get some details if this test (sensitive to timing) fails again in CI. 

There was a recent failure of this test in GH Actions CI: https://github.com/elastic/apm-agent-nodejs/runs/6081847063?check_suite_focus=true#step:8:2934
It might be helpful to know if `span.composite.sum` was exactly 30 for that failure, or less, to know how to best make this test less flaky.