### PR TITLE
feat: Allow starting a span on a transaction that has already ended

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,9 @@ Notes:
   child spans from being added to the exit spans.  See issue for a full list of
   spans types that will be treated as exit spans. ({issues}2601[#2601])
 
+* Allow a new span to be created/started even if its transaction has ended.
+  This is expected to be a very rare use case. ({pull}2653[#2653])
+
 [float]
 ===== Bug fixes
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -133,10 +133,6 @@ Transaction.prototype.createSpan = function (...args) {
   if (!this.sampled) {
     return null
   }
-  if (this.ended) {
-    this._agent.logger.debug('transaction already ended - cannot build new span %o', { trans: this.id, parent: this.parentId, trace: this.traceId }) // TODO: Should this be supported in the new API?
-    return null
-  }
   if (this._builtSpans >= this._agent._conf.transactionMaxSpans) {
     this._droppedSpans++
     return null

--- a/test/instrumentation/transaction.test.js
+++ b/test/instrumentation/transaction.test.js
@@ -17,6 +17,7 @@ const agent = require('../..').start({
 var test = require('tape')
 
 var Transaction = require('../../lib/instrumentation/transaction')
+const Span = require('../../lib/instrumentation/span')
 
 test('init', function (t) {
   t.test('name and type', function (t) {
@@ -565,8 +566,10 @@ test('Transaction API on ended transaction', function (t) {
   trans.ensureParentId()
   t.pass('trans.ensureParentId(...) does not blow up')
 
-  const newSpan = trans.startSpan('aNewSpanName')
-  t.equal(newSpan, null, 'trans.startSpan(...) returns null')
+  // Starting a span after the transaction has ended is allowed.
+  const spanStartedAfterTransEnd = trans.startSpan('aNewSpanName')
+  t.ok(spanStartedAfterTransEnd instanceof Span, 'trans.startSpan(...) works')
+  spanStartedAfterTransEnd.end()
 
   // Ending a span that is a child of the transaction uses some of the
   // transaction fields for breakdown metrics calculation. Ensure that works.


### PR DESCRIPTION
This was a restriction that dated back to the v1 APM Server intake
API that required all a transaction's spans to be sent along with the
transaction.

The Java APM agent, FWIW, allows this.  

This came up in discussion about some edge cases with the OTel Bridge. As we move closer to OTel semantics, the distinction between transactions and spans gets to be less. Currently can start a child span of a span that has already ended, so it is nice to be able to do the same for a transaction.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
