### PR TITLE
test: attempt to avoid spurious failure over temporarily down httpstat.us

### DIFF
--- a/test/instrumentation/modules/http/fixtures/make-http-request.js
+++ b/test/instrumentation/modules/http/fixtures/make-http-request.js
@@ -23,7 +23,7 @@ function makeARequest (opts, cb) {
     apm.startSpan('span-in-http.request-callback').end()
 
     const chunks = []
-    clientRes.once('data', function (chunk) {
+    clientRes.once('data', function (chunk) { // Just get the first chunk
       assert(apm.currentSpan === null)
       apm.startSpan('span-in-clientRes-on-data').end()
       chunks.push(chunk)
@@ -62,7 +62,7 @@ function makeARequest (opts, cb) {
 const t0 = apm.startTransaction('t0')
 makeARequest(
   {
-    // 'http://wwww.google.com/'
+    // 'http://www.google.com/'
     host: 'www.google.com',
     path: '/',
     headers: { accept: '*/*' }

--- a/test/instrumentation/modules/http/fixtures/make-https-request.js
+++ b/test/instrumentation/modules/http/fixtures/make-https-request.js
@@ -23,7 +23,7 @@ function makeARequest (opts, cb) {
     apm.startSpan('span-in-https.request-callback').end()
 
     const chunks = []
-    clientRes.on('data', function (chunk) {
+    clientRes.once('data', function (chunk) { // Just get the first chunk
       assert(apm.currentSpan === null)
       apm.startSpan('span-in-clientRes-on-data').end()
       chunks.push(chunk)
@@ -33,7 +33,7 @@ function makeARequest (opts, cb) {
       assert(apm.currentSpan === null)
       apm.startSpan('span-in-clientRes-on-end').end()
       const body = chunks.join('')
-      console.log('client response body: %j', body)
+      console.log('start of client response body: %j', body.slice(0, 50))
       cb()
     })
   })
@@ -62,9 +62,9 @@ function makeARequest (opts, cb) {
 const t0 = apm.startTransaction('t0')
 makeARequest(
   {
-    // 'https://httpstat.us/200'
-    host: 'httpstat.us',
-    path: '/200',
+    // 'https://www.google.com/'
+    host: 'www.google.com',
+    path: '/',
     headers: { accept: '*/*' }
   },
   function () {

--- a/test/instrumentation/modules/http/http-run-context.test.js
+++ b/test/instrumentation/modules/http/http-run-context.test.js
@@ -69,7 +69,7 @@ const cases = [
         t.equal(e.span.parent_id, trans.id, `span ${e.span.name} is a child of the transaction`)
       })
       const spanGet = events.shift().span
-      t.equal(spanGet.name, 'GET httpstat.us', 'first span.name is "GET httpstat.us"')
+      t.equal(spanGet.name, 'GET www.google.com', 'first span.name is "GET www.google.com"')
     }
   }
 ]


### PR DESCRIPTION
There were a number of spurious test failures in http-run-context.test.js
earlier today during a relatively short time window. All were when
making a request to httpstat.us. A theory is httpstat.us was down
(perhaps for maint) for that time window. Let's switch to using
www.google.com for test requests instead (as was done earlier in #2521
for a similar reason.

httpstat.us is a wonderful service, but no need to be hitting it frequently
in tests and relying on it having many 9s of uptime.
