### PR TITLE
feat: implement isCompressionEligable method

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,7 +37,7 @@ Notes:
 ===== Features
 
 * Adds initial implementaion of
-  https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md[span compression]. To enable, set the `spanCompressionEnabled` configuration field to `true`.  ({issues}2100[#2100])
+  https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md[span compression]. To disable, set the `spanCompressionEnabled` configuration field to `false`.  ({issues}2100[#2100], {issues}2604[#2604])
 
 * Marks spans as "exit spans" across all instrumentations, preventing additional
   child spans from being added to the exit spans.  See issue for a full list of
@@ -45,9 +45,6 @@ Notes:
 
 * Allow a new span to be created/started even if its transaction has ended.
   This is expected to be a very rare use case. ({pull}2653[#2653])
-
-* Span compression now obeys the `isCompressionEligible` rules from https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#eligibility-for-compression[the spec]. Span compression is enabled by default.
-  ({issues}2604[#2604])
 
 * The Trace Context headers are now propagated for http2 requests.
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,7 +46,7 @@ Notes:
 * Allow a new span to be created/started even if its transaction has ended.
   This is expected to be a very rare use case. ({pull}2653[#2653])
 
-* The Trace Context headers are now propagated for http2 requests.
+* The Trace Context headers are now propagated for http2 requests. ({pull}2656[#2656])
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,10 +43,13 @@ Notes:
   child spans from being added to the exit spans.  See issue for a full list of
   spans types that will be treated as exit spans. ({issues}2601[#2601])
 
-* Span compression now obeys the `isCompressionEligable` rules from https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#eligibility-for-compression[the spec]. Span compression is enabled by default.
-  ({issues}2604[#2604])
 * Allow a new span to be created/started even if its transaction has ended.
   This is expected to be a very rare use case. ({pull}2653[#2653])
+
+* Span compression now obeys the `isCompressionEligable` rules from https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#eligibility-for-compression[the spec]. Span compression is enabled by default.
+  ({issues}2604[#2604])
+
+* The Trace Context headers are now propagated for http2 requests.
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,9 @@ Notes:
   child spans from being added to the exit spans.  See issue for a full list of
   spans types that will be treated as exit spans. ({issues}2601[#2601])
 
+* Span compression now obeys the `isCompressionEligable` rules from https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#eligibility-for-compression[the spec]. Span compression is enabled by default.
+  ({issues}2604[#2604])
+
 [float]
 ===== Bug fixes
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,7 +46,7 @@ Notes:
 * Allow a new span to be created/started even if its transaction has ended.
   This is expected to be a very rare use case. ({pull}2653[#2653])
 
-* Span compression now obeys the `isCompressionEligable` rules from https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#eligibility-for-compression[the spec]. Span compression is enabled by default.
+* Span compression now obeys the `isCompressionEligible` rules from https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#eligibility-for-compression[the spec]. Span compression is enabled by default.
   ({issues}2604[#2604])
 
 * The Trace Context headers are now propagated for http2 requests.

--- a/lib/config.js
+++ b/lib/config.js
@@ -70,7 +70,7 @@ var DEFAULTS = {
   sourceLinesErrorLibraryFrames: 5,
   sourceLinesSpanAppFrames: 0,
   sourceLinesSpanLibraryFrames: 0,
-  spanCompressionEnabled: false,
+  spanCompressionEnabled: true,
   spanCompressionExactMatchMaxDuration: '50ms',
   spanCompressionSameKindMaxDuration: '0ms',
   // 'spanStackTraceMinDuration' is explicitly *not* included in DEFAULTS

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -219,11 +219,20 @@ module.exports = function (http2, agent, { enabled }) {
       agent.logger.debug('intercepted call to http2.request')
       var method = headers[':method'] || 'GET'
       const span = ins.createSpan(null, 'external', 'http', method, { exitSpan: true })
+
+      const parentRunContext = ins.currRunContext()
+      var parent = span || parentRunContext.currSpan() || parentRunContext.currTransaction()
+      if (parent) {
+        const newHeaders = Object.assign({}, headers)
+        parent.propagateTraceContextHeaders(newHeaders, function (carrier, name, value) {
+          carrier[name] = value
+        })
+        arguments[0] = newHeaders
+      }
       if (!span) {
         return orig.apply(this, arguments)
       }
 
-      const parentRunContext = ins.currRunContext()
       const spanRunContext = parentRunContext.enterSpan(span)
       var req = ins.withRunContext(spanRunContext, orig, this, ...arguments)
 

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -273,20 +273,26 @@ Span.prototype._encode = function (cb) {
   }
 }
 
-// TODO: Once we have instrumentation correctly marking exit spans and
-// a trace context api that can detect whether the trace context
-// has been propagated to a span or not this hard coded list
-// will be replaced with detection routines looks for exit spans
-// whose trace context has _not_ been propagated.
 Span.prototype.isCompressionEligible = function () {
   if (!this.getParentSpan()) {
     return false
   }
 
-  const subtypes = ['elasticsearch', 'redis', 'memcached', 'mongodb', 'mysql',
-    'postgresql']
+  if (this.outcome !== constants.OUTCOME_UNKNOWN &&
+      this.outcome !== constants.OUTCOME_SUCCESS
+  ) {
+    return false
+  }
 
-  return subtypes.indexOf(this.subtype) !== -1
+  if (!this._exitSpan) {
+    return false
+  }
+
+  if (this._hasPropagatedTraceContext) {
+    return false
+  }
+
+  return true
 }
 
 Span.prototype.tryToCompress = function (spanToCompress) {

--- a/test/instrumentation/modules/cassandra-driver/index.test.js
+++ b/test/instrumentation/modules/cassandra-driver/index.test.js
@@ -5,7 +5,8 @@ const agent = require('../../../..').start({
   secretToken: 'test',
   captureExceptions: false,
   metricsInterval: 0,
-  centralConfig: false
+  centralConfig: false,
+  spanCompressionEnabled: false
 })
 
 const semver = require('semver')

--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -444,6 +444,7 @@ function assertPath (t, trans, secure, port, path, httpVersion) {
   let expectedUrl
   let expectedReqHeaders
   let expectedResHeaders
+
   switch (httpVersion) {
     case '1.1':
       expectedUrl = {
@@ -486,6 +487,12 @@ function assertPath (t, trans, secure, port, path, httpVersion) {
         ':status': 200
       }
       break
+  }
+
+  if (trans.context.request.headers.traceparent) {
+    expectedReqHeaders.traceparent = trans.context.request.headers.traceparent
+    expectedReqHeaders.tracestate = trans.context.request.headers.tracestate
+    expectedReqHeaders['elastic-apm-traceparent'] = trans.context.request.headers['elastic-apm-traceparent']
   }
 
   // What is "expected" for transaction.context.request.socket.remote_address

--- a/test/instrumentation/modules/tedious.test.js
+++ b/test/instrumentation/modules/tedious.test.js
@@ -4,7 +4,8 @@ const agent = require('../../../').start({
   serviceName: 'test-tedious',
   captureExceptions: false,
   metricsInterval: 0,
-  centralConfig: false
+  centralConfig: false,
+  spanCompressionEnabled: false
 })
 
 const semver = require('semver')

--- a/test/instrumentation/span-compression.test.js
+++ b/test/instrumentation/span-compression.test.js
@@ -74,7 +74,7 @@ tape.test('integration/end-to-end span compression tests', function (suite) {
       t.equals(span.name, 'Calls to foo')
       t.equals(span.composite.compression_strategy, constants.STRATEGY_SAME_KIND)
       t.equals(span.composite.count, 3)
-      t.true(span.composite.sum > 25, `span.composite.sum >= 25: ${span.composite.sum}`)
+      t.true(span.composite.sum > 25, `span.composite.sum > 25: ${span.composite.sum}`)
       t.equals(span.duration, (finalSpan._endTimestamp - firstSpan.timestamp) / 1000)
       t.end()
     })

--- a/test/instrumentation/span-compression.test.js
+++ b/test/instrumentation/span-compression.test.js
@@ -37,8 +37,8 @@ tape.test('integration/end-to-end span compression tests', function (suite) {
       t.equals(span.name, 'name1')
       t.equals(span.composite.compression_strategy, constants.STRATEGY_EXACT_MATCH)
       t.equals(span.composite.count, 3)
-      t.true(span.composite.sum > 25 - (3 * SET_TIMEOUT_EPSILON_MS),
-        `span.composite.sum > ~25: ${span.composite.sum}`)
+      t.true(span.composite.sum > 30 - (3 * SET_TIMEOUT_EPSILON_MS),
+        `span.composite.sum > ~30: ${span.composite.sum}`)
       t.equals(span.duration, (finalSpan._endTimestamp - firstSpan.timestamp) / 1000)
       t.end()
     })
@@ -80,8 +80,8 @@ tape.test('integration/end-to-end span compression tests', function (suite) {
       t.equals(span.name, 'Calls to foo')
       t.equals(span.composite.compression_strategy, constants.STRATEGY_SAME_KIND)
       t.equals(span.composite.count, 3)
-      t.true(span.composite.sum > 25 - (3 * SET_TIMEOUT_EPSILON_MS),
-        `span.composite.sum > ~25: ${span.composite.sum}`)
+      t.true(span.composite.sum > 30 - (3 * SET_TIMEOUT_EPSILON_MS),
+        `span.composite.sum > 30: ${span.composite.sum}`)
       t.equals(span.duration, (finalSpan._endTimestamp - firstSpan.timestamp) / 1000)
       t.end()
     })


### PR DESCRIPTION
Implements: https://github.com/elastic/apm-agent-nodejs/issues/2604

This PR finishes up the span compression work by implementing an `isCompressionEligible` method that uses propagated trace context headers, exit span, and outcome to determine whether a span is eligible for compression.  It also ties up a few other loose ends that came up while implementing it. 

- Span compression is enabled by default
- HTTP 2 requests will now propagate the the trace context headers
- Span compression disabled for tedious and cassandra tests (per other "db exit spans")
- Timing adjusted for "same kind compression" test as a possible fix for observed flakiness

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- ~[ ] Update TypeScript typings~
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
