### PR TITLE
test: deal with test flakiness due to early setTimeout callback

### DIFF
--- a/test/instrumentation/span-compression.test.js
+++ b/test/instrumentation/span-compression.test.js
@@ -23,6 +23,11 @@ const destinationContext = {
   }
 }
 
+// `setTimeout` precision is ~1ms. It can fire its callback up to a millisecond
+// early. Comparisons on the minimum time for an action using setTimeout should
+// allow for this.
+const SET_TIMEOUT_EPSILON_MS = 1
+
 tape.test('integration/end-to-end span compression tests', function (suite) {
   suite.test('exact match compression', function (t) {
     resetAgent(function (data) {
@@ -31,7 +36,8 @@ tape.test('integration/end-to-end span compression tests', function (suite) {
       t.equals(span.name, 'name1')
       t.equals(span.composite.compression_strategy, constants.STRATEGY_EXACT_MATCH)
       t.equals(span.composite.count, 3)
-      t.true(span.composite.sum > 30)
+      t.true(span.composite.sum > 30 - (3 * SET_TIMEOUT_EPSILON_MS),
+        `span.composite.sum > ~30: ${span.composite.sum}`)
       t.equals(span.duration, (finalSpan._endTimestamp - firstSpan.timestamp) / 1000)
       t.end()
     })
@@ -73,7 +79,8 @@ tape.test('integration/end-to-end span compression tests', function (suite) {
       t.equals(span.name, 'Calls to foo')
       t.equals(span.composite.compression_strategy, constants.STRATEGY_SAME_KIND)
       t.equals(span.composite.count, 3)
-      t.true(span.composite.sum > 30, `span.composite.sum > 30: ${span.composite.sum}`)
+      t.true(span.composite.sum > 30 - (3 * SET_TIMEOUT_EPSILON_MS),
+        `span.composite.sum > ~30: ${span.composite.sum}`)
       t.equals(span.duration, (finalSpan._endTimestamp - firstSpan.timestamp) / 1000)
       t.end()
     })


### PR DESCRIPTION
These two 'span.composite.sum > 30' tests have been flaky in CI. A recent
failure shows a value of `29.699`. The theory is that this is due to
the setTimeout calls firing slightly sooner than 10ms as discussed at:
https://github.com/nodejs/node/issues/26578#issuecomment-473708703

Refs: #2647

An alternative theory is that this might be related to `Timer` precision issues similar to https://github.com/elastic/apm-agent-nodejs/issues/2180 given that `span.composite.sum` is calculated from span `_duration` which uses our `Timer` class.

### Checklist

- [x] Add tests
