### PR TITLE
docs: update release steps to npm-publish before pushing release tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,36 +171,54 @@ If you have access to make releases, the process is as follows:
 
 ### Current major
 
-1. Be sure you have checked out the `main` branch and have pulled latest changes
-1. Update the version in `package.json` according to the scale of the change. (major, minor or patch)
-1. Update `CHANGELOG.asciidoc`:
-    - Change the "Unreleased" section title to:
+1. Be sure you have checked out the `main` branch and have pulled latest
+   changes.
+1. Make a PR titled "x.y.z" (the new version) which updates:
+    - the version in `package.json`,
+    - "CHANGELOG.asciidoc": Add missing changelog entries, if any. Then change
+      the "Unreleased" section title to:
         ```
-        [[release-notes-x.x.x]]
-        ==== x.x.x - YYYY/MM/DD
+        [[release-notes-x.y.z]]
+        ==== x.y.z - YYYY/MM/DD
         ```
-    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.)
-1. If a major or minor release, update the EOL table in `docs/upgrading.asciidoc`. EOL is 18 months after release date.
-1. Make a PR titled `x.y.z` -- where `x.y.z` is the new version in package.json -- with these changes.
+    - the EOL table in `docs/upgrading.asciidoc`, if this is a major or minor
+      release. EOL is 18 months after release date.
 1. Ensure PR checks pass, then merge to main.
-1. Working on the elastic repo now (not a fork), tag the merged-to-main commit with `git tag vx.y.x && git push origin --tags`. For example: `git tag v1.2.3 && git push origin --tags`.
-1. Reset the latest major branch (currently `3.x`) to point to the current main, e.g. `git branch -f 3.x main && git push origin 3.x`
-1. Publish to npm with `npm publish`
+1. Publish to npm with `npm publish`.
+   This must be done *before* the release tag is pushed, because the automated
+   release process is triggered by the tag push and (the opbeans
+   bump-version.sh release step) depends on the new version having been
+   published to npm.
+1. Working on the elastic repo now (not a fork), tag the merged-to-main commit
+   with `git tag vx.y.x && git push origin vx.y.z`. For example: `git tag
+   v1.2.3 && git push origin v1.2.3`.
+1. Reset the latest major branch (currently `3.x`) to point to the current
+   main, e.g. `git branch -f 3.x main && git push origin 3.x`
 
 ### Past major
 
-1. Be sure you have checked out the branch associated with the major you wish to release and have pulled latest changes, e.g. `2.x`
-1. Update the version in `package.json` according to the scale of the change. (major, minor or patch)
-1. Update `CHANGELOG.asciidoc`:
-    - Change the "Unreleased" section title to:
+1. Be sure you have checked out the branch associated with the major you wish
+   to release and have pulled latest changes, e.g. `2.x`.
+1. Make a PR titled "x.y.z" (the new version) which updates:
+    - the version in `package.json`,
+    - "CHANGELOG.asciidoc": Add missing changelog entries, if any. Then change
+      the "Unreleased" section title to:
         ```
-        [[release-notes-x.x.x]]
-        ==== x.x.x - YYYY/MM/DD
+        [[release-notes-x.y.z]]
+        ==== x.y.z - YYYY/MM/DD
         ```
-    - Add missing changelog entries, if any. (Typically commits will include changelog entries in the "Unreleased" section.)
-1. Commit changes with message `x.y.z` where `x.y.z` is the version in `package.json`
-1. Tag the commit with `git tag vx.y.x`, for example `git tag v1.2.3`
-1. Run tests with `npm test`
-1. Push commits and tags upstream with `git push upstream <major_branch> && git push upstream --tags` (and optionally to your own fork as well)
-1. Publish to npm with `npm publish --tag=2x` (where `2x` is the tag for the past major version being published)
-1. Make a PR against `main` containing the updates to `CHANGELOG.asciidoc` so that `main` always contain information about all releases
+    - the EOL table in `docs/upgrading.asciidoc`, if this is a major or minor
+      release. EOL is 18 months after release date.
+1. Ensure PR checks pass, then merge to main.
+1. Publish to npm with `npm publish --tag=2x`.
+   **It is important to include that `--tag=2x`.**
+   This must be done *before* the release tag is pushed, because the automated
+   release process is triggered by the tag push and (the opbeans
+   bump-version.sh release step) depends on the new version having been
+   published to npm.
+1. Working on the elastic repo now (not a fork), tag the merged-to-main commit
+   with `git tag vx.y.x && git push origin vx.y.z`. For example: `git tag
+   v1.2.3 && git push origin v1.2.3`.
+1. Make a PR against `main` containing the updates to `CHANGELOG.asciidoc` so
+   that `main` always contain information about all releases
+


### PR DESCRIPTION
This is because the current automated release process triggers off the
pushed release tag, but (somewhat indirectly) depends on the npm package
having been published (for the opbeans bump-version.sh release step).
