### PR TITLE
feat: 'parent' option to 'agent.captureError()'

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,25 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+- Add a `parent` option to `agent.captureError(err[, options][, cb])` to allow
+  passing in a Transaction or Span to use as the parent for the error. Before
+  this change the *current* span or transaction, if any, was always used.
++
+This option is not documented in the user docs, nor added to the TypeScript
+types, because it is only expected to be useful for coming OTel Bridge work.
+
+[float]
+===== Bug fixes
+
+
 [[release-notes-3.32.0]]
 ==== 3.32.0 2022/04/27
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -17,6 +17,8 @@ var Metrics = require('./metrics')
 var parsers = require('./parsers')
 var symbols = require('./symbols')
 const { frameCacheStats } = require('./stacktraces')
+const Span = require('./instrumentation/span')
+const Transaction = require('./instrumentation/transaction')
 
 var IncomingMessage = http.IncomingMessage
 var ServerResponse = http.ServerResponse
@@ -255,7 +257,13 @@ Agent.prototype.start = function (opts) {
 
   this._transport = this._conf.transport(this._conf, this)
 
-  this._instrumentation.start()
+  let runContextClass
+  if (this._conf.opentelemetrySdk) {
+    const { setupOTelSDK, OTelBridgeRunContext } = require('./opentelemetry-sdk')
+    runContextClass = OTelBridgeRunContext
+    setupOTelSDK(this)
+  }
+  this._instrumentation.start(runContextClass)
   this._metrics.start()
 
   this._origStackTraceLimit = Error.stackTraceLimit
@@ -387,9 +395,11 @@ const EMPTY_OPTS = {}
 //   - `opts.message` - If `err` is an Error instance, this string is added to
 //     `error.log.message` (unless it matches err.message).
 //   - `opts.request` - HTTP request (node `IncomingMessage` instance) to use
-//     for `error.context.request`.
+//     for `error.context.request`. If not given, a `req` on the parent
+//     transaction (see `opts.parent` below) will be used.
 //   - `opts.response` - HTTP response (node `ServerResponse` instance) to use
-//     for `error.context.response`.
+//     for `error.context.response`. If not given, a `res` on the parent
+//     transaction (see `opts.parent` below) will be used.
 //   - `opts.handled` - Boolean indicating if this exception was handled by
 //     application code. Default true. Setting to `false` also results in the
 //     error being flushed to APM server as soon as it is processed.
@@ -397,6 +407,10 @@ const EMPTY_OPTS = {}
 //     include properties of `err` as attributes on the APM error event.
 //   - `opts.skipOutcome` - Boolean. Default false. Set to true to not have
 //     this captured error set `<currentSpan>.outcome = failure`.
+//   - `opts.parent` - A Transaction or Span instance to make the parent of
+//     this error. If not given (undefined), then the current span or
+//     transaction will be used. If `null` is given, then no span or transaction
+//     will be used.
 // - `cb` is a callback `function (captureErr, apmErrorIdString)`. If provided,
 //   the error will be flushed to APM server as soon as it is processed, and
 //   `cb` will be called when that send is complete.
@@ -431,11 +445,28 @@ Agent.prototype.captureError = function (err, opts, cb) {
   const handled = opts.handled !== false // default true
   const shouldCaptureAttributes = opts.captureAttributes !== false // default true
   const skipOutcome = Boolean(opts.skipOutcome)
-  const span = this._instrumentation.currSpan()
   const timestampUs = (opts.timestamp
     ? Math.floor(opts.timestamp * 1000)
     : Date.now() * 1000)
-  const trans = this._instrumentation.currTransaction()
+
+  // Determine transaction/span context to associate with this error.
+  let parent
+  let span
+  let trans
+  if (opts.parent === undefined) {
+    parent = this._instrumentation.currSpan() || this._instrumentation.currTransaction()
+  } else if (opts.parent === null) {
+    parent = null
+  } else {
+    parent = opts.parent
+  }
+  if (parent instanceof Transaction) {
+    span = null
+    trans = parent
+  } else if (parent instanceof Span) {
+    span = parent
+    trans = parent.transaction
+  }
   const traceContext = (span || trans || {})._context
   const req = (opts.request instanceof IncomingMessage
     ? opts.request

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -257,13 +257,7 @@ Agent.prototype.start = function (opts) {
 
   this._transport = this._conf.transport(this._conf, this)
 
-  let runContextClass
-  if (this._conf.opentelemetrySdk) {
-    const { setupOTelSDK, OTelBridgeRunContext } = require('./opentelemetry-sdk')
-    runContextClass = OTelBridgeRunContext
-    setupOTelSDK(this)
-  }
-  this._instrumentation.start(runContextClass)
+  this._instrumentation.start()
   this._metrics.start()
 
   this._origStackTraceLimit = Error.stackTraceLimit

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -15,6 +15,7 @@ var test = require('tape')
 
 const Agent = require('../lib/agent')
 var config = require('../lib/config')
+const { findObjInArray } = require('./_utils')
 const { MockAPMServer } = require('./_mock_apm_server')
 const { NoopTransport } = require('../lib/noop-transport')
 var packageJson = require('../package.json')
@@ -1709,6 +1710,36 @@ test('#captureError()', function (t) {
         t.end()
       }
     )
+  })
+
+  t.test('options.parent', function (t) {
+    const agent = new Agent().start(ceAgentOpts)
+
+    const t0 = agent.startTransaction('t0')
+    const s1 = t0.startSpan('s1')
+    const s2 = t0.startSpan('s2')
+    agent.captureError(new Error('no parent specified'))
+    agent.captureError(new Error('t0 parent'), { parent: t0 })
+    agent.captureError(new Error('s1 parent'), { parent: s1 })
+    agent.captureError(new Error('null parent'), { parent: null }) // to explicitly say there is no parent
+    s2.end()
+    s1.end()
+    t0.end()
+
+    agent.flush(function () {
+      const errNoParent = findObjInArray(apmServer.events, 'error.exception.message', 'no parent specified').error
+      t.strictEqual(errNoParent.parent_id, s2.id, 'errNoParent parent_id')
+      const errT0Parent = findObjInArray(apmServer.events, 'error.exception.message', 't0 parent').error
+      t.strictEqual(errT0Parent.parent_id, t0.id, 'errT0Parent parent_id')
+      const errS1Parent = findObjInArray(apmServer.events, 'error.exception.message', 's1 parent').error
+      t.strictEqual(errS1Parent.parent_id, s1.id, 'errS1Parent parent_id')
+      const errNullParent = findObjInArray(apmServer.events, 'error.exception.message', 'null parent').error
+      t.strictEqual(errNullParent.parent_id, undefined, 'errNullParent parent_id')
+
+      apmServer.clear()
+      agent.destroy()
+      t.end()
+    })
   })
 
   t.test('teardown mock APM server', function (t) {


### PR DESCRIPTION
This allows specifying an explicit Transaction or Span to be the parent
of the captured APM error. Before this change the *current* Transaction
or Span is always used as the parent. That's usually desired. However,
to support OTel interface Span.recordException(), the captured error
should be a child of the span on which that method is called, even if it
isn't the current span.
https://github.com/open-telemetry/opentelemetry-js-api/blob/v1.1.0/src/trace/span.ts#L122-L128

I have not documented this option in the user docs, nor added it to
the TypeScript types because I don't expect it to be that used.

I'm happy to doc it and add it to types if people disagree. Or we can
always add it later if there are external use cases.

### Checklist

- [x] Implement code
- [x] Add tests
- [ ] ~Update TypeScript typings~
- [ ] ~Update documentation~
- [x] Add CHANGELOG.asciidoc entry
