### PR TITLE
test: incomplete usage of @cucumber/cucumber for testing gherkin-specs

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,0 +1,16 @@
+// https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md
+module.exports = {
+  default: {
+    paths: [
+      // We don't support all of the gherkin specs from apm.git, so list each
+      // one individually.
+      'test/cucumber/gherkin-specs/otel_bridge.feature'
+    ],
+    require: ['test/cucumber/*.js'],
+    publishQuiet: true,
+    backtrace: true, // Enable this to see stacktraces into cucumber library code.
+    // `parallel > 1` should be fine, but avoid it for now to avoid
+    // multi-process execution of tests. Linear should be more debuggable.
+    parallel: 1
+  }
+}

--- a/lib/stacktraces.js
+++ b/lib/stacktraces.js
@@ -12,10 +12,21 @@ var path = require('path')
 
 const asyncCache = require('async-cache')
 const afterAllResults = require('after-all-results')
-const errorCallsites = require('error-callsites')
 const errorStackParser = require('error-stack-parser')
 const loadSourceMap = require('./load-source-map')
 const LRU = require('lru-cache')
+
+// TODO(cucumber): @cucumber/cucumber uses the 'stack-chain' dep for rich stack
+// trace capture. This *conflicts* with this APM agent's usage of
+// 'error-callsites' because stack-chain's `Error.prepareStackTrace` property
+// is *not* configurable:
+// https://github.com/AndreasMadsen/stack-chain/blob/001f69e3/stack-chain.js#L154-L178
+//
+// A possible workaround would be to have a TEST_... envvar used for cucumber
+// test runs that disabled the agent's error-callsite usage.
+//
+const errorCallsites = require('error-callsites')
+// const errorCallsites = function () { return [] }
 
 const fileCache = asyncCache({
   max: 500, // fileCacheMax

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
+    "@cucumber/cucumber": "^8.1.2",
     "@elastic/elasticsearch": "^7.15.0",
     "@elastic/elasticsearch-canary": "^8.1.0-canary.2",
     "@hapi/hapi": "^20.1.2",

--- a/test/cucumber/gherkin-specs/otel_bridge.feature
+++ b/test/cucumber/gherkin-specs/otel_bridge.feature
@@ -1,0 +1,254 @@
+@opentelemetry-bridge
+Feature: OpenTelemetry bridge
+
+  # --- Creating Elastic span or transaction from OTel span
+
+  Scenario: Create transaction from OTel span with remote context
+    Given an agent
+    And OTel span is created with remote context as parent
+    Then Elastic bridged object is a transaction
+    Then Elastic bridged transaction has remote context as parent
+
+  Scenario: Create root transaction from OTel span without parent
+    Given an agent
+    And OTel span is created without parent
+    And OTel span ends
+    Then Elastic bridged object is a transaction
+    Then Elastic bridged transaction is a root transaction
+    # outcome should not be inferred from the lack/presence of errors
+    Then Elastic bridged transaction outcome is "unknown"
+
+  Scenario: Create span from OTel span
+    Given an agent
+    And OTel span is created with local context as parent
+    And OTel span ends
+    Then Elastic bridged object is a span
+    Then Elastic bridged span has local context as parent
+    # outcome should not be inferred from the lack/presence of errors
+    Then Elastic bridged span outcome is "unknown"
+
+  # --- OTel span kind mapping for spans & transactions
+
+  Scenario Outline: OTel span kind <kind> for spans & default span type & subtype
+    Given an agent
+    # TODO(cucumber): There is some issue where @cucumber/cucumber does not
+    # carry async context across steps. The result is that setting
+    # "an active transaction" in this step ...
+    And an active transaction
+    # ... does *not* result in there being an active transaction for this step.
+    # I am not sure if this is a bug in this agent's async context tracking
+    # (perhaps with particular async/await usage in @cucumber/cucumber), or
+    # an issue with @cucumber/cucumber code breaking async context (e.g. with
+    # a userland callback queue).
+    And OTel span is created with kind "<kind>"
+    And OTel span ends
+    Then Elastic bridged object is a span
+    Then Elastic bridged span OTel kind is "<kind>"
+    Then Elastic bridged span type is "<default_type>"
+    Then Elastic bridged span subtype is "<default_subtype>"
+    Examples:
+      | kind     | default_type | default_subtype |
+      | INTERNAL | app          | internal        |
+      # TODO:
+      # | SERVER   | unknown      |                 |
+      # | CLIENT   | unknown      |                 |
+      # | PRODUCER | unknown      |                 |
+      # | CONSUMER | unknown      |                 |
+
+  # TODO(cucumber): Work through the rest of the scenarios:
+  # Scenario Outline: OTel span kind <kind> for transactions & default transaction type
+  #   Given an agent
+  #   And OTel span is created with kind "<kind>"
+  #   And OTel span ends
+  #   Then Elastic bridged object is a transaction
+  #   Then Elastic bridged transaction OTel kind is "<kind>"
+  #   Then Elastic bridged transaction type is 'unknown'
+  #   Examples:
+  #     | kind     |
+  #     | INTERNAL |
+  #     | SERVER   |
+  #     | CLIENT   |
+  #     | PRODUCER |
+  #     | CONSUMER |
+
+  # # OTel span status mapping for spans & transactions
+
+  # Scenario Outline:  OTel span mapping with status <status> for transactions
+  #   Given an agent
+  #   And OTel span is created with kind 'SERVER'
+  #   And OTel span status set to "<status>"
+  #   And OTel span ends
+  #   Then Elastic bridged object is a transaction
+  #   Then Elastic bridged transaction outcome is "<outcome>"
+  #   Examples:
+  #     | status | outcome |
+  #     | unset  | unknown |
+  #     | ok     | success |
+  #     | error  | failure |
+
+  # Scenario Outline:  OTel span mapping with status <status> for spans
+  #   Given an agent
+  #   Given an active transaction
+  #   And OTel span is created with kind 'INTERNAL'
+  #   And OTel span status set to "<status>"
+  #   And OTel span ends
+  #   Then Elastic bridged object is a span
+  #   Then Elastic bridged span outcome is "<outcome>"
+  #   Examples:
+  #     | status | outcome |
+  #     | unset  | unknown |
+  #     | ok     | success |
+  #     | error  | failure |
+
+  # # --- span type, subtype and action inference from OTel attributes
+
+  # # --- HTTP server
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server
+  # Scenario Outline: HTTP server [ <http.url> <http.scheme> ]
+  #   Given an agent
+  #   And OTel span is created with kind 'SERVER'
+  #   And OTel span has following attributes
+  #     | http.url          | <http.url>      |
+  #     | http.scheme       | <http.scheme>   |
+  #   And OTel span ends
+  #   Then Elastic bridged object is a transaction
+  #   Then Elastic bridged transaction type is "request"
+  #   Examples:
+  #     | http.url                | http.scheme |
+  #     | http://testing.invalid/ |             |
+  #     |                         | http        |
+
+  # # --- HTTP client
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client
+  # Scenario Outline: HTTP client [ <http.url> <http.scheme> <http.host> <net.peer.ip> <net.peer.name> <net.peer.port> ]
+  #   Given an agent
+  #   And an active transaction
+  #   And OTel span is created with kind 'CLIENT'
+  #   And OTel span has following attributes
+  #     | http.url          | <http.url>      |
+  #     | http.scheme       | <http.scheme>   |
+  #     | http.host         | <http.host>     |
+  #     | net.peer.ip       | <net.peer.ip>   |
+  #     | net.peer.name     | <net.peer.name> |
+  #     | net.peer.port     | <net.peer.port> |
+  #   And OTel span ends
+  #   Then Elastic bridged span type is 'external'
+  #   Then Elastic bridged span subtype is 'http'
+  #   Then Elastic bridged span OTel attributes are copied as-is
+  #   Then Elastic bridged span destination resource is set to "<resource>"
+  #   Examples:
+  #     | http.url                      | http.scheme | http.host       | net.peer.ip | net.peer.name | net.peer.port | resource             |
+  #     | https://testing.invalid:8443/ |             |                 |             |               |               | testing.invalid:8443 |
+  #     | https://[::1]/                |             |                 |             |               |               | [::1]:443            |
+  #     | http://testing.invalid/       |             |                 |             |               |               | testing.invalid:80   |
+  #     |                               | http        | testing.invalid |             |               |               | testing.invalid:80   |
+  #     |                               | https       | testing.invalid | 127.0.0.1   |               |               | testing.invalid:443  |
+  #     |                               | http        |                 | 127.0.0.1   |               | 81            | 127.0.0.1:81         |
+  #     |                               | https       |                 | 127.0.0.1   |               | 445           | 127.0.0.1:445        |
+  #     |                               | http        |                 | 127.0.0.1   | host1         | 445           | host1:445            |
+  #     |                               | https       |                 | 127.0.0.1   | host2         | 445           | host2:445            |
+
+  # # --- DB client
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md
+  # Scenario Outline: DB client [ <db.system> <net.peer.ip> <net.peer.name> <net.peer.port>]
+  #   Given an agent
+  #   And an active transaction
+  #   And OTel span is created with kind 'CLIENT'
+  #   And OTel span has following attributes
+  #     | db.system         | <db.system>     |
+  #     | db.name           | <db.name>       |
+  #     | net.peer.ip       | <net.peer.ip>   |
+  #     | net.peer.name     | <net.peer.name> |
+  #     | net.peer.port     | <net.peer.port> |
+  #   And OTel span ends
+  #   Then Elastic bridged span type is 'db'
+  #   Then Elastic bridged span subtype is "<db.system>"
+  #   Then Elastic bridged span OTel attributes are copied as-is
+  #   Then Elastic bridged span destination resource is set to "<resource>"
+  #   Examples:
+  #     | db.system | db.name | net.peer.ip | net.peer.name | net.peer.port | resource           |
+  #     | mysql     |         |             |               |               | mysql              |
+  #     | oracle    |         |             | oracledb      |               | oracledb           |
+  #     | oracle    |         | 127.0.0.1   |               |               | 127.0.0.1          |
+  #     | mysql     |         | 127.0.0.1   | dbserver      | 3307          | dbserver:3307      |
+  #     | mysql     | myDb    |             |               |               | mysql/myDb         |
+  #     | oracle    | myDb    |             | oracledb      |               | oracledb/myDb      |
+  #     | oracle    | myDb    | 127.0.0.1   |               |               | 127.0.0.1/myDb     |
+  #     | mysql     | myDb    | 127.0.0.1   | dbserver      | 3307          | dbserver:3307/myDb |
+
+  # # --- Messaging consumer (transaction consuming/receiving a message)
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
+  # Scenario: Messaging consumer
+  #   Given an agent
+  #   And OTel span is created with kind 'CONSUMER'
+  #   And OTel span has following attributes
+  #     | messaging.system  | anything |
+  #   And OTel span ends
+  #   Then Elastic bridged transaction type is 'messaging'
+
+  # # --- Messaging producer (client span emitting a message)
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
+  # Scenario Outline: Messaging producer [ <messaging.system> <messaging.destination> <messaging.url> <net.peer.ip> <net.peer.name> <net.peer.port>]
+  #   Given an agent
+  #   And an active transaction
+  #   And OTel span is created with kind 'PRODUCER'
+  #   And OTel span has following attributes
+  #     | messaging.system       | <messaging.system>      |
+  #     | messaging.destination  | <messaging.destination> |
+  #     | messaging.url          | <messaging.url>         |
+  #     | net.peer.ip            | <net.peer.ip>           |
+  #     | net.peer.name          | <net.peer.name>         |
+  #     | net.peer.port          | <net.peer.port>         |
+  #   And OTel span ends
+  #   Then Elastic bridged span type is 'messaging'
+  #   Then Elastic bridged span subtype is "<messaging.system>"
+  #   Then Elastic bridged span OTel attributes are copied as-is
+  #   Then Elastic bridged span destination resource is set to "<resource>"
+  #   Examples:
+  #     | messaging.system | messaging.destination | messaging.url         | net.peer.ip | net.peer.name | net.peer.port | resource                   |
+  #     | rabbitmq         |                       | amqp://carrot:4444/q1 |             |               |               | carrot:4444                |
+  #     | rabbitmq         |                       |                       | 127.0.0.1   | carrot-server | 7777          | carrot-server:7777         |
+  #     | rabbitmq         |                       |                       |             | carrot-server |               | carrot-server              |
+  #     | rabbitmq         |                       |                       | 127.0.0.1   |               |               | 127.0.0.1                  |
+  #     | rabbitmq         | myQueue               | amqp://carrot:4444/q1 |             |               |               | carrot:4444/myQueue        |
+  #     | rabbitmq         | myQueue               |                       | 127.0.0.1   | carrot-server | 7777          | carrot-server:7777/myQueue |
+  #     | rabbitmq         | myQueue               |                       |             | carrot-server |               | carrot-server/myQueue      |
+  #     | rabbitmq         | myQueue               |                       | 127.0.0.1   |               |               | 127.0.0.1/myQueue          |
+
+  # # --- RPC client
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md
+  # Scenario Outline: RPC client [ <rpc.system>  <rpc.service> <net.peer.ip> <net.peer.name> <net.peer.port>]
+  #   Given an agent
+  #   And an active transaction
+  #   And OTel span is created with kind 'CLIENT'
+  #   And OTel span has following attributes
+  #     | rpc.system    | <rpc.system>    |
+  #     | rpc.service   | <rpc.service>   |
+  #     | net.peer.ip   | <net.peer.ip>   |
+  #     | net.peer.name | <net.peer.name> |
+  #     | net.peer.port | <net.peer.port> |
+  #   And OTel span ends
+  #   Then Elastic bridged span type is 'external'
+  #   Then Elastic bridged span subtype is "<rpc.system>"
+  #   Then Elastic bridged span OTel attributes are copied as-is
+  #   Then Elastic bridged span destination resource is set to "<resource>"
+  #   Examples:
+  #     | rpc.system | rpc.service | net.peer.ip | net.peer.name | net.peer.port | resource                  |
+  #     | grpc       |             |             |               |               | grpc                      |
+  #     | grpc       | myService   |             |               |               | grpc/myService            |
+  #     | grpc       | myService   |             | rpc-server    |               | rpc-server/myService      |
+  #     | grpc       | myService   | 127.0.0.1   | rpc-server    |               | rpc-server/myService      |
+  #     | grpc       |             | 127.0.0.1   | rpc-server    | 7777          | rpc-server:7777           |
+  #     | grpc       | myService   | 127.0.0.1   | rpc-server    | 7777          | rpc-server:7777/myService |
+  #     | grpc       | myService   | 127.0.0.1   |               | 7777          | 127.0.0.1:7777/myService  |
+
+  # # --- RPC server
+  # # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md
+  # Scenario: RPC server
+  #   Given an agent
+  #   And OTel span is created with kind 'SERVER'
+  #   And OTel span has following attributes
+  #     | rpc.system | grpc |
+  #   And OTel span ends
+  #   Then Elastic bridged transaction type is 'request'
+

--- a/test/cucumber/otel_bridge.js
+++ b/test/cucumber/otel_bridge.js
@@ -1,0 +1,119 @@
+const assert = require('assert')
+
+// https://github.com/cucumber/cucumber-js/blob/HEAD/docs/support_files/api_reference.md
+const { Then, Given, After } = require('@cucumber/cucumber')
+
+const agent = require('../..')
+const otel = require('@opentelemetry/api')
+const Transaction = require('../../lib/instrumentation/transaction')
+const Span = require('../../lib/instrumentation/span')
+const { executionAsyncId } = require('async_hooks')
+
+Given('an agent', function () {
+  if (!agent.isStarted()) {
+    agent.start({
+      opentelemetrySdk: true
+    })
+  }
+  this.agent = agent
+  this.tracer = otel.trace.getTracer()
+})
+
+Given('OTel span is created with remote context as parent', function () {
+  this.remoteSpanContext = {
+    traceId: 'd4cda95b652f4a1592b449dd92ffda3b',
+    spanId: '6e0c63ffe4e34c42',
+    traceFlags: otel.TraceFlags.SAMPLED
+  }
+  const remoteSpan = otel.trace.wrapSpanContext(this.remoteSpanContext)
+  const remoteContext = otel.trace.setSpan(otel.context.active(), remoteSpan)
+
+  this.otelSpan = this.tracer.startSpan('aSpan', {}, remoteContext)
+})
+
+Given('OTel span is created without parent', function () {
+  this.otelSpan = this.tracer.startSpan('aSpan')
+})
+
+Given('OTel span is created with local context as parent', function () {
+  this.tracer.startActiveSpan('aParentSpan', aParentSpan => {
+    this.localSpanContext = aParentSpan.spanContext()
+    this.otelSpan = this.tracer.startSpan('aSpan')
+    aParentSpan.end()
+  })
+})
+
+Given('OTel span ends', function () {
+  this.otelSpan.end()
+})
+
+Given('an active transaction', function (cb) {
+  this.transaction = this.agent.startTransaction('aTransaction')
+  console.log('XXX [xid=%d] created transaction', executionAsyncId())
+  console.log('XXX created trans: %s', this.agent._instrumentation._runCtxMgr)
+  cb()
+})
+
+Given('OTel span is created with kind {string}', function (kind) {
+  console.log('XXX [xid=%d] OTel span is created with kind', executionAsyncId())
+  console.log('XXX create span with kind: %s', this.agent._instrumentation._runCtxMgr)
+  this.otelSpan = this.tracer.startSpan('aSpan', { kind })
+  // this.tracer.startActiveSpan('aParentSpan', aParentSpan => {
+  //   this.localSpanContext = aParentSpan.spanContext()
+  //   this.otelSpan = this.tracer.startSpan('aSpan')
+  //   aParentSpan.end()
+  // })
+})
+// And OTel span is created with kind "<kind>"
+// And OTel span ends
+// Then Elastic bridged object is a span
+// Then Elastic bridged span OTel kind is "<kind>"
+// Then Elastic bridged span type is "<default_type>"
+// Then Elastic bridged span subtype is "<default_subtype>"
+
+Then('Elastic bridged object is a transaction', function () {
+  assert(this.otelSpan._span instanceof Transaction, `${this.otelSpan.toString()} is a Transaction`)
+})
+
+Then('Elastic bridged transaction has remote context as parent', function () {
+  assert.strictEqual(this.otelSpan._span.parentId, this.remoteSpanContext.spanId)
+})
+
+Then('Elastic bridged transaction is a root transaction', function () {
+  assert.strictEqual(this.otelSpan._span.parentId, undefined)
+})
+
+Then('Elastic bridged transaction outcome is "unknown"', function () {
+  assert.strictEqual(this.otelSpan._span.outcome, 'unknown')
+})
+
+Then('Elastic bridged object is a span', function () {
+  assert(this.otelSpan._span instanceof Span, `${this.otelSpan.toString()} is a Span`)
+})
+
+Then('Elastic bridged span has local context as parent', function () {
+  assert.strictEqual(this.otelSpan._span.parentId, this.localSpanContext.spanId)
+})
+
+Then('Elastic bridged span outcome is "unknown"', function () {
+  assert.strictEqual(this.otelSpan._span.outcome, 'unknown', `${this.otelSpan.toString()} outcome is "unknown": ${this.otelSpan._span.outcome}`)
+})
+
+// # Scenario: Create span from OTel span
+// #   Given an agent
+// #   And OTel span is created with local context as parent
+// #   And OTel span ends
+// #   Then Elastic bridged object is a span
+// #   Then Elastic bridged span has local context as parent
+// #   # outcome should not be inferred from the lack/presence of errors
+// #   Then Elastic bridged span outcome is "unknown"
+
+// Then('I should have heard {string}', function (expectedResponse) {
+//   assert.equal(this.whatIHeard, expectedResponse)
+// })
+
+After(function () {
+  if (this.transaction && !this.transaction.ended) {
+    this.transaction.end()
+  }
+})


### PR DESCRIPTION
(This builds on OTel Bridge work coming in https://github.com/elastic/apm-agent-nodejs/pull/2641)

This change includes an *incomplete* start at using @cucumber/cucumber
to test shared gherkin-specs files from apm.git for APM agent testing.
This is meant to show the current state and then move on, because there
are issues here.

1. @cucumber/cucumber's usage of 'stack-chain' conflicts with the
   agent's usage of 'error-callsites':

    ```
    % ./node_modules/.bin/cucumber-js
    TypeError: Cannot redefine property: prepareStackTrace
        at Function.defineProperty (<anonymous>)
        at Object.<anonymous> (/Users/trentm/el/apm-agent-nodejs8/node_modules/error-callsites/index.js:11:8)
        at Module._compile (internal/modules/cjs/loader.js:1085:14)
        at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
        at Module.load (internal/modules/cjs/loader.js:950:32)
        at Function.Module._load (internal/modules/cjs/loader.js:790:12)
        at Module.require (internal/modules/cjs/loader.js:974:19)
        at require (internal/modules/cjs/helpers.js:101:18)
        at Object.<anonymous> (/Users/trentm/el/apm-agent-nodejs8/lib/stacktraces.js:28:24)
        at Module._compile (internal/modules/cjs/loader.js:1085:14)
    ```

2. There is an issue where async context is not carried through
   cucumber's steps. This means that setting a current transaction
   (which in the APM agent is stored in async context) does not
   carry through as a current transaction for subsequent steps.
   This makes the "OTel span kind <kind> for spans & default span type &
   subtype" scenario in "otel_bridge.feature" impossible to test.

   My guess is this is an issue with @cucumber/cucumber code losing
   async context -- which isn't unheard of in libraries -- but I have
   not dug into it.

