### PR TITLE
fix: possible crash in instrumentation of an incoming HTTP/2 request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,13 @@ types, because it is only expected to be useful for coming OTel Bridge work.
 [float]
 ===== Bug fixes
 
+- Fix a possible crash in the instrumentation of an incoming HTTP/2 request: if
+  the underlying Http2Session was destroyed before the APM transaction was
+  ended (on Http2Stream end). This resulted in the instrumentation using the
+  [`stream.session.socket`](https://nodejs.org/api/http2.html#http2sessionsocket)
+  proxy, which can throw `ERR_HTTP2_SOCKET_UNBOUND` after the session is
+  destroyed. ({issues}2670[#2670])
+
 
 [[release-notes-3.32.0]]
 ==== 3.32.0 2022/04/27

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -61,9 +61,15 @@ module.exports = function (http2, agent, { enabled }) {
         // core `http.IncomingMessage` and `http.ServerResponse` objects,
         // sufficient for `parsers.getContextFromRequest()` and
         // `parsers.getContextFromResponse()`, respectively.
+        // `remoteAddress` is fetched now, rather than at stream end, because
+        // this `stream.session.socket` is a proxy object that can throw
+        // `ERR_HTTP2_SOCKET_UNBOUND` if the Http2Session has been destroyed.
         trans.req = {
           headers,
-          socket: stream.session.socket,
+          // socket: stream.session.socket,
+          socket: {
+            remoteAddress: stream.session.socket.remoteAddress
+          },
           method: headers[':method'],
           url: headers[':path'],
           httpVersion: '2.0'
@@ -141,7 +147,7 @@ module.exports = function (http2, agent, { enabled }) {
 
   function updateHeaders (headers) {
     var trans = agent._instrumentation.currTransaction()
-    if (trans) {
+    if (trans && !trans.ended) {
       var status = headers[':status'] || 200
       trans.result = 'HTTP ' + status.toString()[0] + 'xx'
       trans.res.statusCode = status

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -66,7 +66,6 @@ module.exports = function (http2, agent, { enabled }) {
         // `ERR_HTTP2_SOCKET_UNBOUND` if the Http2Session has been destroyed.
         trans.req = {
           headers,
-          // socket: stream.session.socket,
           socket: {
             remoteAddress: stream.session.socket.remoteAddress
           },

--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -114,6 +114,56 @@ isSecure.forEach(secure => {
     })
   })
 
+  test(`http2.${method} stream end after session destroy`, t => {
+    t.plan(16)
+
+    resetAgent((data) => {
+      assert(t, data, secure, port)
+      server.close()
+    })
+
+    var port
+    var server = secure
+      ? http2.createSecureServer(pem)
+      : http2.createServer()
+
+    var onError = err => t.error(err)
+    server.on('error', onError)
+    server.on('socketError', onError)
+
+    server.on('stream', function (stream, headers) {
+      var trans = ins.currTransaction()
+      t.ok(trans, 'have current transaction')
+      t.strictEqual(trans.type, 'request')
+
+      stream.respond({
+        'content-type': 'text/plain',
+        ':status': 200
+      })
+
+      // Destroying the Http2Session results in any usage of the
+      // `stream.session.socket` proxy possibly throwing
+      // `ERR_HTTP2_SOCKET_UNBOUND`. This test case ensures the APM agent
+      // doesn't blow up on this.
+      stream.session.destroy()
+
+      stream.end('foo')
+    })
+
+    server.listen(() => {
+      port = server.address().port
+      var client = connect(secure, port)
+      client.on('error', onError)
+      client.on('socketError', onError)
+
+      var req = client.request({ ':path': '/' })
+      assertResponse(t, req, '') // Do not expect 'foo' to get through.
+      req.resume()
+      req.on('end', () => client.destroy())
+      req.end()
+    })
+  })
+
   test(`http2.${method} stream respondWithFD`, t => {
     t.plan(17)
 


### PR DESCRIPTION
This also fixes a crash that was possible in instrumentation if an
HTTP/2 server called `stream.respond()` after the stream had been
destroyed (and the transaction ended):

    ../lib/instrumentation/modules/http2.js:149
          trans.res.statusCode = status
                               ^
    TypeError: Cannot set properties of null (setting 'statusCode')

Fixes: #2670


### Checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
