### PR TITLE
test: lock to cassandra:3.11.11 to workaround CASSANDRA-17581 for now

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -89,7 +89,10 @@ services:
       retries: 5
 
   cassandra:
-    image: cassandra:3
+    # Avoid the latest cassandra:3 until
+    # https://issues.apache.org/jira/browse/CASSANDRA-17581 is resolved and
+    # released to https://hub.docker.com/_/cassandra?tab=tags
+    image: cassandra:3.11.11
     environment:
       MAX_HEAP_SIZE: "1G"
       HEAP_NEWSIZE: 400m

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -242,13 +242,13 @@ docker-compose \
   build >docker-compose.log 2>docker-compose.err
 
 if [ $? -gt 0 ] ; then
-  echo "Docker compose failed, see the below log output"
+  echo "error: 'docker-compose build ...' failed, see the below log output"
   cat docker-compose.log && rm docker-compose.log
   cat docker-compose.err && rm docker-compose.err
   exit 1
 fi
 
-set -e
+set +e
 NVM_NODEJS_ORG_MIRROR=${NVM_NODEJS_ORG_MIRROR} \
 ELASTIC_APM_ASYNC_HOOKS=${ELASTIC_APM_ASYNC_HOOKS} \
 NODE_VERSION=${NODE_VERSION} \
@@ -265,6 +265,14 @@ docker-compose \
   --abort-on-container-exit \
   node_tests
 
+if [ $? -gt 0 ] ; then
+  echo "error: 'docker-compose up ...' failed"
+  # Dump inspect details on all containers. The "State.Healthcheck" key may
+  # contain helpful info on unhealthy containers.
+  docker inspect $(docker ps -q)
+  exit 1
+fi
+
 if ! NODE_VERSION=${NODE_VERSION} docker-compose \
     --no-ansi \
     --log-level ERROR \
@@ -272,7 +280,7 @@ if ! NODE_VERSION=${NODE_VERSION} docker-compose \
     down -v --remove-orphans; then
   # Workaround for this commonly seen error:
   #   error while removing network: network docker_default id $id has active endpoints
-  echo "Unexpected error in 'docker-compose down ...'. Forcing removal of unused networks."
+  echo "error: Unexpected error in 'docker-compose down ...'. Forcing removal of unused networks."
   docker network inspect docker_default || true
   docker network inspect -f '{{range .Containers}}{{ .Name }} {{end}}' docker_default || true
   docker network prune --force || true

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -89,7 +89,10 @@ services:
       retries: 5
 
   cassandra:
-    image: cassandra:3
+    # Avoid the latest cassandra:3 until
+    # https://issues.apache.org/jira/browse/CASSANDRA-17581 is resolved and
+    # released to https://hub.docker.com/_/cassandra?tab=tags
+    image: cassandra:3.11.11
     environment:
       MAX_HEAP_SIZE: "1G"
       HEAP_NEWSIZE: 400m


### PR DESCRIPTION
This also improves the test.sh runner to dump `docker inspect ...`
info for all containers if the `docker-compose up ...` fails. This
is verbose, but allows debugging which and why a container is unhealthy
if that happens.

Fixes: #2677


I've opted not to lock the cassandra image used for GH Actions right now
because it isn't currently failing. It is possible that this Cassandra issue is
resolved before they publish a new cassandra:{4,latest} image.
