### PR TITLE
test: reduce the number of aws-sdk versions tested

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -524,8 +524,8 @@ aws-sdk:
   # Maintenance note: This should be updated periodically using:
   #   ./dev-utils/aws-sdk-tav-versions.sh
   #
-  # Test v2.858.0, every N=41 of 209 releases, and current latest.
-  versions: '2.858.0 || 2.899.0 || 2.940.0 || 2.981.0 || 2.1022.0 || 2.1063.0 || 2.1066.0 || >2.1066.0 <3'
+  # Test v2.858.0, every N=54 of 275 releases, and current latest.
+  versions: '2.858.0 || 2.912.0 || 2.966.0 || 2.1020.0 || 2.1074.0 || 2.1128.0 || 2.1132.0 || >2.1132.0 <3'
   commands:
     - node test/instrumentation/modules/aws-sdk/aws4-retries.test.js
     - node test/instrumentation/modules/aws-sdk/s3.test.js


### PR DESCRIPTION
Use "./dev-utils/aws-sdk-tav-versions.sh" to again reduce the number
of aws-sdk versions tested in TAV tests.


It has been a while and there have been another ~70 aws-sdk package releases. The aws-sdk TAV test steps have climbed again up to the top Jenkins test step times spots:

```
% ./dev-utils/jenkins-build-slow-steps.sh https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/main/154/
...
1320367 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "10"
1327520 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "mongodb-core" "12"
1337269 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "10"
1338317 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "18"
1373482 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "8"
1385100 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "graphql" "14"
1388256 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "18"
1397435 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "pg" "12"
1436903 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "mongodb-core" "14"
1440552 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "16"
1441632 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "fastify" "14"
1450549 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "14"
1458237 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "12"
1458837 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "bluebird" "12"
1479955 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "bluebird" "14"
1498030 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "graphql" "12"
1634833 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "8"
1675248 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "14"
1713946 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "10"
1721964 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "14"
1762099 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "12"
1892325 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "12"
```

That 1892325ms is ~31.5 minutes.