### PR TITLE
test: revert 'docker inspect ...' dump, it makes test failure logs unreadable

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -248,7 +248,7 @@ if [ $? -gt 0 ] ; then
   exit 1
 fi
 
-set +e
+set -e
 NVM_NODEJS_ORG_MIRROR=${NVM_NODEJS_ORG_MIRROR} \
 ELASTIC_APM_ASYNC_HOOKS=${ELASTIC_APM_ASYNC_HOOKS} \
 NODE_VERSION=${NODE_VERSION} \
@@ -264,14 +264,6 @@ docker-compose \
   --remove-orphans \
   --abort-on-container-exit \
   node_tests
-
-if [ $? -gt 0 ] ; then
-  echo "error: 'docker-compose up ...' failed"
-  # Dump inspect details on all containers. The "State.Healthcheck" key may
-  # contain helpful info on unhealthy containers.
-  docker inspect $(docker ps -q)
-  exit 1
-fi
 
 if ! NODE_VERSION=${NODE_VERSION} docker-compose \
     --no-ansi \


### PR DESCRIPTION
This reverts part of the change from #2678. The intent had been to dump
some info to help with "Container '...' is unhealthy" errors.  However,
the main side-effect is that the end of the log file is 1000s of docker
inspect lines and a test failure is nowhere near the end of the log
file.
