### PR TITLE
test: fix running benchmarks

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -383,7 +383,7 @@ pipeline {
       environment {
         HOME = "${env.WORKSPACE}"
         RESULT_FILE = 'apm-agent-benchmark-results.json'
-        BENCH_NODE_VERSION = '14'
+        NODE_VERSION = '14'
       }
       when {
         beforeAgent true
@@ -402,7 +402,7 @@ pipeline {
             deleteDir()
             unstash 'source'
             dir(BASE_DIR){
-              sh '.ci/scripts/run-benchmarks.sh "${RESULT_FILE}" "${BENCH_NODE_VERSION}"'
+              sh '.ci/scripts/run-benchmarks.sh "${RESULT_FILE}" "${NODE_VERSION}"'
             }
           }
         }


### PR DESCRIPTION
I think this change from #2627 may have broken running the benchmarks.

* * *

Benchmarks have broken recently, starting with https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/main/161/ which is ran with commit a289d4428c2c1ac3a57b0767794cb28e928c1da4  which is #2627.

```
[2022-05-12T17:14:55.956Z] + .ci/scripts/run-benchmarks.sh apm-agent-benchmark-results.json 14
[2022-05-12T17:14:55.956Z] + RESULT_FILE=apm-agent-benchmark-results.json
[2022-05-12T17:14:55.956Z] + NODE_VERSION=14
[2022-05-12T17:14:55.956Z] + [[ -z apm-agent-benchmark-results.json ]]
[2022-05-12T17:14:55.956Z] + [[ -z 14 ]]
[2022-05-12T17:14:55.956Z] ++ dirname .ci/scripts/run-benchmarks.sh
[2022-05-12T17:14:55.956Z] + SCRIPTPATH=.ci/scripts
[2022-05-12T17:14:55.956Z] + source ./.ci/scripts/prepare-benchmarks-env.sh
[2022-05-12T17:14:55.956Z] ++ set -xeo pipefail
[2022-05-12T17:14:55.956Z] ++ [[ -z 14 ]]
[2022-05-12T17:14:55.956Z] ++ curl -sS -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh
[2022-05-12T17:14:55.956Z] ++ bash
[2022-05-12T17:14:55.956Z] => Downloading nvm from git to '/var/lib/jenkins/workspace/nodejs_apm-agent-nodejs-mbp_main/.nvm'
[2022-05-12T17:14:55.956Z]
=> Cloning into '/var/lib/jenkins/workspace/nodejs_apm-agent-nodejs-mbp_main/.nvm'...
[2022-05-12T17:14:56.658Z] => Compressing and cleaning up git repository
[2022-05-12T17:14:56.760Z] 
[2022-05-12T17:14:56.760Z] => Profile not found. Tried ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile.
[2022-05-12T17:14:56.760Z] => Create one of them and run this script again
[2022-05-12T17:14:56.760Z]    OR
[2022-05-12T17:14:56.760Z] => Append the following lines to the correct file yourself:
[2022-05-12T17:14:56.760Z] 
[2022-05-12T17:14:56.760Z] export NVM_DIR="$HOME/.nvm"
[2022-05-12T17:14:56.760Z] [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[2022-05-12T17:14:56.760Z] 
[2022-05-12T17:14:56.760Z] N/A: version "16.15.0 -> N/A" is not yet installed.
[2022-05-12T17:14:56.760Z] 
[2022-05-12T17:14:56.760Z] You need to run "nvm install 16.15.0" to install it before using it.
[2022-05-12T17:14:56.760Z] => Close and reopen your terminal to start using nvm or run the following to use it now:
[2022-05-12T17:14:56.760Z] 
[2022-05-12T17:14:56.760Z] export NVM_DIR="$HOME/.nvm"
[2022-05-12T17:14:56.760Z] [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[2022-05-12T17:14:56.760Z] ++ export NVM_DIR=/var/lib/jenkins/workspace/nodejs_apm-agent-nodejs-mbp_main/.nvm
[2022-05-12T17:14:56.760Z] ++ NVM_DIR=/var/lib/jenkins/workspace/nodejs_apm-agent-nodejs-mbp_main/.nvm
[2022-05-12T17:14:56.760Z] ++ set +x
script returned exit code 3
```

I'm not sure exactly what the error is, but a guess is that the change from `NODE_VERSION` to `BENCH_NODE_VERSION` surprisingly contributed. `nvm` apparently uses `NODE_VERSION`, so that seems possible: https://github.com/nvm-sh/nvm#additional-notes