### PR TITLE
test: skip mysql2@2.2.3 in TAV tests to workaround npm v6 install issue with github deps

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -32,6 +32,11 @@ mysql:
   commands:
     - node test/instrumentation/modules/mysql/mysql.test.js
     - node test/instrumentation/modules/mysql/pool-release-1.test.js
+
+# mysql2
+# - v1.6.2 is broken: https://github.com/sidorares/node-mysql2/issues/869
+# - v2.2.3 has a github dep ("@types/mysql": "types/mysql") that hits
+#   npm v6 install issue https://github.com/npm/cli/issues/4896
 mysql2-old:
   name: mysql2
   versions: '>=1.0.0 <1.6.0'
@@ -40,11 +45,12 @@ mysql2-old:
     - node test/instrumentation/modules/mysql2/pool-release-1.test.js
 mysql2-new:
   name: mysql2
-  versions: '1.6.0 || 1.6.1 || >=1.6.3 <3' # v1.6.2 is broken: https://github.com/sidorares/node-mysql2/issues/869
+  versions: '>=1.6.0 <1.6.2 || >=1.6.3 <2.2.3 || >=2.2.4 <3'
   node: '>=6.0.0'
   commands:
     - node test/instrumentation/modules/mysql2/mysql.test.js
     - node test/instrumentation/modules/mysql2/pool-release-1.test.js
+
 redis:
   versions: '>=2.0.0 <4.0.0'
   commands: node test/instrumentation/modules/redis.test.js


### PR DESCRIPTION
mysql2@2.2.3 (and only that version) has a github dep:
    "@types/mysql": "types/mysql",
Attempting to install that version with npm v6 (the npm in node v10, v12, and
v14) hits https://github.com/npm/cli/issues/4896 which results in an
install so slow that is hits the default 2 minute 'npm install' timeout
in the `tav` tool.

This is the same root cause of https://github.com/elastic/apm-integration-testing/issues/1483