### PR TITLE
feat: add "nodejs16.x" lambda runtime to our compatible runtimes

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -45,7 +45,7 @@ publish: validate-layer-name validate-aws-default-region
 		--layer-name "$(ELASTIC_LAYER_NAME)" \
 		--description "AWS Lambda Extension Layer for the Elastic APM Node.js Agent" \
 		--license "Apache-2.0" \
-		--compatible-runtimes nodejs14.x nodejs12.x nodejs10.x \
+		--compatible-runtimes nodejs16.x nodejs14.x nodejs12.x nodejs10.x \
 		--zip-file "fileb://./$(AWS_FOLDER)/elastic-apm-node-lambda-layer-$(BRANCH_NAME).zip"
 
 # Grant public access to the given LAYER in the given AWS region

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,10 @@ Notes:
   control over how the APM Agent uses incoming trace-context headers for context
   propagation. ({issues}2592[#2592])
 
+- Add "nodejs16.x" as one of the compatible runtimes for the Node.js APM agent
+  Lambda layers now that
+  https://aws.amazon.com/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/[this runtime is available on AWS].
+
 [float]
 ===== Bug fixes
 


### PR DESCRIPTION
AFAIK the "compatible runtimes" flag on Lambda layers is just advisory.
For example I can use our current latest Lambda layer with a
nodejs16.x-using Lambda function.
