### PR TITLE
prevent npe when we have no Span as parent

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -364,7 +364,7 @@ Instrumentation.prototype.addEndedSpan = function (span) {
       this._encodeAndSendSpan(span.getBufferedSpan())
     }
 
-    if (span.getParentSpan().ended || !span.isCompressionEligible()) {
+    if (!span.isCompressionEligible() || span.getParentSpan().ended) {
       const buffered = span.getBufferedSpan()
       if (buffered) {
         this._encodeAndSendSpan(buffered)

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -440,6 +440,7 @@ test('#startSpan()', function (t) {
     t.notEqual(span._context.traceparent.id, '00f067aa0ba902b7')
     t.strictEqual(span._context.traceparent.parentId, '00f067aa0ba902b7')
     t.strictEqual(span._context.traceparent.flags, '01')
+    span.end()
     agent.destroy()
     t.end()
   })


### PR DESCRIPTION
I get a

> TypeError: Cannot read properties of null (reading 'ended')\n  at Instrumentation.addEndedSpan (/app/node_modules/elastic-apm-node/lib/instrumentation/index.js:361:29

when continuing a trace from a context. 

Looking at the code `isCompressionEligible` checks whether `getParent` returns anything and if not returns false which makes me think that the order of the conditions is the wrong way around here.