### PR TITLE
refactor: RunContext.exitSpan() -> .leaveSpan()

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -345,7 +345,7 @@ Instrumentation.prototype.addEndedSpan = function (span) {
   // span is the top of stack (i.e. is the current span). However, it is
   // possible to have out-of-order span.end(), in which case the ended span
   // might not.
-  const newRc = this._runCtxMgr.active().exitSpan(span)
+  const newRc = this._runCtxMgr.active().leaveSpan(span)
   if (newRc) {
     this._runCtxMgr.supersedeRunContext(newRc)
   }

--- a/lib/instrumentation/run-context/RunContext.js
+++ b/lib/instrumentation/run-context/RunContext.js
@@ -70,7 +70,7 @@ class RunContext {
 
   // Return a new RunContext with the given transaction (and hence all of its
   // spans) removed.
-  exitTrans () {
+  leaveTrans () {
     return new this.constructor(null, null, this._values)
   }
 
@@ -82,7 +82,7 @@ class RunContext {
   // that isn't part of the current run context stack at all. (See
   // test/instrumentation/run-context/fixtures/end-non-current-spans.js for
   // examples.)
-  exitSpan (span) {
+  leaveSpan (span) {
     let newRc = null
     let newSpans
     const lastSpan = this._spans[this._spans.length - 1]

--- a/lib/opentelemetry-bridge/OTelBridgeRunContext.js
+++ b/lib/opentelemetry-bridge/OTelBridgeRunContext.js
@@ -100,7 +100,7 @@ class OTelBridgeRunContext extends RunContext {
   deleteValue (key) {
     oblog.apicall('OTelBridgeRunContext.deleteValue(%o)', key)
     if (key === SPAN_KEY) {
-      return this.exitTrans()
+      return this.leaveTrans()
     }
     // TODO: Should perhaps proxy deleteValue(key) to the possible underlying OTEL_CONTEXT_KEY entry.
     return super.deleteValue(key)


### PR DESCRIPTION
This avoids the name collision with the "exitSpan" option when creating
a span in the public API.

Closes: #2680
