### PR TITLE
feat: add span links to AWS SQS ReceiveMessage spans for messages with a traceparent

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,10 @@ Notes:
   control over how the APM Agent uses incoming trace-context headers for context
   propagation. ({issues}2592[#2592])
 
+- Add span links to AWS SQS messaging spans on 'ReceiveMessage', one for each
+  message (up to 1000) which has a 'traceparent' message attribute.
+  ({issues}2593[#2593])
+
 - Add "nodejs16.x" as one of the compatible runtimes for the Node.js APM agent
   Lambda layers now that
   https://aws.amazon.com/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/[this runtime is available on AWS].

--- a/examples/trace-sqs-receive-message.js
+++ b/examples/trace-sqs-receive-message.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+// An example showing Elastic APM tracing the polling of messages from an AWS
+// SQS queue.
+//
+// Warning: Running this script can incur costs on your AWS account. This will
+// also call *DeleteMessage* on received messages, so do not use this on
+// production queues.
+//
+// Prerequisites:
+// - AWS credentials are setup. E.g. if using the `aws` CLI
+//   (https://aws.amazon.com/cli/) works, then you should be good.
+// - You have a test queue to use to receive messages from.
+// - Your queue has some messages on it to receive. See the related
+//   "trace-sqs-send-message.js" script.
+//
+// Usage:
+//    node trace-sqs-receive-message.js REGION SQS-QUEUE-NAME
+//
+// Example:
+//    node trace-sqs-receive-message.js us-west-2 my-play-queue
+
+const apm = require('../').start({
+  serviceName: 'example-trace-sqs'
+})
+
+const AWS = require('aws-sdk')
+
+function errExit (err) {
+  console.error(`${process.argv[1]}: error: ${err.toString()}`)
+  process.exit(1)
+}
+
+const region = process.argv[2]
+const queueName = process.argv[3]
+if (!region || !queueName) {
+  console.error(`usage: node ${process.argv[1]} AWS-REGION SQS-QUEUE-NAME`)
+  errExit('missing arguments')
+}
+console.log('SQS ReceiveMessage from region=%s queueName=%s', region, queueName)
+
+AWS.config.update({ region })
+const sqs = new AWS.SQS({ apiVersion: '2012-11-05' })
+
+// For tracing spans to be created, there must be an active transaction.
+// Typically, a transaction is automatically started for incoming HTTP
+// requests to a Node.js server. However, because this script is not running
+// an HTTP server, we manually start a transaction. More details at:
+// https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
+const trans = apm.startTransaction('receive-message')
+
+// 1. Get the URL for this queue.
+sqs.getQueueUrl({ QueueName: queueName }, function (err, data) {
+  if (err) {
+    errExit(err)
+  }
+  const queueUrl = data.QueueUrl
+  console.log('queueUrl:', queueUrl)
+
+  // 2. Doing a long poll (up to 5s) for up to two messages.
+  const params = {
+    QueueUrl: queueUrl,
+    AttributeNames: ['SentTimestamp'],
+    MaxNumberOfMessages: 2,
+    MessageAttributeNames: ['All'],
+    VisibilityTimeout: 20,
+    WaitTimeSeconds: 5 // long poll
+  }
+  sqs.receiveMessage(params, function (err, data) {
+    if (err) {
+      errExit(err)
+    }
+    process.stdout.write('receiveMessage response data: ')
+    console.dir(data, { depth: 5 })
+
+    // 3. Delete any received messages.
+    if (data.Messages && data.Messages.length > 0) {
+      const delEntries = data.Messages
+        .map(m => { return { Id: m.MessageId, ReceiptHandle: m.ReceiptHandle } })
+      sqs.deleteMessageBatch({
+        QueueUrl: queueUrl,
+        Entries: delEntries
+      }, function (err, data) {
+        if (err) {
+          console.log('deleteMessageBatch err:', err)
+        } else if (data && data.Failed && data.Failed.length > 0) {
+          console.log('deleteMessageBatch failed to delete some messages:', data)
+        }
+        trans.end()
+      })
+    } else {
+      trans.end()
+    }
+  })
+})

--- a/examples/trace-sqs-send-message.js
+++ b/examples/trace-sqs-send-message.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+// An example showing Elastic APM tracing the sending of a message to an AWS
+// SQS queue. See the related "trace-sqs-receive-message.js" script.
+//
+// Warning: Running this script can incur costs on your AWS account. Do not
+// use this on production queues.
+//
+// Prerequisites:
+// - AWS credentials are setup. E.g. if using the `aws` CLI
+//   (https://aws.amazon.com/cli/) works, then you should be good.
+// - You have a test queue to which to send messages.
+//
+// Usage:
+//    node trace-sqs-send-message.js REGION SQS-QUEUE-NAME
+//
+// Example:
+//    node trace-sqs-send-message.js us-west-2 my-play-queue
+
+const apm = require('../').start({
+  serviceName: 'example-trace-sqs'
+})
+
+const AWS = require('aws-sdk')
+
+function errExit (err) {
+  console.error(`${process.argv[1]}: error: ${err.toString()}`)
+  process.exit(1)
+}
+
+const region = process.argv[2]
+const queueName = process.argv[3]
+if (!region || !queueName) {
+  console.error(`usage: node ${process.argv[1]} AWS-REGION SQS-QUEUE-NAME`)
+  errExit('missing arguments')
+}
+console.log('SQS SendMessage to region=%s queueName=%s', region, queueName)
+
+AWS.config.update({ region })
+const sqs = new AWS.SQS({ apiVersion: '2012-11-05' })
+
+// For tracing spans to be created, there must be an active transaction.
+// Typically, a transaction is automatically started for incoming HTTP
+// requests to a Node.js server. However, because this script is not running
+// an HTTP server, we manually start a transaction. More details at:
+// https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
+const trans = apm.startTransaction('send-message')
+
+sqs.getQueueUrl({ QueueName: queueName }, function (err, data) {
+  if (err) {
+    errExit(err)
+  }
+  const queueUrl = data.QueueUrl
+  console.log('queueUrl:', queueUrl)
+
+  const params = {
+    QueueUrl: queueUrl,
+    MessageBody: `this is my message (${Math.random()})`,
+    MessageAttributes: {
+      foo: { DataType: 'String', StringValue: 'bar' }
+    }
+  }
+  sqs.sendMessage(params, function (err, data) {
+    if (err) {
+      errExit(err)
+    }
+    process.stdout.write('sendMessage response data: ')
+    console.dir(data, { depth: 5 })
+    trans.end()
+  })
+})

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,5 +8,8 @@ module.exports = {
   OUTCOME_SUCCESS: 'success',
   OUTCOME_UNKNOWN: 'unknown',
   RESULT_SUCCESS: 'success',
-  RESULT_FAILURE: 'failure'
+  RESULT_FAILURE: 'failure',
+
+  // https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-messaging.md#receiving-trace-context
+  MAX_MESSAGES_PROCESSED_FOR_TRACE_CONTEXT: 1000
 }

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -150,6 +150,28 @@ GenericSpan.prototype.addLabels = function (labels, stringify) {
   return true
 }
 
+// This method is private because the APM agents spec says that (for OTel
+// compat), adding links after span creation should not be allowed.
+// https://github.com/elastic/apm/blob/main/specs/agents/span-links.md
+//
+// To support adding span links for SQS ReceiveMessage and equivalent, the
+// message data isn't known until the *response*, after the span has been
+// created.
+//
+// @param {Array} links - An array of objects with a `context` property that is
+//    a Transaction, Span, or TraceParent instance, or a W3C trace-context
+//    'traceparent' string.
+GenericSpan.prototype._addLinks = function (links) {
+  if (links) {
+    for (let i = 0; i < links.length; i++) {
+      const link = linkFromLinkArg(links[i])
+      if (link) {
+        this._links.push(link)
+      }
+    }
+  }
+}
+
 GenericSpan.prototype.setType = function (type = null, subtype = null, action = null) {
   this.type = type
   this.subtype = subtype

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { URL } = require('url')
+const { MAX_MESSAGES_PROCESSED_FOR_TRACE_CONTEXT } = require('../../../constants')
 
 const OPERATIONS_TO_ACTIONS = {
   deleteMessage: 'delete',
@@ -117,6 +118,49 @@ function getSpanNameFromRequest (request) {
   return name
 }
 
+// Extract span links from up to 1000 messages in this batch.
+// https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-messaging.md#receiving-trace-context
+//
+// A span link is created from a `traceparent` message attribute in a message.
+// `msg.messageAttributes` is of the form:
+//    { <attribute-name>: { DataType: <attr-type>, StringValue: <attr-value>, ... } }
+// For example:
+//    { traceparent: { DataType: 'String', StringValue: 'test-traceparent' } }
+function getSpanLinksFromResponseData (data) {
+  if (!data || !data.Messages || data.Messages.length === 0) {
+    return null
+  }
+  const links = []
+  const limit = Math.min(data.Messages.length, MAX_MESSAGES_PROCESSED_FOR_TRACE_CONTEXT)
+  for (let i = 0; i < limit; i++) {
+    const attrs = data.Messages[i].MessageAttributes
+    if (!attrs) {
+      continue
+    }
+
+    let traceparent
+    const attrNames = Object.keys(attrs)
+    for (let j = 0; j < attrNames.length; j++) {
+      const attrVal = attrs[attrNames[j]]
+      if (!attrVal.DataType === 'String') {
+        continue
+      }
+      const attrNameLc = attrNames[j].toLowerCase()
+      if (attrNameLc === 'traceparent') {
+        traceparent = attrVal.StringValue
+        break
+      } else if (attrNameLc === 'elastic-apm-traceparent') {
+        traceparent = attrVal.StringValue
+        // Don't break here, to allow a subsequent 'traceparent' attr to win.
+      }
+    }
+    if (traceparent) {
+      links.push({ context: traceparent })
+    }
+  }
+  return links
+}
+
 function shouldIgnoreRequest (request, agent) {
   const operation = request && request.operation
   // are we interested in this operation/method call?
@@ -162,10 +206,18 @@ function instrumentationSqs (orig, origArguments, request, AWS, agent, { version
       agent.captureError(response.error)
     }
 
+    const receiveMsgData = request.operation === 'receiveMessage' && response && response.data
+    if (receiveMsgData) {
+      const links = getSpanLinksFromResponseData(receiveMsgData)
+      if (links) {
+        span._addLinks(links)
+      }
+    }
+
     span.end()
 
-    if (request.operation === 'receiveMessage' && response && response.data) {
-      recordMetrics(getQueueNameFromRequest(request), response.data, agent)
+    if (receiveMsgData) {
+      recordMetrics(getQueueNameFromRequest(request), receiveMsgData, agent)
     }
   }
   // Bind onComplete to the span's run context so that `captureError` picks

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -142,7 +142,7 @@ function getSpanLinksFromResponseData (data) {
     const attrNames = Object.keys(attrs)
     for (let j = 0; j < attrNames.length; j++) {
       const attrVal = attrs[attrNames[j]]
-      if (!attrVal.DataType === 'String') {
+      if (attrVal.DataType !== 'String') {
         continue
       }
       const attrNameLc = attrNames[j].toLowerCase()

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -149,9 +149,6 @@ function getSpanLinksFromResponseData (data) {
       if (attrNameLc === 'traceparent') {
         traceparent = attrVal.StringValue
         break
-      } else if (attrNameLc === 'elastic-apm-traceparent') {
-        traceparent = attrVal.StringValue
-        // Don't break here, to allow a subsequent 'traceparent' attr to win.
       }
     }
     if (traceparent) {

--- a/lib/opentelemetry-bridge/README.md
+++ b/lib/opentelemetry-bridge/README.md
@@ -146,7 +146,9 @@ the top of `startSpan` in [`OTelTracer`](./OTelTracer.js)
     uses `AttributeValueLengthLimit (Default=Infinity)`.
     (We could consider using the configurable `longFieldMaxLength` for the
     attribute value truncation limit, if there is a need.)
-  - Span links and events are not current supported by this bridge.
+  - Span events are not currently supported by this bridge.
+  - Span link *attributes* are not supported by the bridge (Elastic APM
+    supports span links, but not span link attributes).
 
 - The OpenTelemetry Bridge spec says APM agents
   ["MAY"](https://github.com/elastic/apm/blob/main/specs/agents/tracing-api-otel.md#attributes-mapping)

--- a/test/instrumentation/modules/aws-sdk/fixtures/sqs.js
+++ b/test/instrumentation/modules/aws-sdk/fixtures/sqs.js
@@ -145,6 +145,13 @@ module.exports = {
                 <DataType>Number</DataType>
               </Value>
             </MessageAttribute>
+            <MessageAttribute>
+              <Name>TrAcEpArEnT</Name>
+              <Value>
+                <StringValue>00-460d51b6ed3ab96be45f2580b8016509-8ba4419207a1f2f8-01</StringValue>
+                <DataType>String</DataType>
+              </Value>
+            </MessageAttribute>
           </Message>
         </ReceiveMessageResult>
         <ResponseMetadata>

--- a/test/instrumentation/modules/aws-sdk/sqs.test.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.test.js
@@ -544,6 +544,10 @@ tape.test('AWS SQS: End to End Tests', function (test) {
         t.equals(spanSqs.action, 'poll', 'span action matches API method called')
         t.equals(spanSqs.context.destination.service.type, 'messaging', 'messaging context set')
         t.equals(spanSqs.context.message.queue.name, 'our-queue', 'queue name context set')
+        t.deepEqual(spanSqs.links, [{
+          trace_id: '460d51b6ed3ab96be45f2580b8016509',
+          span_id: '8ba4419207a1f2f8'
+        }], 'span.links')
 
         t.end()
       })


### PR DESCRIPTION
Refs: #2593

This is *part* of https://github.com/elastic/apm-agent-nodejs/issues/2593. The change just for SQS instrumentation got large enough that I'll break it up into a few PRs: SQS, SNS, and Lambda instrumentation updates.