### PR TITLE
chore: enable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     reviewers:
       - "elastic/apm-agent-node-js"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "elastic/apm-agent-node-js"


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates


The goal here is to have dependabot:
1. help us update our devDependencies so that an `npm test` will test with relatively recent versions of instrumented modules;
2. help us be aware of available updates to our "dependencies" in case there;
3. help us be aware of being behind on instrumentation of new major versions of modules we instrument.

This is *not* required for security updates (https://docs.github.com/en/code-security/dependabot/dependabot-security-updates). Those are separately enabled.

I am not exactly what we are in for here. We have a lot of outdated deps (mostly dev deps).  If the deluge is too sustained, then https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates describes config options to ignore updates for some packages and/or to ignore patch-level updates. This might take some fine-tuning over time.


# aside on commit messages

The default commit message when merging a dependabot PR is large, e.g.: https://github.com/elastic/opbeans-node/commit/fc8032ff3ceb4697f6cd5cd18cedc35803a7a206 and low signal-to-noise.

To have `git log ...` be less noisy, I propose to manually delete the commit message body when merge dependabot PRs. The commit message title line has the link to the PR, which has all that information.  E.g.: https://github.com/elastic/opbeans-node/commit/f2cdbe3a68c1ba4ea5f10907bac549320218173f