### PR TITLE
feat: enable ioredis v5

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -64,14 +64,19 @@ redis:
 #   versions: '^4.0.0'
 # However, there are a *lot* of ioredis releases, so we statically list a
 # subset (the first, plus then the latest in each major.minor).
-ioredis-old:
+ioredis-v2-v4:
   name: ioredis
   versions: '2.0.0 || 2.0.1 || 2.1.0 || 2.2.0 || 2.3.1 || 2.4.3 || 2.5.0 || 3.0.0 || 3.1.4 || 3.2.2 || >3.2.2 <4'
   commands: node test/instrumentation/modules/ioredis.test.js
-ioredis-new:
+ioredis-v4-v5:
   name: ioredis
   versions: '4.0.0 || 4.0.2 || 4.1.0 || 4.2.3 || 4.3.1 || 4.4.0 || 4.5.1 || 4.6.3 || 4.7.0 || 4.8.0 || 4.9.0 || 4.9.5 || 4.10.4 || 4.11.2 || 4.12.2 || 4.13.1 || 4.14.4 || 4.15.1 || 4.16.3 || 4.17.3 || 4.18.0 || 4.19.4 || 4.20.0 || 4.21.0 || 4.22.0 || 4.23.1 || 4.24.6 || 4.25.0 || 4.26.0 || 4.27.11 || ^4.28.0'
   node: '>=6'
+  commands: node test/instrumentation/modules/ioredis.test.js
+ioredis:
+  name: ioredis
+  versions: '^5.0.0'
+  node: '>=12.22.0'
   commands: node test/instrumentation/modules/ioredis.test.js
 
 pg-old-node:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,20 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+- Enable support for ioredis v5
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
 
 [[release-notes-3.34.0]]
 ==== 3.34.0 2022/05/26

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -81,7 +81,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 |https://www.npmjs.com/package/handlebars[handlebars] |* |Will instrument compile and render calls
 |https://www.npmjs.com/package/jade[jade] |>=0.5.6 |Will instrument compile and render calls; Deprecated. No longer tested. Use pug.
 |https://www.npmjs.com/package/pug[pug] |'>=0.1.0' |Will instrument compile and render calls
-|https://www.npmjs.com/package/ioredis[ioredis] |>=2.0.0 <5.0.0 |Will instrument all queries
+|https://www.npmjs.com/package/ioredis[ioredis] |>=2.0.0 <6.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/memcached[memcached] |>=2.2.0  |Will instrument all commands.
 |https://www.npmjs.com/package/mongodb-core[mongodb-core] |>=1.2.19 <4 |Will instrument all queries.
 A lot of higher level MongoDB modules use mongodb-core,

--- a/lib/instrumentation/modules/ioredis.js
+++ b/lib/instrumentation/modules/ioredis.js
@@ -18,7 +18,7 @@ module.exports = function (ioredis, agent, { version, enabled }) {
   if (!enabled) {
     return ioredis
   }
-  if (!semver.satisfies(version, '>=2.0.0 <5.0.0')) {
+  if (!semver.satisfies(version, '>=2.0.0 <6.0.0')) {
     agent.logger.debug('ioredis version %s not supported - aborting...', version)
     return ioredis
   }

--- a/test/instrumentation/modules/ioredis.test.js
+++ b/test/instrumentation/modules/ioredis.test.js
@@ -8,6 +8,13 @@ var agent = require('../../..').start({
   spanCompressionEnabled: false
 })
 
+var ioredisVer = require('ioredis/package.json').version
+var semver = require('semver')
+if (semver.gte(ioredisVer, '5.0.0') && semver.lt(process.version, '12.22.0')) {
+  console.log(`# SKIP ioredis@${ioredisVer} does not support node ${process.version}`)
+  process.exit()
+}
+
 var Redis = require('ioredis')
 var test = require('tape')
 


### PR DESCRIPTION
Enable support for ioredis v5

It seems to work all right with this small change, I don't see anything in their [breaking changes](https://github.com/luin/ioredis/blob/main/CHANGELOG.md#500-2022-03-26) that would involve a larger change in APM.
I wasn't sure if this was a feat or a chore, let me know if I should change.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [X] Add CHANGELOG.asciidoc entry
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
