### PR TITLE
fix: get context back for composite spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -72,6 +72,9 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Fixes a bug where the the agent would not serialize the database context of
+  a span. ({issues}2715[#2715])
+
 [float]
 ===== Chores
 

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -119,16 +119,20 @@ Span.prototype.end = function (endTime) {
   this.transaction._captureBreakdown(this)
 
   // Reduce this span's memory usage by dropping references, except to fields
-  // required to support `interface Span`.
-  // Span fields:
-  this._db = null
-  this._http = null
-  this._message = null
-  this._capturedStackTrace = null
-  // GenericSpan fields:
-  // - Cannot drop `this._context` because it is used for traceparent and ids.
-  this._timer = null
-  this._labels = null
+  // required to support `interface Span`. References can't be dropped if this
+  // is a potential composite span since a composite span will encode _after_
+  // it has ended.
+  if (!this._agent._conf.spanCompressionEnabled || !this.isCompressionEligible(this)) {
+    // Span fields:
+    this._db = null
+    this._http = null
+    this._message = null
+    this._capturedStackTrace = null
+    // GenericSpan fields:
+    // - Cannot drop `this._context` because it is used for traceparent and ids.
+    this._timer = null
+    this._labels = null
+  }
 }
 
 Span.prototype.setDbContext = function (context) {

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -117,22 +117,6 @@ Span.prototype.end = function (endTime) {
 
   this._agent._instrumentation.addEndedSpan(this)
   this.transaction._captureBreakdown(this)
-
-  // Reduce this span's memory usage by dropping references, except to fields
-  // required to support `interface Span`. References can't be dropped if this
-  // is a potential composite span since a composite span will encode _after_
-  // it has ended.
-  if (!this._agent._conf.spanCompressionEnabled || !this.isCompressionEligible(this)) {
-    // Span fields:
-    this._db = null
-    this._http = null
-    this._message = null
-    this._capturedStackTrace = null
-    // GenericSpan fields:
-    // - Cannot drop `this._context` because it is used for traceparent and ids.
-    this._timer = null
-    this._labels = null
-  }
 }
 
 Span.prototype.setDbContext = function (context) {
@@ -279,6 +263,20 @@ Span.prototype._encode = function (cb) {
     } else if (frames) {
       payload.stacktrace = frames
     }
+
+    // Reduce this span's memory usage by dropping references once they're
+    // no longer needed.  We also keep fields required to support
+    // `interface Span`.
+    // Span fields:
+    self._db = null
+    self._http = null
+    self._message = null
+    self._capturedStackTrace = null
+    // GenericSpan fields:
+    // - Cannot drop `this._context` because it is used for traceparent and ids.
+    self._timer = null
+    self._labels = null
+
     cb(null, payload)
   }
 }

--- a/test/instrumentation/github-issue-2715.test.js
+++ b/test/instrumentation/github-issue-2715.test.js
@@ -12,7 +12,7 @@ const mockClient = require('../_mock_http_client')
 const tape = require('tape')
 tape.test(function (suite) {
   suite.test(function (t) {
-    resetAgent(function (data) {
+    resetAgent(2, function (data) {
       t.equals(data.length, 2)
       t.equals(data.spans.length, 1)
       const span = data.spans.pop()
@@ -45,8 +45,8 @@ tape.test(function (suite) {
   suite.end()
 })
 
-function resetAgent (/* numExpected, */ cb) {
+function resetAgent (numExpected, cb) {
   agent._instrumentation.testReset()
-  agent._transport = mockClient(/* numExpected, */ cb)
+  agent._transport = mockClient(numExpected, cb)
   agent.captureError = function (err) { throw err }
 }

--- a/test/instrumentation/github-issue-2715.test.js
+++ b/test/instrumentation/github-issue-2715.test.js
@@ -1,0 +1,52 @@
+const agent = require('../..').start({
+  serviceName: 'test-composite-context',
+  captureExceptions: false,
+  metricsInterval: 0,
+  centralConfig: false,
+  cloudProvider: 'none',
+  spanCompressionEnabled: true
+})
+
+const mockClient = require('../_mock_http_client')
+
+const tape = require('tape')
+tape.test(function (suite) {
+  suite.test(function (t) {
+    resetAgent(function (data) {
+      t.equals(data.length, 2)
+      t.equals(data.spans.length, 1)
+      const span = data.spans.pop()
+      t.equals(span.context.db.statement, dbContext.statement)
+      t.equals(span.context.db.type, dbContext.type)
+      console.log()
+      t.end()
+    })
+    const destinationContext = {
+      service: {
+        resource: 'foo'
+      }
+    }
+    const dbContext = { statement: 'SELECT foo from bar', type: 'sql' }
+    agent.startTransaction('test')
+    const span1 = agent.startSpan('name1', 'db', 'mysql', { exitSpan: true })
+
+    span1.setDestinationContext(destinationContext)
+    span1.setDbContext(dbContext)
+    span1.end()
+
+    const span2 = agent.startSpan('name1', 'db', 'mysql', { exitSpan: true })
+    span2.setDestinationContext(destinationContext)
+    span2.setDbContext(dbContext)
+    span2.end()
+
+    agent.endTransaction()
+    agent.flush()
+  })
+  suite.end()
+})
+
+function resetAgent (/* numExpected, */ cb) {
+  agent._instrumentation.testReset()
+  agent._transport = mockClient(/* numExpected, */ cb)
+  agent.captureError = function (err) { throw err }
+}


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-nodejs/issues/2715

When span compression is enabled and a span is compression eligible ensure the context is not nulled out in order to ensure its available for span serialization/encoding. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
~- [ ] Update TypeScript typings~
~- [ ] Update documentation~
- [x] Add CHANGELOG.asciidoc entry
~- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)~
