### PR TITLE
chore: do not add 'community' and 'triage' labels to dependabot PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,7 @@ on:
     types: [opened]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+
 jobs:
   triage:
     runs-on: ubuntu-latest
@@ -25,6 +26,7 @@ jobs:
         usernamesToExclude: |
           apmmachine
           dependabot
+          dependabot[bot]
         GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
     - name: Show team membership
       run: |


### PR DESCRIPTION
We just turned on dependabot version update PRs and they are getting 'community' and 'triage' labels, which they should now. This tweak copies the apm-agent-java https://github.com/elastic/apm-agent-java/blob/main/.github/workflows/labeler.yml#L29