### PR TITLE
fix: build of Lambda layer broke in CI

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -8,6 +8,7 @@ export AWS_FOLDER
 .PHONY: dist
 dist: validate-branch-name
 	../dev-utils/make-lambda-layer-zip.sh
+	@mkdir -p $(AWS_FOLDER)
 	cp $(LAMBDA_LAYER_ZIP_FILE) $(AWS_FOLDER)/elastic-apm-node-lambda-layer-$(BRANCH_NAME).zip
 
 .PHONY: clean


### PR DESCRIPTION
The `BRANCH_NAME=... make -C .ci dist` failed on
    cp: ../build/aws/elastic-apm-node-lambda-layer-...zip: No such file or directory
because the "../build/aws" dir had not been created.
This was broken in #2627.

This fixes the failure in the release pipeline for the [v3.34.0 release](https://github.com/elastic/apm-agent-nodejs/pull/2723): https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/v3.34.0/1/pipeline

```
[2022-05-25T17:36:24.008Z] The lambda layer can be published as follows for dev work:
[2022-05-25T17:36:24.008Z]     aws lambda --output json publish-layer-version --layer-name '-dev-elastic-apm-node' --description ' dev Elastic APM Node.js agent lambda layer' --zip-file 'fileb://build/lambda-layer-zip/elastic-apm-node-lambda-layer.zip'
[2022-05-25T17:36:24.008Z] cp ../build/lambda-layer-zip/elastic-apm-node-lambda-layer.zip ../build/aws/elastic-apm-node-lambda-layer-v3.34.0.zip
[2022-05-25T17:36:24.008Z] cp: cannot create regular file '../build/aws/elastic-apm-node-lambda-layer-v3.34.0.zip': No such file or directory
[2022-05-25T17:36:24.008Z] Makefile:10: recipe for target 'dist' failed
```