### PR TITLE
Fix Lambda _HANDLER=path/to/file.methodName Form

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,8 +42,8 @@ Notes:
 [float]
 ===== Bug fixes
 
-- Fixes automatic Lambda wrapping handler to work with handler that point to
-  subfolders (`_HANDLER=path/to/folder.methodName`)
+- Fixes automatic Lambda handler wrapping to work with handlers that point to
+  subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2725[#2725])
 
 [float]
 ===== Chores

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@ Notes:
 ===== Bug fixes
 
 - Fixes automatic Lambda handler wrapping to work with handlers that point to
-  subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2725[#2725])
+  subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2709[#2709])
 
 [float]
 ===== Chores

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,22 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+- Fixes automatic Lambda wrapping handler to work with handler that point to
+  subfolders (`_HANDLER=path/to/folder.methodName`)
+
+[float]
+===== Chores
 
 [[release-notes-3.34.0]]
 ==== 3.34.0 2022/05/26

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -82,6 +82,7 @@ function Instrumentation (agent) {
 
   // patch for lambda handler needs special handling since its
   // module name will always be different than its handler name
+
   this._lambdaHandlerInfo = getLambdaHandlerInfo(process.env, MODULES, this._log)
   if (this._lambdaHandlerInfo) {
     this.addPatch(
@@ -239,7 +240,7 @@ Instrumentation.prototype._startHook = function () {
     var enabled = self._agent._conf.instrument && !disabled.has(name)
     var pkg, version
 
-    const isHandlingLambda = self._lambdaHandlerInfo && self._lambdaHandlerInfo.module === name
+    const isHandlingLambda = self._isHandlingLambda(self._lambdaHandlerInfo, name)
 
     if (!isHandlingLambda && basedir) {
       pkg = path.join(basedir, 'package.json')
@@ -255,6 +256,18 @@ Instrumentation.prototype._startHook = function () {
 
     return self._patchModule(exports, name, version, enabled)
   })
+}
+
+Instrumentation.prototype._isHandlingLambda = function(handlerInfo, name) {
+  if(!handlerInfo && !handlerInfo.module) {
+    return
+  }
+
+  if(handlerInfo.module === 'fixtures/lambda' && name === 'lambda') {
+    return true
+  }
+
+  return handlerInfo && handlerInfo.module === name
 }
 
 Instrumentation.prototype._patchModule = function (exports, name, version, enabled) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -82,7 +82,6 @@ function Instrumentation (agent) {
 
   // patch for lambda handler needs special handling since its
   // module name will always be different than its handler name
-
   this._lambdaHandlerInfo = getLambdaHandlerInfo(process.env, MODULES, this._log)
   if (this._lambdaHandlerInfo) {
     this.addPatch(
@@ -240,7 +239,7 @@ Instrumentation.prototype._startHook = function () {
     var enabled = self._agent._conf.instrument && !disabled.has(name)
     var pkg, version
 
-    const isHandlingLambda = self._isHandlingLambda(self._lambdaHandlerInfo, name)
+    const isHandlingLambda = self._lambdaHandlerInfo && self._lambdaHandlerInfo.module === name
 
     if (!isHandlingLambda && basedir) {
       pkg = path.join(basedir, 'package.json')
@@ -256,18 +255,6 @@ Instrumentation.prototype._startHook = function () {
 
     return self._patchModule(exports, name, version, enabled)
   })
-}
-
-Instrumentation.prototype._isHandlingLambda = function(handlerInfo, name) {
-  if(!handlerInfo && !handlerInfo.module) {
-    return
-  }
-
-  if(handlerInfo.module === 'fixtures/lambda' && name === 'lambda') {
-    return true
-  }
-
-  return handlerInfo && handlerInfo.module === name
 }
 
 Instrumentation.prototype._patchModule = function (exports, name, version, enabled) {

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -570,7 +570,7 @@ function getLambdaHandlerInfo (env, modules, logger) {
 
   return {
     filePath: handlerFilePath,
-    module: handlerModule.split('/').pop(),
+    module: handlerModule,
     field: handlerFunctionPath
   }
 }

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -553,7 +553,7 @@ function getLambdaHandlerInfo (env, modules, logger) {
   if (!match || match.length !== 3) {
     return
   }
-  const handlerModule = match[1]
+  const handlerModule = match[1].split('/').pop()
   const handlerFunctionPath = match[2]
 
   // if there's a name conflict with an already instrumented module, skip the
@@ -566,11 +566,11 @@ function getLambdaHandlerInfo (env, modules, logger) {
     return
   }
 
-  const handlerFilePath = getFilePath(env.LAMBDA_TASK_ROOT, handlerModule)
+  const handlerFilePath = getFilePath(env.LAMBDA_TASK_ROOT, match[1])
 
   return {
     filePath: handlerFilePath,
-    module: handlerModule,
+    module: handlerModule.split('/').pop(),
     field: handlerFunctionPath
   }
 }

--- a/test/lambda/github-issue-2709.test.js
+++ b/test/lambda/github-issue-2709.test.js
@@ -1,0 +1,38 @@
+const tape = require('tape')
+const path = require('path')
+
+tape.test('test _HANDLER=fixture/lambda.foo form', function (t) {
+  if (process.platform === 'win32') {
+    t.pass('skipping for windows')
+    t.end()
+    return
+  }
+  // fake the enviornment
+  process.env.AWS_LAMBDA_FUNCTION_NAME = 'foo'
+  process.env.LAMBDA_TASK_ROOT = __dirname
+  process.env._HANDLER = 'fixtures/lambda.foo'
+
+  // load and start The Real agent
+  require('../..').start({
+    serviceName: 'lambda test',
+    breakdownMetrics: false,
+    captureExceptions: false,
+    metricsInterval: 0,
+    centralConfig: false,
+    cloudProvider: 'none',
+    spanStackTraceMinDuration: 0, // Always have span stacktraces.
+    logLevel: 'trace',
+    transport: function () {}
+  })
+
+  // load express after agent (for wrapper checking)
+  const express = require('express')
+
+  // check that the handler fixture is wrapped
+  const handler = require(path.join(__dirname, '/fixtures/lambda')).foo
+  t.equals(handler.name, 'wrappedLambda', 'handler function wrapped correctly')
+
+  // did normal patching/wrapping take place
+  t.equals(express.static.name, 'wrappedStatic', 'express module was instrumented correctly')
+  t.end()
+})

--- a/test/lambda/github-issue-2709.test.js
+++ b/test/lambda/github-issue-2709.test.js
@@ -21,7 +21,6 @@ tape.test('test _HANDLER=fixture/lambda.foo form', function (t) {
     centralConfig: false,
     cloudProvider: 'none',
     spanStackTraceMinDuration: 0, // Always have span stacktraces.
-    logLevel: 'trace',
     transport: function () {}
   })
 


### PR DESCRIPTION
Closes: #2709

This PR refactors the `getLambdaHandlerInfo` function to handle lambda function handlers with nested paths (`_HANDLER=path/to/file.methodName`)

When extracting a Lambda Handler's module the `getLambdaHandlerInfo` function will now shift off the final name in the path, matching the behavior of require-in-the-middle.  This, in turn, will allow wrapping to take place. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
~- [ ] Update TypeScript typings~
~- [ ] Update documentation~
- [x] Add CHANGELOG.asciidoc entry

