### PR TITLE
fix: avoid spurious warning about serviceName in Lambda

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -339,6 +339,8 @@ class Config {
     this.sanitizeFieldNamesRegExp = []
     this.ignoreMessageQueuesRegExp = []
 
+    const isLambda = isLambdaExecutionEnvironment()
+
     // If we didn't find a config file on process boot, but a path to one is
     // provided as a config option, let's instead try to load that
     if (confFile === null && opts && opts.configFile) {
@@ -373,7 +375,8 @@ class Config {
         this.logger.error('serviceName "%s" is invalid: %s', this.serviceName, err.message)
         this.serviceName = null
       }
-      this._serviceNameFrom = 'config'
+    } else if (isLambda) {
+      this.serviceName = process.env.AWS_LAMBDA_FUNCTION_NAME
     } else {
       // Zero-conf support: use package.json#name, else
       // `unknown-${service.agent.name}-service`.
@@ -384,26 +387,24 @@ class Config {
       }
       if (!this.serviceName) {
         this.serviceName = 'unknown-nodejs-service'
-        this._serviceNameFrom = 'fallback'
-      } else {
-        this._serviceNameFrom = 'package-json'
       }
     }
-    if (!this.serviceVersion) {
+    if (this.serviceVersion) {
+      // pass
+    } else if (isLambda) {
+      this.serviceVersion = process.env.AWS_LAMBDA_FUNCTION_VERSION
+    } else {
       // Zero-conf support: use package.json#version, if possible.
       try {
         this.serviceVersion = serviceVersionFromPackageJson()
       } catch (err) {
         // pass
       }
-      this._serviceVersionFrom = 'package-json'
-    } else {
-      this._serviceVersionFrom = 'config'
     }
 
     normalize(this, this.logger)
 
-    if (isLambdaExecutionEnvironment()) {
+    if (isLambda) {
       // Override some config in AWS Lambda environment.
       this.metricsInterval = 0
       this.cloudProvider = 'none'

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -41,12 +41,6 @@ function triggerTypeFromEvent (event) {
 function getMetadata (agent, cloudAccountId) {
   return {
     service: {
-      name: (agent._conf._serviceNameFrom === 'config'
-        ? agent._conf.serviceName
-        : process.env.AWS_LAMBDA_FUNCTION_NAME),
-      version: (agent._conf._serviceVersionFrom === 'config'
-        ? agent._conf.serviceVersion
-        : process.env.AWS_LAMBDA_FUNCTION_VERSION),
       framework: {
         // Passing this service.framework.name to Client#setExtraMetadata()
         // ensures that it "wins" over a framework name from

--- a/test/lambda/metadata.test.js
+++ b/test/lambda/metadata.test.js
@@ -11,6 +11,7 @@ const { isLambdaExecutionEnvironment } = require('../../lib/lambda')
 
 // Setup env for both apm.start() and lambdaLocal.execute().
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'fixture-function-name'
+process.env.AWS_LAMBDA_FUNCTION_VERSION = '42'
 // Set these values to have stable data from lambdaLocal.execute().
 process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs14.x'
 process.env.AWS_REGION = 'us-east-1'
@@ -86,7 +87,7 @@ tape.test('lambda config & metadata tests', function (suite) {
         var metadata = server.events[0].metadata
         t.ok(metadata, 'got metadata')
         t.same(metadata.service.name, process.env.AWS_LAMBDA_FUNCTION_NAME, 'service.name')
-        t.same(metadata.service.version, '1.0', 'service.version has lambda-local hardcoded "1.0"')
+        t.same(metadata.service.version, '42', 'service.version')
         t.same(metadata.service.framework.name, 'AWS Lambda', 'service.framework.name')
         t.same(metadata.service.runtime.name, process.env.AWS_EXECUTION_ENV, 'service.runtime.name')
         t.same(metadata.service.node.configured_name, process.env.AWS_LAMBDA_LOG_STREAM_NAME, 'service.node.configured_name')


### PR DESCRIPTION
Recently in #2684 a change was made so that the agent uses
`require.main` to look for "package.json" to infer serviceName.
That doesn't work for a Lambda Node.js env, because `require.main`
is in the Lambda Runtime ("/var/runtime/...") and not the same tree
where the lambda handler is ("/var/task/..."). The result is a spurious
log.warn in lambda logs:
    could not infer serviceName: could not find package.json up from /var/runtime

Per spec, we prefer the AWS_LAMBDA_FUNCTION_NAME envvar for serviceName
so won't use the package.json value at all. This changes to avoid
looking for package.json at all.
