### PR TITLE
Feat: Add support for knex between 0.21 and 0.95.15 included

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -128,20 +128,24 @@ bluebird:
   commands:
     - node test/instrumentation/modules/bluebird/bluebird.test.js
     - node test/instrumentation/modules/bluebird/cancel.test.js
-knex-old:
+# knex (https://github.com/knex/knex/blob/master/UPGRADING.md)
+# - knex 0.18.0 min supported node is v8
+# - knex 0.21.0 min supported node is v10
+# - knex 1.0.0 min supported node is v12
+knex-v0.9-v0.17:
   name: knex
   # v0.16.4 accidentally dropped support for Node.js 6
   versions: ^0.16.5 || <0.16.4 >=0.16.0 || ^0.15.0 || ^0.14.0 || ^0.13.0 || ^0.12.5 || <0.12.4 >0.11.6 || <0.11.6 >0.9.0
   commands: node test/instrumentation/modules/pg/knex.test.js
-knex-new:
+knex-v0.17-v0.21:
   name: knex
   node: '>=8.6.0'
   versions: '>=0.17 <0.21'
   commands: node test/instrumentation/modules/pg/knex.test.js
-knex-gt-nodev8:
+knex-v0.21-v1:
   name: knex
   node: '>=10.22.0'
-  versions: '>=0.21 <0.22'
+  versions: '>=0.21 <1' # Use '<1' to catch a 0.96.x release if there ever is one.
   commands: node test/instrumentation/modules/pg/knex.test.js
 ws-old:
   name: ws

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@ Notes:
 [float]
 ===== Features
 
+- Add support for 'knex' version v0.21 to v1 ({issues}2699[#2699])
+
 - Change the instrumentation of SQS- and SNS-triggered AWS Lambda invocations:
   The special-casing of triggers with a *single* message/record has been
   removed.  That means that instead of a possible continued distributed trace

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -122,7 +122,7 @@ please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM di
 [options="header"]
 |=================================================
 |Module |Version
-|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <0.22.0
+|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <1.0.0
 |=================================================
 
 [float]

--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -7,7 +7,7 @@ var symbols = require('../../symbols')
 
 module.exports = function (Knex, agent, { version, enabled }) {
   if (!enabled) return Knex
-  if (semver.gte(version, '0.22.0')) {
+  if (semver.gte(version, '1.0.0')) {
     agent.logger.debug('knex version %s not supported - aborting...', version)
     return Knex
   }

--- a/test/instrumentation/modules/pg/knex.test.js
+++ b/test/instrumentation/modules/pg/knex.test.js
@@ -15,9 +15,11 @@ var agent = require('../../../..').start({
 var knexVersion = require('knex/package').version
 var semver = require('semver')
 
-if (semver.gte(knexVersion, '0.21.0') && semver.lt(process.version, '10.0.0')) {
-  // Skip these tests: knex@0.21.x dropped support for node v8.
-  process.exit(0)
+// knex 0.18.0 min supported node is v8, knex 0.21.0 min supported node is v10
+if ((semver.gte(knexVersion, '0.18.0') && semver.lt(process.version, '8.6.0')) ||
+  (semver.gte(knexVersion, '0.21.0') && semver.lt(process.version, '10.22.0'))) {
+  console.log(`# SKIP knex@${knexVersion} does not support node ${process.version}`)
+  process.exit()
 }
 
 var Knex = require('knex')


### PR DESCRIPTION
Refs: #2699

Feat: Add support for `knex` between v0.21 and v0.95.15 included

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
