### PR TITLE
3.35.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,27 +31,9 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-==== Unreleased
 
-[float]
-===== Breaking changes
-
-[float]
-===== Features
-
-[float]
-===== Bug fixes
-
-- Fixes automatic Lambda handler wrapping to work with handlers that point to
-  subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2709[#2709])
-
-[float]
-===== Chores
-
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-3.35.0]]
+==== 3.35.0 2022/06/01
 
 [float]
 ===== Features
@@ -69,8 +51,8 @@ Notes:
 [float]
 ===== Bug fixes
 
-[float]
-===== Chores
+- Fixes automatic Lambda handler wrapping to work with handlers that point to
+  subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2709[#2709])
 
 
 [[release-notes-3.34.0]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -36,6 +36,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|3.35.x |2023-12-01 |3.36.0
 |3.34.x |2023-11-26 |3.35.0
 |3.33.x |2023-11-05 |3.34.0
 |3.32.x |2023-10-27 |3.33.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.34.0",
+      "version": "3.35.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
A release mainly to get the fix for https://github.com/elastic/apm-agent-nodejs/issues/2709 out to Lambda users.