### PR TITLE
fix: the "Push Docker Image" jenkins step requires a HOME var

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   environment {
     REPO = 'apm-agent-nodejs'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    HOME = "${env.WORKSPACE}" // required by "bash_standard_lib.sh" for "Push Docker Image" step
     PIPELINE_LOG_LEVEL='INFO'
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'


### PR DESCRIPTION
The requirement is by top-level code in "bash_standard_lib.sh"
(provided by infra) and used in "push-docker.sh" when run in CI.

* * *

This fixes a release failure in https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/v3.35.0/2/pipeline

```
...
[2022-06-02T15:14:37.175Z] ../dev-utils/push-docker.sh docker.elastic.co observability/apm-agent-nodejs 3.35.0
[2022-06-02T15:14:37.175Z] /usr/local/bin/bash_standard_lib.sh: line 4: HOME: unbound variable
[2022-06-02T15:14:37.276Z] Makefile:31: recipe for target 'push-docker' failed
...
```