### PR TITLE
fix: Express route calc when next(err-that-is-not-Error-instance) is used

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,12 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Fix Express route tracking (used for `transaction.name`) when an argument
+  is passed to the `next(arg)` callback of a request handler. Before this
+  change passing `next(<some object not an instance of Error>)` would be
+  considered an error by Express, but not by the APM agent's route
+  tracking. ({pull}2750[#2750])
+
 - Fixes automatic Lambda handler wrapping to work with handlers that point to
   subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2709[#2709])
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,31 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+- Adds https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-dropped-stats.md[dropped span statistics]
+  to transaction payloads allowing APM Server to calculate more accurate
+  throughput metrics. ({issues}2302[#2302])
+
+[float]
+===== Bug fixes
+
+- Fix Express route tracking (used for `transaction.name`) when an argument
+  is passed to the `next(arg)` callback of a request handler. Before this
+  change passing `next(<some object not an instance of Error>)` would be
+  considered an error by Express, but not by the APM agent's route
+  tracking. ({pull}2750[#2750])
+
+[float]
+===== Chores
+
+
 [[release-notes-3.35.0]]
 ==== 3.35.0 2022/06/01
 
@@ -56,12 +81,6 @@ Notes:
 
 [float]
 ===== Bug fixes
-
-- Fix Express route tracking (used for `transaction.name`) when an argument
-  is passed to the `next(arg)` callback of a request handler. Before this
-  change passing `next(<some object not an instance of Error>)` would be
-  considered an error by Express, but not by the APM agent's route
-  tracking. ({pull}2750[#2750])
 
 - Fixes automatic Lambda handler wrapping to work with handlers that point to
   subfolders (ex. `_HANDLER=path/to/folder.methodName`) ({issues}2709[#2709])
@@ -106,8 +125,6 @@ specifying links during span creation (with the limitation that span link
 - Add "nodejs16.x" as one of the compatible runtimes for the Node.js APM agent
   Lambda layers now that
   https://aws.amazon.com/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/[this runtime is available on AWS].
-
-- Adds [dropped span statistics](https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-dropped-stats.md) to transaction payloads allowing APM Server to calculate more accurate throughput metrics.
 
 [float]
 ===== Bug fixes

--- a/lib/instrumentation/modules/express.js
+++ b/lib/instrumentation/modules/express.js
@@ -49,8 +49,16 @@ module.exports = function (express, agent, { version, enabled }) {
           handle = function (req, res, next) {
             if (!layer.route && layerPath && typeof next === 'function') {
               safePush(req, symbols.expressMountStack, layerPath)
-              arguments[2] = function () {
-                if (!(req.route && arguments[0] instanceof Error)) {
+              arguments[2] = function (nextArg) {
+                // https://github.com/expressjs/express/blob/4.18.1/lib/router/route.js#L116-L149
+                // The argument to an Express handler's `next()` can be:
+                // falsey (call the next handler), 'route' (skip handlers for
+                // this route), 'router' (skip handlers for this Router), or
+                // any other value is considered an error (it doesn't have to
+                // be an instance of Error). For all but the last one, Express
+                // will consider other routes, so we want to pop the mount
+                // stack.
+                if (!nextArg || nextArg === 'route' || nextArg === 'router') {
                   req[symbols.expressMountStack].pop()
                 }
                 return next.apply(this, arguments)


### PR DESCRIPTION
Express considers any value passed to a handler's next() handler
to be an error, except the special case 'route' and 'router' strings.
Before this change the agent's Express route handling (used for setting
transaction.name) would only consider the arg to be an error if
`instanceof Error`.

Refs: #2741
