### PR TITLE
fix: handle wrapping Lambda handlers in modules that only provide getters to the handler properties

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "node_modules",
     "/lib/opentelemetry-bridge/opentelemetry-core-mini",
     "/test/babel/out.js",
+    "/test/lambda/fixtures/esbuild-bundled-handler/hello.js",
     "/test/sourcemaps/fixtures/lib",
     "/test/stacktraces/fixtures/dist",
     "/test/types/transpile/index.js",

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Fix the automatic wrapping of Lambda handlers to support handler modules
+  created by `esbuild` bundling -- as is done in some Serverless Framework
+  functions that use TypeScript. ({issues}2753[#2753])
+
 - Fix Express route tracking (used for `transaction.name`) when an argument
   is passed to the `next(arg)` callback of a request handler. Before this
   change passing `next(<some object not an instance of Error>)` would be

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,5 +1,5 @@
 apm-agent-nodejs
-Copyright 2011-2021 Elasticsearch B.V.
+Copyright 2011-2022 Elasticsearch B.V.
 
 # Notice
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -155,3 +155,37 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+## esbuild
+
+A small part of esbuild's runtime JS code is used in this project's
+"lib/propwrap.js" module.
+
+- **path:** [lib/propwrap.js](lib/propwrap.js)
+- **author:** Evan Wallace
+- **project url:** https://github.com/evanw/esbuild
+- **original file:** https://github.com/evanw/esbuild/blob/v0.14.42/internal/runtime/runtime.go
+- **license:** MIT License (MIT), http://opensource.org/licenses/MIT
+
+MIT License
+
+Copyright (c) 2020 Evan Wallace
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/instrumentation/modules/_lambda-handler.js
+++ b/lib/instrumentation/modules/_lambda-handler.js
@@ -1,6 +1,76 @@
 'use strict'
-const { getLambdaHandlerInfo, wrapNestedPath } = require('../../lambda')
+const { getLambdaHandlerInfo } = require('../../lambda')
 const Instrumentation = require('../index')
+
+// XXX from esbuild. Add to NOTICE.
+var __defProp = Object.defineProperty
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor
+var __hasOwnProp = Object.prototype.hasOwnProperty
+var __getOwnPropNames = Object.getOwnPropertyNames
+// XXX check for newer __copyProps in esbuild:internal/runtime/runtime.go
+var __copyProps = (to, from, except, desc) => {
+  if ((from && typeof from === 'object') || typeof from === 'function') {
+    for (const key of __getOwnPropNames(from)) {
+      if (!__hasOwnProp.call(to, key) && key !== except) { __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable }) }
+    }
+  }
+  return to
+}
+
+// XXX could generalize this to not be specific to `agent.lambda(...)` as wrapper
+function shimmerPPWrap (agent, subpath, mod) {
+  const parts = subpath.split('.')
+  if (parts.length === 0) {
+    return mod
+  }
+  const namespaces = [mod]
+  let namespace = mod
+  let key
+  let val
+  for (let i = 0; i < parts.length; i++) {
+    key = parts[i]
+    val = namespace[key]
+    if (!val) {
+      // XXX make these throw and catch for better error logging
+      console.log('WARN: cannot wrap, no "<mod>.%s"', parts.slice(0, i).join('.'))
+      return mod
+    } else if (i < parts.length - 1) {
+      // Limitation: A *function* could be a namespace holding a handler
+      // function as a property. However, if that property is not writeable
+      // then we cannot wrap it.
+      if (typeof val !== 'object') {
+        console.log('WARN: cannot wrap, "<mod>.%s" is not an object', parts.slice(0, i).join('.'))
+        return mod
+      }
+      namespace = val
+      namespaces.push(namespace)
+    } else {
+      // This is the last part of the subpath.
+      if (typeof val !== 'function') {
+        console.log('WARN: cannot wrap, "<mod>.%s" is not a function', subpath)
+        return mod
+      }
+    }
+  }
+  console.log('XXX namespaces', namespaces)
+  // Now work backwards, wrapping each namespace with a new object that has a
+  // copy of all the properties, except the one that we've wrapped.
+  for (let i = parts.length - 1; i >= 0; i--) {
+    key = parts[i]
+    namespace = namespaces[i]
+    val = i === parts.length - 1 ? agent.lambda(namespace[key]) : namespaces[i + 1]
+    const wrappedNamespace = __defProp({}, key, {
+      value: val,
+      enumerable: true // XXX descriptor.enumerable reuse
+    })
+    __copyProps(wrappedNamespace, namespace, key)
+    namespaces[i] = wrappedNamespace
+  }
+  console.log('XXX parts', parts)
+  console.log('XXX namespaces', namespaces)
+
+  return namespaces[0]
+}
 
 module.exports = function (module, agent, { version, enabled }) {
   if (!enabled) {
@@ -8,6 +78,8 @@ module.exports = function (module, agent, { version, enabled }) {
   }
 
   const { field } = getLambdaHandlerInfo(process.env, Instrumentation.modules, agent.logger)
-  wrapNestedPath(agent, field, module)
-  return module
+  // XXX
+  // wrapNestedPath(agent, field, module)
+  const wrappedMod = shimmerPPWrap(agent, field, module)
+  return wrappedMod
 }

--- a/lib/instrumentation/modules/_lambda-handler.js
+++ b/lib/instrumentation/modules/_lambda-handler.js
@@ -1,76 +1,8 @@
 'use strict'
-const { getLambdaHandlerInfo } = require('../../lambda')
+
 const Instrumentation = require('../index')
-
-// XXX from esbuild. Add to NOTICE.
-var __defProp = Object.defineProperty
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor
-var __hasOwnProp = Object.prototype.hasOwnProperty
-var __getOwnPropNames = Object.getOwnPropertyNames
-// XXX check for newer __copyProps in esbuild:internal/runtime/runtime.go
-var __copyProps = (to, from, except, desc) => {
-  if ((from && typeof from === 'object') || typeof from === 'function') {
-    for (const key of __getOwnPropNames(from)) {
-      if (!__hasOwnProp.call(to, key) && key !== except) { __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable }) }
-    }
-  }
-  return to
-}
-
-// XXX could generalize this to not be specific to `agent.lambda(...)` as wrapper
-function shimmerPPWrap (agent, subpath, mod) {
-  const parts = subpath.split('.')
-  if (parts.length === 0) {
-    return mod
-  }
-  const namespaces = [mod]
-  let namespace = mod
-  let key
-  let val
-  for (let i = 0; i < parts.length; i++) {
-    key = parts[i]
-    val = namespace[key]
-    if (!val) {
-      // XXX make these throw and catch for better error logging
-      console.log('WARN: cannot wrap, no "<mod>.%s"', parts.slice(0, i).join('.'))
-      return mod
-    } else if (i < parts.length - 1) {
-      // Limitation: A *function* could be a namespace holding a handler
-      // function as a property. However, if that property is not writeable
-      // then we cannot wrap it.
-      if (typeof val !== 'object') {
-        console.log('WARN: cannot wrap, "<mod>.%s" is not an object', parts.slice(0, i).join('.'))
-        return mod
-      }
-      namespace = val
-      namespaces.push(namespace)
-    } else {
-      // This is the last part of the subpath.
-      if (typeof val !== 'function') {
-        console.log('WARN: cannot wrap, "<mod>.%s" is not a function', subpath)
-        return mod
-      }
-    }
-  }
-  console.log('XXX namespaces', namespaces)
-  // Now work backwards, wrapping each namespace with a new object that has a
-  // copy of all the properties, except the one that we've wrapped.
-  for (let i = parts.length - 1; i >= 0; i--) {
-    key = parts[i]
-    namespace = namespaces[i]
-    val = i === parts.length - 1 ? agent.lambda(namespace[key]) : namespaces[i + 1]
-    const wrappedNamespace = __defProp({}, key, {
-      value: val,
-      enumerable: true // XXX descriptor.enumerable reuse
-    })
-    __copyProps(wrappedNamespace, namespace, key)
-    namespaces[i] = wrappedNamespace
-  }
-  console.log('XXX parts', parts)
-  console.log('XXX namespaces', namespaces)
-
-  return namespaces[0]
-}
+const { getLambdaHandlerInfo } = require('../../lambda')
+const propwrap = require('../../propwrap')
 
 module.exports = function (module, agent, { version, enabled }) {
   if (!enabled) {
@@ -78,8 +10,13 @@ module.exports = function (module, agent, { version, enabled }) {
   }
 
   const { field } = getLambdaHandlerInfo(process.env, Instrumentation.modules, agent.logger)
-  // XXX
-  // wrapNestedPath(agent, field, module)
-  const wrappedMod = shimmerPPWrap(agent, field, module)
-  return wrappedMod
+  try {
+    const newMod = propwrap.wrap(module, field, (orig) => {
+      return agent.lambda(orig)
+    })
+    return newMod
+  } catch (wrapErr) {
+    agent.logger.warn('could not wrap lambda handler: %s', wrapErr)
+    return module
+  }
 }

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -500,25 +500,6 @@ function getLambdaHandlerInfo (env, modules, logger) {
   }
 }
 
-// wraps a nested property on the module object with the lambda handler
-// @param string field ex. "foo.baz.bar"
-// @param object module
-function wrapNestedPath (agent, field, module) {
-  const parts = field.split('.')
-  let object = module
-  while (parts.length > 0) {
-    const prop = parts.shift()
-    if (parts.length === 0 && object[prop]) {
-      object[prop] = agent.lambda(object[prop])
-    } else {
-      object = object[prop]
-    }
-    if (!object) {
-      break
-    }
-  }
-}
-
 function lowerCaseObjectKeys (obj) {
   const lowerCased = {}
   for (const key of Object.keys(obj)) {
@@ -604,6 +585,5 @@ function spanLinksFromSnsRecords (records) {
 module.exports = {
   isLambdaExecutionEnvironment,
   elasticApmAwsLambda,
-  getLambdaHandlerInfo,
-  wrapNestedPath
+  getLambdaHandlerInfo
 }

--- a/lib/propwrap.js
+++ b/lib/propwrap.js
@@ -61,8 +61,8 @@ function wrap (obj, subpath, wrapper) {
   let key
   let val
 
-  // 1. Traverse the subpath parts to sanity check and build up the Objects
-  //    that we will be copying at least level into `namespaces`.
+  // 1. Traverse the subpath parts to sanity check and get references to the
+  //    Objects that will will be copying.
   for (let i = 0; i < parts.length; i++) {
     key = parts[i]
     val = namespace[key]

--- a/lib/propwrap.js
+++ b/lib/propwrap.js
@@ -1,0 +1,107 @@
+'use strict'
+
+// Utilities to wrap properties of an object.
+//
+// This is similar to "./instrumentation/shimmer.js". However, it uses a
+// different technique to support wrapping properties that are only available
+// via a getter (i.e. their property descriptor is `.writable === false`).
+// CommonJS modules produced by TypeScript compilation are objects that only
+// define a getter for exported properties.
+
+// This block is derived from esbuild's bundling support.
+// https://github.com/evanw/esbuild/blob/v0.14.42/internal/runtime/runtime.go#L22
+var __defProp = Object.defineProperty
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor
+var __hasOwnProp = Object.prototype.hasOwnProperty
+var __getOwnPropNames = Object.getOwnPropertyNames
+var __copyProps = (to, from, except, desc) => {
+  if ((from && typeof from === 'object') || typeof from === 'function') {
+    for (const key of __getOwnPropNames(from)) {
+      if (!__hasOwnProp.call(to, key) && key !== except) {
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable })
+      }
+    }
+  }
+  return to
+}
+
+/**
+ * Return a new object that is a copy of `obj`, with its `subpath` property
+ * replaced with the return value of `wrapper(original, subpath)`.
+ *
+ * For example:
+ *    var os = wrap(require('os'), 'platform', (orig) => {
+ *      return function wrappedPlatform () {
+ *        return orig().toUpperCase()
+ *      }
+ *    })
+ *    console.log(os.platform()) // => DARWIN
+ *
+ * The subpath can indicate a nested property. Each property in that subpath,
+ * except the last, much identify an *Object*.
+ *
+ * Limitations:
+ * - This doesn't handle possible Symbol properties on the copied object(s).
+ * - This cannot wrap a property of a function, because we cannot create a
+ *   copy of the function.
+ *
+ * @param {Object} obj
+ * @param {String} subpath - The property subpath on `obj` to wrap. This may
+ *    point to a nested property by using a '.' to separate levels. For example:
+ *        var fs = wrap(fs, 'promises.sync', (orig) => { ... })
+ * @param {Function} wrapper - A function of the form `function (orig)`, where
+ *    `orig` is the original property value. This must synchronously return the
+ *    new property value.
+ * @returns {Object} A new object with the wrapped property.
+ * @throws {TypeError} if the subpath points to a non-existant property, or if
+ *    any but the last subpath part points to a non-Object.
+ */
+function wrap (obj, subpath, wrapper) {
+  const parts = subpath.split('.')
+  const namespaces = [obj]
+  let namespace = obj
+  let key
+  let val
+
+  // 1. Traverse the subpath parts to sanity check and build up the Objects
+  //    that we will be copying at least level into `namespaces`.
+  for (let i = 0; i < parts.length; i++) {
+    key = parts[i]
+    val = namespace[key]
+    if (!val) {
+      throw new TypeError(`cannot wrap "${subpath}": "<obj>.${parts.slice(0, i).join('.')}" is ${typeof val}`)
+    } else if (i < parts.length - 1) {
+      if (typeof val !== 'object') {
+        throw new TypeError(`cannot wrap "${subpath}": "<obj>.${parts.slice(0, i).join('.')}" is not an Object`)
+      }
+      namespace = val
+      namespaces.push(namespace)
+    }
+  }
+
+  // 2. Now work backwards, wrapping each namespace with a new object that has a
+  //    copy of all the properties, except the one that we've wrapped.
+  for (let i = parts.length - 1; i >= 0; i--) {
+    key = parts[i]
+    namespace = namespaces[i]
+    if (i === parts.length - 1) {
+      const orig = namespace[key]
+      val = wrapper(orig)
+    } else {
+      val = namespaces[i + 1]
+    }
+    const desc = __getOwnPropDesc(namespace, key)
+    const wrappedNamespace = __defProp({}, key, {
+      value: val,
+      enumerable: !desc || desc.enumerable
+    })
+    __copyProps(wrappedNamespace, namespace, key)
+    namespaces[i] = wrappedNamespace
+  }
+
+  return namespaces[0]
+}
+
+module.exports = {
+  wrap
+}

--- a/lib/propwrap.js
+++ b/lib/propwrap.js
@@ -25,7 +25,7 @@ var __copyProps = (to, from, except, desc) => {
 
 /**
  * Return a new object that is a copy of `obj`, with its `subpath` property
- * replaced with the return value of `wrapper(original, subpath)`.
+ * replaced with the return value of `wrapper(original)`.
  *
  * For example:
  *    var os = wrap(require('os'), 'platform', (orig) => {

--- a/lib/propwrap.js
+++ b/lib/propwrap.js
@@ -5,8 +5,6 @@
 // This is similar to "./instrumentation/shimmer.js". However, it uses a
 // different technique to support wrapping properties that are only available
 // via a getter (i.e. their property descriptor is `.writable === false`).
-// CommonJS modules produced by TypeScript compilation are objects that only
-// define a getter for exported properties.
 
 // This block is derived from esbuild's bundling support.
 // https://github.com/evanw/esbuild/blob/v0.14.42/internal/runtime/runtime.go#L22

--- a/test/lambda/fixtures/esbuild-bundled-handler/Makefile
+++ b/test/lambda/fixtures/esbuild-bundled-handler/Makefile
@@ -1,0 +1,2 @@
+hello.js: hello.ts
+	npx esbuild@0.14.42 hello.ts --platform=node --bundle --outfile=hello.js

--- a/test/lambda/fixtures/esbuild-bundled-handler/README.md
+++ b/test/lambda/fixtures/esbuild-bundled-handler/README.md
@@ -1,0 +1,6 @@
+This is directory holds the result of using `esbuild` to bundled a TypeScript
+lambda handler -- as is done by a handler built using Serverless Framework
+and TypeScript.
+    https://esbuild.github.io/getting-started/#bundling-for-node
+
+"hello.js" can be rebuilt from "hello.ts" by running `make` in this directory.

--- a/test/lambda/fixtures/esbuild-bundled-handler/hello.js
+++ b/test/lambda/fixtures/esbuild-bundled-handler/hello.js
@@ -1,0 +1,31 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// hello.ts
+var hello_exports = {};
+__export(hello_exports, {
+  main: () => main
+});
+module.exports = __toCommonJS(hello_exports);
+var main = async (event, context) => {
+  return "hi";
+};
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  main
+});

--- a/test/lambda/fixtures/esbuild-bundled-handler/hello.ts
+++ b/test/lambda/fixtures/esbuild-bundled-handler/hello.ts
@@ -1,0 +1,3 @@
+export const main = async (event, context) => {
+  return 'hi'
+}

--- a/test/lambda/wrap-bundled-handler.test.js
+++ b/test/lambda/wrap-bundled-handler.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+// Test the automatic wrapping of a Lambda handler module created by
+//    esbuild foo.ts --platform=node --bundle
+// as is done by a Serverless Framework project using TypeScript.
+// The created module exports its properties only with a getter, so wrapping
+// of the handler cannot modify the module object directly.
+
+const tape = require('tape')
+const path = require('path')
+
+tape.test('automatic wrapping of _HANDLER=esbuild-bundled-handler/hello.main', function (t) {
+  if (process.platform === 'win32') {
+    t.pass('skipping for windows')
+    t.end()
+    return
+  }
+
+  // Fake the Lambda enviornment.
+  process.env.AWS_LAMBDA_FUNCTION_NAME = 'main'
+  process.env.LAMBDA_TASK_ROOT = path.join(__dirname, 'fixtures')
+  process.env._HANDLER = 'esbuild-bundled-handler/hello.main'
+
+  // Start The Real agent.
+  require('../..').start({
+    serviceName: 'lambda test',
+    breakdownMetrics: false,
+    captureExceptions: false,
+    metricsInterval: '0s',
+    centralConfig: false,
+    cloudProvider: 'none',
+    spanStackTraceMinDuration: 0, // Always have span stacktraces.
+    disableSend: true
+  })
+
+  // Load express after the agent has started.
+  const express = require('express')
+
+  const handler = require(path.join(__dirname, 'fixtures/esbuild-bundled-handler/hello')).main
+  t.equals(handler.name, 'wrappedLambda', 'handler function wrapped correctly')
+
+  // Did normal patching/wrapping take place?
+  t.equals(express.static.name, 'wrappedStatic', 'express module was instrumented correctly')
+  t.end()
+})

--- a/test/lambda/wrapper.test.js
+++ b/test/lambda/wrapper.test.js
@@ -3,7 +3,7 @@ const tape = require('tape')
 const path = require('path')
 const Instrumentation = require('../../lib/instrumentation')
 const logging = require('../../lib/logging')
-const { getLambdaHandlerInfo, wrapNestedPath } = require('../../lib/lambda')
+const { getLambdaHandlerInfo } = require('../../lib/lambda')
 
 const MODULES = Instrumentation.modules
 tape.test('unit tests for getLambdaHandlerInfo', function (suite) {
@@ -143,49 +143,4 @@ tape.test('integration test', function (t) {
   // did normal patching/wrapping take place
   t.equals(express.static.name, 'wrappedStatic', 'express module was instrumented correctly')
   t.end()
-})
-
-tape.test('wrapper', function (suite) {
-  suite.test('basic case', function (t) {
-    // wrapNestedPath (agent, field, module) {
-    const agent = {
-      lambda: function (prop) {
-        t.equals(prop, 'bar', 'expected value passed')
-        t.end()
-      }
-    }
-    const module = {
-      foo: 'bar'
-    }
-    wrapNestedPath(agent, 'foo', module)
-  })
-
-  suite.test('property does not exist', function (t) {
-    const agent = {
-      lambda: function (prop) {
-        t.fail()
-      }
-    }
-    const module = {
-      foo: 'bar'
-    }
-    wrapNestedPath(agent, 'fooo', module)
-    t.end()
-  })
-
-  suite.test('deep property does not exist', function (t) {
-    const agent = {
-      lambda: function (prop) {
-        t.fail()
-      }
-    }
-    const module = {
-      foo: {
-        bar: 'baz'
-      }
-    }
-    wrapNestedPath(agent, 'foo.bar.bing', module)
-    t.end()
-  })
-  suite.end()
 })

--- a/test/propwrap.test.js
+++ b/test/propwrap.test.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const tape = require('tape')
+
+const propwrap = require('../lib/propwrap')
+
+tape.test('wrap basic use case', function (t) {
+  t.plan(2)
+  const obj = {
+    foo: 'bar'
+  }
+  const newObj = propwrap.wrap(obj, 'foo', (orig) => {
+    t.equal(orig, 'bar', 'orig')
+    return orig.toUpperCase()
+  })
+  t.equal(newObj.foo, 'BAR', 'newObj.foo')
+  t.end()
+})
+
+tape.test('wrap nested subpath', function (t) {
+  t.plan(2)
+  const obj = {
+    deep: {
+      nested: {
+        foo: 'bar'
+      }
+    }
+  }
+  const newObj = propwrap.wrap(obj, 'deep.nested.foo', (orig) => {
+    t.equal(orig, 'bar', 'orig')
+    return orig.toUpperCase()
+  })
+  t.equal(newObj.deep.nested.foo, 'BAR', 'newObj.deep.nested.foo')
+  t.end()
+})
+
+tape.test('wrap property with only a getter', function (t) {
+  t.plan(2)
+  const obj = {}
+  Object.defineProperty(obj, 'foo', {
+    value: 'bar',
+    writable: false
+  })
+  const newObj = propwrap.wrap(obj, 'foo', (orig) => {
+    t.equal(orig, 'bar', 'orig')
+    return orig.toUpperCase()
+  })
+  t.equal(newObj.foo, 'BAR', 'newObj.foo')
+  t.end()
+})
+
+tape.test('wrap property does not exist', function (t) {
+  t.plan(2)
+  const obj = {
+    foo: 'bar'
+  }
+  try {
+    propwrap.wrap(obj, 'baz', (orig) => {
+      t.fail('should not call wrapper')
+    })
+    t.fail('should not get here')
+  } catch (wrapErr) {
+    t.ok(wrapErr, 'wrapErr')
+    t.ok(wrapErr.message.indexOf('baz') !== -1, 'error message mentions "baz"')
+  }
+  t.end()
+})
+
+tape.test('wrap, part of subpath not exist', function (t) {
+  t.plan(2)
+  const obj = {
+    deep: {
+      baz: null,
+      nested: {
+        foo: 'bar'
+      }
+    }
+  }
+  try {
+    propwrap.wrap(obj, 'deep.baz.foo', (orig) => {
+      t.fail('should not call wrapper')
+    })
+    t.fail('should not get here')
+  } catch (wrapErr) {
+    t.ok(wrapErr, 'wrapErr')
+    t.ok(wrapErr.message.indexOf('baz') !== -1, 'error message mentions "baz"')
+  }
+  t.end()
+})
+
+tape.test('wrap, namespace is not an Object', function (t) {
+  t.plan(3)
+  const obj = {
+    deep: function () {}
+  }
+  obj.deep.ns = {
+    foo: 'bar'
+  }
+
+  try {
+    propwrap.wrap(obj, 'deep.ns.foo', (orig) => {
+      t.fail('should not call wrapper')
+    })
+    t.fail('should not get here')
+  } catch (wrapErr) {
+    t.ok(wrapErr, 'wrapErr')
+    t.ok(wrapErr.message.indexOf('deep') !== -1, 'error message mentions "deep"')
+    t.ok(wrapErr.message.indexOf('Object') !== -1, 'error message mentions "Object"')
+  }
+  t.end()
+})


### PR DESCRIPTION
Fixes: #2753

### checklist

- [x] Implement code
- [x] Add tests
- [x] Add CHANGELOG.asciidoc entry