### PR TITLE
fix: graphql v16 support

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ Notes:
   change passing `next(<some object not an instance of Error>)` would be
   considered an error by Express, but not by the APM agent's route
   tracking. ({pull}2750[#2750])
+- Fix Graphql v16 support ({issues}2508[#2508])
 
 [float]
 ===== Chores

--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -7,7 +7,7 @@ var getPathFromRequest = require('../express-utils').getPathFromRequest
 
 module.exports = function (graphql, agent, { version, enabled }) {
   if (!enabled) return graphql
-  if (!semver.satisfies(version, '>=0.7.0 <16.0.0 || ^14.0.0-rc') ||
+  if (!semver.satisfies(version, '>=0.7.0 <17.0.0 || ^14.0.0-rc') ||
       !graphql.Kind ||
       typeof graphql.Source !== 'function' ||
       typeof graphql.parse !== 'function' ||
@@ -79,7 +79,9 @@ module.exports = function (graphql, agent, { version, enabled }) {
   }
 
   function wrapExecute (orig) {
-    function wrappedExecuteImpl (schema, document, rootValue, contextValue, variableValues, operationName) {
+    return function wrappedExecute() {
+      var { document, operationName } = extractArgs(...arguments);
+      
       agent.logger.debug('intercepted call to graphql.execute')
       const span = ins.createSpan('GraphQL: Unknown Query', 'db', 'graphql', 'execute')
       if (!span) {
@@ -119,25 +121,19 @@ module.exports = function (graphql, agent, { version, enabled }) {
       }
       return p
     }
-
-    return function wrappedExecute (argsOrSchema, document, rootValue, contextValue, variableValues, operationName) {
-      return arguments.length === 1
-        ? wrappedExecuteImpl(
-          argsOrSchema.schema,
-          argsOrSchema.document,
-          argsOrSchema.rootValue,
-          argsOrSchema.contextValue,
-          argsOrSchema.variableValues,
-          argsOrSchema.operationName
-        )
-        : wrappedExecuteImpl(
-          argsOrSchema,
-          document,
-          rootValue,
-          contextValue,
-          variableValues,
-          operationName
-        )
+  }
+  
+  function extractArgs(argsOrSchema, document, rootValue, contextValue, variableValues, operationName) {
+    // Arg object
+    if (arguments.length === 1) {
+      return {
+        document: argsOrSchema.document,
+        operationName: argsOrSchema.operationName,
+      };
+    }
+    return {
+      document,
+      operationName,
     }
   }
 


### PR DESCRIPTION
Adds support for graph16.

From what I could tell, this broke because graphql dropped support for [positional arguments](https://github.com/graphql/graphql-js/pull/2904), and the APM agent was forcing the arg object to be converted to positional args.

This PR simply passes the args straight through to graphql, just as they are passed to it.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
