### PR TITLE
fix: graphql@16 has peer dep conflicts with express-graphql@0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "generic-pool": "^3.7.1",
         "get-port": "^5.1.1",
         "got": "^9.6.0",
-        "graphql": "^16.5.0",
+        "graphql": "^15.8.0",
         "handlebars": "^4.7.3",
         "https-pem": "^3.0.0",
         "ioredis": "^4.28.0",
@@ -8521,12 +8521,12 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-      "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-tag": {
@@ -23145,9 +23145,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-      "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "dev": true
     },
     "graphql-tag": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "generic-pool": "^3.7.1",
     "get-port": "^5.1.1",
     "got": "^9.6.0",
-    "graphql": "^16.5.0",
+    "graphql": "^15.8.0",
     "handlebars": "^4.7.3",
     "https-pem": "^3.0.0",
     "ioredis": "^4.28.0",


### PR DESCRIPTION
This peer dep conflict breaks our dist build (make -C .ci dist).
Fix the conflict by backing up to graphql@15 for now -- until we
separate out testing deps to separate package dirs, or until
express-graphql updates to support graphql@16.
We still test graphql@16 with our TAV tests.

Fixes: #2773
