### PR TITLE
docs: drop potentially confusing language in config precendence

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -18,9 +18,9 @@ Use the following pages to configure the APM Agent.
 [[configuring-the-agent]]
 === Configuring the agent
 
-There are multiple ways to configure the Node.js agent. In order of precedence (higher overwrites lower):
+There are multiple ways to configure the Node.js agent. In order of precedence:
 
-1. APM Agent Configuration via Kibana.
+1. APM Agent Central Configuration via Kibana.
 (supported options are marked with <<dynamic-configuration, image:./images/dynamic-config.svg[] >>)
 
 2. Environment variables.


### PR DESCRIPTION
The "(higher overwrites lower)" for config precendence can be
confusing because "4" is higher than "1" in the numbered bullets,
but that's not what is intended.
