### PR TITLE
feat: replace metrics impl with one based on @otel/sdk-metrics-base

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -19,7 +19,12 @@ var errors = require('./errors')
 const { InflightEventSet } = require('./InflightEventSet')
 var Instrumentation = require('./instrumentation')
 var { elasticApmAwsLambda } = require('./lambda')
-var Metrics = require('./metrics')
+var Metrics // XXX
+if (process.env.OLD_METRICS) {
+  Metrics = require('./metrics')
+} else {
+  Metrics = require('./metrics2')
+}
 var parsers = require('./parsers')
 var symbols = require('./symbols')
 const { frameCacheStats } = require('./stacktraces')

--- a/lib/metrics/reporter.js
+++ b/lib/metrics/reporter.js
@@ -60,6 +60,7 @@ class MetricsReporter extends Reporter {
 
       if (this._agent._transport) {
         for (const metric of seen.values()) {
+          console.log('XXX sendMetricSet: ', metric)
           this._agent._transport.sendMetricSet(metric)
         }
       }

--- a/lib/metrics2/index.js
+++ b/lib/metrics2/index.js
@@ -1,0 +1,265 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+const { AggregationTemporality, MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics-base')
+const { ExportResultCode } = require('@opentelemetry/core')
+const eventLoopMonitor = require('monitor-event-loop-delay')
+
+const eventLoopMonitorResolution = 10
+
+/**
+ * The `timestamp` in a metricset for APM Server intake is "UTC based and
+ * formatted as microseconds since Unix epoch".
+ */
+function metricTimestampFromOTelHrTime (otelHrTime) {
+  // OTel's HrTime is `[<seconds since unix epoch>, <nanoseconds>]`
+  return Math.round(otelHrTime[0] * 1e6 + otelHrTime[1] / 1e3)
+}
+
+/**
+ * XXX
+ * implements PushMetricExporter
+ *
+ * XXX Given warning about not doing the grouping of metrics into metricsets with multiple items. We *could*
+ *    do a best-effort of that (i.e. skip sorting attributes fields). Or a possible faster one
+ *    is to only do it for sequential ones ... on the assumption they come in together for
+ *    batch metrics and for common case for no custom labels (guessing).
+ */
+class ApmMetricExporter {
+  constructor (agent) {
+    this._agent = agent
+  }
+
+  // export1 (resourceMetrics, resultCallback) { // XXX
+  //   console.log('XXX ApmMetricExporter.export')
+  //   console.dir(resourceMetrics, { depth: 10 })
+  //   return resultCallback({ code: ExportResultCode.SUCCESS })
+  // }
+
+  // // Adapted from https://github.com/open-telemetry/opentelemetry-js/blob/experimental/v0.27.0/experimental/packages/opentelemetry-sdk-metrics-base/src/export/ConsoleMetricExporter.ts
+  // export2 (resourceMetrics, resultCallback) { // XXX
+  //   for (const scopeMetrics of resourceMetrics.scopeMetrics) {
+  //     for (const metricData of scopeMetrics.metrics) {
+  //       for (const dataPoint of metricData.dataPoints) {
+  //         console.log('-- dataPoint')
+  //         console.log('metricData.descriptor:', metricData.descriptor)
+  //         console.log('dataPoint.attributes:', dataPoint.attributes)
+  //         console.log('dataPoint.endTime:', dataPoint.endTime)
+  //         console.log('dataPoint.value:', dataPoint.value)
+  //       }
+  //     }
+  //   }
+  //   return resultCallback({ code: ExportResultCode.SUCCESS })
+  // }
+
+  // export3 (resourceMetrics, resultCallback) {
+  //   console.log('XXX ApmMetricExporter.export')
+  //   console.dir(resourceMetrics, { depth: 10 }) // XXX
+  //   for (const scopeMetrics of resourceMetrics.scopeMetrics) {
+  //     for (const metricData of scopeMetrics.metrics) {
+  //       for (const dataPoint of metricData.dataPoints) {
+  //         const sample = {
+  //           value: dataPoint.value
+  //           // XXX type?, unit?, handle Histogram (counts, values)
+  //         }
+  //         const metricset = {
+  //           samples: {
+  //             [metricData.descriptor.name]: sample
+  //           },
+  //           timestamp: metricTimestampFromOTelHrTime(dataPoint.endTime),
+  //           tags: Object.assign(dataPoint.attributes) // XXX clone needed?
+  //         }
+  //         console.log('XXX sendMetricSet: ', metricset)
+  //         this._agent._transport.sendMetricSet(metricset)
+  //       }
+  //     }
+  //   }
+  //   return resultCallback({ code: ExportResultCode.SUCCESS })
+  // }
+
+  // This is a version of `export3` that does the best-effort grouping for similar tags.
+  // This should reduce duplication for the common case.
+  export (resourceMetrics, resultCallback) {
+    let currLabelsHash
+    let currMetricset
+    for (const scopeMetrics of resourceMetrics.scopeMetrics) {
+      for (const metricData of scopeMetrics.metrics) {
+        for (const dataPoint of metricData.dataPoints) {
+          const sample = {
+            value: dataPoint.value
+            // XXX type?, unit?, handle Histogram (counts, values)
+          }
+          // XXX We are assuming dataPoint.endTime is identical for all resourceMetrics. Is that true?
+          const labelsHash = JSON.stringify(dataPoint.attributes)
+          if (labelsHash === currLabelsHash) {
+            currMetricset.samples[metricData.descriptor.name] = sample
+          } else {
+            currLabelsHash = labelsHash
+            if (currMetricset) {
+              console.log('XXX sendMetricSet: ', currMetricset)
+              this._agent._transport.sendMetricSet(currMetricset)
+            }
+            currMetricset = {
+              samples: {
+                [metricData.descriptor.name]: sample
+              },
+              timestamp: metricTimestampFromOTelHrTime(dataPoint.endTime),
+              tags: Object.assign(dataPoint.attributes) // XXX is this clone needed?
+            }
+          }
+        }
+      }
+    }
+    if (currMetricset) {
+      console.log('XXX sendMetricSet (last one): ', currMetricset)
+      this._agent._transport.sendMetricSet(currMetricset)
+    }
+    return resultCallback({ code: ExportResultCode.SUCCESS })
+  }
+
+  selectAggregationTemporality (_instrumentType) {
+    // XXX I do not have an good at all understanding of what is required here, esp.
+    //     when we get into the various instrument types.
+    return AggregationTemporality.CUMULATIVE
+  }
+
+  async forceFlush () {
+    console.log('XXX ApmMetricExporter.forceFlush')
+  }
+
+  async shutdown () {
+    console.log('XXX ApmMetricExporter.shutdown')
+  }
+}
+
+class Metrics {
+  constructor (agent) {
+    this._agent = agent
+    this._meterProvider = null
+    this._meter = null
+  }
+
+  start (refTimers) {
+    const metricsInterval = this._agent._conf.metricsInterval
+    const enabled = metricsInterval !== 0 && !this._agent._conf.contextPropagationOnly
+    if (enabled) {
+      this._meterProvider = new MeterProvider({
+        // XXX I think we do not require a Resource here because, as long as we
+        //     are sending metrics via APM Server's intake API, then all the
+        //     "metadata" fields are added to metric documents in ES.
+        //     If this is to be used for the OTel Bridge that might export
+        //     metrics via OTLP, then that changes things.
+      })
+      this._meterProvider.addMetricReader(
+        new PeriodicExportingMetricReader({
+          exporter: new ApmMetricExporter(this._agent),
+          exportIntervalMillis: metricsInterval * 1000,
+          exportTimeoutMillis: metricsInterval / 2 * 1000
+        })
+      )
+      this._meter = this._meterProvider.getMeter('elastic-apm-node') // XXX add agent version arg here?
+
+      // Add default metrics collectors.
+      this._addRuntimeMetrics()
+    }
+  }
+
+  stop () {
+    if (this._meterProvider) {
+      // XXX This returns a promise. Do we need/care to await it?
+      this._meterProvider.shutdown()
+      this._meterProvider = null
+      this._meter = null
+    }
+  }
+
+  _addRuntimeMetrics () {
+    if (typeof process._getActiveHandles === 'function') {
+      this._meter.createObservableGauge('nodejs.handles.active')
+        .addCallback(async (observableResult) => {
+          observableResult.observe(process._getActiveHandles().length)
+        })
+    }
+    if (typeof process._getActiveRequests === 'function') {
+      this._meter.createObservableGauge('nodejs.requests.active')
+        .addCallback(async (observableResult) => {
+          observableResult.observe(process._getActiveRequests().length)
+        })
+    }
+
+    const elMonitor = eventLoopMonitor({ resolution: eventLoopMonitorResolution })
+    elMonitor.enable()
+    this._meter.createObservableGauge('nodejs.eventloop.delay.avg.ms')
+      .addCallback(async (observableResult) => {
+        const loopDelay = Math.max(0, ((elMonitor.mean || 0) / 1e6) - eventLoopMonitorResolution)
+        observableResult.observe(loopDelay)
+        elMonitor.reset()
+      })
+
+    const memoryGauges = [
+      'nodejs.memory.heap.allocated.bytes',
+      'nodejs.memory.heap.used.bytes',
+      'nodejs.memory.external.bytes',
+      'nodejs.memory.arrayBuffers.bytes'
+    ].map(name => this._meter.createObservableGauge(name))
+    this._meter.addBatchObservableCallback(async (batchObservableResult) => {
+      const memoryUsage = process.memoryUsage()
+      batchObservableResult.observe(memoryGauges[0], memoryUsage.heapTotal)
+      batchObservableResult.observe(memoryGauges[1], memoryUsage.heapUsed)
+      batchObservableResult.observe(memoryGauges[2], memoryUsage.external)
+      // `.arrayBuffers` is only available in NodeJS +13.0.
+      batchObservableResult.observe(memoryGauges[3], memoryUsage.arrayBuffers || 0)
+    }, memoryGauges)
+  }
+
+  getOrCreateCounter (...args) {
+    throw new Error('XXX')
+    if (!this[registrySymbol]) {
+      return
+    }
+    return this[registrySymbol].getOrCreateCounter(...args)
+  }
+
+  incrementCounter (name, dimensions, amount = 1) {
+    throw new Error('XXX')
+    if (!this[registrySymbol]) {
+      return
+    }
+
+    this.getOrCreateCounter(name, dimensions).inc(amount)
+  }
+
+  getOrCreateGauge (name, cb, labels) {
+    // XXX @otel/sdk-metrics-base requires attributes to be string=>string map.
+    //     elastic-apm-node allows this:
+    //           type LabelValue = string | number | boolean | null | undefined;
+    //           interface Labels {
+    //             [key: string]: LabelValue;
+    //           }
+    //      TODO: grok if this is a blocker!!!
+    const gauge = this._meter.createObservableGauge(name)
+    gauge.addCallback(async (observableResult) => {
+      observableResult.observe(cb(), labels)
+    })
+    return gauge
+  }
+
+  // factory function for creating a queue metrics collector
+  //
+  // called from instrumentation, only when the agent receives a queue message
+  createQueueMetricsCollector (queueOrTopicName) {
+    throw new Error('XXX')
+    if (!this[registrySymbol]) {
+      return
+    }
+    const collector = createQueueMetrics(queueOrTopicName, this[registrySymbol])
+    return collector
+  }
+}
+
+module.exports = Metrics

--- a/lib/metrics2/index.js
+++ b/lib/metrics2/index.js
@@ -219,19 +219,19 @@ class Metrics {
 
   getOrCreateCounter (...args) {
     throw new Error('XXX')
-    if (!this[registrySymbol]) {
-      return
-    }
-    return this[registrySymbol].getOrCreateCounter(...args)
+    // if (!this[registrySymbol]) {
+    //   return
+    // }
+    // return this[registrySymbol].getOrCreateCounter(...args)
   }
 
   incrementCounter (name, dimensions, amount = 1) {
     throw new Error('XXX')
-    if (!this[registrySymbol]) {
-      return
-    }
+    // if (!this[registrySymbol]) {
+    //   return
+    // }
 
-    this.getOrCreateCounter(name, dimensions).inc(amount)
+    // this.getOrCreateCounter(name, dimensions).inc(amount)
   }
 
   getOrCreateGauge (name, cb, labels) {
@@ -254,11 +254,11 @@ class Metrics {
   // called from instrumentation, only when the agent receives a queue message
   createQueueMetricsCollector (queueOrTopicName) {
     throw new Error('XXX')
-    if (!this[registrySymbol]) {
-      return
-    }
-    const collector = createQueueMetrics(queueOrTopicName, this[registrySymbol])
-    return collector
+    // if (!this[registrySymbol]) {
+    //   return
+    // }
+    // const collector = createQueueMetrics(queueOrTopicName, this[registrySymbol])
+    // return collector
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/core": "^1.3.1",
         "@opentelemetry/sdk-metrics-base": "^0.29.2",
         "after-all-results": "^2.0.0",
         "async-cache": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/sdk-metrics-base": "^0.29.2",
         "after-all-results": "^2.0.0",
         "async-cache": "^1.1.0",
         "async-value-promise": "^1.1.1",
@@ -3094,6 +3095,71 @@
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-metrics": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics-base": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
+      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=8.12.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "engines": {
+        "node": ">=8.12.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -10802,6 +10868,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -18984,6 +19055,47 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
+    "@opentelemetry/api-metrics": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.29.2.tgz",
+      "integrity": "sha512-yRdF5beqKuEdsPNoO7ijWCQ9HcyN0Tlgicf8RS6gzGOI54d6Hj7yKquJ6+X9XV+CSRbRWJYb+lOsXyso7uyX2g==",
+      "requires": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "@opentelemetry/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==",
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "requires": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      }
+    },
+    "@opentelemetry/sdk-metrics-base": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
+      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
+      "requires": {
+        "@opentelemetry/api-metrics": "0.29.2",
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "lodash.merge": "4.6.2"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -25045,6 +25157,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "dependencies": {
     "@elastic/ecs-pino-format": "^1.2.0",
     "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/core": "^1.3.1",
     "@opentelemetry/sdk-metrics-base": "^0.29.2",
     "after-all-results": "^2.0.0",
     "async-cache": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "dependencies": {
     "@elastic/ecs-pino-format": "^1.2.0",
     "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/sdk-metrics-base": "^0.29.2",
     "after-all-results": "^2.0.0",
     "async-cache": "^1.1.0",
     "async-value-promise": "^1.1.1",


### PR DESCRIPTION
OpenTelemetry JS Metrics is nearing 1.0. (The Java, Python, and Go
OTel projects have, I think, reached 1.0.) This SDK might be a good
replacement for the node-measured libs we are using for handling
metrics. It could be a path to working on current limitations in our
metrics support.

This PR uses `@opentelemetry/sdk-metrics-base` for the agent's metrics generation.

# status

This is incomplete, and currently is just a PoC.

Supported so far:
- The `apm.registerMetric()` only public API for adding custom metrics.
- Runtime metrics (`nodejs.*`).

Not yet:
- breakdown metrics
- system mertics
- queue metrics for SQS instrumentation
- perf comparison
- etc.
