### PR TITLE
tests: fix test failures with node v19 change to default http clients to use keep-alive

### DIFF
--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -455,6 +455,7 @@ test('handling HTTP/1.1 request to http2.createSecureServer with allowHTTP1:true
 
     // Make an HTTP/1.1 request.
     var getOpts = {
+      agent: new https.Agent(),
       protocol: 'https:',
       host: 'localhost',
       port: port,

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -239,6 +239,7 @@ function onRequest (cb) {
 
   server.listen(function () {
     var opts = {
+      agent: new http.Agent(),
       port: server.address().port
     }
     var req = http.request(opts, function (res) {


### PR DESCRIPTION
As of https://github.com/nodejs/node/issues/37184 node v19 and later
defaults the http,https.globalAgent to use keep-alive:

    - globalAgent: new Agent()
    + globalAgent: new Agent({ keepAlive: true, scheduling: 'lifo', timeout: 5000 })

This change in default broke a couple tests. The agent itself is
unaffected because our http client already uses a custom http agent
using keep-alive.

* * *

This should fix recent Jenkins CI failures in the "Nightly Test" stage.
E.g. https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/main/267/pipeline/7010

This started failing with the `v19.0.0-nightly20220630350a6a8d59` nightly node build which included these node commits:

```
* 350a6a8d59 - perf_hooks: add initiatorType getter
* a0440c9174 - doc: add `backport-open-vN.x` step to backporting guide
* dc3e5408aa - tools: update lint-md-dependencies
* 49a5e81887 - src: fix compiler warning in src/heap_utils.cc
* ed1e9ae402 - events: improve `EventListener` validation
* 4267b92604 - http: use Keep-Alive by default in global agents
* 8e19dab677 - net: fix net keepalive and noDelay
* e2225ba8e1 - test_runner: expose `describe` and `it`
* d636fee319 - benchmark: fix fork detection
```

It is commit `4267b92604 - http: use Keep-Alive by default in global agents` that was impacted our tests.