### PR TITLE
test: fix setup of benchmarks in CI on new CPU models

### DIFF
--- a/test/benchmarks/scripts/run-benchmarks-ci.sh
+++ b/test/benchmarks/scripts/run-benchmarks-ci.sh
@@ -18,6 +18,8 @@ fi
 
 echo $(pwd)
 
+# Share this 'setUp' implementation with
+# https://github.com/elastic/apm-agent-java/blob/main/scripts/jenkins/run-benchmarks.sh
 function setUp() {
     echo "Setting CPU frequency to base frequency"
 

--- a/test/benchmarks/scripts/run-benchmarks-ci.sh
+++ b/test/benchmarks/scripts/run-benchmarks-ci.sh
@@ -37,10 +37,6 @@ function setUp() {
     then
         CORE_INDEX=7
         BASE_FREQ="3.6GHz"
-    elif [ "${CPU_MODEL}" == "Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz " ]
-    then
-        CORE_INDEX=7
-        BASE_FREQ="1.9GHz"
     elif [ "${CPU_MODEL}" == "Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz " ]
     then
         CORE_INDEX=9

--- a/test/benchmarks/scripts/run-benchmarks-ci.sh
+++ b/test/benchmarks/scripts/run-benchmarks-ci.sh
@@ -35,10 +35,18 @@ function setUp() {
     then
         CORE_INDEX=7
         BASE_FREQ="3.6GHz"
+    elif [ "${CPU_MODEL}" == "Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz " ]
+    then
+        CORE_INDEX=7
+        BASE_FREQ="1.9GHz"
     elif [ "${CPU_MODEL}" == "Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz " ]
     then
         CORE_INDEX=9
         BASE_FREQ="2.90GHz"
+    elif [ "${CPU_MODEL}" == "12th Gen Intel(R) Core(TM) i5-12500 " ]
+    then
+        CORE_INDEX=11
+        BASE_FREQ="3.0GHz"
     else
         >&2 echo "Cannot determine base frequency for CPU model [${CPU_MODEL}]. Please adjust the build script."
         exit 1


### PR DESCRIPTION
"12th Gen Intel(R) Core(TM) i5-12500" is a new CPU model appearing in CI
benchmark runs in the last week.

* * *

This should fix recent "Benchmarks" CI failures, e.g. https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/main/265/pipeline

```
...
[2022-06-30T18:44:11.560Z] + setUp
[2022-06-30T18:44:11.560Z] + echo 'Setting CPU frequency to base frequency'
[2022-06-30T18:44:11.560Z] Setting CPU frequency to base frequency
[2022-06-30T18:44:11.560Z] ++ lscpu
[2022-06-30T18:44:11.560Z] ++ grep 'Model name'
[2022-06-30T18:44:11.560Z] ++ awk '{for(i=3;i<=NF;i++){printf "%s ", $i}; printf "\n"}'
[2022-06-30T18:44:11.560Z] + CPU_MODEL='12th Gen Intel(R) Core(TM) i5-12500 '
[2022-06-30T18:44:11.560Z] + '[' '12th Gen Intel(R) Core(TM) i5-12500 ' == 'Intel(R) Xeon(R) CPU E3-1246 v3 @ 3.50GHz ' ']'
[2022-06-30T18:44:11.560Z] + '[' '12th Gen Intel(R) Core(TM) i5-12500 ' == 'Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz ' ']'
[2022-06-30T18:44:11.560Z] + '[' '12th Gen Intel(R) Core(TM) i5-12500 ' == 'Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz ' ']'
[2022-06-30T18:44:11.560Z] + '[' '12th Gen Intel(R) Core(TM) i5-12500 ' == 'Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz ' ']'
[2022-06-30T18:44:11.560Z] + echo 'Cannot determine base frequency for CPU model [12th Gen Intel(R) Core(TM) i5-12500 ]. Please adjust the build script.'
[2022-06-30T18:44:11.560Z] Cannot determine base frequency for CPU model [12th Gen Intel(R) Core(TM) i5-12500 ]. Please adjust the build script.
[2022-06-30T18:44:11.560Z] + exit 1
[2022-06-30T18:44:11.560Z] + tearDown
[2022-06-30T18:44:11.560Z] + echo 'Destroying cgroups'
[2022-06-30T18:44:11.561Z] Destroying cgroups
[2022-06-30T18:44:11.561Z] + sudo -n cset set --destroy /os
[2022-06-30T18:44:11.662Z] cset: **> cpuset "/os" not found in cpusets
[2022-06-30T18:44:11.662Z] npm ERR! code ELIFECYCLE
[2022-06-30T18:44:11.662Z] npm ERR! errno 2
...
```

See https://github.com/elastic/apm-agent-java/pull/2693 which is the same issue for the Java APM agent.