### PR TITLE
chore: allow use with node v19

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": "^8.6.0 || 10 || 12 || 14 || 16 || 17 || 18"
+    "node": "^8.6.0 || 10 || 12 || 14 || 16 || 17 || 18 || 19"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
There are node v19 nightlies now and tests (currently) pass.
Adding v19 to "engines" avoids "EBADENGINE" warnings from 'npm install
elastic-apm-node'

* * *

Currently this is what a user of node v19 sees when trying to install:

```
% node --version
v19.0.0-nightly202206287cbcc4fc43

% npm install elastic-apm-node
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'elastic-apm-node@3.36.0',
npm WARN EBADENGINE   required: { node: '^8.6.0 || 10 || 12 || 14 || 16 || 17 || 18' },
npm WARN EBADENGINE   current: { node: 'v19.0.0-nightly202206287cbcc4fc43', npm: '8.13.1' }
npm WARN EBADENGINE }

up to date, audited 132 packages in 493ms

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```