### PR TITLE
fix: "Dist" step failed in Jenkins with ELSPROBLEMS

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     NOTIFY_TO = 'build-apm+apm-agent-nodejs@elastic.co'
     NPMRC_SECRET = 'secret/jenkins-ci/npmjs/elasticmachine'
     TOTP_SECRET = 'totp/code/npmjs-elasticmachine'
-    BUILD_NODE_VERSION = 'v16.15.0'
+    BUILD_NODE_VERSION = 'v16.15.1'
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
   }

--- a/dev-utils/gen-notice.sh
+++ b/dev-utils/gen-notice.sh
@@ -53,13 +53,16 @@ DIST_DIR="$1"
 [[ -n "$DIST_DIR" ]] || fatal "missing DIST_DIR argument"
 [[ -f "$DIST_DIR/package.json" ]] || fatal "invalid DIST_DIR: $DIST_DIR/package.json does not exist"
 
-# Guard against accidentally using this script with a too-old npm.
-if [[ $(npm --version | cut -d. -f1) -lt 8 ]]; then
+# Guard against accidentally using this script with a too-old npm (<v8.7.0).
+npmVer=$(npm --version)
+npmMajorVer=$(echo "$npmVer" | cut -d. -f1)
+npmMinorVer=$(echo "$npmVer" | cut -d. -f2)
+if [[ $npmMajorVer -lt 8 || ($npmMajorVer -eq 8 && $npmMinorVer -lt 7) ]]; then
     if [[ "$LINT_MODE" == "true" ]]; then
-        warn "npm version is too old for 'npm ci --omit=dev': $(npm --version)"
+        warn "npm version is too old for 'npm ci --omit=dev': $npmVer"
         exit 0
     fi
-    fatal "npm version is too old for 'npm ci --omit=dev': $(npm --version)"
+    fatal "npm version is too old for 'npm ci --omit=dev': $npmVer"
 fi
 
 # Directory holding some "license.*.txt" files for inclusion below.


### PR DESCRIPTION
The "Dist" step in the release process in Jenkinsfile was failing with

    npm ERR! code ELSPROBLEMS
    npm ERR! missing: @babel/cli@^7.8.4, required by elastic-apm-node@3.37.0
    ... ditto for every *dev* dependency ...

The part that was actually failing was 'npm ls --omit=dev --all --parseable'
in "gen-notice.sh" when run in a dist try that only has the non-dev deps
installed.

The issue was a too-old npm: node 16.15.0 includes npm 8.5.5, but we
require npm v8.7.0 to get support for 'npm ls --omit=dev ...'
(https://github.com/npm/cli/pull/4744).

* * *

Initial discussion for this was on the PR for the 3.37.0 release here: https://github.com/elastic/apm-agent-nodejs/pull/2830#issuecomment-1188303303
I wasn't able to reproduce this on my dev machine initially because (a) initially I'd been using node v16.15.1 which has a new-enough npm and (b) when I did attempt to repro with v16.15.0 I was foiled because at some point I had upgraded the npm version in my local node v16.15.0 (bad me).