### PR TITLE
test: Fix benchmarks reporting to an ES 8.x

### DIFF
--- a/test/benchmarks/utils/analyzer.js
+++ b/test/benchmarks/utils/analyzer.js
@@ -66,7 +66,7 @@ function storeResult () {
     bench
   }
 
-  const data = `{"index":{"_index":"benchmark-nodejs","_type":"_doc"}}\n${JSON.stringify(result)}\n`
+  const data = `{"index":{"_index":"benchmark-nodejs"}}\n${JSON.stringify(result)}\n`
 
   appendFile(outputFile, data, function (err) {
     if (err) throw err


### PR DESCRIPTION
Our benchmarks deployment was updated from 7.x to 8.x, which means no
mapping types, which means no `_type` field, which is an easy fix
because we weren't using that type distinction for anything.
    https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

Fixes: #2834

* * *

This is the same fix the Java agent did in https://github.com/elastic/apm-agent-java/pull/2710