### PR TITLE
fast exit spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,22 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+- Added `exitSpanMinDuration` configuration field, allowing end users to
+  set a time threshold for dropping exit spans. ({pull}2843[#2843])
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
 
 [[release-notes-3.37.0]]
 ==== 3.37.0 2022/07/18

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1331,3 +1331,28 @@ require('elastic-apm-node').start({
   opentelemetryBridgeEnabled: true
 })
 ----
+
+[[span-compression-same-kind-max-duration]]
+==== `exitSpanMinDuration`
+* *Type:* String
+* *Default:* `0ms`
+* *Env:* `ELASTIC_APM_EXIT_SPAN_MIN_DURATION`
+
+Sets the minimum duration of exit spans. If an exit span's duration is less than
+this threshold the agent will attempt to drop the span and not send it.
+
+In some cases exit spans will not be discarded. Spans that propagate the trace
+context to downstream services, such as outgoing HTTP requests, will not be
+discarded. However, external calls that don't propagate context, such as calls
+to a database, can be discarded using this threshold.
+
+Additionally, spans that lead to an error will not be discarded.
+
+Example usage:
+
+[source,js]
+----
+require('elastic-apm-node').start({
+  exitSpanMinDuraction:'10ms'
+})
+----

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1332,7 +1332,7 @@ require('elastic-apm-node').start({
 })
 ----
 
-[[span-compression-same-kind-max-duration]]
+[[exit-span-min-duration]]
 ==== `exitSpanMinDuration`
 * *Type:* String
 * *Default:* `0ms`

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1337,6 +1337,7 @@ require('elastic-apm-node').start({
 * *Type:* String
 * *Default:* `0ms`
 * *Env:* `ELASTIC_APM_EXIT_SPAN_MIN_DURATION`
+* <<dynamic-configuration, image:./images/dynamic-config.svg[] >> *Central config name:* `exit_span_min_duration`
 
 Sets the minimum duration of exit spans. If an exit span's duration is less than
 this threshold the agent will attempt to drop the span and not send it.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1354,6 +1354,6 @@ Example usage:
 [source,js]
 ----
 require('elastic-apm-node').start({
-  exitSpanMinDuraction:'10ms'
+  exitSpanMinDuration: '10ms'
 })
 ----

--- a/index.d.ts
+++ b/index.d.ts
@@ -252,7 +252,7 @@ declare namespace apm {
     environment?: string;
     errorMessageMaxLength?: string; // DEPRECATED: use `longFieldMaxLength`.
     errorOnAbortedRequests?: boolean;
-    exitSpanMinDuration: string;
+    exitSpanMinDuration?: string;
     filterHttpHeaders?: boolean;
     frameworkName?: string;
     frameworkVersion?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -252,6 +252,7 @@ declare namespace apm {
     environment?: string;
     errorMessageMaxLength?: string; // DEPRECATED: use `longFieldMaxLength`.
     errorOnAbortedRequests?: boolean;
+    exitSpanMinDuration: string;
     filterHttpHeaders?: boolean;
     frameworkName?: string;
     frameworkVersion?: string;

--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,7 @@ var DEFAULTS = {
   disableSend: false,
   environment: process.env.NODE_ENV || 'development',
   errorOnAbortedRequests: false,
+  exitSpanMinDuration: '0ms',
   filterHttpHeaders: true,
   globalLabels: undefined,
   ignoreMessageQueues: [],
@@ -122,6 +123,7 @@ var ENV_TABLE = {
   disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
   disableSend: 'ELASTIC_APM_DISABLE_SEND',
   environment: 'ELASTIC_APM_ENVIRONMENT',
+  exitSpanMinDuration: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
   ignoreMessageQueues: ['ELASTIC_IGNORE_MESSAGE_QUEUES', 'ELASTIC_APM_IGNORE_MESSAGE_QUEUES'],
   errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
   errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
@@ -228,6 +230,12 @@ var DURATION_OPTS = [
     name: 'apiRequestTime',
     defaultUnit: 's',
     allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'exitSpanMinDuration',
+    defaultUnit: 'ms',
+    allowedUnits: ['us', 'ms', 's', 'm'],
     allowNegative: false
   },
   {

--- a/lib/config.js
+++ b/lib/config.js
@@ -182,7 +182,8 @@ var CENTRAL_CONFIG = {
   sanitize_field_names: 'sanitizeFieldNames',
   ignore_message_queues: 'ignoreMessageQueues',
   span_stack_trace_min_duration: 'spanStackTraceMinDuration',
-  trace_continuation_strategy: 'traceContinuationStrategy'
+  trace_continuation_strategy: 'traceContinuationStrategy',
+  exit_span_min_duration: 'exitSpanMinDuration'
 }
 
 var BOOL_OPTS = [

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -222,6 +222,10 @@ GenericSpan.prototype.isComposite = function () {
   return this._compression.isComposite()
 }
 
+GenericSpan.prototype.getCompositeSum = function () {
+  return this._compression.composite.sum
+}
+
 // https://github.com/elastic/apm/blob/main/specs/agents/tracing-api-otel.md#span-kind
 // @param {String} kind
 GenericSpan.prototype._setOTelKind = function (kind) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -381,12 +381,6 @@ Instrumentation.prototype.addEndedSpan = function (span) {
     return
   }
 
-  const duration = span.isComposite() ? span.getCompositeSum() : span.duration()
-  if (span.discardable && duration / 1000 < this._agent._conf.exitSpanMinDuration) {
-    span.transaction.captureDroppedSpan(span)
-    return
-  }
-
   if (!this._agent._conf.spanCompressionEnabled) {
     this._encodeAndSendSpan(span)
   } else {
@@ -416,6 +410,12 @@ Instrumentation.prototype.addEndedSpan = function (span) {
 }
 
 Instrumentation.prototype._encodeAndSendSpan = function (span) {
+  const duration = span.isComposite() ? span.getCompositeSum() : span.duration()
+  if (span.discardable && duration / 1000 < this._agent._conf.exitSpanMinDuration) {
+    span.transaction.captureDroppedSpan(span)
+    return
+  }
+
   const agent = this._agent
   // Note this error as an "inflight" event. See Agent#flush().
   const inflightEvents = agent._inflightEvents

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -381,9 +381,8 @@ Instrumentation.prototype.addEndedSpan = function (span) {
     return
   }
 
-  if (
-    span.discardable &&
-    span.duration() / 1000 < this._agent._conf.exitSpanMinDuration
+  const duration = span.isComposite() ? span.getCompositeSum() : span.duration()
+  if (span.discardable && duration / 1000 < this._agent._conf.exitSpanMinDuration
   ) {
     span.transaction.captureDroppedSpan(span)
     return

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -381,6 +381,15 @@ Instrumentation.prototype.addEndedSpan = function (span) {
     return
   }
 
+  if(
+    span._exitSpan &&
+    span.discardable &&
+    span.duration() / 1000 < this._agent._conf.exitSpanMinDuration
+  ) {
+    span.transaction.captureDroppedSpan(span)
+    return
+  }
+
   if (!this._agent._conf.spanCompressionEnabled) {
     this._encodeAndSendSpan(span)
   } else {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -381,8 +381,7 @@ Instrumentation.prototype.addEndedSpan = function (span) {
     return
   }
 
-  if(
-    span._exitSpan &&
+  if (
     span.discardable &&
     span.duration() / 1000 < this._agent._conf.exitSpanMinDuration
   ) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -382,8 +382,7 @@ Instrumentation.prototype.addEndedSpan = function (span) {
   }
 
   const duration = span.isComposite() ? span.getCompositeSum() : span.duration()
-  if (span.discardable && duration / 1000 < this._agent._conf.exitSpanMinDuration
-  ) {
+  if (span.discardable && duration / 1000 < this._agent._conf.exitSpanMinDuration) {
     span.transaction.captureDroppedSpan(span)
     return
   }

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -42,6 +42,8 @@ function Span (transaction, ...args) {
   }
 
   this._exitSpan = !!opts.exitSpan
+  this.discardable = this._exitSpan
+
   delete opts.exitSpan
 
   GenericSpan.call(this, transaction._agent, ...tsaArgs, opts)
@@ -160,14 +162,14 @@ Span.prototype.setOutcome = function (outcome) {
     return
   }
   this._freezeOutcome()
-  this.outcome = outcome
+  this._setOutcome(outcome)
 }
 
 Span.prototype._setOutcomeFromErrorCapture = function (outcome) {
   if (this._isOutcomeFrozen) {
     return
   }
-  this.outcome = outcome
+  this._setOutcome(outcome)
 }
 
 Span.prototype._setOutcomeFromHttpStatusCode = function (statusCode) {
@@ -181,9 +183,9 @@ Span.prototype._setOutcomeFromHttpStatusCode = function (statusCode) {
    */
   if (typeof statusCode !== 'undefined') {
     if (statusCode >= 400) {
-      this.outcome = constants.OUTCOME_FAILURE
+      this._setOutcome(constants.OUTCOME_FAILURE)
     } else {
-      this.outcome = constants.OUTCOME_SUCCESS
+      this._setOutcome(constants.OUTCOME_SUCCESS)
     }
   }
 
@@ -192,7 +194,19 @@ Span.prototype._setOutcomeFromHttpStatusCode = function (statusCode) {
 
 Span.prototype._setOutcomeFromSpanEnd = function () {
   if (this.outcome === constants.OUTCOME_UNKNOWN && !this._isOutcomeFrozen) {
-    this.outcome = constants.OUTCOME_SUCCESS
+    this._setOutcome(constants.OUTCOME_SUCCESS)
+  }
+}
+
+/**
+ * Central setting for outcome
+ *
+ * Enables "when outcome does X, Y should also happen" behaviors
+ */
+Span.prototype._setOutcome = function (outcome) {
+  this.outcome = outcome
+  if (outcome !== constants.OUTCOME_SUCCESS) {
+    this.discardable = false
   }
 }
 
@@ -319,6 +333,11 @@ Span.prototype.isRecorded = function () {
 
 Span.prototype.setRecorded = function (value) {
   return this._context.setRecorded(value)
+}
+
+Span.prototype.propagateTraceContextHeaders = function (carrier, setter) {
+  this.discardable = false
+  return GenericSpan.prototype.propagateTraceContextHeaders.call(this, carrier, setter)
 }
 
 function filterCallSite (callsite) {

--- a/test/central-config-enabled.test.js
+++ b/test/central-config-enabled.test.js
@@ -71,7 +71,8 @@ test('remote config enabled', function (t) {
     transaction_ignore_urls: ['foo'],
     log_level: 'warn',
     span_stack_trace_min_duration: '50ms',
-    trace_continuation_strategy: 'restart_external'
+    trace_continuation_strategy: 'restart_external',
+    exit_span_min_duration: '25ms',
   }
   const expect = {
     transactionSampleRate: 0.42,
@@ -80,7 +81,8 @@ test('remote config enabled', function (t) {
     transactionIgnoreUrls: ['foo'],
     logLevel: 'warn',
     spanStackTraceMinDuration: 0.05,
-    traceContinuationStrategy: 'restart_external'
+    traceContinuationStrategy: 'restart_external',
+    exitSpanMinDuration: .025
   }
 
   runTestsWithServer(t, updates, expect)

--- a/test/central-config-enabled.test.js
+++ b/test/central-config-enabled.test.js
@@ -72,7 +72,7 @@ test('remote config enabled', function (t) {
     log_level: 'warn',
     span_stack_trace_min_duration: '50ms',
     trace_continuation_strategy: 'restart_external',
-    exit_span_min_duration: '25ms',
+    exit_span_min_duration: '25ms'
   }
   const expect = {
     transactionSampleRate: 0.42,
@@ -82,7 +82,7 @@ test('remote config enabled', function (t) {
     logLevel: 'warn',
     spanStackTraceMinDuration: 0.05,
     traceContinuationStrategy: 'restart_external',
-    exitSpanMinDuration: .025
+    exitSpanMinDuration: 0.025
   }
 
   runTestsWithServer(t, updates, expect)

--- a/test/instrumentation/drop-fast-exit-spans.test.js
+++ b/test/instrumentation/drop-fast-exit-spans.test.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+const { CapturingTransport } = require('../_capturing_transport')
+const agent = require('../..').start({
+  serviceName: 'test-fast-exit-span',
+  breakdownMetrics: false,
+  captureExceptions: false,
+  metricsInterval: 0,
+  centralConfig: false,
+  cloudProvider: 'none',
+  exitSpanMinDuration: '10ms',
+  spanStackTraceMinDuration: 0, // Always have span stacktraces.
+  transport () { return new CapturingTransport() }
+})
+const Transaction = require('../../lib/instrumentation/transaction')
+const Span = require('../../lib/instrumentation/span')
+const { OUTCOME_FAILURE } = require('../../lib/constants')
+const mockClient = require('../_mock_http_client')
+const tape = require('tape')
+
+tape.test('discardable tests', function (t) {
+  const trans = new Transaction(agent)
+  const spanDefault = new Span(trans, 'foo', 'bar')
+  t.equals(spanDefault.discardable, false, 'spans are not discardable by default')
+
+  const spanExit = new Span(trans, 'foo', 'bar', { exitSpan: true })
+  t.equals(spanExit.discardable, true, 'exit spans are discardable')
+
+  const spanOutcome = new Span(trans, 'foo', 'bar', { exitSpan: true })
+  t.equals(spanOutcome.discardable, true, 'exit spans are discardable')
+  spanOutcome.setOutcome(OUTCOME_FAILURE)
+  t.equals(spanOutcome.discardable, false, 'failed spans are not discardable')
+
+  const spanPropagation = new Span(trans, 'foo', 'bar', { exitSpan: true })
+  t.equals(spanPropagation.discardable, true, 'exit spans are discardable')
+
+  const newHeaders = {}
+  spanPropagation.propagateTraceContextHeaders(newHeaders, function (carrier, name, value) {
+    carrier[name] = value
+  })
+  t.equals(spanPropagation.discardable, false, 'spans with propagated context are not discardable')
+  t.end()
+})
+
+tape.test('end to end test', function (t) {
+  resetAgent(function (data) {
+    t.equals(data.length, 2)
+    const span = data.spans.pop()
+    t.equals(span.name, 'long span')
+    t.end()
+  })
+
+  agent.startTransaction('test')
+  const span1 = agent.startSpan('short span', 'type', 'subtype', 'action', { exitSpan: true })
+  span1.end() // almost immediate, shorter than exitSpanMinDuraction
+
+  const span2 = agent.startSpan('long span', 'type', 'subtype', 'action', { exitSpan: true })
+  setTimeout(function () {
+    span2.end()
+    agent.endTransaction()
+    agent.flush()
+  }, 20) // longer than exitSpanMinDuration
+})
+
+function resetAgent (/* numExpected, */ cb) {
+  agent._instrumentation.testReset()
+  agent._transport = mockClient(/* numExpected, */ cb)
+  agent.captureError = function (err) { throw err }
+}

--- a/test/instrumentation/drop-fast-exit-spans.test.js
+++ b/test/instrumentation/drop-fast-exit-spans.test.js
@@ -56,7 +56,7 @@ tape.test('end to end test', function (t) {
 
   agent.startTransaction('test')
   const span1 = agent.startSpan('short span', 'type', 'subtype', 'action', { exitSpan: true })
-  span1.end() // almost immediate, shorter than exitSpanMinDuraction
+  span1.end() // almost immediate, shorter than exitSpanMinDuration
 
   const span2 = agent.startSpan('long span', 'type', 'subtype', 'action', { exitSpan: true })
   setTimeout(function () {


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-nodejs/issues/2301

Refs: https://github.com/elastic/apm/issues/496

Introduces the `exitSpanMinDuration` configuration value.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
