### PR TITLE
fix: 'http' spans should be marked as exitSpans

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -137,7 +137,7 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
   return function (orig) {
     return function (...args) {
       const parentRunContext = ins.currRunContext()
-      var span = ins.createSpan(null, 'external', 'http')
+      var span = ins.createSpan(null, 'external', 'http', { exitSpan: true })
       var id = span && span.transaction.id
 
       agent.logger.debug('intercepted call to %s.%s %o', moduleName, method, { id: id })


### PR DESCRIPTION
I don't think this currently impacts anything. Because http spans always
propagate trace-context they cannot be compressed or dropped. If we
later add child HTTP spans (to breakdown dns, connect, etc. phases) then
it will matter.
