### PR TITLE
test: bump test exitSpanMinDuration to avoid spurious test failures due to event-loop delay

### DIFF
--- a/test/instrumentation/drop-fast-exit-spans.test.js
+++ b/test/instrumentation/drop-fast-exit-spans.test.js
@@ -4,6 +4,8 @@
  * compliance with the BSD 2-Clause License.
  */
 
+// Test `exitSpanMinDuration` handling.
+
 const { CapturingTransport } = require('../_capturing_transport')
 const agent = require('../..').start({
   serviceName: 'test-fast-exit-span',
@@ -12,7 +14,7 @@ const agent = require('../..').start({
   metricsInterval: 0,
   centralConfig: false,
   cloudProvider: 'none',
-  exitSpanMinDuration: '10ms',
+  exitSpanMinDuration: '50ms', // Using a large value to not get surprised by event-loop delay on busy CI VMs.
   spanStackTraceMinDuration: 0, // Always have span stacktraces.
   transport () { return new CapturingTransport() }
 })
@@ -50,7 +52,7 @@ tape.test('end to end test', function (t) {
   resetAgent(function (data) {
     t.equals(data.length, 2)
     const span = data.spans.pop()
-    t.equals(span.name, 'long span')
+    t.equals(span.name, 'long span', `the long span was not dropped (duration ${span.duration}ms > ${agent._conf.exitSpanMinDuration * 1000}ms) was not dropped`)
     t.end()
   })
 
@@ -63,14 +65,13 @@ tape.test('end to end test', function (t) {
     span2.end()
     agent.endTransaction()
     agent.flush()
-  }, 20) // longer than exitSpanMinDuration
+  }, 100) // longer than exitSpanMinDuration
 })
 
+// Test that a composite span faster than `exitSpanMinDuration` is dropped.
 tape.test('end to end test with compression', function (t) {
   resetAgent(function (data) {
-    // would normally be a single compressed span, but here there's
-    // no spans because min duration was not hit
-    t.equals(data.spans.length, 0)
+    t.equals(data.spans.length, 0, 'the composite span was dropped')
     t.end()
   })
 


### PR DESCRIPTION
In one of my PRs I saw this spurious test failure in drop-fast-exit-spans.test.js:

https://github.com/elastic/apm-agent-nodejs/runs/7681916973?check_suite_focus=true

```
running test: cd . && node --require /home/runner/work/apm-agent-nodejs/apm-agent-nodejs/test/_promise_rejection.js test/instrumentation/drop-fast-exit-spans.test.js
TAP version 13
# discardable tests
ok 1 spans are not discardable by default
ok 2 exit spans are discardable
ok 3 exit spans are discardable
ok 4 failed spans are not discardable
ok 5 exit spans are discardable
ok 6 spans with propagated context are not discardable
# end to end test
ok 7 should be strictly equal
ok 8 should be strictly equal
# end to end test with compression
not ok 9 should be strictly equal
  ---
    operator: equal
    expected: 0
    actual:   1
    at: <anonymous> (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/test/instrumentation/drop-fast-exit-spans.test.js:73:7)
    stack: |-
      Error: should be strictly equal
          at Test.assert [as _assert] (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/node_modules/tape/lib/test.js:314:54)
          at Test.bound [as _assert] (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/node_modules/tape/lib/test.js:99:32)
          at Test.strictEqual (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/node_modules/tape/lib/test.js:478:10)
          at Test.bound [as equals] (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/node_modules/tape/lib/test.js:99:32)
          at /home/runner/work/apm-agent-nodejs/apm-agent-nodejs/test/instrumentation/drop-fast-exit-spans.test.js:73:7
          at Timeout._onTimeout (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/test/_mock_http_client.js:80:7)
          at ontimeout (timers.js:469:11)
          at tryOnTimeout (timers.js:304:5)
          at Timer.listOnTimeout (timers.js:264:5)
  ...

1..9
# tests 9
# pass  8
# fail  1
```

A passing, typical run looks like:

```
% node test/instrumentation/drop-fast-exit-spans.test.js
TAP version 13
# discardable tests
ok 1 spans are not discardable by default
ok 2 exit spans are discardable
ok 3 exit spans are discardable
ok 4 failed spans are not discardable
ok 5 exit spans are discardable
ok 6 spans with propagated context are not discardable
# end to end test
ok 7 should be strictly equal
ok 8 should be strictly equal
# end to end test with compression
ok 9 should be strictly equal

1..9
# tests 9
# pass  9

# ok
```

So basically those three ~1ms spans added up to more than the configured 10ms `exitSpanMinDuration`.

Using the following printf, in local testing on my mac, I've seen it get up to ~7ms, so it is understandable that in a busy shared CI multi-tenant machine event-loop delay could get that up over 10ms.

```
diff --git a/lib/instrumentation/index.js b/lib/instrumentation/index.js
index d2a5f587..618632f5 100644
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -412,6 +412,7 @@ Instrumentation.prototype.addEndedSpan = function (span) {
 Instrumentation.prototype._encodeAndSendSpan = function (span) {
   const duration = span.isComposite() ? span.getCompositeSum() : span.duration()
   if (span.discardable && duration / 1000 < this._agent._conf.exitSpanMinDuration) {
+    console.log('XXX dropping fast exit span: %s < %s', duration / 1000, this._agent._conf.exitSpanMinDuration)
     span.transaction.captureDroppedSpan(span)
     return
   }
```

I've bumped the configured exitSpanMinDuration to a higher value to avoid the spurious failure. An alternative would be to explicitly pass `endTime` into the `span.end()` calls to be precise on their duration.

