### PR TITLE
fix: lambda instrumentation must set transaction *default* name to allow subsequent override by graphql instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Fix an issue where the transaction `name` for a trace of a Lambda function
+  implementing a GraphQL server (e.g. via https://www.apollographql.com/docs/apollo-server/deployment/lambda/[apollo-server-lambda])
+  would not get the GraphQL-specific naming. ({issues}2832[#2832])
+
 [float]
 ===== Chores
 

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -93,7 +93,7 @@ function getFaasData (context, faasId, isColdStart, faasTriggerType, requestId) 
 
 function setGenericData (trans, event, context, faasId, isColdStart) {
   trans.type = 'request'
-  trans.name = context.functionName
+  trans.setDefaultName(context.functionName)
 
   trans.setFaas(getFaasData(context, faasId, isColdStart, 'other'))
 
@@ -138,7 +138,7 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
     }
   }
   trans.type = 'request'
-  trans.name = name
+  trans.setDefaultName(name)
 
   trans.setFaas(getFaasData(context, faasId, isColdStart,
     'http', requestContext.requestId))
@@ -176,7 +176,7 @@ function setSqsData (agent, trans, event, context, faasId, isColdStart) {
   const queueName = arnParts[5]
   const accountId = arnParts[4]
 
-  trans.name = `RECEIVE ${queueName}`
+  trans.setDefaultName(`RECEIVE ${queueName}`)
   trans.type = 'messaging'
 
   const serviceContext = {
@@ -217,7 +217,7 @@ function setSnsData (agent, trans, event, context, faasId, isColdStart) {
   const accountId = arnParts[4]
   const region = arnParts[3]
 
-  trans.name = `RECEIVE ${topicName}`
+  trans.setDefaultName(`RECEIVE ${topicName}`)
   trans.type = 'messaging'
 
   const serviceContext = {
@@ -252,7 +252,7 @@ function setS3SingleData (trans, event, context, faasId, isColdStart) {
   trans.setFaas(getFaasData(context, faasId, isColdStart, 'datasource',
     record.responseElements && record.responseElements['x-amz-request-id']))
 
-  trans.name = `${record && record.eventName} ${record && record.s3 && record.s3.bucket && record.s3.bucket.name}`
+  trans.setDefaultName(`${record && record.eventName} ${record && record.s3 && record.s3.bucket && record.s3.bucket.name}`)
   trans.type = 'request'
 
   const serviceContext = {

--- a/test/lambda/mock/transaction.js
+++ b/test/lambda/mock/transaction.js
@@ -24,6 +24,10 @@ module.exports = class TransactionMock {
     this.opts = opts
   }
 
+  setDefaultName (name) {
+    this.name = name
+  }
+
   setCustomContext (custom) {
     if (!custom) {
       return

--- a/test/lambda/trans-setDefaultName.test.js
+++ b/test/lambda/trans-setDefaultName.test.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Test that instrumentation using `Transaction.setDefaultName(...)` still
+// works after the Lambda instrumentation has set the transaction name.
+
+const lambdaLocal = require('lambda-local')
+const tape = require('tape')
+
+const apm = require('../../')
+const { MockAPMServer } = require('../_mock_apm_server')
+
+// Setup env for both apm.start() and lambdaLocal.execute().
+process.env.AWS_LAMBDA_FUNCTION_NAME = 'fixture-function-name'
+// Set these values to have stable data from lambdaLocal.execute().
+process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs14.x'
+process.env.AWS_REGION = 'us-east-1'
+process.env.AWS_ACCOUNT_ID = '123456789012'
+// A lambda-local limitation is that it doesn't set AWS_LAMBDA_LOG_GROUP_NAME
+// and AWS_LAMBDA_LOG_STREAM_NAME (per
+// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html).
+process.env.AWS_LAMBDA_LOG_GROUP_NAME = `/aws/lambda/${process.env.AWS_LAMBDA_FUNCTION_NAME}`
+process.env.AWS_LAMBDA_LOG_STREAM_NAME = '2021/11/01/[1.0]lambda/e7b05091b39b4aa2aef19efe4d262e79'
+// Avoid the lambda-local loading AWS credentials and session info from
+// a configured real AWS profile and possibly emitting this warning:
+//    warning Using both auth systems: aws_access_key/id and secret_access_token!
+process.env.AWS_PROFILE = 'fake'
+
+function loadFixture (file) {
+  return require('./fixtures/' + file)
+}
+
+tape.test('lambda instrumentation does not break trans.setDefaultName', function (suite) {
+  let server
+  let serverUrl
+
+  suite.test('setup', function (t) {
+    server = new MockAPMServer()
+    server.start(function (serverUrl_) {
+      serverUrl = serverUrl_
+      t.comment('mock APM serverUrl: ' + serverUrl)
+      apm.start({
+        serverUrl,
+        logLevel: 'off',
+        captureExceptions: false
+      })
+      t.comment('APM agent started')
+      t.end()
+    })
+  })
+
+  const eventCases = [
+    {
+      name: 'TRIGGER_GENERIC',
+      event: loadFixture('generic.json')
+    },
+    {
+      name: 'TRIGGER_API_GATEWAY',
+      event: loadFixture('aws_api_http_test_data.json')
+    },
+    {
+      name: 'TRIGGER_SNS',
+      event: loadFixture('aws_sns_test_data.json')
+    },
+    {
+      name: 'TRIGGER_SQS',
+      event: loadFixture('aws_sqs_test_data.json')
+    },
+    {
+      name: 'TRIGGER_S3_SINGLE_EVENT',
+      event: loadFixture('aws_s3_test_data.json')
+    }
+  ]
+  eventCases.forEach(eventCase => {
+    suite.test(`trans.setDefaultName(...) works with ${eventCase.name} event type`, function (t) {
+      const handler = apm.lambda((event, _context, cb) => {
+        // Simulate some other instrumentation using `Transaction.setDefaultName(...)`.
+        // For example the graphql instrumentation will do this to set the
+        // transaction name. This should *work*.
+        apm.currentTransaction.setDefaultName('setting this trans name should work')
+
+        cb(null, 'hi')
+      })
+
+      lambdaLocal.execute({
+        event: eventCase.event,
+        lambdaFunc: {
+          [process.env.AWS_LAMBDA_FUNCTION_NAME]: handler
+        },
+        lambdaHandler: process.env.AWS_LAMBDA_FUNCTION_NAME,
+        timeoutMs: 3000,
+        verboseLevel: 0,
+        callback: function (err, result) {
+          t.error(err, `no error from executing the lambda handler: err=${JSON.stringify(err)}`)
+          const trans = server.events[1].transaction
+          t.equal(trans.name, 'setting this trans name should work')
+          t.end()
+        }
+      })
+    })
+  })
+
+  suite.test('teardown', function (t) {
+    server.close()
+    t.end()
+    apm.destroy()
+  })
+
+  suite.end()
+})


### PR DESCRIPTION
Before this the Lambda instrumentation was setting `trans.name = ...`,
which (via the Transaction.name setter) would set `trans._customName`,
which has higher prio than the `trans._defaultName`. Setting
`_customName` is intended for the *user* to override. If a Lambda
function is using GraphQL, the graphql instrumentation should be able to
override the transaction name.

Fixes: #2832