### PR TITLE
fix: an S3 ListBuckets span was invalid for APM server intake

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,9 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Fix the span for an instrumented S3 ListBuckets API call to not be invalid
+  for APM server intake.
+
 [float]
 ===== Chores
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,7 +46,7 @@ Notes:
 ===== Bug fixes
 
 - Fix the span for an instrumented S3 ListBuckets API call to not be invalid
-  for APM server intake.
+  for APM server intake. ({pull}2866[#2866])
 
 [float]
 ===== Chores

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ Notes:
 
 - Fix the span for an instrumented S3 ListBuckets API call to not be invalid
   for APM server intake. ({pull}2866[#2866])
+
 - Fix an issue where the transaction `name` for a trace of a Lambda function
   implementing a GraphQL server (e.g. via https://www.apollographql.com/docs/apollo-server/deployment/lambda/[apollo-server-lambda])
   would not get the GraphQL-specific naming. ({issues}2832[#2832])

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -82,18 +82,17 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
     // '.httpRequest.endpoint' might differ from '.service.endpoint' if
     // the bucket is in a different region.
     const endpoint = httpRequest && httpRequest.endpoint
-    const destContext = {
-      service: {
-        name: SUBTYPE,
-        type: TYPE
-      }
-    }
+    const destContext = {}
     if (endpoint) {
       destContext.address = endpoint.hostname
       destContext.port = endpoint.port
     }
     if (resource) {
-      destContext.service.resource = resource
+      destContext.service = {
+        name: SUBTYPE,
+        type: TYPE,
+        resource
+      }
     }
     if (region) {
       destContext.cloud = { region }

--- a/test/_validate_schema.js
+++ b/test/_validate_schema.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Validate an APM server intake object against its schema.
+//
+// Usage example:
+//    const { validateSpan } = require('./_validate_schema')
+//    const errs = validateSpan(mySpanObj)
+// `errs` is null if mySpanObj is valid, else it is an array of ajv ErrorObject.
+
+const fs = require('fs')
+const { join } = require('path')
+
+const Ajv = require('ajv').default
+
+const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, strict: true })
+const schemaDir = join(__dirname, 'integration', 'api-schema', 'apm-server-schema')
+
+/**
+ * Create a validator function for the given APM Server intake type (e.g.
+ * 'span', 'metadata').
+ *
+ * @returns {(data: object) => null | ajv.ErrorObject[]}
+ */
+function createValidator (apmType, cb) {
+  const schemaPath = join(schemaDir, apmType + '.json')
+  const content = fs.readFileSync(schemaPath, { encoding: 'utf8' })
+  const schema = JSON.parse(content)
+  const validate = ajv.compile(schema)
+
+  return function (data) {
+    const valid = validate(data)
+    if (valid) {
+      return null
+    } else {
+      return validate.errors
+    }
+  }
+}
+
+module.exports = {
+  validateMetadata: createValidator('metadata'),
+  validateTransaction: createValidator('transaction'),
+  validateSpan: createValidator('span'),
+  validateError: createValidator('error'),
+  validateMetricset: createValidator('metricset')
+}

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -20,6 +20,7 @@ const { execFile } = require('child_process')
 const tape = require('tape')
 
 const { MockAPMServer } = require('../../../_mock_apm_server')
+const { validateSpan } = require('../../../_validate_schema')
 
 const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost'
 const endpoint = 'http://' + LOCALSTACK_HOST + ':4566'
@@ -70,6 +71,10 @@ tape.test('simple S3 usage scenario', function (t) {
         // Compare some common fields across all spans.
         const spans = events.filter(e => e.span)
           .map(e => e.span)
+        spans.forEach(s => {
+          const errs = validateSpan(s)
+          t.equal(errs, null, 'span is valid  (per apm-server intake schema)')
+        })
         t.equal(spans.filter(s => s.trace_id === tx.trace_id).length,
           spans.length, 'all spans have the same trace_id')
         t.equal(spans.filter(s => s.transaction_id === tx.id).length,
@@ -103,7 +108,6 @@ tape.test('simple S3 usage scenario', function (t) {
             destination: {
               address: LOCALSTACK_HOST,
               port: 4566,
-              service: { name: 's3', type: 'storage' },
               cloud: { region: 'us-east-2' }
             }
           },


### PR DESCRIPTION
The APM agent spec for S3 spans says
`span.context.destination.service.resource` should be the bucket name
or access point, if available. That isn't available for ListBuckets,
which doesn't operate on a bucket. In this case the APM agent was emiting:

    span.context.destination.service = { name: ..., type: ... }

which fails APM server schema validation with

    missingProperty: 'resource'

and results in APM server intake logs with:

    Error: validation error: span: context: destination: service: 'resource' required

The fix, for now, is to skip `span.context.destination.service` entirely
for ListBuckets.

----

Dropping `span.context.destination.service` for `ListBuckets` spans will mean the span will be accepted by APM server (good), but won't result in "S3" being recognized as a backend for the service (not the best, but any other S3 spans will make that connection).

Longer term, the [coming](https://github.com/elastic/apm-agent-nodejs/issues/2822) replacement of `span.context.destination.service.*` fields with `span.context.service.target.*` fields provides a mechanism to handle this better.