### PR TITLE
fix: captureError would fail on an Error attribute that is an invalid date

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,9 @@ Notes:
 [float]
 ===== Bug fixes
 
+- Capturing an error would fail if the Error instance had an attribute that
+  was an invalid date. ({issues}2030[#2030])
+
 - Fix the span for an instrumented S3 ListBuckets API call to not be invalid
   for APM server intake. ({pull}2866[#2866])
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -91,10 +91,13 @@ function attributesFromErr (err) {
         continue
       case 'object':
         // Ignore all objects except Dates.
-        if (typeof val.toISOString !== 'function') {
+        if (typeof val.toISOString !== 'function' || typeof val.getTime !== 'function') {
           continue
+        } else if (Number.isNaN(val.getTime())) {
+          val = 'Invalid Date' // calling toISOString() on invalid dates throws
+        } else {
+          val = val.toISOString()
         }
-        val = val.toISOString()
     }
     attrs[key] = val
     n++
@@ -280,5 +283,6 @@ module.exports = {
   createAPMError,
 
   // Exported for testing.
+  attributesFromErr,
   _moduleNameFromFrames
 }

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -13,7 +13,7 @@ const path = require('path')
 const tape = require('tape')
 
 const logging = require('../lib/logging')
-const { createAPMError, generateErrorId, _moduleNameFromFrames } = require('../lib/errors')
+const { createAPMError, generateErrorId, attributesFromErr, _moduleNameFromFrames } = require('../lib/errors')
 const { dottedLookup } = require('./_utils')
 
 const log = logging.createLogger('off')
@@ -325,6 +325,46 @@ tape.test('#_moduleNameFromFrames()', function (suite) {
 
       t.strictEqual(_moduleNameFromFrames(opts.frames), opts.expected,
         'got ' + opts.expected)
+      t.end()
+    })
+  })
+
+  suite.end()
+})
+
+tape.test('#attributesFromErr()', function (suite) {
+  var cases = [
+    // 'err' is an Error instance, or a function that returns one.
+    {
+      name: 'no attrs',
+      err: new Error('boom'),
+      expectedAttrs: undefined
+    },
+    {
+      name: 'string attr',
+      err: () => {
+        const err = new Error('boom')
+        err.aStr = 'hello'
+        return err
+      },
+      expectedAttrs: { aStr: 'hello' }
+    },
+    {
+      name: 'Invalid Date attr',
+      err: () => {
+        const err = new Error('boom')
+        err.aDate = new Date('invalid')
+        return err
+      },
+      expectedAttrs: { aDate: 'Invalid Date' }
+    }
+  ]
+
+  cases.forEach(function (opts) {
+    suite.test(opts.name, function (t) {
+      const err = typeof (opts.err) === 'function' ? opts.err() : opts.err
+      const attrs = attributesFromErr(err)
+      t.deepEqual(attrs, opts.expectedAttrs, 'got expected attrs')
       t.end()
     })
   })


### PR DESCRIPTION
Fixes: #2030

----

Example of the tests failing without the fix:

```
...
# #attributesFromErr()
# no attrs
ok 39 got expected attrs
# string attr
ok 40 got expected attrs
# Invalid Date attr
/Users/trentm/el/apm-agent-nodejs6/lib/errors.js:99
          val = val.toISOString()
                    ^

RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at attributesFromErr (/Users/trentm/el/apm-agent-nodejs6/lib/errors.js:99:21)
    at Test.<anonymous> (/Users/trentm/el/apm-agent-nodejs6/test/errors.test.js:366:21)
    at Test.bound [as _cb] (/Users/trentm/el/apm-agent-nodejs6/node_modules/tape/lib/test.js:99:32)
    at Test.run (/Users/trentm/el/apm-agent-nodejs6/node_modules/tape/lib/test.js:117:31)
    at Test.bound [as run] (/Users/trentm/el/apm-agent-nodejs6/node_modules/tape/lib/test.js:99:32)
    at Test._end (/Users/trentm/el/apm-agent-nodejs6/node_modules/tape/lib/test.js:220:11)
    at Test.bound [as _end] (/Users/trentm/el/apm-agent-nodejs6/node_modules/tape/lib/test.js:99:32)
    at Test.<anonymous> (/Users/trentm/el/apm-agent-nodejs6/node_modules/tape/lib/test.js:219:40)
    at Test.emit (node:events:527:28)
```

and they pass after.