### PR TITLE
chore: improve usability of "Bug report" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -37,19 +37,20 @@ Steps to reproduce the behavior: <!-- replace example steps below -->
 
 <!-- Add any other context about the problem here. -->
 
-- Agent config options <!-- be careful not to post sensitive information -->
-  <details>
-    <summary>Click to expand</summary>
+Agent config options: <!-- be careful not to post sensitive information -->
+<details>
+  <summary>Click to expand</summary>
 
-    ```
-    replace this line with your agent config options
-    ```
-  </details>
-- `package.json` dependencies:
-  <details>
-    <summary>Click to expand</summary>
+```
+replace this line with your agent config options
+```
+</details>
 
-    ```
-    replace this line with your dependencies section from package.json
-    ```
-  </details>
+`package.json` dependencies:
+<details>
+  <summary>Click to expand</summary>
+
+```
+replace this line with your dependencies section from package.json
+```
+</details>


### PR DESCRIPTION
Before this change, if you pasted in multiline content for the
"replace this line with ..." lines and didn't manually indent all those
pasted lines, then the GitHub rendered markdown `<details>` segments
would not be rendered as intended. By left justifying all the markup,
the bug reporter doesn't need to manually indent pasted lines.
