### PR TITLE
perf: disable Knex instrumentation if spanStackTraceMinDuration=-1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,10 @@ Notes:
 [float]
 ===== Chores
 
+- Disable knex instrumentation when not collecting span stack traces
+  (because there is no point). This is a performance improvement for
+  Knex usage in the default configuration.
+
 
 [[release-notes-3.38.0]]
 ==== 3.38.0 2022/08/11

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,7 +53,7 @@ Notes:
 
 - Disable knex instrumentation when not collecting span stack traces
   (because there is no point). This is a performance improvement for
-  Knex usage in the default configuration.
+  Knex usage in the default configuration. ({pull}2879[#2879])
 
 
 [[release-notes-3.38.0]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -153,19 +153,18 @@ so those should be supported as well.
 [[compatibility-better-stack-traces]]
 ==== Better Stack Traces
 
-When viewing a span in Elastic APM,
-you'll see where in your code you initiated the span (e.g. a database query).
+The APM agent <<span-stack-trace-min-duration,can be configured>> to capture
+span stack traces, to show where in your code a span (e.g. for a database query)
+was initiated.
 
-Given the async nature of Node.js,
-it's not possible for us to see further back than the last async boundary.
-We therefore make sure to monitor as close to your code as possible.
-But some modules will interfere with this monitoring by injecting an async call between your code and the actual monitored function.
+Given the async nature of Node.js, it's not possible for the APM agent to see
+further back than the last async boundary. Modules that happen to have an async
+boundary between a call from your application code and the action that leads
+to an APM span will limit the utility of these span stack traces.
 
-We monitor these "offending" modules directly to give you a better experience.
-
-The modules and versions listed below are the ones we support.
-If you use an unsupported version you might not be able to see your own code in the spans.
-This does not impact the stability of your application in any way - only the collected metrics.
+The modules listed below are those that the APM agent instruments to provide
+more useful span stack traces -- ones that point to your application code --
+when enabled.
 
 If you don't see your own code in spans,
 please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM discuss forum] and include information about your dependencies.
@@ -173,7 +172,7 @@ please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM di
 [options="header"]
 |=================================================
 |Module |Version |Note
-|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <1.0.0 | Instrumentation of Knex >=0.95.0 is not supported when using the deprecated <<context-manager,`contextManager=patch`>> configuration option.
+|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <1.0.0 | Provides better span stack traces for 'pg' and 'mysql' spans. Instrumentation of Knex >=0.95.0 is not supported when using the deprecated <<context-manager,`contextManager=patch`>> configuration option.
 |=================================================
 
 [float]

--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -4,6 +4,10 @@
  * compliance with the BSD 2-Clause License.
  */
 
+// Knex instrumentation exists to capture a more useful span stacktrace at
+// the start of a Knex query, and use that stacktrace on the 'pg' or 'mysql'
+// span.
+
 'use strict'
 
 var semver = require('semver')
@@ -13,6 +17,11 @@ var symbols = require('../../symbols')
 
 module.exports = function (Knex, agent, { version, enabled }) {
   if (!enabled) {
+    return Knex
+  }
+  if (agent._conf.spanStackTraceMinDuration < 0) {
+    agent.logger.trace('not instrumenting knex because not capturing span stack traces (spanStackTraceMinDuration=%s)',
+      agent._conf.spanStackTraceMinDuration)
     return Knex
   }
   if (semver.gte(version, '1.0.0')) {

--- a/test/instrumentation/modules/pg/knex-no-span-stack-traces.test.js
+++ b/test/instrumentation/modules/pg/knex-no-span-stack-traces.test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+var agent = require('../../../..').start({
+  serviceName: 'test-knex-no-span-stack-traces',
+  secretToken: 'test',
+  captureExceptions: false,
+  metricsInterval: 0,
+  centralConfig: false,
+  apmServerVersion: '8.0.0',
+  // Disable span stack traces, to test that knex instrumentation is then disabled.
+  spanStackTraceMinDuration: -1
+})
+
+var knexVersion = require('knex/package').version
+var semver = require('semver')
+
+// knex 0.18.0 min supported node is v8, knex 0.21.0 min supported node is v10
+if ((semver.gte(knexVersion, '0.18.0') && semver.lt(process.version, '8.6.0')) ||
+  (semver.gte(knexVersion, '0.21.0') && semver.lt(process.version, '10.22.0'))) {
+  console.log(`# SKIP knex@${knexVersion} does not support node ${process.version}`)
+  process.exit()
+}
+// Instrumentation does not work with Knex >=0.95.0 and `contextManager=patch`.
+// The "patch" context manager is deprecated.
+if (semver.gte(knexVersion, '0.95.0') && agent._conf.contextManager === 'patch') {
+  console.log(`# SKIP knex@${knexVersion} and contextManager='patch' is not support`)
+  process.exit()
+}
+
+var Knex = require('knex')
+var test = require('tape')
+
+test('knex instrumentation is disabled if not collecting span stacktraces', t => {
+  // To test that knex instrumentation did *not* happen, we are assuming that
+  // knex instrumentation wraps `Knex.Client.prototype.runner` and changes the
+  // method name (to `wrappedRunner`).
+  const runnerMethod = Knex.Client.prototype.runner
+  t.equal(runnerMethod.name, 'runner', 'Knex.Client.prototype.runner method name has not been changed')
+  t.end()
+})


### PR DESCRIPTION
Knex instrumentation exists only for better span stack traces. It should
be disabled when not collecting span stack traces. This should be a
perf win for default usage of Knex because we avoid an expensive
`Error.captureStackTrace(obj)` for each wrapped knex query.

Obsoletes: #506

* * *

Here I'm finishing up work started by @watson in #506. I updated for the newer config var (`spanStackTraceMinDuration`), added a test, and tweaked the knex-related docs.
