### PR TITLE
feat: improve SQL summarization to match cross-agent spec

### DIFF
--- a/test/sql-signature.test.js
+++ b/test/sql-signature.test.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Test the Node.js APM agent's summarization of SQL statements used to set
+// 'span.name' for DB spans against the cross-agent JSON spec.
+
+const sqlSummary = require('sql-summary')
+const tape = require('tape')
+
+tape.test('cross-agent SQL statement summary/signature', function (t) {
+  const sqlSigCases = require('./fixtures/json-specs/sql_signature_examples.json')
+  sqlSigCases.forEach(sqlSigCase => {
+    let desc = JSON.stringify(sqlSigCase.input)
+    if (sqlSigCase.comment) {
+      desc += ' # ' + sqlSigCase.comment
+    }
+    t.equal(sqlSummary(sqlSigCase.input), sqlSigCase.output, desc)
+  })
+  t.end()
+})


### PR DESCRIPTION
The cross-agent APM spec defines test cases for SQL statement
summarization used for 'span.name'
https://github.com/elastic/apm/blob/main/tests/agents/json-specs/sql_signature_examples.json


# status / motivation

Currently the Node.js APM agent does not conform to the cross-agent SQL signature/summarization spec (see the test summary below). That spec was initially added because it was shared across the Go and Ruby agents. There isn't a specific user request to get the Node.js APM agent to conform. The only motivation is to be up to date on cross-agent specs. tl;dr: This is currently low priority.

So far this PR just adds a test file that shows where the Node.js APM agent currently fails spec.


# checklist

- [ ] Update the Node.js APM agent's sql summarization to match spec, or discuss and skip some of these tests.


# initial test state

Currently the Node.js agent passes 18 and fails 17 of the sql_signature_examples cases.

```
% node test/sql-signature.test.js | rg "(not | expected:| actual:|^#|^\s*')"  | cat
# cross-agent SQL statement summary/signature
not ok 5 "SELECT * FROM `foo.bar`"
    expected: 'SELECT FROM foo.bar'
    actual:   'SELECT FROM `foo.bar`'
not ok 6 "SELECT * FROM \"foo.bar\""
    expected: 'SELECT FROM foo.bar'
    actual:   'SELECT FROM "foo.bar"'
not ok 7 "SELECT * FROM [foo.bar]"
    expected: 'SELECT FROM foo.bar'
    actual:   'SELECT FROM [foo.bar]'
not ok 8 "SELECT (x, y) FROM foo,bar,baz"
    expected: 'SELECT FROM foo'
    actual:   'SELECT FROM foo,bar,baz'
not ok 11 "SELECT id FROM \"myta\n-æøåble\" WHERE id = 2323"
    expected: |-
      'SELECT FROM myta\n-æøåble'
    actual: |-
      'SELECT FROM "myta'
not ok 12 "SELECT * FROM foo-- abc\n./*def*/bar"
    expected: |-
      'SELECT FROM foo.bar'
    actual: |-
      'SELECT FROM foo--'
not ok 13 "SELECT *,(SELECT COUNT(*) FROM table2 WHERE table2.field1 = table1.id) AS count FROM table1 WHERE table1.field1 = 'value'" # We capture the first table of the outermost select statement
    expected: 'SELECT FROM table1'
    actual:   'SELECT FROM table2'
not ok 14 "SELECT * FROM (SELECT foo FROM bar) AS foo_bar" # If the outermost select operates on derived tables, then we just return 'SELECT' (i.e. the fallback)
    expected: 'SELECT'
    actual:   'SELECT FROM ('
not ok 16 "UPDATE IGNORE foo.bar SET bar=1 WHERE baz=2"
    expected: 'UPDATE foo.bar'
    actual:   'UPDATE IGNORE'
not ok 17 "UPDATE ONLY foo AS bar SET baz=1"
    expected: 'UPDATE foo'
    actual:   'UPDATE ONLY'
not ok 20 "CALL foo(bar, 123)"
    expected: 'CALL foo'
    actual:   'CALL'
not ok 21 "ALTER TABLE foo ADD ()" # For DDL we only capture the first token
    expected: 'ALTER'
    actual:   'ALTER TABLE foo'
not ok 22 "CREATE TABLE foo ..."
    expected: 'CREATE'
    actual:   'CREATE TABLE foo'
not ok 23 "DROP TABLE foo"
    expected: 'DROP'
    actual:   'DROP TABLE foo'
not ok 28 "SELECT * FROM (SELECT EOF" # For broken statements we only capture the first token
    expected: 'SELECT'
    actual:   'SELECT FROM ('
not ok 29 "SELECT 'neverending literal FROM (SELECT * FROM ..."
    expected: 'SELECT'
    actual:   'SELECT FROM ('
not ok 32 "UPDATE 99"
    expected: 'UPDATE'
    actual:   'UPDATE 99'
# tests 35
# pass  18
# fail  17
```