### PR TITLE
ci: use github commit status

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/main'
-    GITHUB_CHECK = 'true'
+    GITHUB_CHECK = 'false'
     RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
     SLACK_CHANNEL = '#apm-agent-node'
     NOTIFY_TO = 'build-apm+apm-agent-nodejs@elastic.co'


### PR DESCRIPTION
### What

Enable GitHub commit status for the GitHub checks

### Why

As long as the mask-pass is still 3.3 based, we cannot use GitHub check notifications but GitHub commit status.

GitHub check notifications are enabled with the feature environment variable, by unsetting it then the previous behaviour regarding GitHub commit status will be enabled, GitHub check notifications are the ones using the regex in the mask-pass, as part of the JWT.