### PR TITLE
feat: tedious@15 support

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -459,10 +459,16 @@ tedious-v11-v12:
   versions: '11.x'
   commands: node test/instrumentation/modules/tedious.test.js
 
-tedious:
+tedious-v12-v15:
   name: tedious
   node: '>=12.3.0'
   versions: '12.x || 13.x || 14.x'
+  commands: node test/instrumentation/modules/tedious.test.js
+
+tedious:
+  name: tedious
+  node: '>=14'
+  versions: '15.x'
   commands: node test/instrumentation/modules/tedious.test.js
 
 cassandra-driver:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@ Notes:
 [float]
 ===== Features
 
+- Support instrumentation of tedious@15. ({pull}2897[#2897])
+
 - Improve the captured information for Elasticsearch client instrumentation.
   For all outgoing Elasticsearch client requests, the full HTTP url is
   now captured (stored in the "url.original" field). For Elasticsearch requests

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -144,7 +144,7 @@ so those should be supported as well.
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <3.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/redis[redis] |>=2.0.0 <4.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <15.0.0 | (Excluding v4.0.0.) Will instrument all queries
+|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <16.0.0 | (Excluding v4.0.0.) Will instrument all queries
 |https://www.npmjs.com/package/undici[undici] | >=4.7.1 <6 | Will instrument undici HTTP requests, except HTTP CONNECT. Requires node v14.17.0 or later, or the user to have installed the https://www.npmjs.com/package/diagnostics_channel['diagnostics_channel' polyfill].
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages
 |=======================================================================

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -14,7 +14,7 @@ var { getDBDestination } = require('../context')
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious
-  if (!semver.satisfies(version, '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x')) {
+  if (!semver.satisfies(version, '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x || 15.x')) {
     agent.logger.debug('tedious version %s not supported - aborting...', version)
     return tedious
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "send": "^0.17.1",
         "tap-junit": "^5.0.1",
         "tape": "^5.0.0",
-        "tedious": "^14.5.0",
+        "tedious": "^15.1.0",
         "test-all-versions": "^4.1.1",
         "thunky": "^1.1.0",
         "typescript": "^4.7.4",
@@ -13984,9 +13984,9 @@
       }
     },
     "node_modules/tedious": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-14.7.0.tgz",
-      "integrity": "sha512-d3qlmZcvZyt7akyPHiOdR+knfzObWZH3mW+gouQTSb7YTSwtpHuYHcvsQabfbY7oOvgbs51xRb7CwOahWK/t9w==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.0.tgz",
+      "integrity": "sha512-D96Z8SL4ALE/rS6rOAfzWd/x+RD9vWbnNT3w5KZ0e0Tdh5FX1bKEODS+1oemSQM2ok5SktLHqSJqYQRx4yu3WA==",
       "dev": true,
       "dependencies": {
         "@azure/identity": "^2.0.4",
@@ -14004,7 +14004,7 @@
         "sprintf-js": "^1.1.2"
       },
       "engines": {
-        "node": ">=12.3.0"
+        "node": ">=14"
       }
     },
     "node_modules/tedious/node_modules/bl": {
@@ -26061,9 +26061,9 @@
       "dev": true
     },
     "tedious": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-14.7.0.tgz",
-      "integrity": "sha512-d3qlmZcvZyt7akyPHiOdR+knfzObWZH3mW+gouQTSb7YTSwtpHuYHcvsQabfbY7oOvgbs51xRb7CwOahWK/t9w==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.0.tgz",
+      "integrity": "sha512-D96Z8SL4ALE/rS6rOAfzWd/x+RD9vWbnNT3w5KZ0e0Tdh5FX1bKEODS+1oemSQM2ok5SktLHqSJqYQRx4yu3WA==",
       "dev": true,
       "requires": {
         "@azure/identity": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "send": "^0.17.1",
     "tap-junit": "^5.0.1",
     "tape": "^5.0.0",
-    "tedious": "^14.5.0",
+    "tedious": "^15.1.0",
     "test-all-versions": "^4.1.1",
     "thunky": "^1.1.0",
     "typescript": "^4.7.4",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1020,7 +1020,7 @@ test('disableInstrumentations', function (t) {
     // https://github.com/restify/node-restify/issues/1888
     modules.delete('restify')
   }
-  if (semver.lt(process.version, '12.3.0')) {
+  if (semver.lt(process.version, '14.0.0')) {
     modules.delete('tedious')
   }
   if (semver.lt(process.version, '12.18.0')) {

--- a/test/instrumentation/modules/tedious.test.js
+++ b/test/instrumentation/modules/tedious.test.js
@@ -11,13 +11,14 @@ const agent = require('../../../').start({
   captureExceptions: false,
   metricsInterval: 0,
   centralConfig: false,
+  apmServerVersion: '8.0.0',
   spanCompressionEnabled: false
 })
 
-// tedious >=12 only supports node >=12.3.0, tedious 11 only supports node >=10.17.0
 const tediousVer = require('../../../node_modules/tedious/package.json').version
 const semver = require('semver')
-if ((semver.gte(tediousVer, '12.0.0') && semver.lt(process.version, '12.3.0')) ||
+if ((semver.gte(tediousVer, '15.0.0') && semver.lt(process.version, '14.0.0')) ||
+    (semver.gte(tediousVer, '12.0.0') && semver.lt(process.version, '12.3.0')) ||
     (semver.gte(tediousVer, '11.0.0') && semver.lt(process.version, '10.17.0'))) {
   console.log(`# SKIP tedious@${tediousVer} does not support node ${process.version}`)
   process.exit()


### PR DESCRIPTION
This adds support for tedious 15.x, which was first published in July:

```
$ npm info tedious time
...
  '15.0.0-beta.1': '2022-07-11T08:22:36.753Z',
  '15.0.0': '2022-07-11T17:56:34.399Z',
  '15.0.1': '2022-07-26T08:11:31.852Z',
  '15.1.0': '2022-08-17T20:33:59.478Z'
}
```

tedious@15 drops support for Node 12.
https://github.com/tediousjs/tedious/releases/tag/v15.0.0

Supersedes: https://github.com/elastic/apm-agent-nodejs/pull/2893 (dependabot PR for this)

### Checklist

- [x] Add tests
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
