### PR TITLE
chore: reduce freq of dependabot updates for some deps to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     reviewers:
       - "elastic/apm-agent-node-js"
+    ignore:
+      - dependency-name: @babel/core
+      - dependency-name: @babel/preset-env
+      - dependency-name: @types/node
+      - dependency-name: aws-sdk
+
+  # Some dev-deps are frequently updated and not that important to be on latest.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "elastic/apm-agent-node-js"
+    allow:
+      - dependency-name: @babel/core
+      - dependency-name: @babel/preset-env
+      - dependency-name: @types/node
+      - dependency-name: aws-sdk


### PR DESCRIPTION
These deps are updated frequently (aws-sdk almost daily) and distract from more important dependabot updates.

Also bump the default to 10 for the weekly updates so we can actually get through the backlog.

---

I picked the set of monthly deps partially from the frequency of dependabot merges that we've done so far:

```
% git log --oneline | rg deps-dev | cut -d' ' -f4 | sort | uniq -c | sort -n | tail
   2 @elastic/elasticsearch
   2 apollo-server-express
   2 undici
   2 ws
   3 @babel/preset-env
   3 fastify
   3 ioredis
   3 mongodb
   4 @babel/core
   5 @types/node
```

Also, for interest sake, https://github.com/elastic/apm-agent-nodejs/network/updates/456488058 shows a log of the latest dependabot run against the repo. Grepping that log for deps that need updates yet:

```
% rg 'Updating ' dependabot-run.log
106:updater | INFO <job_456488058> Updating @fastify/formbody from 7.0.1 to 7.2.0
168:updater | INFO <job_456488058> Updating typescript from 4.7.4 to 4.8.3
402:updater | INFO <job_456488058> Updating fastify from 4.4.0 to 4.5.3
486:updater | INFO <job_456488058> Updating pg from 8.7.3 to 8.8.0
617:updater | INFO <job_456488058> Updating @opentelemetry/api from 1.1.0 to 1.2.0
772:updater | INFO <job_456488058> Updating eslint from 6.8.0 to 7.32.0
947:updater | INFO <job_456488058> Updating @types/node from 18.7.16 to 18.7.17
1039:updater | INFO <job_456488058> Updating lambda-local from 2.0.2 to 2.0.3
```

So we should expect ~8 dependabot PRs the next go round.