### PR TITLE
fix: graphql instrumentation for versions <=0.9 were broken

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -159,10 +159,12 @@ ws-new:
   commands: node test/instrumentation/modules/ws.test.js
 
 graphql-v0.7-v16:
+  name: graphql
   preinstall: npm uninstall express-graphql
   versions: '>=0.7.0 <0.11.0 || >=0.11.1 <16'
   commands: node test/instrumentation/modules/graphql.test.js
 graphql:
+  name: graphql
   preinstall: npm uninstall express-graphql
   node: '>=12'
   versions: '>=16.0.0 <17'

--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -23,6 +23,19 @@ module.exports = function (graphql, agent, { version, enabled }) {
     return graphql
   }
 
+  // Over the many versions the `graphql()` and `execute()` functions have
+  // changed in what arguments they accept:
+  // - Initially they only supported positional arguments:
+  //      function graphql(schema, requestString, rootValue, contextValue, variableValues, operationName)
+  // - Starting in v0.10.0 (in #356), they started accepting a second form where
+  //   all fields were passed in an object as the first argument:
+  //      function graphql(argsOrSchema, source, rootValue, contextValue, variableValues, operationName, fieldResolver)
+  //   and `arguments.length === 1` was used as the test to determine which.
+  // - Starting in v16 (in #2904), they dropped positional arguments:
+  //      function graphql(args)
+  const onlySupportsPositionalArgs = semver.lt(version, '0.10.0')
+  const onlySupportsSingleArg = semver.gte(version, '16.0.0')
+
   const ins = agent._instrumentation
 
   return clone({}, graphql, {
@@ -57,13 +70,12 @@ module.exports = function (graphql, agent, { version, enabled }) {
       let schema
       let source
       let operationName
-      if (arguments.length === 1) {
+      const singleArgForm = onlySupportsSingleArg || (!onlySupportsPositionalArgs && arguments.length === 1)
+      if (singleArgForm) {
         schema = args.schema
         source = args.source
         operationName = args.operationName
       } else {
-        // graphql <=v15 supported positional arguments:
-        //    function (schema, source, rootValue, contextValue, variableValues, operationName)
         schema = arguments[0]
         source = arguments[1]
         operationName = arguments[5]
@@ -112,12 +124,11 @@ module.exports = function (graphql, agent, { version, enabled }) {
 
       let document
       let operationName
-      if (arguments.length === 1) {
+      const singleArgForm = onlySupportsSingleArg || (!onlySupportsPositionalArgs && arguments.length === 1)
+      if (singleArgForm) {
         document = args.document
         operationName = args.operationName
       } else {
-        // graphql <=v15 supported positional arguments:
-        //    function (schema, document, rootValue, contextValue, variableValues, operationName)
         document = arguments[1]
         operationName = arguments[5]
       }


### PR DESCRIPTION
The changes in #2761 to support graphql@16 accidentally broken
instrumentation for really old graphql (versions before 0.10.0).
This wasn't noticed because the .tav.yml block for older graphql
versions didn't have `name: graphql`, so it was never run in CI.
