### PR TITLE
[DOC] Improve docs on auto-instrumentation

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -149,6 +149,8 @@ so those should be supported as well.
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages
 |=======================================================================
 
+NOTE: Traces are collected only when made within a sampled transaction. When not using a support framework, the user needs to take care of creating a transaction. Please check https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
+
 [float]
 [[compatibility-better-stack-traces]]
 ==== Better Stack Traces


### PR DESCRIPTION
Warn users the agent will only trace database queries if they're made within the context of a sampled transaction. Typically people use the agent with web applications, measuring the latency of requests, with details of operations such as database queries in those requests.

When not using a framework, the user needs to start a transaction using `apm.startTransaction` before making the query, and end the transaction after the query has completed.

Ideally, it might be just a warning banner with a pointer to https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html

From https://discuss.elastic.co/t/nodejs-apm-does-not-report-postgres-queries/208984/2

Please review the wording. This is just a doc improvement which I would like the docs team to review and backport

### Checklist

- [x] Update documentation
