### PR TITLE
fix: avoid a possible max call stack exceeded error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -105,6 +105,8 @@ paths are considered for body capture. ({pull}2873[#2873])
   Instrumentation of these older graphql versions was broken in v3.36.0.
   ({pull}2927[#2927])
 
+* Fix a possible Maximum call stack size exceeded error when looking for parent timers.
+
 [float]
 ===== Chores
 

--- a/lib/instrumentation/timer.js
+++ b/lib/instrumentation/timer.js
@@ -9,8 +9,16 @@
 var microtime = require('relative-microtime')
 
 function maybeTime (timer, time) {
-  if (timer._parent) return maybeTime(timer._parent, time)
-  return time >= 0 ? time * 1000 : timer._timer()
+  if (time >= 0) {
+    return time * 1000
+  }
+
+  let rootTimer = timer
+  while (rootTimer._parent) {
+    rootTimer = rootTimer._parent
+  }
+
+  return rootTimer._timer()
 }
 
 module.exports = class Timer {


### PR DESCRIPTION
<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->
Sometimes, our production servers hit the following error:
```
RangeError: Maximum call stack size exceeded
    at maybeTime (/home/runner/application/node_modules/.pnpm/elastic-apm-node@3.38.0/node_modules/elastic-apm-node/lib/instrumentation/timer.js:11:20)
    at maybeTime (/home/runner/application/node_modules/.pnpm/elastic-apm-node@3.38.0/node_modules/elastic-apm-node/lib/instrumentation/timer.js:12:29)
    at maybeTime (/home/runner/application/node_modules/.pnpm/elastic-apm-node@3.38.0/node_modules/elastic-apm-node/lib/instrumentation/timer.js:12:29)
    at maybeTime (/home/runner/application/node_modules/.pnpm/elastic-apm-node@3.38.0/node_modules/elastic-apm-node/lib/instrumentation/timer.js:12:29)
    at maybeTime (/home/runner/application/node_modules/.pnpm/elastic-apm-node@3.38.0/node_modules/elastic-apm-node/lib/instrumentation/timer.js:12:29)
...
```
We don't yet have an explanation, but we strongly suspect that https://github.com/elastic/apm-agent-nodejs/issues/2611 is involved because it mostly happens on long-running async/await chains.

Until it's fixed, I think this function can be rewritten iteratively instead of recursively. Also, it doesn't appear to need to look up for parents if `time` is provided, as it's going to be constant all the way.

Do you feel this change needs tests?

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [X] Add CHANGELOG.asciidoc entry
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
