### PR TITLE
test: lock to mongo:5 container, recently released mongo:6 breaks our healthcheck

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 30
 
   mongodb:
-    image: mongo
+    image: mongo:5
     ports:
       - "27017:27017"
     volumes:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: 'trust'
 
       mongodb:
-        image: mongo
+        image: mongo:5
         ports:
           - 27017:27017
         volumes:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 30
 
   mongodb:
-    image: mongo
+    image: mongo:5
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
With MongoDB 6 containers (released in the last week), the `mongo`
binary is gone, replaced by `mongosh`.
See https://github.com/docker-library/mongo/issues/558

Our tests were using `mongo:latest`. For now let's lock to mongo:5 and
then have a separate issue for updating container versions for testing.
