### PR TITLE
fix avoids a possible 'RangeError: Maximum call stack size exceeded' in maybeTime(...)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -101,6 +101,9 @@ paths are considered for body capture. ({pull}2873[#2873])
 [float]
 ===== Bug fixes
 
+* Avoid a possible `RangeError: Maximum call stack size exceeded` in
+  Span timer handler for exceedingly deep Span trees. ({pull}2939[#2939])
+
 * Fix instrumentation of (very old) 'graphql' module versions <=0.9.6.
   Instrumentation of these older graphql versions was broken in v3.36.0.
   ({pull}2927[#2927])

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -34,6 +34,13 @@ function Span (transaction, ...args) {
     : {}
   const [name, ...tsaArgs] = args // "tsa" === Type, Subtype, Action
 
+  if (opts.timer) {
+    process.emitWarning(
+      'specifying the `timer` option to `new Span()` was never a public API and will be removed',
+      'DeprecationWarning',
+      'ELASTIC_APM_SPAN_TIMER_OPTION'
+    )
+  }
   if (!opts.childOf) {
     const defaultChildOf = transaction._agent._instrumentation.currSpan() || transaction
     opts.childOf = defaultChildOf

--- a/lib/instrumentation/timer.js
+++ b/lib/instrumentation/timer.js
@@ -8,17 +8,29 @@
 
 var microtime = require('relative-microtime')
 
+/**
+ * Return `time`, if given and valid, or the current time (calculated using
+ * the given `timer`).
+ *
+ * @param {Timer} timer
+ * @param {Number} [time] - An optional float number of milliseconds since
+ *    the epoch (i.e. the same as provided by `Date.now()`).
+ * @returns {Number} A time in *microseconds* since the Epoch.
+ */
 function maybeTime (timer, time) {
-  if (timer._parent) return maybeTime(timer._parent, time)
-  return time >= 0 ? time * 1000 : timer._timer()
+  if (time >= 0) {
+    return time * 1000
+  } else {
+    return timer._timer()
+  }
 }
 
 module.exports = class Timer {
   // `startTime`: millisecond float
-  constructor (timer, startTime) {
-    this._parent = timer
-    this._timer = timer ? timer._timer : microtime()
-    this.start = maybeTime(this, startTime) // microsecond integer
+  constructor (parentTimer, startTime) {
+    this._parent = parentTimer
+    this._timer = parentTimer ? parentTimer._timer : microtime()
+    this.start = maybeTime(this, startTime) // microsecond integer (note: might not be an integer)
     this.endTimestamp = null
     this.duration = null // millisecond float
     this.selfTime = null // millisecond float

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -53,6 +53,13 @@ function Transaction (agent, name, ...args) {
     ? (args.pop() || {})
     : {}
 
+  if (opts.timer) {
+    process.emitWarning(
+      'specifying the `timer` option to `new Span()` was never a public API and will be removed',
+      'DeprecationWarning',
+      'ELASTIC_APM_SPAN_TIMER_OPTION'
+    )
+  }
   if (opts.tracestate) {
     opts.tracestate = TraceState.fromStringFormatString(opts.tracestate)
   }

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -55,7 +55,7 @@ function Transaction (agent, name, ...args) {
 
   if (opts.timer) {
     process.emitWarning(
-      'specifying the `timer` option to `new Span()` was never a public API and will be removed',
+      'specifying the `timer` option to `new Transaction()` was never a public API and will be removed',
       'DeprecationWarning',
       'ELASTIC_APM_SPAN_TIMER_OPTION'
     )


### PR DESCRIPTION
This avoids a possible 'RangeError: Maximum call stack size exceeded' as
described in #2929.

The case the user hit is in `maybeTime(...)` used in Span timer handling.
Fixed by dropping the recursion.  A `Timer` instance's `_timer` is always the
same object as its parent's `_timer` if it has a parent, so there is no
need to walk the chain.

Refs: #2929 

---

See the discussion at https://github.com/elastic/apm-agent-nodejs/pull/2929 for why this doesn't include tests. We don't have a perfect understanding of how this is happening so don't have a good test to add.  If this passes the current breakdown metrics tests ("test/metrics/breakdown.test.js"), then I think this should be good as a workaround for the user's issue.
