### PR TITLE
test: reduce TAV tested versions of aws-sdk

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -568,8 +568,8 @@ aws-sdk:
   # Maintenance note: This should be updated periodically using:
   #   ./dev-utils/aws-sdk-tav-versions.sh
   #
-  # Test v2.858.0, every N=54 of 275 releases, and current latest.
-  versions: '2.858.0 || 2.912.0 || 2.966.0 || 2.1020.0 || 2.1074.0 || 2.1128.0 || 2.1132.0 || >2.1132.0 <3'
+  # Test v2.858.0, every N=72 of 365 releases, and current latest.
+  versions: '2.858.0 || 2.930.0 || 2.1002.0 || 2.1074.0 || 2.1146.0 || 2.1218.0 || 2.1222.0 || >2.1222.0 <3'
   commands:
     - node test/instrumentation/modules/aws-sdk/aws4-retries.test.js
     - node test/instrumentation/modules/aws-sdk/s3.test.js


### PR DESCRIPTION
This reduces from 97 versions tests down to 7.

----

The time for TAV runs on main (in Jenkins CI) has crept up from ~1h to 1h20m of late.

```
% ./dev-utils/jenkins-build-slow-steps.sh https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/main/410/ | tail
1619313 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "8"
1642453 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "14"
1651751 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "18"
1802458 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "12"
2038386 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "14"
2123879 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "12"
2179244 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "14"
2314545 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "8"
2396499 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "10"
2425001 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "12"
```