### PR TITLE
test: reduce apollo-server-express and express-graphql TAV matrix

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -178,92 +178,6 @@ express:
     - node test/instrumentation/modules/express/capture-exceptions-on.test.js
     - node test/instrumentation/modules/express/set-framework.test.js
 
-express-graphql-0.6.1_graphql-0.8:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.8.2
-  versions: '0.6.1'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
-express-graphql-0.6.2_graphql-0.9:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.9.0
-  versions: '>=0.6.2 <0.6.6'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
-express-graphql-0.6.6_graphql-0.10:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.10.0
-  versions: '>=0.6.6 <0.6.8'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
-express-graphql-0.6.11_graphql-0.10:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.10.0
-  versions: '0.6.11'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-express-graphql-0.6.11_graphql-0.11:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.11.0
-  versions: '0.6.11'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
-express-graphql-0.6.12_graphql-0.10:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.10.0
-  versions: '^0.6.12'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-express-graphql-0.6.12_graphql-0.11:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.11.0
-  versions: '^0.6.12'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-express-graphql-0.6.12_graphql-0.12:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.12.0
-  versions: '^0.6.12'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-express-graphql-0.6.12_graphql-0.13:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.13.0
-  versions: '^0.6.12'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
-express-graphql-0.7.1_graphql-0.12:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.12.0
-  versions: '>=0.7.1 <0.9.0'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-express-graphql-0.7.1_graphql-0.13:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^0.13.0
-  versions: '>=0.7.1 <0.9.0'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-express-graphql-0.7.1_graphql-14:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^14.0.0
-  versions: '>=0.7.1 <0.9.0'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
-express-graphql-0.9.0_graphql-14:
-  name: express-graphql
-  preinstall: npm uninstall apollo-server-express
-  peerDependencies: graphql@^14.4.1
-  versions: '>=0.9.0 <0.10.0'
-  node: '>=7.6.0'
-  commands: node test/instrumentation/modules/express-graphql.test.js
-
 # - Skip express-graphql@0.10.0 because it briefly, accidentally introduced
 #   syntax that required ES2020 (node v14).
 # - Limit to node >=10.4 because of a known issue.
@@ -298,31 +212,7 @@ express-graphql-0.11.0_graphql-15:
   node: '>=10.4'
   commands: node test/instrumentation/modules/express-graphql.test.js
 
-apollo-server-express-2_12:
-  name: apollo-server-express
-  preinstall: npm uninstall express-graphql
-  peerDependencies: graphql@^0.12.0
-  # We want this version range:
-  #   versions: '>=2.9.16 <2.2 || >= 2.3.2 <3'
-  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
-  #
-  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
-  node: '>=6'
-  commands: node test/instrumentation/modules/apollo-server-express.test.js
-apollo-server-express-2_13:
-  name: apollo-server-express
-  preinstall: npm uninstall express-graphql
-  peerDependencies: graphql@^0.13.0
-  # We want this version range:
-  #   versions: '>=2.9.16 <2.2 || >= 2.3.2 <3'
-  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
-  #
-  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  versions: '2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
-  node: '>=6'
-  commands: node test/instrumentation/modules/apollo-server-express.test.js
-apollo-server-express-2_14:
+apollo-server-express-2_graphql-14:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^14.0.0
@@ -334,7 +224,7 @@ apollo-server-express-2_14:
   versions: '2.9.16 || 2.10.1 || 2.11.0 || 2.12.0 || 2.13.1 || 2.14.5 || 2.15.1 || 2.16.1 || 2.17.0 || 2.18.2 || 2.19.2 || 2.20.0 || 2.21.2 || 2.22.2 || 2.23.0 || 2.24.1 || 2.25.0 || >2.25.x <3'
   node: '>=6'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
-apollo-server-express-2_15:
+apollo-server-express-2_graphql-15:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^15.0.0
@@ -349,13 +239,16 @@ apollo-server-express-2_15:
   # graphql v15 supports node v8 as a minimum.
   node: '>=8'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
-
-apollo-server-express-3_15:
+apollo-server-express-3_graphql-15:
   name: apollo-server-express
   preinstall: npm uninstall express-graphql
   peerDependencies: graphql@^15.0.0
-  versions: '^3.0.0'
-  node: '>=12'
+  # We want this version range:
+  #   versions: '^3.0.0'
+  # but only test the latest MAJOR.MINOR.x to reduce the test matrix.
+  #
+  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
+  versions: '3.0.2 || 3.1.2 || 3.2.0 || 3.3.0 || 3.4.1 || 3.5.0 || 3.6.8 || 3.7.0 || 3.8.2 || 3.9.0 || ^3.10.2'
   commands: node test/instrumentation/modules/apollo-server-express.test.js
 
 express-queue:

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -107,8 +107,8 @@ These modules override that behavior to give better insights into specialized HT
 [options="header"]
 |=======================================================================
 |Module |Version |Note
-|https://www.npmjs.com/package/express-graphql[express-graphql] |>=0.6.1 <0.13.0 |Will name all transactions by the GraphQL query name. (There is https://github.com/elastic/apm-agent-nodejs/issues/2516[known issue with node <10.4].)
-|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |>=2.0.4 <4|Will name all transactions by the GraphQL query name
+|https://www.npmjs.com/package/express-graphql[express-graphql] |>=0.6.1 <0.13.0 |Will name all transactions by the GraphQL query name. There is a https://github.com/elastic/apm-agent-nodejs/issues/2516[known issue with node <10.4]. Versions before 0.10.0 are no longer tested.
+|https://www.npmjs.com/package/apollo-server-express[apollo-server-express] |>=2.0.4 <4|Will name all transactions by the GraphQL query name. Versions before 2.9.6 are no longer tested.
 |=======================================================================
 
 [float]


### PR DESCRIPTION
This removes TAV testing of apollo-server-express@2 versions with
graphql@^0.12.0 and graphql@^0.13.0. We still test
apollo-server-express@2 with more recent versions of graphql. The
latest graphql 0.13 release was 2018-03-16.

This removes TAV testing of express-graphql versions before 0.10.0 --
the latest such release was 2019-07-15.

---

Motivation: apollo-server-express TAV testing is one of our slow ones -- up to ~40 minutes for each node version.
Also, FWIW, the config for testing apollo-server-express and express-graphql in ".tav.yml" is
179 of the total 586 lines. Much of that is to be continuously testing versions of packages that are more than 3 years old.

```
% ./dev-utils/jenkins-build-slow-steps.sh https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/main/410/ | tail
1619313 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "8"
1642453 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "14"
1651751 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "18"
1802458 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "12"
2038386 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "14"
2123879 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "apollo-server-express" "12"
2179244 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "14"
2314545 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "8"
2396499 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "10"
2425001 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "12"
```

# apollo-server-express

Apollo-server-express TAV testing is a top slow step. Let's reduce the matrix if/where it makes sense.

Currently we are testing a number of `[apollo-server-express, graphql]` version combinations:

- apollo-server-express@2, graphql@^0.12.0
- apollo-server-express@2, graphql@^0.13.0
- apollo-server-express@2, graphql@^14.0.0
- apollo-server-express@2, graphql@^15.0.0
- apollo-server-express@3, graphql@^15.0.0

Here are the latest release times of each of the major versions of graphql:

```
'0.12.3': '2017-12-17T04:35:04.749Z',
'0.13.2': '2018-03-16T20:59:48.546Z',
'14.7.0': '2020-07-06T16:56:10.444Z',
'15.8.0': '2021-12-07T12:17:43.375Z',
'16.6.0': '2022-08-16T19:26:38.481Z',
```

I think we can drop testing for graphql@0.12.x and 0.13.x given they are over 4 years old at this point.

(Aside: We don't test yet apollo-server-express@3 with graphql@16, but the latest apollo-server-express@3 release has graphql@15.8.0 as its dep.)


# express-graphql

Similarly, we test a number of combinations of `express-graphql` and `graphql`, back to 'express-graphl@0.6.1'. Releases of express-graphql are:

```
  ...
  '0.6.1': '2016-11-12T03:29:39.016Z',
  '0.6.2': '2017-01-24T21:39:00.626Z',
  '0.6.3': '2017-02-01T01:59:22.180Z',
  '0.6.4': '2017-03-31T17:57:10.496Z',
  '0.6.5': '2017-05-15T22:37:56.256Z',
  '0.6.6': '2017-05-26T19:24:58.442Z',
  '0.6.7': '2017-07-28T16:16:00.193Z',
  '0.6.11': '2017-08-29T16:22:47.198Z',
  '0.6.12': '2018-02-19T20:58:28.585Z',
  '0.7.0': '2018-10-29T01:36:16.539Z',
  '0.7.1': '2018-10-29T06:34:56.919Z',
  '0.8.0': '2019-04-14T07:09:43.577Z',
  '0.9.0': '2019-07-15T13:16:20.769Z',
  '0.10.0': '2020-07-05T07:30:36.962Z',
  '0.10.1': '2020-07-05T15:14:46.120Z',
  '0.10.2': '2020-07-05T19:57:12.419Z',
  '0.11.0': '2020-07-06T18:58:19.281Z',
  '0.12.0': '2020-11-19T15:09:19.169Z',  // current latest release
```

I suggest we drop testing of express-graphql versions before 0.10.0. This means dropping testing of versions more than 3 years old.

