### PR TITLE
chore: drop unsupported second dependabot.yml config block for package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,22 +7,3 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "elastic/apm-agent-node-js"
-    ignore:
-      - dependency-name: "@babel/core"
-      - dependency-name: "@babel/preset-env"
-      - dependency-name: "@types/node"
-      - dependency-name: "aws-sdk"
-
-  # Some dev-deps are frequently updated and not that important to be on latest.
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "elastic/apm-agent-node-js"
-    allow:
-      - dependency-name: "@babel/core"
-      - dependency-name: "@babel/preset-env"
-      - dependency-name: "@types/node"
-      - dependency-name: "aws-sdk"


### PR DESCRIPTION
https://github.com/elastic/apm-agent-nodejs/network/updates was showing:

> The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'

What we'd been *intending* in our dependabot config was to say "update
my package.json deps weekly, except for this subset of
frequently-updated modules that I just want updated monthly".  I guess
we cannot use two config blocks in dependabot.yml to get the desired
behaviour.

* * *

Alternative options:
1. Drop the second config block, give up, and just take frequent dependabot version update PRs for `@babel/preset-env` and others.
2. Drop the second config block, and use the `@dependabot ignore this major|minor version` command on the next version update PR for those frequently-updated dependencies.
3. Refactor how we use these dependencies to *separate package.json files*, so we can have independent dependabot.yml config blocks for them. While we might want to be separating some dev-dependencies for testing out to one or more separate package.json files, it isn't for this purpose. So this option isn't that helpful.

**I propose doing option 2.  We'll use the `@dependabot ignore ...` command as appropriate for each of the frequently updated deps.**  Note that I have used that ignore command for some already (e.g. [here for aws-sdk](https://github.com/elastic/apm-agent-nodejs/pull/2853#issuecomment-1203327047)). I don't know how to get a summary of those outstanding ignore commands without trawling through [unmerged dependabot PRs](https://github.com/elastic/apm-agent-nodejs/pulls?q=is%3Apr+is%3Aclosed+is%3Aunmerged+label%3Adependencies).

* * * 

See https://github.com/elastic/apm-agent-nodejs/pull/2966 for a recent fix of a syntax error in dependabot.yml.
See https://github.com/elastic/apm-agent-java/pull/2822 for the Java APM agent's attempt to workaround the same limitation.