### PR TITLE
docs: fix formatting of the Frameworks table; also update koa-router repo link

### DIFF
--- a/docs/koa.asciidoc
+++ b/docs/koa.asciidoc
@@ -13,7 +13,7 @@ include::./shared-set-up.asciidoc[tag=introduction]
 
 Koa doesn't have a built-in router,
 so we can't support Koa directly since we rely on router information for full support.
-We currently support the most popular Koa router called https://github.com/alexmingoia/koa-router[koa-router].
+We currently support the most popular Koa router called https://github.com/koajs/koa-router[koa-router].
 
 If you use another router with your Koa application,
 please https://github.com/elastic/apm-agent-nodejs/issues[open an issue] so we can make sure to support your stack.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -87,14 +87,14 @@ These are the frameworks that we officially support:
 
 [options="header"]
 |=======================================================================
-|Framework |Version |Note
-|<<express,Express>> |^4.0.0
-|<<hapi,hapi>> |>=9.0.0 <19.0.0 | Deprecated. No longer tested.
-|<<hapi,@hapi/hapi>> |>=17.9.0 <21.0.0
-|<<koa,Koa>> via koa-router or @koa/router | >=5.2.0 <13.0.0 | Koa doesn't have a built in router, so we can't support Koa directly since we rely on router information for full support. We currently support the most popular Koa router called https://github.com/alexmingoia/koa-router[koa-router].
-|<<restify,Restify>> |>=5.2.0
-|<<fastify,Fastify>> |>=1.0.0 | See also https://www.fastify.io/docs/latest/Reference/LTS/[Fastify's own LTS documentation]
-|<<lambda,AWS Lambda>> |N/A
+| Framework             | Version | Note
+| <<lambda,AWS Lambda>> | N/A |
+| <<express,Express>>   | ^4.0.0 |
+| <<fastify,Fastify>>   | >=1.0.0 | See also https://www.fastify.io/docs/latest/Reference/LTS/[Fastify's own LTS documentation]
+| <<hapi,@hapi/hapi>>   | >=17.9.0 <21.0.0 |
+| <<hapi,hapi>>         | >=9.0.0 <19.0.0 | Deprecated. No longer tested.
+| <<koa,Koa>> via koa-router or @koa/router | >=5.2.0 <13.0.0 | Koa doesn't have a built in router, so we can't support Koa directly since we rely on router information for full support. We currently support the most popular Koa router called https://github.com/koajs/koa-router[koa-router].
+| <<restify,Restify>>   | >=5.2.0 |
 |=======================================================================
 
 [float]


### PR DESCRIPTION
This fixes the formatting of the "Frameworks" table in the supported-technologies doc page. It was broken by me recently in #2924. It never made it to a release.

This also updates the repo link for koa-router. The previous link *was* the original, but now it redirects to a fork (https://github.com/ZijianHe/koa-router) that hasn't been updated since 2019. At some point the official `koa-router` npm package releases moved to https://github.com/koajs/router

# broken state

You can currently see the broken state at https://www.elastic.co/guide/en/apm/agent/nodejs/master/supported-technologies.html#compatibility-frameworks  
The rows are all messed up. AsciiDoc table markup is definitely not Markdown table markup.

* * *
![Screen Shot 2022-10-14 at 3 52 00 PM](https://user-images.githubusercontent.com/46866/195956069-bd49233e-65d6-4bd5-83f3-706b946cdd23.png)



# fixed state

I've also re-ordered the table to be mostly alphabetical.

* * *
![Screen Shot 2022-10-14 at 4 03 45 PM](https://user-images.githubusercontent.com/46866/195956116-e3b0b4f7-b51e-4b28-bb22-32ceda581eda.png)


