### PR TITLE
chore: test node v20 nightlies now that v19.0.0 has been released

### DIFF
--- a/.ci/.jenkins_nightly_nodejs.yml
+++ b/.ci/.jenkins_nightly_nodejs.yml
@@ -9,4 +9,4 @@
 # made, these will stop and there will be no value in testing v17 nightlies.
 #
 NODEJS_VERSION:
-  - "19"
+  - "20"


### PR DESCRIPTION
Now that v19.0.0 is out, nightlies at https://nodejs.org/download/nightly/ are for v20.

E.g.:

```
v20.0.0-nightly2022101987cdf7d412/                 19-Oct-2022 07:00                   -
v20.0.0-nightly20221020b4efac4820/                 20-Oct-2022 07:30                   -
v20.0.0-nightly20221021eb32a8443a/                 21-Oct-2022 07:30                   -
v20.0.0-nightly20221022e43d191bcb/                 22-Oct-2022 07:00                   -
v20.0.0-nightly2022102389c4e1f967/                 25-Oct-2022 12:00                   -
v20.0.0-nightly20221024aab9f3246e/                 25-Oct-2022 12:00                   -
v20.0.0-nightly20221025c6c18a9a24/                 25-Oct-2022 07:00                   -
v20.0.0-nightly202210265e2aeae032/                 26-Oct-2022 09:00                   -
v20.0.0-nightly20221027aaed438165/                 27-Oct-2022 07:00                   -
```