### PR TITLE
test: fix two TAV=next test failures with Next.js v11

### DIFF
--- a/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
+++ b/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
@@ -6,10 +6,14 @@
 # - Next.js 11 supports back to node v12.22.0 and v14.5.0. However, when this
 #   instrumentation was added, Node v12 was already EOL, so there is less value
 #   in testing it.
+# - Next.js 11 crashes with Node >=17 unless this workaround is used;
+#      NODE_OPTIONS=--openssl-legacy-provider ...
+#   See https://github.com/vercel/next.js/issues/30078 for details. There isn't
+#   much value in testing this old Next.js version with newer Node versions.
 next-11:
   name: next
   versions: '11.1.0 || 11.1.4'
-  node: '>=14.5.0'
+  node: '>=14.5.0 <17.0.0'
   commands: node ../next.test.js
   peerDependencies:
     - "react@^17.0.2"

--- a/test/instrumentation/modules/next/next.test.js
+++ b/test/instrumentation/modules/next/next.test.js
@@ -663,7 +663,11 @@ tape.test('-- prod server tests --', suite => {
         env: Object.assign({}, process.env, {
           NODE_OPTIONS: '-r ../../../../../start-next.js',
           ELASTIC_APM_SERVER_URL: serverUrl,
-          ELASTIC_APM_API_REQUEST_TIME: '2s'
+          ELASTIC_APM_API_REQUEST_TIME: '2s',
+          // Disable Next.js telemetry (https://nextjs.org/telemetry),
+          // otherwise get additional `POST telemetry.nextjs.org` spans that
+          // break assertions.
+          NEXT_TELEMETRY_DISABLED: '1'
         })
       }
     )
@@ -755,7 +759,11 @@ tape.test('-- dev server tests --', suite => {
         env: Object.assign({}, process.env, {
           NODE_OPTIONS: '-r ../../../../../start-next.js',
           ELASTIC_APM_SERVER_URL: serverUrl,
-          ELASTIC_APM_API_REQUEST_TIME: '2s'
+          ELASTIC_APM_API_REQUEST_TIME: '2s',
+          // Disable Next.js telemetry (https://nextjs.org/telemetry),
+          // otherwise get additional `POST telemetry.nextjs.org` spans that
+          // break assertions.
+          NEXT_TELEMETRY_DISABLED: '1'
         })
       }
     )


### PR DESCRIPTION
1. next.test.js was failing in Docker/CI with node v14 and v16
   because https://nextjs.org/telemetry automatically turned on
   which resulted in APM spans for `POST telemetry.nextjs.org`
   during tests, which broke assertions.
2. `next build` with Next.js v11 and Node.js >=17 crashes due to
   https://github.com/vercel/next.js/issues/30188
   We just skip testing that older Next.js with newer Node.js.
