### PR TITLE
test, docs: @hapi/hapi@21

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -366,7 +366,7 @@ pug:
   commands:
     - node test/instrumentation/modules/hapi/basic.test.js
     - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
-'@hapi/hapi-v19-v20':
+'@hapi/hapi':
   name: '@hapi/hapi'
   versions: '>=21.0.0'
   node: '>=14'

--- a/.tav.yml
+++ b/.tav.yml
@@ -351,6 +351,7 @@ pug:
 # - Node version compat:
 #   - @hapi/hapi@19: supports node >=v12 (judging from commit 50d8d7d)
 #   - @hapi/hapi@20: appears (from travis template refs) to support node >=v12
+#   - @hapi/hapi@21: dropped support for node v12
 '@hapi/hapi-v17-v18':
   name: '@hapi/hapi'
   versions: '>=17.0.0 <19.0.0'
@@ -358,10 +359,17 @@ pug:
   commands:
     - node test/instrumentation/modules/hapi/basic.test.js
     - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
-'@hapi/hapi':
+'@hapi/hapi-v19-v20':
   name: '@hapi/hapi'
-  versions: '>=19.0.0'
+  versions: '>=19.0.0 <21.0.0'
   node: '>=12'
+  commands:
+    - node test/instrumentation/modules/hapi/basic.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
+'@hapi/hapi-v19-v20':
+  name: '@hapi/hapi'
+  versions: '>=21.0.0'
+  node: '>=14'
   commands:
     - node test/instrumentation/modules/hapi/basic.test.js
     - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js

--- a/.tav.yml
+++ b/.tav.yml
@@ -351,7 +351,8 @@ pug:
 # - Node version compat:
 #   - @hapi/hapi@19: supports node >=v12 (judging from commit 50d8d7d)
 #   - @hapi/hapi@20: appears (from travis template refs) to support node >=v12
-#   - @hapi/hapi@21: dropped support for node v12
+#   - @hapi/hapi@21: dropped support for node v12, and requires v14.10.0
+#     for 'performance.eventLoopUtilization'
 '@hapi/hapi-v17-v18':
   name: '@hapi/hapi'
   versions: '>=17.0.0 <19.0.0'
@@ -369,7 +370,7 @@ pug:
 '@hapi/hapi':
   name: '@hapi/hapi'
   versions: '>=21.0.0'
-  node: '>=14'
+  node: '>=14.10.0'
   commands:
     - node test/instrumentation/modules/hapi/basic.test.js
     - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -90,7 +90,7 @@ These are the frameworks that we officially support:
 | <<lambda,AWS Lambda>> | N/A |
 | <<express,Express>>   | ^4.0.0 |
 | <<fastify,Fastify>>   | >=1.0.0 | See also https://www.fastify.io/docs/latest/Reference/LTS/[Fastify's own LTS documentation]
-| <<hapi,@hapi/hapi>>   | >=17.9.0 <21.0.0 |
+| <<hapi,@hapi/hapi>>   | >=17.9.0 <22.0.0 |
 | <<hapi,hapi>>         | >=9.0.0 <19.0.0 | Deprecated. No longer tested.
 | <<koa,Koa>> via koa-router or @koa/router | >=5.2.0 <13.0.0 | Koa doesn't have a built in router, so we can't support Koa directly since we rely on router information for full support. We currently support the most popular Koa router called https://github.com/koajs/koa-router[koa-router].
 | <<nextjs,Next.js>>    | >=11.1.0 <14.0.0 | (Technical Preview) This instruments Next.js routing to name transactions for incoming HTTP transactions; and reports errors in user pages. It supports the Next.js production server (`next start`) and development server (`next dev`). See the <<nextjs,Getting Started document>>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@elastic/elasticsearch": "^8.2.1",
         "@elastic/elasticsearch-canary": "^8.2.0-canary.2",
         "@fastify/formbody": "^7.0.1",
-        "@hapi/hapi": "^20.1.2",
+        "@hapi/hapi": "^21.0.0",
         "@koa/router": "^12.0.0",
         "@types/node": "^18.0.1",
         "@types/pino": "^6.3.8",
@@ -2516,156 +2516,225 @@
       "dev": true
     },
     "node_modules/@hapi/accept": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
-      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
+      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
+    },
+    "node_modules/@hapi/accept/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/ammo": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
+      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
+    },
+    "node_modules/@hapi/ammo/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/b64": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
+    },
+    "node_modules/@hapi/b64/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "10.x.x"
       }
+    },
+    "node_modules/@hapi/boom/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/bounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
+      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
+    "node_modules/@hapi/bounce/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
     "node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
       "dev": true
     },
     "node_modules/@hapi/call": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
+      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
+    "node_modules/@hapi/call/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
     "node_modules/@hapi/catbox": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.0.1.tgz",
+      "integrity": "sha512-EJnj0KJt9LZ/c+mo6NB7mesFhy+s+CDX3AT7de5VRCOHkzOm4ENxN/rgNd0HyI/AfT8FqyUKt1Gccd1DVg8tQA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
     "node_modules/@hapi/catbox-memory": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
-      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
+      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
     },
+    "node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
+    "node_modules/@hapi/catbox/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
     "node_modules/@hapi/content": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       }
     },
     "node_modules/@hapi/cryptiles": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
+      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@hapi/file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
       "dev": true
     },
     "node_modules/@hapi/hapi": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
-      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.0.0.tgz",
+      "integrity": "sha512-gqGifa4X4nskhsmsgp3AwBq4LPIl7XOlnzpdWSogdc46Z4Hfy/WDjCcaO2yK84tQRmGSlg0nZowOfSCyeT0hRw==",
       "dev": true,
       "dependencies": {
-        "@hapi/accept": "^5.0.1",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/bounce": "^2.0.0",
-        "@hapi/call": "^8.0.0",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "^5.0.0",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/mimos": "^6.0.0",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.5",
-        "@hapi/somever": "^3.0.0",
-        "@hapi/statehood": "^7.0.4",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "^5.1.1",
-        "@hapi/topo": "^5.0.0",
-        "@hapi/validate": "^1.1.1"
+        "@hapi/accept": "^6.0.0",
+        "@hapi/ammo": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/call": "^9.0.0",
+        "@hapi/catbox": "^12.0.0",
+        "@hapi/catbox-memory": "^6.0.0",
+        "@hapi/heavy": "^8.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/mimos": "^7.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/shot": "^6.0.0",
+        "@hapi/somever": "^4.1.0",
+        "@hapi/statehood": "^8.0.0",
+        "@hapi/subtext": "^8.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/topo": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@hapi/heavy": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+    "node_modules/@hapi/hapi/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
+    "node_modules/@hapi/hapi/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
+    },
+    "node_modules/@hapi/heavy": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
+      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
+      }
+    },
+    "node_modules/@hapi/heavy/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -2674,122 +2743,170 @@
       "dev": true
     },
     "node_modules/@hapi/iron": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
+      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
       "dev": true,
       "dependencies": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
+    },
+    "node_modules/@hapi/iron/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/mimos": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
-      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
+      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "mime-db": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "mime-db": "^1.52.0"
       }
+    },
+    "node_modules/@hapi/mimos/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/nigel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
+      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/vise": "^5.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/@hapi/nigel/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/pez": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
+      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
       "dev": true,
       "dependencies": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/nigel": "^5.0.0"
       }
+    },
+    "node_modules/@hapi/pez/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/podium": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
-      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
       }
+    },
+    "node_modules/@hapi/podium/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/shot": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
-      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
+      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
       }
     },
+    "node_modules/@hapi/shot/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
     "node_modules/@hapi/somever": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
-      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
+      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
       "dev": true,
       "dependencies": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@hapi/statehood": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
-      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
+      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/iron": "^7.0.0",
+        "@hapi/validate": "^2.0.0"
       }
+    },
+    "node_modules/@hapi/statehood/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@hapi/subtext": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
-      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
+      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/pez": "^6.0.0",
+        "@hapi/wreck": "^18.0.0"
       }
     },
+    "node_modules/@hapi/subtext/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
     "node_modules/@hapi/teamwork": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
-      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
       "dev": true,
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@hapi/topo": {
@@ -2802,34 +2919,61 @@
       }
     },
     "node_modules/@hapi/validate": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      }
+    },
+    "node_modules/@hapi/validate/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
+    "node_modules/@hapi/validate/node_modules/@hapi/topo": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+      "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0"
       }
     },
     "node_modules/@hapi/vise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
+      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
       }
     },
+    "node_modules/@hapi/vise/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
+    },
     "node_modules/@hapi/wreck": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
-      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
+      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
       "dev": true,
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
       }
+    },
+    "node_modules/@hapi/wreck/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+      "dev": true
     },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
@@ -17097,149 +17241,238 @@
       }
     },
     "@hapi/accept": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
-      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.0.tgz",
+      "integrity": "sha512-aG/Ml4kSBWCVmWvR8N8ULRuB385D8K/3OI7lquZQruH11eM7sHR5Nha30BbDzijJHtyV7Vwc6MlMwNfwb70ISg==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/ammo": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.0.tgz",
+      "integrity": "sha512-lhX7SYtWScQaeAIL5XnE54WzyDgS5RXVeEtFEovyZcTdVzTYbo0nem56Bwko1PBcRxRUIw1v2tMb6sjFs6vEwg==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/b64": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.0.tgz",
+      "integrity": "sha512-Es6o4BtzvMmNF28KJGuwUzUtMjF6ToZ1hQt3UOjaXc6TNkRefel+NyQSjc9b5q3Re7xwv23r0xK3Vo3yreaJHQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.0.tgz",
+      "integrity": "sha512-1YVs9tLHhypBqqinKQRqh7FUERIolarQApO37OWkzD+z6y6USi871Sv746zBPKcIOBuI6g6y4FrwX87mmJ90Gg==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "10.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/bounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.0.tgz",
+      "integrity": "sha512-L0G4NcwwOYRhpcXeL76hNrLTUcObqtZMB3z4kcRVUZcR/w3v6C5Q1cTElV4/V7og1fG+wOyDR55UMFA+tWfhtA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
       "dev": true
     },
     "@hapi/call": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.0.tgz",
+      "integrity": "sha512-Z6byqbEtKF3RIH2kWG6cX64RwEqHBWYEVkNoEx6oKvkPaTrC6WTPRgr+ANo9Xa8G1GXyvs/NCMTnn3Mdj12TSA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/catbox": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.0.1.tgz",
+      "integrity": "sha512-EJnj0KJt9LZ/c+mo6NB7mesFhy+s+CDX3AT7de5VRCOHkzOm4ENxN/rgNd0HyI/AfT8FqyUKt1Gccd1DVg8tQA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/catbox-memory": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
-      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.0.tgz",
+      "integrity": "sha512-A1O30g8GdaODx/GinytF6jFm772pdTPVWJe0cF2RiTOfhgIAAagzCcpBqRgQ8olLui0F5bzUF/SAi4BmkZ4yxA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/content": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       }
     },
     "@hapi/cryptiles": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.0.tgz",
+      "integrity": "sha512-CUypQJI2F3HaKZjwlky3KyLu7p0O4WJXNJj+2AZ0czqwkwQIz8j+btOkzA3OMar8WTntnCrDx0f92PzxEK+JlA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x"
+        "@hapi/boom": "^10.0.0"
       }
     },
     "@hapi/file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
       "dev": true
     },
     "@hapi/hapi": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
-      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.0.0.tgz",
+      "integrity": "sha512-gqGifa4X4nskhsmsgp3AwBq4LPIl7XOlnzpdWSogdc46Z4Hfy/WDjCcaO2yK84tQRmGSlg0nZowOfSCyeT0hRw==",
       "dev": true,
       "requires": {
-        "@hapi/accept": "^5.0.1",
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/bounce": "^2.0.0",
-        "@hapi/call": "^8.0.0",
-        "@hapi/catbox": "^11.1.1",
-        "@hapi/catbox-memory": "^5.0.0",
-        "@hapi/heavy": "^7.0.1",
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/mimos": "^6.0.0",
-        "@hapi/podium": "^4.1.1",
-        "@hapi/shot": "^5.0.5",
-        "@hapi/somever": "^3.0.0",
-        "@hapi/statehood": "^7.0.4",
-        "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "^5.1.1",
-        "@hapi/topo": "^5.0.0",
-        "@hapi/validate": "^1.1.1"
+        "@hapi/accept": "^6.0.0",
+        "@hapi/ammo": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/call": "^9.0.0",
+        "@hapi/catbox": "^12.0.0",
+        "@hapi/catbox-memory": "^6.0.0",
+        "@hapi/heavy": "^8.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/mimos": "^7.0.0",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/shot": "^6.0.0",
+        "@hapi/somever": "^4.1.0",
+        "@hapi/statehood": "^8.0.0",
+        "@hapi/subtext": "^8.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/topo": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        }
       }
     },
     "@hapi/heavy": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.0.tgz",
+      "integrity": "sha512-NpKo74mF66GSwYu31IZwp11/6NmaUYxHeMTKSky09XBs8fVbzQDP83856+l+Ji6wxGmUeg75itCu1ujvEF6mdA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/hoek": {
@@ -17249,116 +17482,180 @@
       "dev": true
     },
     "@hapi/iron": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.0.tgz",
+      "integrity": "sha512-NNXJP5fpeiTCPj/4OJG2PWBjWC0/V5D8YggS9RZeuBbfUUuTYE6TbdGqLUsCzIpPI54I8W5dhwEGbRv1CnWQtw==",
       "dev": true,
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/mimos": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
-      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.0.tgz",
+      "integrity": "sha512-ALORTrZrrBPOUX05rW4htNajoekEjQtUi1PB+17/3xs/hkdQ+gSEFbs5GdJihA49qWf7td3v4PgnvOe8mcf/jQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "mime-db": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "mime-db": "^1.52.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/nigel": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.0.tgz",
+      "integrity": "sha512-I9eq43BnSdz1BkvMpG7mFL7J+SIfn6DLNThuxFpIOAMUnkWbPgtcFP+HHrBAeoFkowfgQrr02vsIAkAPml4hvw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^9.0.4",
-        "@hapi/vise": "^4.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/vise": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/pez": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.0.0.tgz",
+      "integrity": "sha512-3bMmsvlqrVNqaNEe4JWLZVpJ40jXuQ3vDy1+fbhyJmuAdMCMCkWexsKc7fT+mu18pFIwJzlenjc4/VE3weTq7w==",
       "dev": true,
       "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/nigel": "4.x.x"
+        "@hapi/b64": "^6.0.0",
+        "@hapi/boom": "^10.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/nigel": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/podium": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
-      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.0.tgz",
+      "integrity": "sha512-SbhFdu8LOIscMS82Zsoj9abcllAqbK4qBgznzJ9yr+vS2j1EomJTukkhxb76Lml0BHCd4Hn79F+3EQg06kcf8g==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/shot": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
-      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.0.tgz",
+      "integrity": "sha512-RLGgzXy9GciJDunhY40NbVnLgYqp5gfBooZ2fOkAr4KbCEav/SJtYQS1N+knR7WFGzy8aooCR3XBUPI4ghHAkQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/validate": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/somever": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
-      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.0.tgz",
+      "integrity": "sha512-koNBYu7Jdcb7gaC4VcnU78rFxSlsYwuElm6NMznE0EEeznzJtvLLmDZX0SPX8kXWC/E7ONlE29HF/yiSOgWG1Q==",
       "dev": true,
       "requires": {
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "@hapi/statehood": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
-      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.0.0.tgz",
+      "integrity": "sha512-umQTPID7BwmqAv9Rx7yLtbTNzsYg4va96aLqKneb3mlBQG32uq4iOQZ6luwBVACDFhqU3C3ewhznhukN09ZkZQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/iron": "6.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bounce": "^3.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/iron": "^7.0.0",
+        "@hapi/validate": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/subtext": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
-      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.0.0.tgz",
+      "integrity": "sha512-fD+LY1U1SIUNHZJrNMIbuGl3CAd9JN8slljarFO4b8RrifkzjqbvdlZu/6iT6zlNM35GtDExf7hIepbUFUkT7A==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/content": "^5.0.2",
-        "@hapi/file": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/pez": "^5.0.1",
-        "@hapi/wreck": "17.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/pez": "^6.0.0",
+        "@hapi/wreck": "^18.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/teamwork": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
-      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
       "dev": true
     },
     "@hapi/topo": {
@@ -17371,33 +17668,66 @@
       }
     },
     "@hapi/validate": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.0.tgz",
+      "integrity": "sha512-w5m8MvBgqGndbMIB+AWmXTb8CLtF1DlIxbnbAHNAo7aFuNQuI1Ywc2e0zDLK5fbFXDoqRzNrHnC7JjNJ+hDigw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/hoek": "^10.0.0",
+        "@hapi/topo": "^6.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.0.tgz",
+          "integrity": "sha512-aorJvN1Q1n5xrZuA50Z4X6adI6VAM2NalIVm46ALL9LUvdoqhof3JPY69jdJH8asM3PsWr2SUVYzp57EqUP41A==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^10.0.0"
+          }
+        }
       }
     },
     "@hapi/vise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.0.tgz",
+      "integrity": "sha512-bz/PA7DHIvsd/2eoW7t9WpU8+k9pofZHppYEn1mCTOVnC/cGN3hCEYaoAe6BpoeJM72iJDKZEOWvQvfgCrmzxA==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "9.x.x"
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@hapi/wreck": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
-      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.0.tgz",
+      "integrity": "sha512-Yk9STxoM06Hjjq58cH0KFG91u9F2h9eVE72o8vUr3AfK80qt7I2POG5+cDGTEntbnvvzm0ERow2sjG3QsqCWUA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/hoek": "9.x.x"
+        "@hapi/boom": "^10.0.0",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^10.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw==",
+          "dev": true
+        }
       }
     },
     "@ioredis/commands": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@elastic/elasticsearch": "^8.2.1",
     "@elastic/elasticsearch-canary": "^8.2.0-canary.2",
     "@fastify/formbody": "^7.0.1",
-    "@hapi/hapi": "^20.1.2",
+    "@hapi/hapi": "^21.0.0",
     "@koa/router": "^12.0.0",
     "@types/node": "^18.0.1",
     "@types/pino": "^6.3.8",

--- a/test/_is_hapi_incompat.js
+++ b/test/_is_hapi_incompat.js
@@ -30,6 +30,10 @@ function isHapiIncompat (moduleName) {
   if (semver.gte(process.version, '16.0.0') && semver.lt(hapiVersion, '20.1.2')) {
     return true
   }
+  // hapi 21+ requires Node.js 14 or higher.
+  if (semver.lt(process.version, '14.0.0') && semver.gte(hapiVersion, '21.0.0')) {
+    return true
+  }
 
   // hapi does not work on early versions of Node.js 10 because of
   // https://github.com/nodejs/node/issues/20516

--- a/test/_is_hapi_incompat.js
+++ b/test/_is_hapi_incompat.js
@@ -30,8 +30,8 @@ function isHapiIncompat (moduleName) {
   if (semver.gte(process.version, '16.0.0') && semver.lt(hapiVersion, '20.1.2')) {
     return true
   }
-  // hapi 21+ requires Node.js 14 or higher.
-  if (semver.lt(process.version, '14.0.0') && semver.gte(hapiVersion, '21.0.0')) {
+  // hapi 21+ requires Node.js 14.10.0 or higher.
+  if (semver.lt(process.version, '14.10.0') && semver.gte(hapiVersion, '21.0.0')) {
     return true
   }
 


### PR DESCRIPTION
Our instrumentation already worked with hapi v21, but the tests
would attempt to use node v12 (which hapi v21 dropped support for).
