### PR TITLE
test: fix nightly tests to properly skip prerelease node versions >=18

### DIFF
--- a/test/_is_restify_incompat.js
+++ b/test/_is_restify_incompat.js
@@ -29,7 +29,7 @@ function isRestifyIncompat () {
   const restifyVer = require('restify/package.json').version
   const msg = `restify@${restifyVer} is incompatible with node@${nodeVer}`
 
-  if (semver.satisfies(restifyVer, '<10.0.0') && semver.satisfies(nodeVer, '>=18.0.0')) {
+  if (semver.satisfies(restifyVer, '<10.0.0') && semver.satisfies(nodeVer, '>=18.0.0', { includePrerelease: true })) {
     return msg
   }
   if (semver.satisfies(restifyVer, '>=9.0.0') && semver.satisfies(nodeVer, '<14.18.0')) {


### PR DESCRIPTION
This is a follow-on to #3031 to handle testing of Node.js nightly
builds. These have a prerelease version, e.g.
"v20.0.0-nightly202211186f9175deaa", and therefore need the
includePrelease semver option for gte comparison.

Refs: #3031
