### PR TITLE
feat: capture HTTP context for API Gateway-triggered Lambda functions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,26 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+* Capture HTTP context (status code, headers, etc.) on transactions (and
+  captured errors) for Lambda functions triggered by API Gateway.
+  ({issues}2419[#2419])
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+
 [[release-notes-3.40.1]]
 ==== 3.40.1 2022/11/15
 

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -166,7 +166,7 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
   }
   trans.type = 'request'
   trans.setDefaultName(name)
-  trans.req = pseudoReq // Used parsers.getContextFromRequest() context on transaction and errors.
+  trans.req = pseudoReq // Used by parsers.getContextFromRequest() for adding context to transaction and errors.
 
   trans.setFaas(getFaasData(context, faasId, isColdStart,
     'http', requestContext.requestId))

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -10,6 +10,7 @@ const constants = require('./constants')
 const shimmer = require('./instrumentation/shimmer')
 const fs = require('fs')
 const path = require('path')
+const querystring = require('querystring')
 
 const { MAX_MESSAGES_PROCESSED_FOR_TRACE_CONTEXT } = require('./constants')
 
@@ -113,6 +114,7 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
   const requestContext = event.requestContext
 
   let name
+  let pseudoReq
   if (requestContext.http) { // 2.0
     if (agent._conf.usePathAsTransactionName) {
       name = `${requestContext.http.method} ${requestContext.http.path}`
@@ -130,15 +132,41 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
       }
       name = `${requestContext.http.method} /${requestContext.stage}${routeKeyPath}`
     }
-  } else { // 1.0
+    pseudoReq = {
+      httpVersion: (requestContext.http.protocol
+        ? requestContext.http.protocol.split('/')[1] // 'HTTP/1.1' -> '1.1'
+        : undefined),
+      method: requestContext.http.method,
+      url: event.rawPath + (event.rawQueryString ? '?' + event.rawQueryString : ''),
+      headers: event.normedHeaders,
+      socket: { remoteAddress: requestContext.http.sourceIp },
+      body: event.body
+    }
+  } else { // payload version format 1.0
     if (agent._conf.usePathAsTransactionName) {
       name = `${requestContext.httpMethod} ${requestContext.path}`
     } else {
       name = `${requestContext.httpMethod} /${requestContext.stage}${requestContext.resourcePath}`
     }
+    pseudoReq = {
+      httpVersion: (requestContext.protocol
+        ? requestContext.protocol.split('/')[1] // 'HTTP/1.1' -> '1.1'
+        : undefined),
+      method: requestContext.httpMethod,
+      url: requestContext.path + (event.queryStringParameters
+        ? '?' + querystring.encode(event.queryStringParameters)
+        : ''),
+      headers: event.normedHeaders,
+      socket: { remoteAddress: requestContext.identity && requestContext.identity.sourceIp },
+      // Limitation: Note that `getContextFromRequest` does *not* use this body,
+      // because API Gateway payload format 1.0 does not include the
+      // Content-Length header from the original request.
+      body: event.body
+    }
   }
   trans.type = 'request'
   trans.setDefaultName(name)
+  trans.req = pseudoReq // Used parsers.getContextFromRequest() context on transaction and errors.
 
   trans.setFaas(getFaasData(context, faasId, isColdStart,
     'http', requestContext.requestId))
@@ -386,11 +414,17 @@ function elasticApmAwsLambda (agent) {
       // Look for trace-context info in headers or messageAttributes.
       let traceparent
       let tracestate
-      let normedHeaders
       if (triggerType === TRIGGER_API_GATEWAY && event.headers) {
-        normedHeaders = lowerCaseObjectKeys(event.headers)
-        traceparent = normedHeaders.traceparent || normedHeaders['elastic-apm-traceparent']
-        tracestate = normedHeaders.tracestate
+        // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+        // says "Header names are lowercased." However, that isn't the case for
+        // payload format version 1.0. We need lowercased headers for processing.
+        if (!event.requestContext.http) { // 1.0
+          event.normedHeaders = lowerCaseObjectKeys(event.headers)
+        } else {
+          event.normedHeaders = event.headers
+        }
+        traceparent = event.normedHeaders.traceparent || event.normedHeaders['elastic-apm-traceparent']
+        tracestate = event.normedHeaders.tracestate
       }
 
       // Start the transaction and set some possibly trigger-specific data.

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -194,6 +194,48 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
   trans.setCloudContext(cloudContext)
 }
 
+/**
+ * Set transaction data for HTTP-y triggers -- API Gateway -- from the
+ * Lambda function result.
+ */
+function setTransDataFromHttpyResult (err, result, trans, event, triggerType) {
+  if (err) {
+    trans.result = 'HTTP 5xx'
+  } else if (result && result.statusCode) {
+    trans.result = 'HTTP ' + result.statusCode.toString()[0] + 'xx'
+  } else {
+    trans.result = constants.RESULT_SUCCESS
+  }
+
+  // This doc defines the format of API Gateway-triggered responses, from which
+  // we can infer `transaction.context.response` values.
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response
+  if (err) {
+    trans.res = {
+      statusCode: 500
+    }
+  } else if (event.requestContext.http) { // payload format version 2.0
+    if (result && result.statusCode) {
+      trans.res = {
+        statusCode: result.statusCode,
+        headers: result.headers
+      }
+    } else {
+      trans.res = {
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' }
+      }
+    }
+  } else { // payload format version 1.0
+    if (result && result.statusCode) {
+      trans.res = {
+        statusCode: result.statusCode,
+        headers: result.headers
+      }
+    }
+  }
+}
+
 function setSqsData (agent, trans, event, context, faasId, isColdStart) {
   const record = event && event.Records && event.Records[0]
   const eventSourceARN = record.eventSourceARN ? record.eventSourceARN : ''
@@ -310,6 +352,14 @@ function elasticApmAwsLambda (agent) {
   function endAndFlushTransaction (err, result, trans, event, context, triggerType, cb) {
     log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: fn end')
 
+    if (triggerType === TRIGGER_API_GATEWAY) {
+      setTransDataFromHttpyResult(err, result, trans, event, triggerType)
+    } else if (err) {
+      trans.result = constants.RESULT_FAILURE
+    } else {
+      trans.result = constants.RESULT_SUCCESS
+    }
+
     if (err) {
       // Capture the error before trans.end() so it associates with the
       // current trans.  `skipOutcome` to avoid setting outcome on a possible
@@ -317,18 +367,8 @@ function elasticApmAwsLambda (agent) {
       // sub-span.
       agent.captureError(err, { skipOutcome: true })
       trans.setOutcome(constants.OUTCOME_FAILURE)
-      if (triggerType === TRIGGER_API_GATEWAY) {
-        trans.result = 'HTTP 5xx'
-      } else {
-        trans.result = constants.RESULT_FAILURE
-      }
     } else {
       trans.setOutcome(constants.OUTCOME_SUCCESS)
-      if (triggerType === TRIGGER_API_GATEWAY && result && result.statusCode) {
-        trans.result = 'HTTP ' + result.statusCode.toString()[0] + 'xx'
-      } else {
-        trans.result = constants.RESULT_SUCCESS
-      }
     }
 
     trans.end()

--- a/test/lambda/fixtures/aws_api_http_test_data.json
+++ b/test/lambda/fixtures/aws_api_http_test_data.json
@@ -2,10 +2,11 @@
     "version": "2.0",
     "routeKey": "ANY /the-function-name",
     "rawPath": "/default/the-function-name",
-    "rawQueryString": "",
+    "rawQueryString": "q=foo",
     "headers": {
       "accept": "*/*",
-      "content-length": "0",
+      "content-length": "13",
+      "content-type": "application/json",
       "host": "21mj4tsk90.execute-api.us-west-2.amazonaws.com",
       "user-agent": "curl/7.64.1",
       "x-amzn-trace-id": "Root=1-611598fd-16b2bd060ca70cab7eb87c47",
@@ -13,13 +14,14 @@
       "x-forwarded-port": "443",
       "x-forwarded-proto": "https"
     },
+    "queryStringParameters": { "q": "huh" },
     "requestContext": {
       "accountId": "000000000000",
       "apiId": "21mj4tsk90",
       "domainName": "21mj4tsk90.execute-api.us-west-2.amazonaws.com",
       "domainPrefix": "21mj4tsk90",
       "http": {
-        "method": "GET",
+        "method": "POST",
         "path": "/default/the-function-name",
         "protocol": "HTTP/1.1",
         "sourceIp": "67.171.184.49",
@@ -31,5 +33,6 @@
       "time": "12/Aug/2021:21:56:13 +0000",
       "timeEpoch": 1628805373222
     },
+    "body": "{\"foo\":\"bar\"}",
     "isBase64Encoded": false
 }

--- a/test/lambda/fixtures/aws_api_rest_test_data.json
+++ b/test/lambda/fixtures/aws_api_rest_test_data.json
@@ -78,8 +78,8 @@
             "https"
         ]
     },
-    "queryStringParameters": null,
-    "multiValueQueryStringParameters": null,
+    "queryStringParameters": { "q": "myquery" },
+    "multiValueQueryStringParameters": { "q": [ "myquery" ] },
     "pathParameters": null,
     "stageVariables": null,
     "requestContext": {

--- a/test/lambda/trans-setDefaultName.test.js
+++ b/test/lambda/trans-setDefaultName.test.js
@@ -87,6 +87,7 @@ tape.test('lambda instrumentation does not break trans.setDefaultName', function
         cb(null, 'hi')
       })
 
+      server.clear()
       lambdaLocal.execute({
         event: eventCase.event,
         lambdaFunc: {

--- a/test/lambda/transaction.test.js
+++ b/test/lambda/transaction.test.js
@@ -54,7 +54,7 @@ tape.test('transaction data TRIGGER_API_GATEWAY v2', function (t) {
   t.strictEquals(transaction._faas.trigger.type, 'http', 'execution value set')
   t.strictEquals(transaction._faas.trigger.request_id, event.requestContext.requestId, 'execution value set')
   t.strictEquals(transaction.type, 'request', 'transaction type set')
-  t.strictEquals(transaction.name, 'GET /default/the-function-name', 'transaction named correctly')
+  t.strictEquals(transaction.name, 'POST /default/the-function-name', 'transaction named correctly')
   t.strictEquals(transaction._cloud.origin.provider, 'aws', 'cloud origin provider set correctly')
   t.strictEquals(transaction._service.origin.name, '21mj4tsk90.execute-api.us-west-2.amazonaws.com', 'service origin name set correctly')
   t.strictEquals(transaction._service.origin.id, '21mj4tsk90', 'service origin id set correctly')

--- a/test/lambda/transaction2.test.js
+++ b/test/lambda/transaction2.test.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Test "transaction" objects created for Lambda instrumentation.
+//
+// (This is similar to "transaction.test.js", but uses the real Agent, not the
+// "AgentMock". The mock doesn't fully test the "transaction" intake event
+// object creation path.)
+
+const lambdaLocal = require('lambda-local')
+const tape = require('tape')
+
+const apm = require('../../')
+const { MockAPMServer } = require('../_mock_apm_server')
+
+// Setup env for both apm.start() and lambdaLocal.execute().
+process.env.AWS_LAMBDA_FUNCTION_NAME = 'fixture-function-name'
+// Set these values to have stable data from lambdaLocal.execute().
+process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs14.x'
+process.env.AWS_REGION = 'us-east-1'
+process.env.AWS_ACCOUNT_ID = '123456789012'
+// A lambda-local limitation is that it doesn't set AWS_LAMBDA_LOG_GROUP_NAME
+// and AWS_LAMBDA_LOG_STREAM_NAME (per
+// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html).
+process.env.AWS_LAMBDA_LOG_GROUP_NAME = `/aws/lambda/${process.env.AWS_LAMBDA_FUNCTION_NAME}`
+process.env.AWS_LAMBDA_LOG_STREAM_NAME = '2021/11/01/[1.0]lambda/e7b05091b39b4aa2aef19efe4d262e79'
+// Avoid the lambda-local loading AWS credentials and session info from
+// a configured real AWS profile and possibly emitting this warning:
+//    warning Using both auth systems: aws_access_key/id and secret_access_token!
+process.env.AWS_PROFILE = 'fake'
+
+function loadFixture (file) {
+  return require('./fixtures/' + file)
+}
+
+tape.test('lambda transactions', function (suite) {
+  let server
+  let serverUrl
+
+  suite.test('setup', function (t) {
+    server = new MockAPMServer()
+    server.start(function (serverUrl_) {
+      serverUrl = serverUrl_
+      t.comment('mock APM serverUrl: ' + serverUrl)
+      apm.start({
+        serverUrl,
+        logLevel: 'off',
+        captureExceptions: false,
+        captureBody: 'all'
+      })
+      t.comment('APM agent started')
+      t.end()
+    })
+  })
+
+  // Test HTTP context -- `transaction.context.{request,response}` -- for
+  // some event types.
+  const httpContextCases = [
+    {
+      name: 'API Gateway (payload format version 1.0)',
+      event: loadFixture('aws_api_rest_test_data.json'),
+      checkApmEvents: (t, events) => {
+        const trans = events[1].transaction
+        t.deepEqual(trans.context.request, {
+          http_version: '1.1',
+          method: 'GET',
+          url: {
+            raw: '/dev/fetch_all?q=myquery',
+            protocol: 'https:',
+            hostname: '02plqthge2.execute-api.us-east-1.amazonaws.com',
+            port: '443',
+            pathname: '/dev/fetch_all',
+            search: '?q=myquery',
+            full: 'https://02plqthge2.execute-api.us-east-1.amazonaws.com:443/dev/fetch_all?q=myquery'
+          },
+          headers: {
+            accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'accept-encoding': 'gzip, deflate, br',
+            'accept-language': 'en-US,en;q=0.5',
+            'cloudfront-forwarded-proto': 'https',
+            'cloudfront-is-desktop-viewer': 'true',
+            'cloudfront-is-mobile-viewer': 'false',
+            'cloudfront-is-smarttv-viewer': 'false',
+            'cloudfront-is-tablet-viewer': 'false',
+            'cloudfront-viewer-country': 'US',
+            host: '02plqthge2.execute-api.us-east-1.amazonaws.com',
+            'upgrade-insecure-requests': '1',
+            'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0',
+            via: '2.0 969f35f01b6eddd92239a3e818fc1e0d.cloudfront.net (CloudFront)',
+            'x-amz-cf-id': 'eDbpfDwO-CRYymEFLkW6CBCsU_H_PS8R93_us53QWvXWLS45v3NvQw==',
+            'x-amzn-trace-id': 'Root=1-5e502af4-fd0c1c6fdc164e1d6361183b',
+            'x-forwarded-for': '76.76.241.57, 52.46.47.139',
+            'x-forwarded-port': '443',
+            'x-forwarded-proto': 'https'
+          },
+          socket: { remote_address: '76.76.241.57' }
+        }, 'transaction.context.request')
+      }
+    },
+    {
+      // skip: true, // XXX
+      name: 'API Gateway (payload format version 2.0)',
+      event: loadFixture('aws_api_http_test_data.json'),
+      checkApmEvents: (t, events) => {
+        const trans = events[1].transaction
+        t.deepEqual(trans.context.request, {
+          http_version: '1.1',
+          method: 'POST',
+          url: {
+            raw: '/default/the-function-name?q=foo',
+            protocol: 'https:',
+            hostname: '21mj4tsk90.execute-api.us-west-2.amazonaws.com',
+            port: '443',
+            pathname: '/default/the-function-name',
+            search: '?q=foo',
+            full: 'https://21mj4tsk90.execute-api.us-west-2.amazonaws.com:443/default/the-function-name?q=foo'
+          },
+          headers: {
+            accept: '*/*',
+            'content-length': '13',
+            'content-type': 'application/json',
+            host: '21mj4tsk90.execute-api.us-west-2.amazonaws.com',
+            'user-agent': 'curl/7.64.1',
+            'x-amzn-trace-id': 'Root=1-611598fd-16b2bd060ca70cab7eb87c47',
+            'x-forwarded-for': '67.171.184.49',
+            'x-forwarded-port': '443',
+            'x-forwarded-proto': 'https'
+          },
+          socket: { remote_address: '67.171.184.49' },
+          body: '{"foo":"bar"}'
+        }, 'transaction.context.request')
+      }
+    },
+    {
+      name: 'API Gateway event, handler returns error, captured error should have HTTP context',
+      event: loadFixture('aws_api_http_test_data.json'),
+      handler: (_event, _context, cb) => {
+        cb(new Error('boom'))
+      },
+      checkApmEvents: (t, events) => {
+        const trans = events[1].transaction
+        const error = events[2].error
+        t.equal(trans.outcome, 'failure', 'transaction.outcome')
+        t.equal(error.transaction_id, trans.id, 'error.transaction_id')
+        t.ok(error.context.request, 'has error.context.request')
+      }
+    }
+  ]
+  httpContextCases.forEach(c => {
+    suite.test(c.name, { skip: c.skip || false }, function (t) {
+      const handler = c.handler || (
+        (_event, _context, cb) => {
+          cb(null, 'hi')
+        }
+      )
+      const wrappedHandler = apm.lambda(handler)
+
+      server.clear()
+      lambdaLocal.execute({
+        event: c.event,
+        lambdaFunc: {
+          [process.env.AWS_LAMBDA_FUNCTION_NAME]: wrappedHandler
+        },
+        lambdaHandler: process.env.AWS_LAMBDA_FUNCTION_NAME,
+        timeoutMs: 3000,
+        verboseLevel: 0,
+        callback: function (_err, _result) {
+          c.checkApmEvents(t, server.events)
+          t.end()
+        }
+      })
+    })
+  })
+
+  suite.test('teardown', function (t) {
+    server.close()
+    t.end()
+    apm.destroy()
+  })
+
+  suite.end()
+})


### PR DESCRIPTION
https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-aws-lambda.md#api-gateway--lambda-urls
> The agent should use the information in the request and response
> objects to fill the HTTP context (context.request and context.response)
> fields in the same way it is done for HTTP transactions.

Closes: #2419

# Checklist

- [x] `context.response` as well (initial commit just has `context.request` handling
- [x] changelog entry