### PR TITLE
Support publishing a snapshot build for each commit to main

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -252,11 +252,13 @@ pipeline {
     }
 
     /**
-    Daily snapshots.
+    Publish a snapshot. A "snapshot" is a packaging of the latest *unreleased* APM agent,
+    published to a known GCS bucket for use in edge demo/test environments.
     */
-    stage('Daily snapshots') {
+    stage('Publish snapshot') {
       options { skipDefaultCheckout() }
       environment {
+        BUCKET_NAME = 'oblt-artifacts'
         DOCKER_REGISTRY = 'docker.elastic.co'
         DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
         GCS_ACCOUNT_SECRET = 'secret/observability-team/ci/snapshoty'
@@ -266,11 +268,11 @@ pipeline {
         withGithubNotify(context: 'Publish snapshot packages') {
           deleteDir()
           unstash name: 'source'
-          withNodeJSEnv(version: readFile(file: "${BASE_DIR}/.nvmrc")?.trim()) {
+          withNodeJSEnv(version: env.BUILD_NODE_VERSION) {
             dir(env.BASE_DIR) {
-              sh(label: 'generate tarball', script: 'npm run package:tarball')
+              sh(label: 'package snapshot', script: 'npm run package:snapshot')
               snapshoty(
-                bucket: 'obtl-artifacts',
+                bucket: env.BUCKET_NAME,
                 gcsAccountSecret: env.GCS_ACCOUNT_SECRET,
                 dockerRegistry: env.DOCKER_REGISTRY,
                 dockerSecret: env.DOCKER_REGISTRY_SECRET

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -250,6 +250,37 @@ pipeline {
         }
       }
     }
+
+    /**
+    Daily snapshots.
+    */
+    stage('Daily snapshots') {
+      options { skipDefaultCheckout() }
+      environment {
+        DOCKER_REGISTRY = 'docker.elastic.co'
+        DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
+        GCS_ACCOUNT_SECRET = 'secret/observability-team/ci/snapshoty'
+      }
+      when { branch 'main' }
+      steps {
+        withGithubNotify(context: 'Publish snapshot packages') {
+          deleteDir()
+          unstash name: 'source'
+          withNodeJSEnv(version: readFile(file: "${BASE_DIR}/.nvmrc")?.trim()) {
+            dir(env.BASE_DIR) {
+              sh(label: 'generate tarball', script: 'npm run package:tarball')
+              snapshoty(
+                bucket: 'obtl-artifacts',
+                gcsAccountSecret: env.GCS_ACCOUNT_SECRET,
+                dockerRegistry: env.DOCKER_REGISTRY,
+                dockerSecret: env.DOCKER_REGISTRY_SECRET
+              )
+            }
+          }
+        }
+      }
+    }
+
     stage('Release') {
       options { skipDefaultCheckout() }
       when {

--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -19,7 +19,7 @@ account:
 # List of artifacts
 artifacts:
   # Path to use for artifacts discovery 
-  - path: './build/dist'
+  - path: './build/snapshot'
     # Files pattern to match
     files_pattern: 'elastic-apm-node-(?P<app_version>\d+\.\d+\.\d+)\.tgz'
     # File layout on GCS bucket

--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -1,0 +1,36 @@
+---
+
+# Version of configuration to use
+version: '1.0'
+
+# You can define a Google Cloud Account to use
+account:
+  # Project id of the service account
+  project: '${GCS_PROJECT}'
+  # Private key id of the service account
+  private_key_id: '${GCS_PRIVATE_KEY_ID}'
+  # Private key of the service account
+  private_key: '${GCS_PRIVATE_KEY}'
+  # Email of the service account
+  client_email: '${GCS_CLIENT_EMAIL}'
+  # URI token
+  token_uri: 'https://oauth2.googleapis.com/token'
+
+# List of artifacts
+artifacts:
+  # Path to use for artifacts discovery 
+  - path: './build/dist'
+    # Files pattern to match
+    files_pattern: 'elastic-apm-node-(?P<app_version>\d+\.\d+\.\d+)\.tgz'
+    # File layout on GCS bucket
+    output_pattern: '{project}/{jenkins_branch_name}/elastic-apm-node-{app_version}-{jenkins_git_commit_short}.tgz'
+    # List of metadata processors to use.
+    metadata:
+      # Define static custom metadata
+      - name: 'custom'
+        data:
+          project: 'apm-agent-nodejs'
+      # Add git metadata
+      - name: 'git'
+      # Add jenkins metadata
+      - name: 'jenkins'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "docker:start": "docker-compose -f ./test/docker-compose.yml up -d",
     "docker:stop": "docker-compose -f ./test/docker-compose.yml down",
     "docker:clean": "./test/script/docker/cleanup.sh",
-    "docker:dev": "docker-compose -f ./dev-utils/docker-compose.yml run --workdir=/agent nodejs-agent"
+    "docker:dev": "docker-compose -f ./dev-utils/docker-compose.yml run --workdir=/agent nodejs-agent",
+    "package:tarball": "mkdir -p ./build/dist && npm pack --pack-destination ./build/dist"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "docker:stop": "docker-compose -f ./test/docker-compose.yml down",
     "docker:clean": "./test/script/docker/cleanup.sh",
     "docker:dev": "docker-compose -f ./dev-utils/docker-compose.yml run --workdir=/agent nodejs-agent",
-    "package:tarball": "mkdir -p ./build/dist && npm pack --pack-destination ./build/dist"
+    "package:snapshot": "rm -rf ./build/snapshot && mkdir -p ./build/snapshot && npm pack --pack-destination ./build/snapshot"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

### Description

* Add support for daily snapshots.

### Checklist

- [x] Implement code


Validation: https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/PR-3050/11/
