### PR TITLE
chore: mark Lambda layer as supporting the new nodejs18.x lambda runtime

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -58,7 +58,7 @@ publish: validate-layer-name validate-aws-default-region
 		--layer-name "$(ELASTIC_LAYER_NAME)" \
 		--description "AWS Lambda Extension Layer for the Elastic APM Node.js Agent" \
 		--license "Apache-2.0" \
-		--compatible-runtimes nodejs16.x nodejs14.x nodejs12.x nodejs10.x \
+		--compatible-runtimes nodejs18.x nodejs16.x nodejs14.x nodejs12.x nodejs10.x \
 		--zip-file "fileb://./$(AWS_FOLDER)/elastic-apm-node-lambda-layer-$(BRANCH_NAME).zip"
 
 # Grant public access to the given LAYER in the given AWS region

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,9 @@ Notes:
 [float]
 ===== Chores
 
+* Mark the published Lambda layer as supporting the recently released
+  "nodejs18.x" Lambda Runtime (`--compatible-runtimes`).
+
 
 [[release-notes-3.40.1]]
 ==== 3.40.1 2022/11/15


### PR DESCRIPTION
This is just about adding "nodejs18.x" to the advisory "compatible runtimes" for the published layers. The previous images supported the nodejs18.x runtime just fine already.

### Checklist

- [x] Implement code
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
