### PR TITLE
character encoding when reading version from modules giving error resolved

### DIFF
--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -291,7 +291,7 @@ Instrumentation.prototype._startHook = function () {
     if (!isHandlingLambda && basedir) {
       pkg = path.join(basedir, 'package.json')
       try {
-        version = JSON.parse(fs.readFileSync(pkg)).version
+        version = JSON.parse(fs.readFileSync(pkg, 'utf8')).version
       } catch (e) {
         self._agent.logger.debug('could not shim %s module: %s', name, e.message)
         return exports


### PR DESCRIPTION
<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
