### PR TITLE
fix: span compression bug where a buffered span would not be sent when an incompressible sibling ended

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "license-header/header": [ "error", "./dev-utils/license-header.js" ]
   },
   "ignorePatterns": [
+    "/*.example.js", // a pattern for uncommited local dev files to avoid linting
     "/.nyc_output",
     "/build",
     "node_modules",

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,25 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix a bug in span compression with sending spans that were buffered for
+  possible compression. Before this fix a compressible span could be sent
+  *twice* or not sent at all. ({pull}3076[#3076])
+
+[float]
+===== Chores
+
+
 [[release-notes-3.41.0]]
 ==== 3.41.0 2022/12/12
 

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -417,18 +417,19 @@ Instrumentation.prototype.addEndedSpan = function (span) {
       span.setBufferedSpan(null)
     }
 
-    if (!span.isCompressionEligible() || span.getParentSpan().ended) {
-      const buffered = span.getParentSpan().getBufferedSpan()
+    const parentSpan = span.getParentSpan()
+    if ((parentSpan && parentSpan.ended) || !span.isCompressionEligible()) {
+      const buffered = parentSpan && parentSpan.getBufferedSpan()
       if (buffered) {
         this._encodeAndSendSpan(buffered)
-        span.getParentSpan().setBufferedSpan(null)
+        parentSpan.setBufferedSpan(null)
       }
       this._encodeAndSendSpan(span)
-    } else if (!span.getParentSpan().getBufferedSpan()) {
+    } else if (!parentSpan.getBufferedSpan()) {
       // span is compressible and there's nothing buffered
       // add to buffer, move on
       span.getParentSpan().setBufferedSpan(span)
-    } else if (!span.getParentSpan().getBufferedSpan().tryToCompress(span)) {
+    } else if (!parentSpan.getBufferedSpan().tryToCompress(span)) {
       // we could not compress span so SEND bufferend span
       // and buffer the span we could not compress
       this._encodeAndSendSpan(span.getParentSpan().getBufferedSpan())

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -414,13 +414,14 @@ Instrumentation.prototype.addEndedSpan = function (span) {
     // if I have ended and I have something buffered, send that buffered thing
     if (span.getBufferedSpan()) {
       this._encodeAndSendSpan(span.getBufferedSpan())
+      span.setBufferedSpan(null)
     }
 
     if (!span.isCompressionEligible() || span.getParentSpan().ended) {
-      const buffered = span.getBufferedSpan()
+      const buffered = span.getParentSpan().getBufferedSpan()
       if (buffered) {
         this._encodeAndSendSpan(buffered)
-        span.setBufferedSpan(null)
+        span.getParentSpan().setBufferedSpan(null)
       }
       this._encodeAndSendSpan(span)
     } else if (!span.getParentSpan().getBufferedSpan()) {

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -428,12 +428,12 @@ Instrumentation.prototype.addEndedSpan = function (span) {
     } else if (!parentSpan.getBufferedSpan()) {
       // span is compressible and there's nothing buffered
       // add to buffer, move on
-      span.getParentSpan().setBufferedSpan(span)
+      parentSpan.setBufferedSpan(span)
     } else if (!parentSpan.getBufferedSpan().tryToCompress(span)) {
       // we could not compress span so SEND bufferend span
       // and buffer the span we could not compress
-      this._encodeAndSendSpan(span.getParentSpan().getBufferedSpan())
-      span.getParentSpan().setBufferedSpan(span)
+      this._encodeAndSendSpan(parentSpan.getBufferedSpan())
+      parentSpan.setBufferedSpan(span)
     }
   }
 }


### PR DESCRIPTION
https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-compress.md#span-buffering says:
> A buffered span gets reported when
>  1. its parent ends
>  2. a non-compressible sibling ends

Before this change, case 2 was not being handled. Further, a possibly
buffered span on the ending sibling would incorrectly get sent *twice*.
The scenario is as follows:
```
   trans t0
     span s1: _bufferdSpan=s2
       span s2: ended, compressible -> buffered on s1
       span s3: incompressible, _bufferdSpan=s4
         span s4: ended, compressible -> buffered on s3
```
What happens when s3 ends? We expect:
- s4 is encoded and sent
- s2 is encoded and sent
- s3 is encoded and sent

Before this change the agent would send: s4, s4, s3

Refs: https://discuss.elastic.co/t/apm-agent-send-duplicate-record-in-mysql/321440
