### PR TITLE
3.41.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,23 +32,15 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
+[[release-notes-3.41.1]]
+==== 3.41.1 2022/12/21
 
 [float]
 ===== Bug fixes
 
 * Fix a bug in span compression with sending spans that were buffered for
-  possible compression. Before this fix a compressible span could be sent
-  *twice* or not sent at all. ({pull}3076[#3076])
-
-[float]
-===== Chores
+  possible compression. Before this fix, in some cases a compressible span could
+  be sent *twice* or not sent at all. ({pull}3076[#3076])
 
 
 [[release-notes-3.41.0]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1259,7 +1259,7 @@ views.
 * *Default:* `true`
 * *Env:* `ELASTIC_APM_SPAN_COMPRESSION_ENABLED`
 
-Setting this option to false will disable the span compression feature. Span compression reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that some information, such as DB statements of all the compressed spans, will not be collected.
+Setting this option to false will disable the https://www.elastic.co/guide/en/apm/guide/current/span-compression.html[Span compression] feature. Span compression reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that some information, such as DB statements of all the compressed spans, will not be collected.
 
 Example usage:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.41.0",
+  "version": "3.41.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.41.0",
+      "version": "3.41.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.41.0",
+  "version": "3.41.1",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Release 3.41.1.
The recently fixed https://github.com/elastic/apm-agent-nodejs/pull/3076 is a significant enough bug for a new release.