### PR TITLE
fix bitrot.js dev-util to work for Next.js versions

### DIFF
--- a/dev-utils/bitrot.js
+++ b/dev-utils/bitrot.js
@@ -208,7 +208,6 @@ function loadSupportedDoc () {
       results.push({ name: match[1], versions: row[1] })
     }
   })
-  console.log('XXX results: ', results)
   return results
 }
 


### PR DESCRIPTION
- The script was mistakenly assuming that the anchor in the "Frameworks"
  doc table, "nextjs", matched the npm package name, "next".
- Also, it wasn't looking at the separate .tav.yml in the Next.js test
  dir.
