### PR TITLE
fix TAV test failure with @elastic/elasticsearch@8.6.0 and node v14

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -48,23 +48,31 @@ function culpritFromStacktrace (frames) {
 // or on Windows:
 //    node_modules\@myorg\mymodule\lib\subpath\index.js
 //                 ^^^^^^^^^^^^^^^
-let SEP = path.sep
-if (SEP === '\\') {
-  SEP = '\\' + SEP // Escape this for use in a regex.
-}
-const MODULE_NAME_REGEX = new RegExp(`node_modules${SEP}([^${SEP}]*)(${SEP}([^${SEP}]*))?`)
 function _moduleNameFromFrames (frames) {
-  if (frames.length === 0) return
-  var frame = frames[0]
-  if (!frame.library_frame) return
-  var match = frame.filename.match(MODULE_NAME_REGEX)
-  if (!match) return
-  var moduleName = match[1]
-  if (moduleName && moduleName[0] === '@' && match[3]) {
-    // Normalize the module name separator to '/', even on Windows.
-    moduleName += '/' + match[3]
+  if (frames.length === 0) {
+    return null
   }
-  return moduleName
+  var frame = frames[0]
+  if (!frame.library_frame) {
+    return null
+  }
+  var idx = frame.filename.lastIndexOf('node_modules' + path.sep)
+  if (idx === -1) {
+    return null
+  }
+  var parts = frame.filename.slice(idx).split(path.sep)
+  if (!parts[1]) {
+    return null
+  } else if (parts[1].startsWith('@')) {
+    if (!parts[2]) { // node_modules/@foo
+      return null
+    } else {
+      // Normalize the module name separator to '/', even on Windows.
+      return parts[1] + '/' + parts[2]
+    }
+  } else {
+    return parts[1]
+  }
 }
 
 // Gather properties from `err` to be used for `error.exception.attributes`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.8.4",
         "@babel/preset-env": "^7.8.4",
-        "@elastic/elasticsearch": "^8.2.1",
+        "@elastic/elasticsearch": "^8.6.0",
         "@elastic/elasticsearch-canary": "^8.2.0-canary.2",
         "@fastify/formbody": "^7.0.1",
         "@hapi/hapi": "^21.0.0",
@@ -2286,12 +2286,12 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz",
-      "integrity": "sha512-iOgr/3zQi84WmPhAplnK2W13R89VXD2oc6WhlQmH3bARQwmI+De23ZJKBEn7bvuG/AHMAqasPXX7uJIiJa2MqQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.6.0.tgz",
+      "integrity": "sha512-mN5EbbgSp1rfRmQ/5Hv7jqAK8xhGJxCg7G84xje8hSefE59P+HPPCv/+DgesCUSJdZpwXIo0DwOWHfHvktxxLw==",
       "dev": true,
       "dependencies": {
-        "@elastic/transport": "^8.2.0",
+        "@elastic/transport": "^8.3.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2312,9 +2312,9 @@
       }
     },
     "node_modules/@elastic/transport": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.2.0.tgz",
-      "integrity": "sha512-H/HmefMNQfLiBSVTmNExu2lYs5EzwipUnQB53WLr17RCTDaQX0oOLHcWpDsbKQSRhDAMPPzp5YZsZMJxuxPh7A==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.1.tgz",
+      "integrity": "sha512-jv/Yp2VLvv5tSMEOF8iGrtL2YsYHbpf4s+nDsItxUTLFTzuJGpnsB/xBlfsoT2kAYEnWHiSJuqrbRcpXEI/SEQ==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -2322,7 +2322,7 @@
         "ms": "^2.1.3",
         "secure-json-parse": "^2.4.0",
         "tslib": "^2.4.0",
-        "undici": "^5.1.1"
+        "undici": "^5.5.1"
       },
       "engines": {
         "node": ">=14"
@@ -16856,12 +16856,12 @@
       }
     },
     "@elastic/elasticsearch": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz",
-      "integrity": "sha512-iOgr/3zQi84WmPhAplnK2W13R89VXD2oc6WhlQmH3bARQwmI+De23ZJKBEn7bvuG/AHMAqasPXX7uJIiJa2MqQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.6.0.tgz",
+      "integrity": "sha512-mN5EbbgSp1rfRmQ/5Hv7jqAK8xhGJxCg7G84xje8hSefE59P+HPPCv/+DgesCUSJdZpwXIo0DwOWHfHvktxxLw==",
       "dev": true,
       "requires": {
-        "@elastic/transport": "^8.2.0",
+        "@elastic/transport": "^8.3.1",
         "tslib": "^2.4.0"
       }
     },
@@ -16876,9 +16876,9 @@
       }
     },
     "@elastic/transport": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.2.0.tgz",
-      "integrity": "sha512-H/HmefMNQfLiBSVTmNExu2lYs5EzwipUnQB53WLr17RCTDaQX0oOLHcWpDsbKQSRhDAMPPzp5YZsZMJxuxPh7A==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.1.tgz",
+      "integrity": "sha512-jv/Yp2VLvv5tSMEOF8iGrtL2YsYHbpf4s+nDsItxUTLFTzuJGpnsB/xBlfsoT2kAYEnWHiSJuqrbRcpXEI/SEQ==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",
@@ -16886,7 +16886,7 @@
         "ms": "^2.1.3",
         "secure-json-parse": "^2.4.0",
         "tslib": "^2.4.0",
-        "undici": "^5.1.1"
+        "undici": "^5.5.1"
       },
       "dependencies": {
         "hpagent": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
-    "@elastic/elasticsearch": "^8.2.1",
+    "@elastic/elasticsearch": "^8.6.0",
     "@elastic/elasticsearch-canary": "^8.2.0-canary.2",
     "@fastify/formbody": "^7.0.1",
     "@hapi/hapi": "^21.0.0",

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -285,9 +285,31 @@ tape.test('#_moduleNameFromFrames()', function (suite) {
       expected: '@elastic/elasticsearch'
     },
     {
+      name: 'deep package',
+      frames: [
+        {
+          library_frame: true,
+          filename: 'node_modules/foo/node_modules/bar/lib/baz.js'
+        }
+        // More frames... Only top frame is used by _moduleNameFromFrames.
+      ],
+      expected: 'bar'
+    },
+    {
+      name: 'namespaced package missing name',
+      frames: [
+        {
+          library_frame: true,
+          filename: 'node_modules/@ns/'
+        }
+        // More frames... Only top frame is used by _moduleNameFromFrames.
+      ],
+      expected: null
+    },
+    {
       name: 'empty frames',
       frames: [],
-      expected: undefined
+      expected: null
     },
     {
       name: 'not library_frame',
@@ -297,7 +319,7 @@ tape.test('#_moduleNameFromFrames()', function (suite) {
           filename: 'node:_http_common'
         }
       ],
-      expected: undefined
+      expected: null
     },
     {
       name: 'frame in node lib',
@@ -310,7 +332,7 @@ tape.test('#_moduleNameFromFrames()', function (suite) {
           abs_path: 'timers.js'
         }
       ],
-      expected: undefined
+      expected: null
     }
 
   ]


### PR DESCRIPTION
The test for `error.exception.module` for a reported APM error using
`@elastic/elasticsearch` broke with the recent `8.6.0` version...  as
installed by the npm in node v14.

The issue was that the install tree changed such that the error stack
top frame was in:
    node_modules/@elastic/elasticsearch/node_modules/@elastic/transport/lib/Transport.js
rather than:
    node_modules/@elastic/transport/lib/Transport.js
for reasons independent of the `@elastic/elasticsearch@8.6.0` release.
The `_moduleNameFromFrames` utility didn't handle a nested
`node_modules/...` dir.  This change fixes that.

---

This was failing in TAV tests for the last few days. E.g.:

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/main/565/pipeline

```
-- installing ["@elastic/elasticsearch@8.6.0"]
-- running test "node test/instrumentation/modules/@elastic/elasticsearch.test.js" with @elastic/elasticsearch
[2023-01-12T06:54:24.566Z] node_tests_1     | # ResponseError
[2023-01-12T06:54:24.566Z] node_tests_1     | ok 187 no currentSpan in sync code after @elastic/elasticsearch client command
[2023-01-12T06:54:24.566Z] node_tests_1     | ok 188 got an error from search callback
[2023-01-12T06:54:24.566Z] node_tests_1     | ok 189 error name is "ResponseError"
[2023-01-12T06:54:24.566Z] node_tests_1     | {"log.level":"info","@timestamp":"2023-01-12T06:54:23.206Z","log":{"logger":"elastic-apm-node"},"ecs":{"version":"1.6.0"},"message":"Sending error to Elastic APM: {\"id\":\"46ce4b1e76f2c2679541976013f98611\"}"}
[2023-01-12T06:54:24.566Z] node_tests_1     | ok 190 sent an error to APM server
[2023-01-12T06:54:24.567Z] node_tests_1     | ok 191 err.id
[2023-01-12T06:54:24.567Z] node_tests_1     | ok 192 err.exception.message
[2023-01-12T06:54:24.567Z] node_tests_1     | ok 193 err.exception.type
[2023-01-12T06:54:24.567Z] node_tests_1     | not ok 194 should be strictly equal
[2023-01-12T06:54:24.567Z] node_tests_1     |   ---
[2023-01-12T06:54:24.567Z] node_tests_1     |     operator: equal
[2023-01-12T06:54:24.567Z] node_tests_1     |     expected: '@elastic/transport'
[2023-01-12T06:54:24.567Z] node_tests_1     |     actual:   '@elastic/elasticsearch'
[2023-01-12T06:54:24.567Z] node_tests_1     |     at: done (/app/test/instrumentation/modules/@elastic/elasticsearch.test.js:473:13)
[2023-01-12T06:54:24.567Z] node_tests_1     |     stack: |-
[2023-01-12T06:54:24.567Z] node_tests_1     |       Error: should be strictly equal
[2023-01-12T06:54:24.567Z] node_tests_1     |           at Test.assert [as _assert] (/app/node_modules/tape/lib/test.js:312:48)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at Test.bound [as _assert] (/app/node_modules/tape/lib/test.js:95:17)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at Test.strictEqual (/app/node_modules/tape/lib/test.js:476:7)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at Test.bound [as equal] (/app/node_modules/tape/lib/test.js:95:17)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at done (/app/test/instrumentation/modules/@elastic/elasticsearch.test.js:473:13)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at Timeout._onTimeout (/app/test/_mock_http_client.js:80:7)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at listOnTimeout (internal/timers.js:557:17)
[2023-01-12T06:54:24.567Z] node_tests_1     |           at processTimers (internal/timers.js:500:7)
[2023-01-12T06:54:24.567Z] node_tests_1     |   ...
```
