### PR TITLE
chore: switch to transaction.type="scheduled" for timer-triggered Azure Functions

### DIFF
--- a/lib/instrumentation/azure-functions.js
+++ b/lib/instrumentation/azure-functions.js
@@ -40,8 +40,9 @@ const TRIGGER_TIMER = 3 // https://learn.microsoft.com/en-ca/azure/azure-functio
 const TRANS_TYPE_FROM_TRIGGER_TYPE = {
   [TRIGGER_OTHER]: 'request',
   [TRIGGER_HTTP]: 'request',
-  // Note: `transaction.type = "timer"` is not in the shared APM agent spec yet.
-  [TRIGGER_TIMER]: 'timer'
+  // Note: `transaction.type = "scheduled"` is not in the shared APM agent spec,
+  // but the Java agent used the same value for some instrumentations.
+  [TRIGGER_TIMER]: 'scheduled'
 }
 // See APM spec and OTel `faas.trigger` at
 // https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/faas/


### PR DESCRIPTION
From "timer". Neither value is in the APM agents shared spec, but
"scheduled" is prior art from some Java instrumentations (e.g. for
Quartz).

Refs: #3071

---

Bias to a common value for similar usage from the Java agent. Possible spec'ing of this in the shared APM agents specs can come later.