### PR TITLE
fix: add "s3/" prefix to destination.service.resource for S3 spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,17 @@ Notes:
   values, e.g. `https://user:pass@...`, then the auth fields were not
   included in the actual HTTP request.  ({issues}2044[#2044])
 
+* Fix `span.context.destination.service.resource` for S3 spans to have an
+  "s3/" prefix.
++
+*Note*: While this is considered a bugfix, but it can potentially be a breaking
+change in the Kibana APM app: It can break the history of the S3-Spans / metrics
+for users relying on `context.destination.service.resource`. If users happen to
+run agents both with and without this fix (for same or different languages), the
+same S3-buckets can appear twice in the service map (with and without
+s3-prefix).
+
+
 [float]
 ===== Chores
 

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -79,13 +79,7 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
     const region = httpRequest && httpRequest.region
 
     span.setServiceTarget('s3', resource)
-    const destContext = {
-      // Typically 'destination.service.resource' is calculated from
-      // 'service.target' in Span.end(), but S3 is a special case in the spec.
-      service: {
-        resource
-      }
-    }
+    const destContext = {}
     // '.httpRequest.endpoint' might differ from '.service.endpoint' if
     // the bucket is in a different region.
     const endpoint = httpRequest && httpRequest.endpoint

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -127,7 +127,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200, response: { encoded_body_size: 177 } }
           },
@@ -145,7 +145,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200 }
           },
@@ -163,7 +163,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200 }
           },
@@ -181,7 +181,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200 }
           },
@@ -199,7 +199,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200, response: { encoded_body_size: 8 } }
           },
@@ -217,7 +217,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 304 }
           },
@@ -235,7 +235,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200, response: { encoded_body_size: 8 } }
           },
@@ -254,7 +254,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 404, response: { encoded_body_size: 207 } }
           },
@@ -276,7 +276,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 204 }
           },
@@ -294,7 +294,7 @@ tape.test('simple S3 usage scenario', function (t) {
               address: LOCALSTACK_HOST,
               port: 4566,
               cloud: { region: 'us-east-2' },
-              service: { type: '', name: '', resource: 'elasticapmtest-bucket-1' }
+              service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 204 }
           },


### PR DESCRIPTION
Closes: #3084
Refs: https://github.com/elastic/apm/pull/738
