### PR TITLE
fix: ensure `transaction.dropped_spans_stats[*].duration.sum.us` is an int

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,11 @@ run agents both with and without this fix (for same or different languages), the
 same S3-buckets can appear twice in the service map (with and without
 s3-prefix).
 
+* Ensure collected dropped spans stats follow the intake API type requirements.
+  Before this change `transaction.dropped_spans_stats[*].duration.sum.us` could
+  have been a floating-point value, but the intake API requires an int. The
+  result was dropped transactions and errors in the agent log.
+  ({issues}3104[#3104])
 
 [float]
 ===== Chores

--- a/lib/instrumentation/dropped-span-stats.js
+++ b/lib/instrumentation/dropped-span-stats.js
@@ -73,7 +73,16 @@ class DroppedSpanStats {
   }
 
   encode () {
-    return Array.from(this.statsMap.values())
+    // `duration.sum.us` is an integer in the intake API, but is stored as
+    // a float. We assume this `.encode()` is typically only called when the
+    // transaction is ended, so the in-place loss of the fractional value is
+    // acceptable.
+    const result = []
+    for (const stats of this.statsMap.values()) {
+      stats.duration.sum.us = Math.round(stats.duration.sum.us)
+      result.push(stats)
+    }
+    return result
   }
 
   size () {

--- a/test/instrumentation/dropped-span-stats.test.js
+++ b/test/instrumentation/dropped-span-stats.test.js
@@ -64,7 +64,7 @@ tape.test('test DroppedSpanStats objects', function (test) {
     span.setOutcome(OUTCOME_SUCCESS)
     span.setServiceTarget('aTargType', 'aTargName')
     span.end()
-    span._duration = 1000 // override duration so we can test the sum
+    span._duration = 1000.0001 // override duration so we can test the sum
     test.ok(
       transaction.captureDroppedSpan(span)
     )
@@ -90,7 +90,8 @@ tape.test('test DroppedSpanStats objects', function (test) {
 
   test.equals(stats[2].duration.count, 4)
   test.equals(stats[2].destination_service_resource, 'aTargType/aTargName')
-  test.equals(stats[2].duration.sum.us, 4000000)
+  test.ok(Number.isInteger(stats[2].duration.sum.us), 'duration.sum.us is an integer (as required by intake API)')
+  test.equals(stats[2].duration.sum.us, 4000000, 'dropped_span_stats[2].duration.sum.us')
   test.equals(stats[2].service_target_type, 'aTargType', 'dropped_span_stats[2].service_target_type')
   test.equals(stats[2].service_target_name, 'aTargName', 'dropped_span_stats[2].service_target_name')
   test.equals(stats[2].outcome, OUTCOME_SUCCESS, 'dropped_span_stats[2].outcome')


### PR DESCRIPTION
Before this change it could be a float, which is rejected by the APM
server intake API.

Fixes: #3104
