### PR TITLE
test: fix TAV=@hapi/hapi test failure with node v8

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -351,23 +351,33 @@ pug:
 # - Node version compat:
 #   - @hapi/hapi@19: supports node >=v12 (judging from commit 50d8d7d)
 #   - @hapi/hapi@20: appears (from travis template refs) to support node >=v12
+#   - @hapi/hapi@20.1.2 fixed an issue (https://github.com/hapijs/hapi/pull/4225)
+#     needed to work with node >=16. Earlier versions of Hapi will crash when
+#     handling a POST.
 #   - @hapi/hapi@21: dropped support for node v12, and requires v14.10.0
 #     for 'performance.eventLoopUtilization'
-'@hapi/hapi-v17-v18':
+'@hapi/hapi-v17-v19':
   name: '@hapi/hapi'
   versions: '>=17.0.0 <19.0.0'
-  node: '>=8.12.0'
+  node: '>=8.12.0 <16.0.0'
   commands:
     - node test/instrumentation/modules/hapi/basic.test.js
     - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
-'@hapi/hapi-v19-v20':
+'@hapi/hapi-v19-v20.1.2':
   name: '@hapi/hapi'
-  versions: '>=19.0.0 <21.0.0'
-  node: '>=12'
+  versions: '>=19.0.0 <20.1.2'
+  node: '>=12.0.0 <16.0.0'
   commands:
     - node test/instrumentation/modules/hapi/basic.test.js
     - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
-'@hapi/hapi':
+'@hapi/hapi-v20.1.2-v21':
+  name: '@hapi/hapi'
+  versions: '>=20.1.2 <21.0.0'
+  node: '>=12.0.0'
+  commands:
+    - node test/instrumentation/modules/hapi/basic.test.js
+    - node test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
+'@hapi/hapi-v21-':
   name: '@hapi/hapi'
   versions: '>=21.0.0'
   node: '>=14.10.0'

--- a/test/_is_hapi_incompat.js
+++ b/test/_is_hapi_incompat.js
@@ -25,7 +25,7 @@ function isHapiIncompat (moduleName) {
   // - hapi 18.1.0 (the last hapi 18.x) was released before node v12 was released,
   //   and tests with hapi@18 and node >=16 is known to hang.
   // - @hapi/hapi@20.1.2 fixed an issue (https://github.com/hapijs/hapi/pull/4225)
-  //   need to work with node >=16. Earlier versions of Hapi will crash when
+  //   needed to work with node >=16. Earlier versions of Hapi will crash when
   //   handling a POST.
   if (semver.gte(process.version, '16.0.0') && semver.lt(hapiVersion, '20.1.2')) {
     return true

--- a/test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
+++ b/test/instrumentation/modules/hapi/set-framework-hapihapi.test.js
@@ -14,6 +14,7 @@ const agent = require('../../../..').start({
 var isHapiIncompat = require('../../../_is_hapi_incompat')
 if (isHapiIncompat('@hapi/hapi')) {
   // Skip out of this test.
+  console.log(`# SKIP this version of '@hapi/hapi' is incompatible with node ${process.version}`)
   process.exit()
 }
 const tape = require('tape')

--- a/test/instrumentation/modules/hapi/shared.js
+++ b/test/instrumentation/modules/hapi/shared.js
@@ -97,11 +97,11 @@ module.exports = (moduleName) => {
     var server = startServer(function (err, port) {
       t.error(err)
       const cReq = http.request(
-        'http://localhost:' + port + '/postSomeData',
         {
           method: 'POST',
           hostname: 'localhost',
           port,
+          path: '/postSomeData',
           headers: {
             'Content-Type': 'application/json',
             'Content-Length': Buffer.byteLength(postData)


### PR DESCRIPTION
The 'http.request' instrumentation fix in #3090 uncovered a bug in our
tests for @hapi/hapi when with node v8 (a version before
`http.request(url, opts, cb)` was supported in node). This fixes that.

This also updates the .tav.yml section for '@hapi/hapi' to align with
logic in "_is_hapi_incompat.js" so the TAV tests don't waste time
installing a version of Hapi for which tests will be skipped anyway.

Refs: #3090

---

A TAV test failure example is here: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fapm-agent-nodejs-mbp/detail/main/578/pipeline/2844
The test hanged:

```
.ci/scripts/test.sh -b "release" -t "@hapi/hapi" "8" 
...
[2023-01-18T07:05:32.394Z] node_tests_1  | -- required packages ["@hapi/hapi@18.4.1"]
[2023-01-18T07:05:32.394Z] node_tests_1  | -- installing ["@hapi/hapi@18.4.1"]
[2023-01-18T07:05:47.859Z] node_tests_1  | -- running test "node test/instrumentation/modules/hapi/basic.test.js" with @hapi/hapi
[2023-01-18T07:05:49.066Z] node_tests_1  | (node:136) UnhandledPromiseRejectionWarning: TypeError: "listener" argument must be a function
[2023-01-18T07:05:49.066Z] node_tests_1  |     at ClientRequest.once (events.js:340:11)
[2023-01-18T07:05:49.066Z] node_tests_1  |     at new ClientRequest (_http_client.js:174:10)
[2023-01-18T07:05:49.066Z] node_tests_1  |     at Object.request (http.js:39:10)
[2023-01-18T07:05:49.066Z] node_tests_1  |     at Object.request (/app/lib/instrumentation/http-shared.js:224:21)
[2023-01-18T07:05:49.066Z] node_tests_1  |     at /app/test/instrumentation/modules/hapi/shared.js:99:25
[2023-01-18T07:05:49.066Z] node_tests_1  |     at server.start.then (/app/test/instrumentation/modules/hapi/shared.js:606:15)
[2023-01-18T07:05:49.066Z] node_tests_1  |     at <anonymous>
[2023-01-18T07:05:49.066Z] node_tests_1  |     at process._tickCallback (internal/process/next_tick.js:189:7)
[2023-01-18T07:05:49.066Z] node_tests_1  | (node:136) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
[2023-01-18T07:05:49.066Z] node_tests_1  | (node:136) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[2023-01-18T08:48:48.480Z] Sending interrupt signal to process
```
