### PR TITLE
feat: support restify@11

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -425,14 +425,14 @@ restify-v8-v9:
     - node test/instrumentation/modules/restify/set-framework.test.js
 restify-v9-v10:
   name: restify
-  versions: '>=9.0.0'
+  versions: '>=9.0.0 <10.0.0'
   node: '>=14.18.0 <18.0.0'
   commands:
     - node test/instrumentation/modules/restify/basic.test.js
     - node test/instrumentation/modules/restify/set-framework.test.js
-restify:
+restify-v10-v12:
   name: restify
-  versions: '>=10.0.0'
+  versions: '>=10.0.0 <12.0.0'
   node: '>=14.18.0'
   commands:
     - node test/instrumentation/modules/restify/basic.test.js

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,8 @@ Notes:
   See the <<azure-functions>> document.
   ({pull}3071[#3071], https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-azure-functions.md[spec])
 
+* Support `restify@11`.
+
 [float]
 ===== Bug fixes
 

--- a/dev-utils/bitrot.js
+++ b/dev-utils/bitrot.js
@@ -183,7 +183,7 @@ function loadSupportedDoc () {
     if (row[1] === 'N/A') {
 
     } else if (row[0].includes('<<')) {
-      match = /^\s*<<(\w+),(.*?)>>/.exec(row[0])
+      match = /^\s*<<([\w-]+),(.*?)>>/.exec(row[0])
       if (!match) {
         throw new Error(`could not parse this table cell text from docs/supported-technologies.asciidoc: ${JSON.stringify(row[0])}`)
       }
@@ -194,6 +194,8 @@ function loadSupportedDoc () {
         moduleNames = [match[2]]
       } else if (match[1] === 'koa') {
         moduleNames = ['koa-router', '@koa/router']
+      } else if (match[1] === 'azure-functions') {
+        moduleNames = [] // Azure Functions compat isn't about an NPM package version.
       } else {
         moduleNames = [match[1]]
       }

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -95,7 +95,7 @@ These are the frameworks that we officially support:
 | <<hapi,hapi>>         | >=9.0.0 <19.0.0 | Deprecated. No longer tested.
 | <<koa,Koa>> via koa-router or @koa/router | >=5.2.0 <13.0.0 | Koa doesn't have a built in router, so we can't support Koa directly since we rely on router information for full support. We currently support the most popular Koa router called https://github.com/koajs/koa-router[koa-router].
 | <<nextjs,Next.js>>    | >=11.1.0 <14.0.0 | (Technical Preview) This instruments Next.js routing to name transactions for incoming HTTP transactions; and reports errors in user pages. It supports the Next.js production server (`next start`) and development server (`next dev`). See the <<nextjs,Getting Started document>>.
-| <<restify,Restify>>   | >=5.2.0 <11.0.0 |
+| <<restify,Restify>>   | >=5.2.0 <12.0.0 |
 |=======================================================================
 
 [float]

--- a/lib/instrumentation/modules/restify.js
+++ b/lib/instrumentation/modules/restify.js
@@ -14,7 +14,7 @@ module.exports = function (restify, agent, { version, enabled }) {
   if (!enabled) {
     return restify
   }
-  if (!semver.satisfies(version, '>=5.2.0 <11.0.0')) {
+  if (!semver.satisfies(version, '>=5.2.0 <12.0.0')) {
     agent.logger.debug('restify version %s not supported, skipping', version)
     return restify
   }


### PR DESCRIPTION
Also fix a bug in the bitrot.js dev util for the recent
Azure Functions addition.

---

This will also fix a recent `TAV=restify` test run failure. restify v11.0.0 was released yesterday.