### PR TITLE
refactor: s/dropped_span_stats/dropped_spans_stats/ and similar

### DIFF
--- a/lib/instrumentation/dropped-spans-stats.js
+++ b/lib/instrumentation/dropped-spans-stats.js
@@ -6,15 +6,15 @@
 
 'use strict'
 
-const MAX_DROPPED_SPAN_STATS = 128
+const MAX_DROPPED_SPANS_STATS = 128
 
-class DroppedSpanStats {
+class DroppedSpansStats {
   constructor () {
     this.statsMap = new Map()
   }
 
   /**
-   * Record this span in dropped span stats.
+   * Record this span in dropped spans stats.
    *
    * @param {Span} span
    * @returns {boolean} True iff this span was added to stats. This return value
@@ -48,7 +48,7 @@ class DroppedSpanStats {
       return stats
     }
 
-    if (this.statsMap.size >= MAX_DROPPED_SPAN_STATS) {
+    if (this.statsMap.size >= MAX_DROPPED_SPANS_STATS) {
       return
     }
 
@@ -91,8 +91,8 @@ class DroppedSpanStats {
 }
 
 module.exports = {
-  DroppedSpanStats,
+  DroppedSpansStats,
 
   // Exported for testing-only.
-  MAX_DROPPED_SPAN_STATS
+  MAX_DROPPED_SPANS_STATS
 }

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -11,7 +11,7 @@ var util = require('util')
 var ObjectIdentityMap = require('object-identity-map')
 
 const constants = require('../constants')
-const { DroppedSpanStats } = require('./dropped-span-stats')
+const { DroppedSpansStats } = require('./dropped-spans-stats')
 var getPathFromRequest = require('./express-utils').getPathFromRequest
 var GenericSpan = require('./generic-span')
 var parsers = require('../parsers')
@@ -101,7 +101,7 @@ function Transaction (agent, name, ...args) {
   this._service = undefined
   this._message = undefined
   this._cloud = undefined
-  this._droppedSpanStats = new DroppedSpanStats()
+  this._droppedSpansStats = new DroppedSpansStats()
   this.outcome = constants.OUTCOME_UNKNOWN
 }
 
@@ -295,8 +295,8 @@ Transaction.prototype.toJSON = function () {
     payload.links = this._links
   }
 
-  if (this._droppedSpanStats.size() > 0) {
-    payload.dropped_spans_stats = this._droppedSpanStats.encode()
+  if (this._droppedSpansStats.size() > 0) {
+    payload.dropped_spans_stats = this._droppedSpansStats.encode()
   }
   return payload
 }
@@ -452,7 +452,7 @@ Transaction.prototype._captureBreakdown = function (span) {
 }
 
 Transaction.prototype.captureDroppedSpan = function (span) {
-  return this._droppedSpanStats.captureDroppedSpan(span)
+  return this._droppedSpansStats.captureDroppedSpan(span)
 }
 
 function transactionBreakdownDetails ({ name, type } = {}) {

--- a/test/instrumentation/dropped-spans-stats.test.js
+++ b/test/instrumentation/dropped-spans-stats.test.js
@@ -6,7 +6,7 @@
 
 'use strict'
 const agent = require('../..').start({
-  serviceName: 'test-dropped-span-stats',
+  serviceName: 'test-dropped-spans-stats',
   captureExceptions: false,
   metricsInterval: 0,
   centralConfig: false,
@@ -18,9 +18,9 @@ const agent = require('../..').start({
 
 const tape = require('tape')
 const { OUTCOME_FAILURE, OUTCOME_SUCCESS } = require('../../lib/constants')
-const { MAX_DROPPED_SPAN_STATS } = require('../../lib/instrumentation/dropped-span-stats')
+const { MAX_DROPPED_SPANS_STATS } = require('../../lib/instrumentation/dropped-spans-stats')
 
-tape.test('test DroppedSpanStats invalid cases', function (test) {
+tape.test('test DroppedSpansStats invalid cases', function (test) {
   const transaction = agent.startTransaction('trans')
 
   const span = agent.startSpan('foo', 'baz', 'bar', { exitSpan: true })
@@ -39,7 +39,7 @@ tape.test('test DroppedSpanStats invalid cases', function (test) {
   test.end()
 })
 
-tape.test('test DroppedSpanStats objects', function (test) {
+tape.test('test DroppedSpansStats objects', function (test) {
   const transaction = agent.startTransaction('trans')
   for (let i = 0; i < 2; i++) {
     const span = agent.startSpan('aSpanName', 'aSpanType', 'aSpanSubtype', { exitSpan: true })
@@ -72,36 +72,36 @@ tape.test('test DroppedSpanStats objects', function (test) {
   transaction.end()
 
   // three distinct resource/outcome pairs captured
-  test.equals(transaction._droppedSpanStats.statsMap.size, 3)
+  test.equals(transaction._droppedSpansStats.statsMap.size, 3)
 
   const payload = transaction._encode()
   const stats = payload.dropped_spans_stats
   test.equals(stats[0].duration.count, 2)
   test.equals(stats[0].destination_service_resource, 'aSpanSubtype')
-  test.equals(stats[0].service_target_type, 'aSpanSubtype', 'dropped_span_stats[0].service_target_type')
-  test.equals(stats[0].service_target_name, undefined, 'dropped_span_stats[0].service_target_name')
-  test.equals(stats[0].outcome, OUTCOME_SUCCESS, 'dropped_span_stats[0].outcome')
+  test.equals(stats[0].service_target_type, 'aSpanSubtype', 'dropped_spans_stats[0].service_target_type')
+  test.equals(stats[0].service_target_name, undefined, 'dropped_spans_stats[0].service_target_name')
+  test.equals(stats[0].outcome, OUTCOME_SUCCESS, 'dropped_spans_stats[0].outcome')
 
   test.equals(stats[1].duration.count, 3)
   test.equals(stats[1].destination_service_resource, 'aSpanSubtype')
-  test.equals(stats[1].service_target_type, 'aSpanSubtype', 'dropped_span_stats[1].service_target_type')
-  test.equals(stats[1].service_target_name, undefined, 'dropped_span_stats[1].service_target_name')
-  test.equals(stats[1].outcome, OUTCOME_FAILURE, 'dropped_span_stats[1].outcome')
+  test.equals(stats[1].service_target_type, 'aSpanSubtype', 'dropped_spans_stats[1].service_target_type')
+  test.equals(stats[1].service_target_name, undefined, 'dropped_spans_stats[1].service_target_name')
+  test.equals(stats[1].outcome, OUTCOME_FAILURE, 'dropped_spans_stats[1].outcome')
 
   test.equals(stats[2].duration.count, 4)
   test.equals(stats[2].destination_service_resource, 'aTargType/aTargName')
   test.ok(Number.isInteger(stats[2].duration.sum.us), 'duration.sum.us is an integer (as required by intake API)')
-  test.equals(stats[2].duration.sum.us, 4000000, 'dropped_span_stats[2].duration.sum.us')
-  test.equals(stats[2].service_target_type, 'aTargType', 'dropped_span_stats[2].service_target_type')
-  test.equals(stats[2].service_target_name, 'aTargName', 'dropped_span_stats[2].service_target_name')
-  test.equals(stats[2].outcome, OUTCOME_SUCCESS, 'dropped_span_stats[2].outcome')
+  test.equals(stats[2].duration.sum.us, 4000000, 'dropped_spans_stats[2].duration.sum.us')
+  test.equals(stats[2].service_target_type, 'aTargType', 'dropped_spans_stats[2].service_target_type')
+  test.equals(stats[2].service_target_name, 'aTargName', 'dropped_spans_stats[2].service_target_name')
+  test.equals(stats[2].outcome, OUTCOME_SUCCESS, 'dropped_spans_stats[2].outcome')
 
   test.end()
 })
 
-tape.test('test DroppedSpanStats max items', function (test) {
+tape.test('test DroppedSpansStats max items', function (test) {
   const transaction = agent.startTransaction('trans')
-  for (let i = 0; i < MAX_DROPPED_SPAN_STATS; i++) {
+  for (let i = 0; i < MAX_DROPPED_SPANS_STATS; i++) {
     const span = agent.startSpan('foo', 'baz', 'bar', { exitSpan: true })
     span.setServiceTarget('aTargType', 'aTargName-' + i)
     span.setOutcome(OUTCOME_FAILURE)
@@ -114,7 +114,7 @@ tape.test('test DroppedSpanStats max items', function (test) {
   span.setServiceTarget('aTargType', 'aTargName')
   span.setOutcome(OUTCOME_FAILURE)
   span.end()
-  test.ok(!transaction.captureDroppedSpan(span), 'did not capture stats for this dropped span (hit MAX_DROPPED_SPAN_STATS)')
+  test.ok(!transaction.captureDroppedSpan(span), 'did not capture stats for this dropped span (hit MAX_DROPPED_SPANS_STATS)')
 
   // and we're still able to increment spans that fit the previous profile
   const span2 = agent.startSpan('foo', 'baz', 'bar', { exitSpan: true })
@@ -124,6 +124,6 @@ tape.test('test DroppedSpanStats max items', function (test) {
   test.ok(transaction.captureDroppedSpan(span2), 'DID capture stats for this previously seen span stats key')
 
   transaction.end()
-  test.equals(transaction._droppedSpanStats.statsMap.size, MAX_DROPPED_SPAN_STATS)
+  test.equals(transaction._droppedSpansStats.statsMap.size, MAX_DROPPED_SPANS_STATS)
   test.end()
 })

--- a/test/instrumentation/dropped-spans-stats.test.js
+++ b/test/instrumentation/dropped-spans-stats.test.js
@@ -5,6 +5,7 @@
  */
 
 'use strict'
+
 const agent = require('../..').start({
   serviceName: 'test-dropped-spans-stats',
   captureExceptions: false,
@@ -16,36 +17,36 @@ const agent = require('../..').start({
   spanCompressionSameKindMaxDuration: '50ms'
 })
 
-const tape = require('tape')
+const { test } = require('tape')
 const { OUTCOME_FAILURE, OUTCOME_SUCCESS } = require('../../lib/constants')
 const { MAX_DROPPED_SPANS_STATS } = require('../../lib/instrumentation/dropped-spans-stats')
 
-tape.test('test DroppedSpansStats invalid cases', function (test) {
+test('test DroppedSpansStats invalid cases', function (t) {
   const transaction = agent.startTransaction('trans')
 
   const span = agent.startSpan('foo', 'baz', 'bar', { exitSpan: true })
   span.setOutcome(OUTCOME_SUCCESS)
   span.end()
-  test.ok(transaction.captureDroppedSpan(span), 'captured dropped stats for span')
+  t.ok(transaction.captureDroppedSpan(span), 'captured dropped stats for span')
 
-  test.ok(!transaction.captureDroppedSpan(null), 'did not capture dropped stats for span=null')
+  t.ok(!transaction.captureDroppedSpan(null), 'did not capture dropped stats for span=null')
 
   const nonExitSpan = agent.startSpan('foo', 'baz', 'bar')
   nonExitSpan.setOutcome(OUTCOME_SUCCESS)
   nonExitSpan.end()
-  test.ok(!transaction.captureDroppedSpan(nonExitSpan), 'did not capture dropped stats for nonExitSpan')
+  t.ok(!transaction.captureDroppedSpan(nonExitSpan), 'did not capture dropped stats for nonExitSpan')
 
   transaction.end()
-  test.end()
+  t.end()
 })
 
-tape.test('test DroppedSpansStats objects', function (test) {
+test('test DroppedSpansStats objects', function (t) {
   const transaction = agent.startTransaction('trans')
   for (let i = 0; i < 2; i++) {
     const span = agent.startSpan('aSpanName', 'aSpanType', 'aSpanSubtype', { exitSpan: true })
     span.setOutcome(OUTCOME_SUCCESS)
     span.end()
-    test.ok(
+    t.ok(
       transaction.captureDroppedSpan(span)
     )
   }
@@ -54,7 +55,7 @@ tape.test('test DroppedSpansStats objects', function (test) {
     const span = agent.startSpan('aSpanName', 'aSpanType', 'aSpanSubtype', { exitSpan: true })
     span.setOutcome(OUTCOME_FAILURE)
     span.end()
-    test.ok(
+    t.ok(
       transaction.captureDroppedSpan(span)
     )
   }
@@ -65,48 +66,48 @@ tape.test('test DroppedSpansStats objects', function (test) {
     span.setServiceTarget('aTargType', 'aTargName')
     span.end()
     span._duration = 1000.0001 // override duration so we can test the sum
-    test.ok(
+    t.ok(
       transaction.captureDroppedSpan(span)
     )
   }
   transaction.end()
 
   // three distinct resource/outcome pairs captured
-  test.equals(transaction._droppedSpansStats.statsMap.size, 3)
+  t.equals(transaction._droppedSpansStats.statsMap.size, 3)
 
   const payload = transaction._encode()
   const stats = payload.dropped_spans_stats
-  test.equals(stats[0].duration.count, 2)
-  test.equals(stats[0].destination_service_resource, 'aSpanSubtype')
-  test.equals(stats[0].service_target_type, 'aSpanSubtype', 'dropped_spans_stats[0].service_target_type')
-  test.equals(stats[0].service_target_name, undefined, 'dropped_spans_stats[0].service_target_name')
-  test.equals(stats[0].outcome, OUTCOME_SUCCESS, 'dropped_spans_stats[0].outcome')
+  t.equals(stats[0].duration.count, 2)
+  t.equals(stats[0].destination_service_resource, 'aSpanSubtype')
+  t.equals(stats[0].service_target_type, 'aSpanSubtype', 'dropped_spans_stats[0].service_target_type')
+  t.equals(stats[0].service_target_name, undefined, 'dropped_spans_stats[0].service_target_name')
+  t.equals(stats[0].outcome, OUTCOME_SUCCESS, 'dropped_spans_stats[0].outcome')
 
-  test.equals(stats[1].duration.count, 3)
-  test.equals(stats[1].destination_service_resource, 'aSpanSubtype')
-  test.equals(stats[1].service_target_type, 'aSpanSubtype', 'dropped_spans_stats[1].service_target_type')
-  test.equals(stats[1].service_target_name, undefined, 'dropped_spans_stats[1].service_target_name')
-  test.equals(stats[1].outcome, OUTCOME_FAILURE, 'dropped_spans_stats[1].outcome')
+  t.equals(stats[1].duration.count, 3)
+  t.equals(stats[1].destination_service_resource, 'aSpanSubtype')
+  t.equals(stats[1].service_target_type, 'aSpanSubtype', 'dropped_spans_stats[1].service_target_type')
+  t.equals(stats[1].service_target_name, undefined, 'dropped_spans_stats[1].service_target_name')
+  t.equals(stats[1].outcome, OUTCOME_FAILURE, 'dropped_spans_stats[1].outcome')
 
-  test.equals(stats[2].duration.count, 4)
-  test.equals(stats[2].destination_service_resource, 'aTargType/aTargName')
-  test.ok(Number.isInteger(stats[2].duration.sum.us), 'duration.sum.us is an integer (as required by intake API)')
-  test.equals(stats[2].duration.sum.us, 4000000, 'dropped_spans_stats[2].duration.sum.us')
-  test.equals(stats[2].service_target_type, 'aTargType', 'dropped_spans_stats[2].service_target_type')
-  test.equals(stats[2].service_target_name, 'aTargName', 'dropped_spans_stats[2].service_target_name')
-  test.equals(stats[2].outcome, OUTCOME_SUCCESS, 'dropped_spans_stats[2].outcome')
+  t.equals(stats[2].duration.count, 4)
+  t.equals(stats[2].destination_service_resource, 'aTargType/aTargName')
+  t.ok(Number.isInteger(stats[2].duration.sum.us), 'duration.sum.us is an integer (as required by intake API)')
+  t.equals(stats[2].duration.sum.us, 4000000, 'dropped_spans_stats[2].duration.sum.us')
+  t.equals(stats[2].service_target_type, 'aTargType', 'dropped_spans_stats[2].service_target_type')
+  t.equals(stats[2].service_target_name, 'aTargName', 'dropped_spans_stats[2].service_target_name')
+  t.equals(stats[2].outcome, OUTCOME_SUCCESS, 'dropped_spans_stats[2].outcome')
 
-  test.end()
+  t.end()
 })
 
-tape.test('test DroppedSpansStats max items', function (test) {
+test('test DroppedSpansStats max items', function (t) {
   const transaction = agent.startTransaction('trans')
   for (let i = 0; i < MAX_DROPPED_SPANS_STATS; i++) {
     const span = agent.startSpan('foo', 'baz', 'bar', { exitSpan: true })
     span.setServiceTarget('aTargType', 'aTargName-' + i)
     span.setOutcome(OUTCOME_FAILURE)
     span.end()
-    test.ok(transaction.captureDroppedSpan(span))
+    t.ok(transaction.captureDroppedSpan(span))
   }
 
   // one too many
@@ -114,16 +115,16 @@ tape.test('test DroppedSpansStats max items', function (test) {
   span.setServiceTarget('aTargType', 'aTargName')
   span.setOutcome(OUTCOME_FAILURE)
   span.end()
-  test.ok(!transaction.captureDroppedSpan(span), 'did not capture stats for this dropped span (hit MAX_DROPPED_SPANS_STATS)')
+  t.ok(!transaction.captureDroppedSpan(span), 'did not capture stats for this dropped span (hit MAX_DROPPED_SPANS_STATS)')
 
   // and we're still able to increment spans that fit the previous profile
   const span2 = agent.startSpan('foo', 'baz', 'bar', { exitSpan: true })
   span2.setServiceTarget('aTargType', 'aTargName-' + 0)
   span2.setOutcome(OUTCOME_FAILURE)
   span2.end()
-  test.ok(transaction.captureDroppedSpan(span2), 'DID capture stats for this previously seen span stats key')
+  t.ok(transaction.captureDroppedSpan(span2), 'DID capture stats for this previously seen span stats key')
 
   transaction.end()
-  test.equals(transaction._droppedSpansStats.statsMap.size, MAX_DROPPED_SPANS_STATS)
-  test.end()
+  t.equals(transaction._droppedSpansStats.statsMap.size, MAX_DROPPED_SPANS_STATS)
+  t.end()
 })


### PR DESCRIPTION
The intake field name is the plural. It is helpful for avoiding
confusion if the internal vars/fields are as well.

Also, refactor s/test/t/ for tape Test object in test functions 
as is the more common usage.