### PR TITLE
test: run 'npm ci' on a second test run if the first 'npm ci' possibly failed

### DIFF
--- a/test/instrumentation/modules/next/next.test.js
+++ b/test/instrumentation/modules/next/next.test.js
@@ -556,7 +556,7 @@ function checkExpectedApmEvents (t, apmEvents) {
 // We need to `npm ci` for a first test run. However, *only* for a first test
 // run, otherwise this will override any possible `npm install --no-save ...`
 // changes made by a TAV runner.
-const haveNodeModules = fs.existsSync(path.join(testAppDir, 'node_modules'))
+const haveNodeModules = fs.existsSync(path.join(testAppDir, 'node_modules', '.bin', 'next'))
 tape.test(`setup: npm ci (in ${testAppDir})`, { skip: haveNodeModules }, t => {
   const startTime = Date.now()
   exec(


### PR DESCRIPTION
Recently there was a spurious CI test failure with Node.js v14 where
a first test run ran this 'npm ci' and it failed with:

    Error: Command failed: npm ci
    npm ERR! cb() never called!

This is an old old npm issue that will never get fixed, because we are
running tests with an old node and old npm.

The CI setup currently will retry the full test run on failure. The
*second* run failed because the `npm ci` was skipped -- because the
first failed attempt created "./node_modules" but not the full install
under it -- and then went on to fail to spawn
"./node_modules/.bin/next".
