### PR TITLE
fix: activation_method='k8s-attach' now uses explicit ELASTIC_APM_ACTIVATION_METHOD

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,12 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix `metadata.service.agent.activation_method=k8s-attach` handling to
+  (a) use an explicit marker from the k8s apm attacher
+  (`ELASTIC_APM_ACTIVATION_METHOD`) and (b) use the specified "k8s-attach"
+  value, rather than the incorrect "k8s-attacher".
+  ({issue}3119[#3119])
+
 [float]
 ===== Chores
 

--- a/lib/activation-method.js
+++ b/lib/activation-method.js
@@ -74,8 +74,8 @@ function agentActivationMethodFromStartStack (startStack, log) {
       // and created by "dev-utils/make-distribution.sh".
       return 'aws-lambda-layer'
     } else if (process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S') {
-      // XXX https://github.com/elastic/apm-mutating-webhook/pull/69  which release of the hook will have this?
-      // https://github.com/elastic/apm-mutating-webhook/blob/main/charts/apm-attacher/values.yaml
+      // This envvar will be set in versions of apm-mutating-webhook after v0.1.0.
+      // https://github.com/elastic/apm-mutating-webhook/blob/4faff6299dc689491d628c26503568b09f078cfa/charts/apm-attacher/values.yaml#L33-L38
       return 'k8s-attach'
     } else if (process.env.NODE_OPTIONS &&
         CONTAINS_R_ELASTIC_APM_NODE_START.test(process.env.NODE_OPTIONS)) {

--- a/lib/activation-method.js
+++ b/lib/activation-method.js
@@ -33,7 +33,7 @@ const CONTAINS_R_ELASTIC_APM_NODE_START = /(-r\s+|--require\s*=?\s*).*elastic-ap
  *         import 'elastic-apm-node/start.js'
  *         import apm from 'elastic-apm-node'; apm.start()
  *    - "aws-lambda-layer": `NODE_OPTIONS` using Agent installed at /opt/nodejs/node_modules/elastic-apm-node
- *    - "k8s-attacher": `NODE_OPTIONS` using Agent installed at /elastic/apm/agent/elastic-apm-node
+ *    - "k8s-attach": `NODE_OPTIONS` using Agent, and `ELASTIC_APM_ACTIVATION_METHOD=K8S` in env
  *    - "env-attach": Fallback for any other usage of NODE_OPTIONS='-r elastic-apm-node/start'
  *    - "preload": For usage of `node -r elastic-apm-node/start` without `NODE_OPTIONS`.
  */
@@ -73,9 +73,10 @@ function agentActivationMethodFromStartStack (startStack, log) {
       // This path is defined by https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
       // and created by "dev-utils/make-distribution.sh".
       return 'aws-lambda-layer'
-    } else if (topDir === '/elastic/apm/agent/elastic-apm-node') {
-      // https://github.com/elastic/apm-mutating-webhook/blob/v0.1.0/charts/apm-attacher/values.yaml#L37
-      return 'k8s-attacher'
+    } else if (process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S') {
+      // XXX https://github.com/elastic/apm-mutating-webhook/pull/69  which release of the hook will have this?
+      // https://github.com/elastic/apm-mutating-webhook/blob/main/charts/apm-attacher/values.yaml
+      return 'k8s-attach'
     } else if (process.env.NODE_OPTIONS &&
         CONTAINS_R_ELASTIC_APM_NODE_START.test(process.env.NODE_OPTIONS)) {
       return 'env-attach'

--- a/test/activation-method/activation-method.test.js
+++ b/test/activation-method/activation-method.test.js
@@ -42,9 +42,8 @@ tape.test(`setup: npm install (in ${fixturesDir})`, { skip: haveNodeModules }, t
 })
 
 tape.test('metadata.system.agent.activation_method fixtures', function (suite) {
-  // Note: We do not test the "aws-lambda-layer" and "k8s-attacher" cases.
-  // Testing these would require simulating an agent install to the special
-  // paths used in those cases.
+  // Note: We do not test the "aws-lambda-layer" case, because this would
+  // require simulating an agent install to the special path used in that case.
   var cases = [
     {
       script: 'require1.js',
@@ -68,6 +67,14 @@ tape.test('metadata.system.agent.activation_method fixtures', function (suite) {
       script: 'hi.js',
       nodeOpts: ['-r', 'elastic-apm-node/start'],
       expectedMethod: 'preload'
+    },
+    {
+      script: 'hi.js',
+      env: {
+        NODE_OPTIONS: '-r elastic-apm-node/start',
+        ELASTIC_APM_ACTIVATION_METHOD: 'K8S'
+      },
+      expectedMethod: 'k8s-attach'
     },
     {
       script: 'hi.js',


### PR DESCRIPTION
This also fixes a bug where the value "k8s-attacher" was erroneously
used.

Closes: #3119
Refs: #3041, https://github.com/elastic/apm-mutating-webhook/pull/69

# checklist

- [x] wait for the apm-mutaging-webhook change to go in (would be nice to have a release to refer to)
- [x] update the XXX-comment