### PR TITLE
chore: correct comment on ES client instrumentation

### DIFF
--- a/lib/instrumentation/modules/@elastic/elasticsearch.js
+++ b/lib/instrumentation/modules/@elastic/elasticsearch.js
@@ -8,10 +8,6 @@
 
 // Instrument the @elastic/elasticsearch module.
 //
-// This uses to 'request' and 'response' events from the Client (documented at
-// https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html)
-// to hook into all ES server interactions.
-//
 // Limitations:
 // - In @elastic/elasticsearch >=7.14 <8, the diagnostic events sent for ES
 //   spans started before the product-check is finished will have an incorrect


### PR DESCRIPTION
In #2550 this module was rewritten to not be primarily based on
the ES client "diagnostic" events for instrumentation. That change
should have also removed this part of the top-comment.

Refs: #2550

---

No functional change.