### PR TITLE
snapshoty: migrate to github actions

### DIFF
--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -18,12 +18,12 @@ account:
 
 # List of artifacts
 artifacts:
-  # Path to use for artifacts discovery 
+  # Path to use for artifacts discovery
   - path: './build/snapshot'
     # Files pattern to match
     files_pattern: 'elastic-apm-node-(?P<app_version>\d+\.\d+\.\d+)\.tgz'
     # File layout on GCS bucket
-    output_pattern: '{project}/{jenkins_branch_name}/elastic-apm-node-{app_version}-{jenkins_git_commit_short}.tgz'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-node-{app_version}-{github_sha_short}.tgz'
     # List of metadata processors to use.
     metadata:
       # Define static custom metadata
@@ -32,5 +32,5 @@ artifacts:
           project: 'apm-agent-nodejs'
       # Add git metadata
       - name: 'git'
-      # Add jenkins metadata
-      - name: 'jenkins'
+      # Add github_actions metadata
+      - name: 'github_actions'


### PR DESCRIPTION
### What

Use github-actions metadata and git branch references


### Why

Otherwise, it fails

```
⇒ Loading configuration...
✓ Succeeded to load configuration
Traceback (most recent call last):
  File "snapshoty/artifacts.py", line 78, in walk
  File "string.py", line ***63, in format
  File "string.py", line ***67, in vformat
  File "string.py", line ***07, in _vformat
  File "string.py", line ***7***, in get_field
  File "string.py", line ***9, in get_value
KeyError: 'jenkins_***_name'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "snapshoty/commands.py", line 87, in ***
  File "snapshoty/artifacts.py", line 8***, in walk
ValueError: Failed to find `jenkins_***_name` metadata
```

when running on debug mode, see [here](https://github.com/elastic/apm-agent-nodejs/actions/runs/4006803609/jobs/6879318111)

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
