### PR TITLE
fix: add missing 'contextManager' config var to TypeScript types

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,9 @@ Notes:
   value, rather than the incorrect "k8s-attacher".
   ({issue}3119[#3119])
 
+* Add missing <<opentelemetry-bridge-enabled>> ({pull}3121[#3121]) and
+  <<context-manager>> Agent configuration options to the TypeScript types.
+
 [float]
 ===== Chores
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -244,9 +244,11 @@ declare namespace apm {
      * @deprecated Use `spanStackTraceMinDuration`.
      */
     captureSpanStackTraces?: boolean;
+    centralConfig?: boolean;
     cloudProvider?: string;
     configFile?: string;
     containerId?: string;
+    contextManager?: string;
     contextPropagationOnly?: boolean;
     disableInstrumentations?: string | string[];
     disableSend?: boolean;
@@ -278,7 +280,6 @@ declare namespace apm {
     metricsLimit?: number;
     opentelemetryBridgeEnabled?: boolean;
     payloadLogFile?: string;
-    centralConfig?: boolean;
     sanitizeFieldNames?: Array<string>;
     secretToken?: string;
     serverCaCertFile?: string;


### PR DESCRIPTION
Prompted by https://github.com/elastic/apm-agent-nodejs/pull/3121 for another missing config option from this type.