### PR TITLE
feat: support for Lambda function URL and ELB-triggered Lambdas

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,9 @@ Notes:
   incoming messages with trace-context. This allows linking between
   producer and consumer in the Kibana APM app. ({pull}3044[#3044])
 
+* Extend Lambda instrumentation to capture details for Lambda function URL
+  and ELB-triggered Lambdas. ({issues}2901[#2901])
+
 [float]
 ===== Bug fixes
 

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -21,15 +21,21 @@ let gFaasId // Set on first invocation.
 // The trigger types for which we support special handling.
 // https://docs.aws.amazon.com/lambda/latest/dg/lambda-services.html
 const TRIGGER_GENERIC = 1
-const TRIGGER_API_GATEWAY = 2
+const TRIGGER_API_GATEWAY = 2 // This includes Lambda URLs which use the same event format.
 const TRIGGER_SNS = 3
 const TRIGGER_SQS = 4
 const TRIGGER_S3_SINGLE_EVENT = 5
+const TRIGGER_ELB = 6 // Elastic Load Balancer, aka Application Load Balancer
 
 function triggerTypeFromEvent (event) {
-  if (event.requestContext && event.requestContext.requestId) {
-    return TRIGGER_API_GATEWAY
-  } else if (event.Records && event.Records.length >= 1) {
+  if (event.requestContext) {
+    if (event.requestContext.elb) {
+      return TRIGGER_ELB
+    } else if (event.requestContext.requestId) {
+      return TRIGGER_API_GATEWAY
+    }
+  }
+  if (event.Records && event.Records.length >= 1) {
     const eventSource = (event.Records[0].eventSource || // S3 and SQS
       event.Records[0].EventSource) // SNS
     if (eventSource === 'aws:sns') {
@@ -180,36 +186,42 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
   }
   trans.setServiceContext(serviceContext)
 
+  const originSvcName = (
+    // `<url-id>.lambda-url.<region>.on.aws` indicates this is a Lambda URL.
+    requestContext.domainName && requestContext.domainPrefix &&
+      requestContext.domainName.startsWith(requestContext.domainPrefix + '.lambda-url.')
+      ? 'lambda url'
+      : 'api gateway')
   const cloudContext = {
     origin: {
       provider: 'aws',
       service: {
-        name: 'api gateway'
+        name: originSvcName
       },
       account: {
-        id: event && event.requestContext.accountId
+        id: requestContext.accountId
       }
     }
   }
   trans.setCloudContext(cloudContext)
 }
 
-/**
- * Set transaction data for HTTP-y triggers -- API Gateway -- from the
- * Lambda function result.
- */
-function setTransDataFromHttpyResult (err, result, trans, event, triggerType) {
+function setTransDataFromApiGatewayResult (err, result, trans, event) {
   if (err) {
     trans.result = 'HTTP 5xx'
+    trans._setOutcomeFromHttpStatusCode(500)
   } else if (result && result.statusCode) {
     trans.result = 'HTTP ' + result.statusCode.toString()[0] + 'xx'
+    trans._setOutcomeFromHttpStatusCode(result.statusCode)
   } else {
     trans.result = constants.RESULT_SUCCESS
+    trans._setOutcomeFromHttpStatusCode(200)
   }
 
   // This doc defines the format of API Gateway-triggered responses, from which
   // we can infer `transaction.context.response` values.
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response
+  // https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads
   if (err) {
     trans.res = {
       statusCode: 500
@@ -234,6 +246,84 @@ function setTransDataFromHttpyResult (err, result, trans, event, triggerType) {
       }
     }
   }
+}
+
+// https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html
+function setElbData (agent, trans, event, context, faasId, isColdStart) {
+  trans.type = 'request'
+  let name
+  if (agent._conf.usePathAsTransactionName) {
+    name = `${event.httpMethod} ${event.path}`
+  } else {
+    name = `${event.httpMethod} unknown route`
+  }
+  trans.setDefaultName(name)
+  trans.req = { // Used by parsers.getContextFromRequest() for adding context to transaction and errors.
+    method: event.httpMethod,
+    url: event.path + (
+      event.queryStringParameters && Object.keys(event.queryStringParameters) > 0
+        ? '?' + querystring.encode(event.queryStringParameters)
+        : ''),
+    headers: event.normedHeaders,
+    body: event.body,
+    bodyIsBase64Encoded: event.isBase64Encoded
+  }
+
+  trans.setFaas(getFaasData(context, faasId, isColdStart, 'http'))
+
+  const targetGroupArn = event.requestContext.elb.targetGroupArn
+  const arnParts = targetGroupArn.split(':')
+  trans.setServiceContext({
+    origin: {
+      name: arnParts[5].split('/')[1],
+      id: targetGroupArn
+    }
+  })
+
+  trans.setCloudContext({
+    origin: {
+      provider: 'aws',
+      region: arnParts[3],
+      service: {
+        name: 'elb'
+      },
+      account: {
+        id: arnParts[4]
+      }
+    }
+  })
+}
+
+function setTransDataFromElbResult (err, result, trans) {
+  // ELB defaults to 502 Bad Gateway if there is an error or `result.statusCode`
+  // is missing or not an integer.
+  const validStatusCode = (
+    result && result.statusCode && typeof result.statusCode === 'number' && Number.isInteger(result.statusCode)
+      ? result.statusCode
+      : null
+  )
+
+  if (err) {
+    trans.result = 'HTTP 5xx'
+  } else if (validStatusCode) {
+    trans.result = 'HTTP ' + validStatusCode.toString()[0] + 'xx'
+  } else {
+    trans.result = 'HTTP 5xx'
+  }
+
+  // Set an appropriate pseudo `trans.res`, used by `parsers.getContextFromResponse()`.
+  if (err) {
+    trans.res = {
+      statusCode: 502
+    }
+  } else {
+    trans.res = {
+      statusCode: validStatusCode || 502,
+      headers: result.headers
+    }
+  }
+
+  trans._setOutcomeFromHttpStatusCode(validStatusCode || 502)
 }
 
 function setSqsData (agent, trans, event, context, faasId, isColdStart) {
@@ -352,12 +442,22 @@ function elasticApmAwsLambda (agent) {
   function endAndFlushTransaction (err, result, trans, event, context, triggerType, cb) {
     log.trace({ awsRequestId: context && context.awsRequestId }, 'lambda: fn end')
 
-    if (triggerType === TRIGGER_API_GATEWAY) {
-      setTransDataFromHttpyResult(err, result, trans, event, triggerType)
-    } else if (err) {
-      trans.result = constants.RESULT_FAILURE
-    } else {
-      trans.result = constants.RESULT_SUCCESS
+    switch (triggerType) {
+      case TRIGGER_API_GATEWAY:
+        setTransDataFromApiGatewayResult(err, result, trans, event)
+        break
+      case TRIGGER_ELB:
+        setTransDataFromElbResult(err, result, trans)
+        break
+      default:
+        if (err) {
+          trans.result = constants.RESULT_FAILURE
+          trans.setOutcome(constants.OUTCOME_FAILURE)
+        } else {
+          trans.result = constants.RESULT_SUCCESS
+          trans.setOutcome(constants.OUTCOME_SUCCESS)
+        }
+        break
     }
 
     if (err) {
@@ -366,9 +466,6 @@ function elasticApmAwsLambda (agent) {
       // currentSpan, because this error applies to the transaction, not any
       // sub-span.
       agent.captureError(err, { skipOutcome: true })
-      trans.setOutcome(constants.OUTCOME_FAILURE)
-    } else {
-      trans.setOutcome(constants.OUTCOME_SUCCESS)
     }
 
     trans.end()
@@ -454,7 +551,7 @@ function elasticApmAwsLambda (agent) {
       // Look for trace-context info in headers or messageAttributes.
       let traceparent
       let tracestate
-      if (triggerType === TRIGGER_API_GATEWAY && event.headers) {
+      if ((triggerType === TRIGGER_API_GATEWAY || triggerType === TRIGGER_ELB) && event.headers) {
         // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
         // says "Header names are lowercased." However, that isn't the case for
         // payload format version 1.0. We need lowercased headers for processing.
@@ -475,6 +572,9 @@ function elasticApmAwsLambda (agent) {
       switch (triggerType) {
         case TRIGGER_API_GATEWAY:
           setApiGatewayData(agent, trans, event, context, gFaasId, isColdStart)
+          break
+        case TRIGGER_ELB:
+          setElbData(agent, trans, event, context, gFaasId, isColdStart)
           break
         case TRIGGER_SQS:
           setSqsData(agent, trans, event, context, gFaasId, isColdStart)

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -512,7 +512,7 @@ function elasticApmAwsLambda (agent) {
   return function wrapLambda (type, fn) {
     if (typeof type === 'function') {
       fn = type
-      type = 'lambda'
+      type = 'request'
     }
     if (!agent._conf.active) {
       // Manual usage of `apm.lambda(...)` should be a no-op when not active.

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -18,6 +18,25 @@ const {
   redactKeysFromPostedFormVariables
 } = require('./filters/sanitize-field-names')
 
+/**
+ * Extract appropriate `{transaction,error}.context.request` from an HTTP
+ * request object. This handles header and body capture and redaction
+ * according to the agent config.
+ *
+ * @param {Object} req - Typically `req` is a Node.js `http.IncomingMessage`
+ *    (https://nodejs.org/api/all.html#all_http_class-httpincomingmessage).
+ *    However, some cases (e.g. Lambda and Azure Functions instrumentation)
+ *    create a pseudo-req object that matches well enough for this function.
+ *    Some relevant fields: (TODO: document all used fields)
+ *    - `body` - The incoming request body, if available. The `json` and
+ *      `payload` fields are also checked to accomodate some web frameworks.
+ *    - `bodyIsBase64Encoded` - An optional boolean. If `true`, then the `body`
+ *      needs to be base64-decoded before inclusion and redaction. Used by
+ *      Lambda instrumentation in some cases (e.g. for ELB triggers).
+ * @param {Object} conf - The full agent configuration.
+ * @param {String} type - 'errors' or 'transactions'. Indicates if this req
+ *    is being captured for an APM error or transaction event.
+ */
 function getContextFromRequest (req, conf, type) {
   var captureBody = conf.captureBody === type || conf.captureBody === 'all'
 
@@ -52,6 +71,9 @@ function getContextFromRequest (req, conf, type) {
     } else if (Buffer.isBuffer(body)) {
       context.body = '<Buffer>'
     } else {
+      if (typeof body === 'string' && req.bodyIsBase64Encoded === true) {
+        body = Buffer.from(body, 'base64').toString('utf8')
+      }
       body = redactKeysFromPostedFormVariables(body, req.headers, conf.sanitizeFieldNamesRegExp)
       if (typeof body !== 'string') {
         body = tryJsonStringify(body) || stringify(body)

--- a/test/lambda/fixtures/aws_elb_test_data.json
+++ b/test/lambda/fixtures/aws_elb_test_data.json
@@ -1,0 +1,24 @@
+{
+    "requestContext": {
+        "elb": {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:us-west-2:919493274929:targetgroup/my-target-group-1/e88598a9d8909e9f"
+        }
+    },
+    "httpMethod": "POST",
+    "path": "/foo/",
+    "queryStringParameters": {},
+    "headers": {
+        "accept": "*/*",
+        "content-length": "23",
+        "content-type": "application/x-www-form-urlencoded",
+        "host": "my-alb-598237592.us-west-2.elb.amazonaws.com",
+        "traceparent": "00-12345678901234567890123456789012-1234567890123456-01",
+        "user-agent": "curl/7.86.0",
+        "x-amzn-trace-id": "Root=1-63d18943-06b173755b217e7d2efa2249",
+        "x-forwarded-for": "1.2.3.4",
+        "x-forwarded-port": "80",
+        "x-forwarded-proto": "http"
+    },
+    "body": "aGFtPWVnZ3MmbXlUb2tlbj1zZWtyaXQ=",
+    "isBase64Encoded": true
+}

--- a/test/lambda/mock/transaction.js
+++ b/test/lambda/mock/transaction.js
@@ -67,6 +67,14 @@ module.exports = class TransactionMock {
     this.outcome = outcome
   }
 
+  _setOutcomeFromHttpStatusCode (statusCode) {
+    if (statusCode && statusCode >= 500) {
+      this.outcome = constants.OUTCOME_FAILURE
+    } else {
+      this.outcome = constants.OUTCOME_SUCCESS
+    }
+  }
+
   _addLinks (links) {
     this._links = this._links.concat(links)
   }

--- a/test/lambda/trace-context.test.js
+++ b/test/lambda/trace-context.test.js
@@ -23,6 +23,8 @@ test('API Gateway trigger: traceparent header present', function (t) {
   const handlerName = 'greet.hello'
   const mockApiGatewayEventWithTraceContext = {
     requestContext: {
+      domainName: '21mj4tsk90.execute-api.us-west-2.amazonaws.com',
+      domainPrefix: '21mj4tsk90',
       routeKey: 'ANY /the-function-name',
       requestId: '1d108eda-bfc2-4e1a-8942-d82db026cdf9',
       stage: 'default',

--- a/test/lambda/transaction2.test.js
+++ b/test/lambda/transaction2.test.js
@@ -178,14 +178,11 @@ tape.test('lambda transactions', function (suite) {
         t.equal(trans.trace_id, '12345678901234567890123456789012', 'transaction.trace_id')
         t.equal(trans.parent_id, '1234567890123456', 'transaction.parent_id')
         t.equal(trans.type, 'request', 'transaction.type')
-        // XXX update spec for this:
-        // `name` | e.g. `GET /prod/proxy/{proxy+}` | Transaction name: Http method followed by a whitespace and the (resource) path. See section below. | -
         t.equal(trans.name, 'POST unknown route', 'transaction.name')
-        // XXX update spec for no statusCode cases
         t.equal(trans.result, 'HTTP 2xx', 'transaction.result')
         t.equal(trans.outcome, 'success', 'transaction.outcome')
         t.equal(trans.faas.trigger.type, 'http', 'transaction.faas.trigger.type')
-        // XXX other faas.*?
+        t.equal(trans.faas.trigger.request_id, undefined, 'no transaction.faas.trigger.request_id for ELB')
         t.equal(trans.context.service.origin.name, 'my-target-group-1', 'transaction.context.service.origin.name')
         t.equal(trans.context.service.origin.id, 'arn:aws:elasticloadbalancing:us-west-2:919493274929:targetgroup/my-target-group-1/e88598a9d8909e9f', 'transaction.context.service.origin.id')
         t.equal(trans.context.cloud.origin.service.name, 'elb', 'transaction.context.cloud.origin.service.name')


### PR DESCRIPTION
The transaction captured for a Lambda triggered by a Lambda function URL
or by ELB (an Application Load Balancer targetting the Lambda function)
will now include data according to spec
(https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-aws-lambda.md#elastic-load-balancer-elb).

Closes: #2901

# checklist

- [x] possible update to spec for trans.name and trans.result for ELB: https://github.com/elastic/apm/pull/749
- [x] remove dev comments
