### PR TITLE
test: reduce the number of aws-sdk versions tested in TAV tests

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -507,8 +507,8 @@ aws-sdk:
   # Maintenance note: This should be updated periodically using:
   #   ./dev-utils/aws-sdk-tav-versions.sh
   #
-  # Test v2.858.0, every N=72 of 365 releases, and current latest.
-  versions: '2.858.0 || 2.930.0 || 2.1002.0 || 2.1074.0 || 2.1146.0 || 2.1218.0 || 2.1222.0 || >2.1222.0 <3'
+  # Test v2.858.0, every N=88 of 445 releases, and current latest.
+  versions: '2.858.0 || 2.946.0 || 2.1034.0 || 2.1122.0 || 2.1210.0 || 2.1298.0 || 2.1302.0 || >2.1302.0 <3'
   commands:
     - node test/instrumentation/modules/aws-sdk/aws4-retries.test.js
     - node test/instrumentation/modules/aws-sdk/s3.test.js


### PR DESCRIPTION
The aws-sdk TAV tests are again getting to be the longest-running
ones, taking over 30m in Jenkins CI.

---

```
$ ./dev-utils/jenkins-build-slow-steps.sh https://apm-ci.elastic.co/job/apm-agent-nodejs/job/apm-agent-nodejs-mbp/job/main/592/
...
1469845 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "pg" "12"
1470370 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "tedious" "12"
1473120 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "tedious" "14"
1474314 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "fastify" "14"
1474713 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "graphql" "14"
1475815 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "graphql" "12"
1478359 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "16"
1481406 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "18"
1485740 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "19"
1602140 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "10"
1619067 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "12"
1702329 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "knex" "14"
2091735 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "8"
2093469 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "14"
2197420 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "12"
2283006 FINISHED SUCCESS .ci/scripts/test.sh -b "release" -t "aws-sdk" "10"
```