### PR TITLE
feat: Make Agent.flush() return a Promise if no callback is passed as param

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,7 +50,7 @@ Notes:
 * Extend Lambda instrumentation to capture details for Lambda function URL
   and ELB-triggered Lambdas. ({issues}2901[#2901])
 
-* Make `Agent.flush()` return a `Promise` if no callback is passed as param ({issues}2857(#2857)
+* Make `Agent.flush()` return a `Promise` if no callback is passed as param. ({issues}2857(#2857))
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,8 @@ Notes:
 * Extend Lambda instrumentation to capture details for Lambda function URL
   and ELB-triggered Lambdas. ({issues}2901[#2901])
 
+* Make `Agent.flush()` return a `Promise` if no callback is passed as param ({issues}2857(#2857)
+
 [float]
 ===== Bug fixes
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -695,16 +695,35 @@ remember to terminate the node process.
 
 [source,js]
 ----
+// with node-style callback
 apm.flush(function (err) {
   // Flush complete
 })
+
+// with promises
+apm.flush().then(function () {
+  // Flush complete
+}).catch(function (err) {
+  // Flush returned an error
+})
+
+// inside of an async function
+try {
+  await apm.flush()
+  // Flush complete
+} catch (err) {
+  // Flush returned an error
+}
 ----
 
 Manually end the active outgoing HTTP request to the APM Server.
 The HTTP request is otherwise ended automatically at regular intervals,
 controlled by the <<api-request-time,`apiRequestTime`>> and <<api-request-size,`apiRequestSize`>> config options.
 
-The callback is called *after* the active HTTP request has ended.
+If an optional `callback` is provided as the first argument to this method, it will call `callback(flushErr)` when complete. 
+If no `callback` is provided, then a `Promise` will be returned, which will either resolve with `void` or reject with `flushErr`.
+
+The callback is called (or the `Promise` resolves if no `callback` argument is provided) *after* the active HTTP request has ended.
 The callback is called even if no HTTP request is currently active.
 
 [[apm-lambda]]

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,6 +127,7 @@ declare namespace apm {
     addSpanFilter (fn: FilterFn): void;
     addTransactionFilter (fn: FilterFn): void;
     addMetadataFilter (fn: FilterFn): void;
+    flush (): Promise<void>;
     flush (callback?: Function): void;
     destroy (): void;
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -666,25 +666,22 @@ Agent.prototype.flush = function (cb) {
   // being reported to APM server".
   const DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS = 1000
 
+  // shared options for the private `._flush()` API.
+  const opts = { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS }
+
   if (typeof cb !== 'function') {
     return new Promise((resolve, reject) => {
-      this._flush(
-        { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS },
-        (err) => {
-          if (err) {
-            reject(err)
-          }
-
-          resolve()
+      this._flush(opts, (err) => {
+        if (err) {
+          reject(err)
         }
-      )
+
+        resolve()
+      })
     })
   }
 
-  return this._flush(
-    { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS },
-    cb
-  )
+  return this._flush(opts, cb)
 }
 
 // The internal-use `.flush()` that supports some options not exposed to the

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -629,7 +629,7 @@ Agent.prototype.handleUncaughtExceptions = function (cb) {
 // Flush all ended APM events (transactions, spans, errors, metricsets) to APM
 // server as soon as possible. If the optional `cb` is given, it will be called
 // `cb(flushErr)` when this is complete. If no `cb` is given, then a `Promise`
-// will be returned, which will either resolve with `void` or reject with 
+// will be returned, which will either resolve with `void` or reject with
 // `flushErr`.
 //
 // Encoding and passing event data to the agent's transport is *asynchronous*
@@ -664,7 +664,7 @@ Agent.prototype.flush = function (cb) {
   // This 1s timeout is a subjective balance between "long enough for spans
   // and errors to reasonably encode" and "short enough to not block data
   // being reported to APM server".
-  const DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS = 1000;
+  const DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS = 1000
 
   if (typeof cb !== 'function') {
     return new Promise((resolve, reject) => {
@@ -672,20 +672,20 @@ Agent.prototype.flush = function (cb) {
         { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS },
         (err) => {
           if (err) {
-            reject(err);
+            reject(err)
           }
 
-          resolve();
+          resolve()
         }
-      );
-    });
+      )
+    })
   }
 
   return this._flush(
     { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS },
     cb
-  );
-};
+  )
+}
 
 // The internal-use `.flush()` that supports some options not exposed to the
 // public API.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -628,7 +628,9 @@ Agent.prototype.handleUncaughtExceptions = function (cb) {
 
 // Flush all ended APM events (transactions, spans, errors, metricsets) to APM
 // server as soon as possible. If the optional `cb` is given, it will be called
-// `cb(flushErr)` when this is complete.
+// `cb(flushErr)` when this is complete. If no `cb` is given, then a `Promise`
+// will be returned, which will either resolve with `void` or reject with 
+// `flushErr`.
 //
 // Encoding and passing event data to the agent's transport is *asynchronous*
 // for some event types: spans and errors. This flush will make a *best effort*
@@ -662,10 +664,28 @@ Agent.prototype.flush = function (cb) {
   // This 1s timeout is a subjective balance between "long enough for spans
   // and errors to reasonably encode" and "short enough to not block data
   // being reported to APM server".
-  const DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS = 1000
+  const DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS = 1000;
 
-  return this._flush({ inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS }, cb)
-}
+  if (typeof cb !== 'function') {
+    return new Promise((resolve, reject) => {
+      this._flush(
+        { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS },
+        (err) => {
+          if (err) {
+            reject(err);
+          }
+
+          resolve();
+        }
+      );
+    });
+  }
+
+  return this._flush(
+    { inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS },
+    cb
+  );
+};
 
 // The internal-use `.flush()` that supports some options not exposed to the
 // public API.

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -1148,6 +1148,21 @@ test('#flush()', function (t) {
     })
   })
 
+  t.test('flush can be used without a callback to return a Promise', function (t) {
+    t.plan(1)
+
+    const agent = new Agent()
+
+    agent.flush().then(function () {
+      t.pass('should resolve the Promise for agent.flush')
+    }).catch(function (err) {
+      t.error(err, 'no error passed to agent.flush callback')
+    }).finally(function () {
+      agent.destroy()
+      t.end()
+    })
+  })
+
   t.end()
 })
 

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -1155,11 +1155,10 @@ test('#flush()', function (t) {
 
     agent.flush().then(function () {
       t.pass('should resolve the Promise for agent.flush')
-    }).catch(function (err) {
-      t.error(err, 'no error passed to agent.flush callback')
-    }).finally(function () {
       agent.destroy()
       t.end()
+    }).catch(function (err) {
+      t.error(err, 'no error passed to agent.flush callback')
     })
   })
 


### PR DESCRIPTION
Fixes #2857.

This PR modifies `Agent.flush()` to return a `Promise` if no `callback` parameter is supplied to the function. This allows the method to be usable with the `await` keyword.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
