### PR TITLE
chore: Do not block instrumentation for mongodb driver v5.x

### DIFF
--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -17,7 +17,7 @@ const HOSTNAME_PORT_RE = /^(.+):(\d+)$/
 
 module.exports = (mongodb, agent, { version, enabled }) => {
   if (!enabled) return mongodb
-  if (!semver.satisfies(version, '>=3.3 <5.0')) {
+  if (!semver.satisfies(version, '>=3.3 <6.0')) {
     agent.logger.debug('mongodb version %s not instrumented (mongodb <3.3 is instrumented via mongodb-core)', version)
     return mongodb
   }


### PR DESCRIPTION
It looks like instrumentation for mongodb v5.x driver just works.

BTW. Why `span` outcome is not set?

### Checklist

- [x] Implement code
