### PR TITLE
fix: transaction name for Next.js API routes in next@13.2 was broken

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,10 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix the transaction name for *API* routes in Next.js >=13.2.x. Before this
+  change internal changes in next@13.2.0 resulted in transactions for Next.js
+  API routes being `{method} unknown route`.
+
 * Fix `metadata.service.agent.activation_method=k8s-attach` handling to
   (a) use an explicit marker from the k8s apm attacher
   (`ELASTIC_APM_ACTIVATION_METHOD`) and (b) use the specified "k8s-attach"

--- a/lib/instrumentation/modules/next/README.md
+++ b/lib/instrumentation/modules/next/README.md
@@ -60,12 +60,12 @@ where this method is not used to handle an exception. This instrumentation isn't
 capturing those.)
 
 *API* routes ("pages/api/...") are handled differently from other pages.
-The `catchAllRoute` route handler calls `handleApiRequest`, which resolves
-the URL path to a possibly dynamic route name (e.g. `/api/widgets/[id]`,
-**we instrument `ensureApiPage` to get that resolve route name**), loads the
-webpack-compiled user module for that route, and calls `apiResolver` in
-"api-utils/node.ts" to execute. **We instrument that `apiResolve()` function
-to capture any errors in the user's handler.**
+The `catchAllRoute` route handler calls `handleApiRequest`, which calls
+`runApi`. **We instrument `runApi` to get the resolved (e.g. handling dynamic
+routes) route name.**  `runApi` loads the webpack-compiled user module
+for that route, and calls `apiResolver` in "api-utils/node.ts" to execute it.
+**We instrument that `apiResolver()` function to capture any errors in the
+user's handler.**
 
 
 ## dist/server/dev/next-dev-server.js
@@ -79,6 +79,6 @@ class to capture results specific to the dev-server. For example
 
 ## dist/server/api-utils/node.js
 
-See the `apiResolve()` mention above.
+See the `apiResolver()` mention above.
 
 

--- a/lib/instrumentation/modules/next/README.md
+++ b/lib/instrumentation/modules/next/README.md
@@ -62,10 +62,11 @@ capturing those.)
 *API* routes ("pages/api/...") are handled differently from other pages.
 The `catchAllRoute` route handler calls `handleApiRequest`, which calls
 `runApi`. **We instrument `runApi` to get the resolved (e.g. handling dynamic
-routes) route name.**  `runApi` loads the webpack-compiled user module
-for that route, and calls `apiResolver` in "api-utils/node.ts" to execute it.
-**We instrument that `apiResolver()` function to capture any errors in the
-user's handler.**
+routes) route name.**  (For next@11, `ensureApiPage` is instrumented instead
+because `runApi` was only added in next@12.) `runApi` loads the webpack-compiled
+user module for that route, and calls `apiResolver` in "api-utils/node.ts" to
+execute it. **We instrument that `apiResolver()` function to capture any errors
+in the user's handler.**
 
 
 ## dist/server/dev/next-dev-server.js

--- a/lib/instrumentation/modules/next/dist/server/dev/next-dev-server.js
+++ b/lib/instrumentation/modules/next/dist/server/dev/next-dev-server.js
@@ -12,6 +12,7 @@ const semver = require('semver')
 
 const shimmer = require('../../../../../shimmer')
 
+// `kSetTransNameFn` symbol is shared with "next-server.js" instrumentation.
 const kSetTransNameFn = Symbol.for('ElasticAPMNextJsSetTransNameFn')
 
 const noopFn = () => {}
@@ -30,7 +31,6 @@ module.exports = function (mod, agent, { version, enabled }) {
 
   const DevServer = mod.default
   shimmer.wrap(DevServer.prototype, 'generateRoutes', wrapGenerateRoutes)
-  shimmer.wrap(DevServer.prototype, 'ensureApiPage', wrapEnsureApiPage)
   shimmer.wrap(DevServer.prototype, 'findPageComponents', wrapFindPageComponents)
   // Instrumenting the DevServer also uses the wrapping of
   // 'NextNodeServer.renderErrorToResponse' in "next-server.js".
@@ -151,21 +151,6 @@ module.exports = function (mod, agent, { version, enabled }) {
         }
       }
       return origRouteFn.apply(this, arguments)
-    }
-  }
-
-  function wrapEnsureApiPage (orig) {
-    return function wrappedEnsureApiPage (pathname) {
-      if (this.constructor !== DevServer) {
-        return orig.apply(this, arguments)
-      }
-      const trans = ins.currTransaction()
-      if (trans && trans.req) {
-        log.trace({ pathname }, 'set transaction name from ensureApiPage')
-        trans.setDefaultName(`${trans.req.method} ${pathname}`)
-        trans[kSetTransNameFn] = noopFn
-      }
-      return orig.apply(this, arguments)
     }
   }
 

--- a/lib/instrumentation/modules/next/dist/server/dev/next-dev-server.js
+++ b/lib/instrumentation/modules/next/dist/server/dev/next-dev-server.js
@@ -32,6 +32,10 @@ module.exports = function (mod, agent, { version, enabled }) {
   const DevServer = mod.default
   shimmer.wrap(DevServer.prototype, 'generateRoutes', wrapGenerateRoutes)
   shimmer.wrap(DevServer.prototype, 'findPageComponents', wrapFindPageComponents)
+  if (semver.satisfies(version, '11.x')) {
+    // See comment for `wrapEnsureApiPage` in "../next-server.js".
+    shimmer.wrap(DevServer.prototype, 'ensureApiPage', wrapEnsureApiPage)
+  }
   // Instrumenting the DevServer also uses the wrapping of
   // 'NextNodeServer.renderErrorToResponse' in "next-server.js".
 
@@ -151,6 +155,22 @@ module.exports = function (mod, agent, { version, enabled }) {
         }
       }
       return origRouteFn.apply(this, arguments)
+    }
+  }
+
+  // Only used with next@11.
+  function wrapEnsureApiPage (orig) {
+    return function wrappedEnsureApiPage (pathname) {
+      if (this.constructor !== DevServer) {
+        return orig.apply(this, arguments)
+      }
+      const trans = ins.currTransaction()
+      if (trans && trans.req) {
+        log.trace({ pathname }, 'set transaction name from ensureApiPage')
+        trans.setDefaultName(`${trans.req.method} ${pathname}`)
+        trans[kSetTransNameFn] = noopFn
+      }
+      return orig.apply(this, arguments)
     }
   }
 

--- a/lib/instrumentation/modules/next/dist/server/next-server.js
+++ b/lib/instrumentation/modules/next/dist/server/next-server.js
@@ -32,7 +32,15 @@ module.exports = function (mod, agent, { version, enabled }) {
 
   const NextNodeServer = mod.default
   shimmer.wrap(NextNodeServer.prototype, 'generateRoutes', wrapGenerateRoutes)
-  shimmer.wrap(NextNodeServer.prototype, 'runApi', wrapRunApi)
+  // Capturing the resolve page name for *API* routes: We are instrumenting a
+  // function called inside `NextNodeServer.handleApiRequest()`.
+  // `this.ensureApiPage(page)` existed up to next@13.2.0. `this.runApi(...)`
+  // was added in next@12.
+  if (semver.satisfies(version, '11.x')) {
+    shimmer.wrap(NextNodeServer.prototype, 'ensureApiPage', wrapEnsureApiPage)
+  } else {
+    shimmer.wrap(NextNodeServer.prototype, 'runApi', wrapRunApi)
+  }
   shimmer.wrap(NextNodeServer.prototype, 'findPageComponents', wrapFindPageComponents)
   shimmer.wrap(NextNodeServer.prototype, 'renderErrorToResponse', wrapRenderErrorToResponse)
 
@@ -149,6 +157,22 @@ module.exports = function (mod, agent, { version, enabled }) {
         }
       }
       return origRouteFn.apply(this, arguments)
+    }
+  }
+
+  // Only used with next@11.
+  function wrapEnsureApiPage (orig) {
+    return function wrappedEnsureApiPage (pathname) {
+      if (this.constructor !== NextNodeServer) {
+        return orig.apply(this, arguments)
+      }
+      const trans = ins.currTransaction()
+      if (trans && trans.req) {
+        log.trace({ pathname }, 'set transaction name from ensureApiPage')
+        trans.setDefaultName(`${trans.req.method} ${pathname}`)
+        trans[kSetTransNameFn] = noopFn
+      }
+      return orig.apply(this, arguments)
     }
   }
 

--- a/lib/instrumentation/modules/next/dist/server/next-server.js
+++ b/lib/instrumentation/modules/next/dist/server/next-server.js
@@ -12,6 +12,7 @@ const semver = require('semver')
 
 const shimmer = require('../../../../shimmer')
 
+// `kSetTransNameFn` symbol is shared with "next-dev-server.js" instrumentation.
 const kSetTransNameFn = Symbol.for('ElasticAPMNextJsSetTransNameFn')
 const kErrIsCaptured = Symbol.for('ElasticAPMNextJsErrIsCaptured')
 
@@ -31,7 +32,7 @@ module.exports = function (mod, agent, { version, enabled }) {
 
   const NextNodeServer = mod.default
   shimmer.wrap(NextNodeServer.prototype, 'generateRoutes', wrapGenerateRoutes)
-  shimmer.wrap(NextNodeServer.prototype, 'ensureApiPage', wrapEnsureApiPage)
+  shimmer.wrap(NextNodeServer.prototype, 'runApi', wrapRunApi)
   shimmer.wrap(NextNodeServer.prototype, 'findPageComponents', wrapFindPageComponents)
   shimmer.wrap(NextNodeServer.prototype, 'renderErrorToResponse', wrapRenderErrorToResponse)
 
@@ -151,15 +152,15 @@ module.exports = function (mod, agent, { version, enabled }) {
     }
   }
 
-  function wrapEnsureApiPage (orig) {
-    return function wrappedEnsureApiPage (pathname) {
-      if (this.constructor !== NextNodeServer) {
+  function wrapRunApi (orig) {
+    return function wrappedRunApi (_req, _res, _query, _params, page, _builtPagePath) {
+      if (typeof (page) !== 'string') { // Sanity check on args to `runApi()`.
         return orig.apply(this, arguments)
       }
       const trans = ins.currTransaction()
       if (trans && trans.req) {
-        log.trace({ pathname }, 'set transaction name from ensureApiPage')
-        trans.setDefaultName(`${trans.req.method} ${pathname}`)
+        log.trace({ page }, 'set transaction name from runApi')
+        trans.setDefaultName(`${trans.req.method} ${page}`)
         trans[kSetTransNameFn] = noopFn
       }
       return orig.apply(this, arguments)

--- a/test/instrumentation/modules/next/a-nextjs-app/package-lock.json
+++ b/test/instrumentation/modules/next/a-nextjs-app/package-lock.json
@@ -9,20 +9,20 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "next": "^13.1.6",
+        "next": "^13.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
     },
     "node_modules/@next/env": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.1.6.tgz",
-      "integrity": "sha512-s+W9Fdqh5MFk6ECrbnVmmAOwxKQuhGMT7xXHrkYIBMBcTiOqNWhv5KbJIboKR5STXxNXl32hllnvKaffzFaWQg=="
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.1.tgz",
+      "integrity": "sha512-Hq+6QZ6kgmloCg8Kgrix+4F0HtvLqVK3FZAnlAoS0eonaDemHe1Km4kwjSWRE3JNpJNcKxFHF+jsZrYo0SxWoQ=="
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
-      "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.1.tgz",
+      "integrity": "sha512-Yua7mUpEd1wzIT6Jjl3dpRizIfGp9NR4F2xeRuQv+ae+SDI1Em2WyM9m46UL+oeW5GpMiEHoaBagr47RScZFmQ==",
       "cpu": [
         "arm"
       ],
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
-      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.1.tgz",
+      "integrity": "sha512-Bifcr2f6VwInOdq1uH/9lp8fH7Nf7XGkIx4XceVd32LPJqG2c6FZU8ZRBvTdhxzXVpt5TPtuXhOP4Ij9UPqsVw==",
       "cpu": [
         "arm64"
       ],
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.1.6.tgz",
-      "integrity": "sha512-KKRQH4DDE4kONXCvFMNBZGDb499Hs+xcFAwvj+rfSUssIDrZOlyfJNy55rH5t2Qxed1e4K80KEJgsxKQN1/fyw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.1.tgz",
+      "integrity": "sha512-gvqm+fGMYxAkwBapH0Vvng5yrb6HTkIvZfY4oEdwwYrwuLdkjqnJygCMgpNqIFmAHSXgtlWxfYv1VC8sjN81Kw==",
       "cpu": [
         "arm64"
       ],
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.6.tgz",
-      "integrity": "sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.1.tgz",
+      "integrity": "sha512-HGqVqmaZWj6zomqOZUVbO5NhlABL0iIaxTmd0O5B0MoMa5zpDGoaHSG+fxgcWMXcGcxmUNchv1NfNOYiTKoHOg==",
       "cpu": [
         "x64"
       ],
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.6.tgz",
-      "integrity": "sha512-qaEALZeV7to6weSXk3Br80wtFQ7cFTpos/q+m9XVRFggu+8Ib895XhMWdJBzew6aaOcMvYR6KQ6JmHA2/eMzWw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.1.tgz",
+      "integrity": "sha512-N/a4JarAq+E+g+9K2ywJUmDIgU2xs2nA+BBldH0oq4zYJMRiUhL0iaN9G4e72VmGOJ61L/3W6VN8RIUOwTLoqQ==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.6.tgz",
-      "integrity": "sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.1.tgz",
+      "integrity": "sha512-WaFoerF/eRbhbE57TaIGJXbQAERADZ/RZ45u6qox9beb5xnWsyYgzX+WuN7Tkhyvga0/aMuVYFzS9CEay7D+bw==",
       "cpu": [
         "arm"
       ],
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.6.tgz",
-      "integrity": "sha512-yCH+yDr7/4FDuWv6+GiYrPI9kcTAO3y48UmaIbrKy8ZJpi7RehJe3vIBRUmLrLaNDH3rY1rwoHi471NvR5J5NQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.1.tgz",
+      "integrity": "sha512-R+Jhc1/RJTnncE9fkePboHDNOCm1WJ8daanWbjKhfPySMyeniKYRwGn5SLYW3S8YlRS0QVdZaaszDSZWgUcsmA==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.6.tgz",
-      "integrity": "sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.1.tgz",
+      "integrity": "sha512-oI1UfZPidGAVddlL2eOTmfsuKV9EaT1aktIzVIxIAgxzQSdwsV371gU3G55ggkurzfdlgF3GThFePDWF0d8dmw==",
       "cpu": [
         "arm64"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.6.tgz",
-      "integrity": "sha512-GT5w2mruk90V/I5g6ScuueE7fqj/d8Bui2qxdw6lFxmuTgMeol5rnzAv4uAoVQgClOUO/MULilzlODg9Ib3Y4Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.1.tgz",
+      "integrity": "sha512-PCygPwrQmS+7WUuAWWioWMZCzZm4PG91lfRxToLDg7yIm/3YfAw5N2EK2TaM9pzlWdvHQAqRMX/oLvv027xUiA==",
       "cpu": [
         "x64"
       ],
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.6.tgz",
-      "integrity": "sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.1.tgz",
+      "integrity": "sha512-sUAKxo7CFZYGHNxheGh9nIBElLYBM6md/liEGfOTwh/xna4/GTTcmkGWkF7PdnvaYNgcPIQgHIMYiAa6yBKAVw==",
       "cpu": [
         "x64"
       ],
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.6.tgz",
-      "integrity": "sha512-OwertslIiGQluFvHyRDzBCIB07qJjqabAmINlXUYt7/sY7Q7QPE8xVi5beBxX/rxTGPIbtyIe3faBE6Z2KywhQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.1.tgz",
+      "integrity": "sha512-qDmyEjDBpl/vBXxuOOKKWmPQOcARcZIMach1s7kjzaien0SySut/PHRlj56sosa81Wt4hTGhfhZ1R7g1n7+B8w==",
       "cpu": [
         "arm64"
       ],
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.6.tgz",
-      "integrity": "sha512-g8zowiuP8FxUR9zslPmlju7qYbs2XBtTLVSxVikPtUDQedhcls39uKYLvOOd1JZg0ehyhopobRoH1q+MHlIN/w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.1.tgz",
+      "integrity": "sha512-2joqFQ81ZYPg6DcikIzQn3DgjKglNhPAozx6dL5sCNkr1CPMD0YIkJgT3CnYyMHQ04Qi3Npv0XX3MD6LJO8OCA==",
       "cpu": [
         "ia32"
       ],
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.6.tgz",
-      "integrity": "sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.1.tgz",
+      "integrity": "sha512-r3+0fSaIZT6N237iMzwUhfNwjhAFvXjqB+4iuW+wcpxW+LHm1g/IoxN8eSRcb8jPItC86JxjAxpke0QL97qd6g==",
       "cpu": [
         "x64"
       ],
@@ -270,11 +270,11 @@
       }
     },
     "node_modules/next": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.1.6.tgz",
-      "integrity": "sha512-hHlbhKPj9pW+Cymvfzc15lvhaOZ54l+8sXDXJWm3OBNBzgrVj6hwGPmqqsXg40xO1Leq+kXpllzRPuncpC0Phw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.1.tgz",
+      "integrity": "sha512-qhgJlDtG0xidNViJUPeQHLGJJoT4zDj/El7fP3D3OzpxJDUfxsm16cK4WTMyvSX1ciIfAq05u+0HqFAa+VJ+Hg==",
       "dependencies": {
-        "@next/env": "13.1.6",
+        "@next/env": "13.2.1",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -287,21 +287,22 @@
         "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "13.1.6",
-        "@next/swc-android-arm64": "13.1.6",
-        "@next/swc-darwin-arm64": "13.1.6",
-        "@next/swc-darwin-x64": "13.1.6",
-        "@next/swc-freebsd-x64": "13.1.6",
-        "@next/swc-linux-arm-gnueabihf": "13.1.6",
-        "@next/swc-linux-arm64-gnu": "13.1.6",
-        "@next/swc-linux-arm64-musl": "13.1.6",
-        "@next/swc-linux-x64-gnu": "13.1.6",
-        "@next/swc-linux-x64-musl": "13.1.6",
-        "@next/swc-win32-arm64-msvc": "13.1.6",
-        "@next/swc-win32-ia32-msvc": "13.1.6",
-        "@next/swc-win32-x64-msvc": "13.1.6"
+        "@next/swc-android-arm-eabi": "13.2.1",
+        "@next/swc-android-arm64": "13.2.1",
+        "@next/swc-darwin-arm64": "13.2.1",
+        "@next/swc-darwin-x64": "13.2.1",
+        "@next/swc-freebsd-x64": "13.2.1",
+        "@next/swc-linux-arm-gnueabihf": "13.2.1",
+        "@next/swc-linux-arm64-gnu": "13.2.1",
+        "@next/swc-linux-arm64-musl": "13.2.1",
+        "@next/swc-linux-x64-gnu": "13.2.1",
+        "@next/swc-linux-x64-musl": "13.2.1",
+        "@next/swc-win32-arm64-msvc": "13.2.1",
+        "@next/swc-win32-ia32-msvc": "13.2.1",
+        "@next/swc-win32-x64-msvc": "13.2.1"
       },
       "peerDependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
         "react": "^18.2.0",
@@ -309,6 +310,9 @@
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
         "fibers": {
           "optional": true
         },
@@ -417,86 +421,86 @@
   },
   "dependencies": {
     "@next/env": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.1.6.tgz",
-      "integrity": "sha512-s+W9Fdqh5MFk6ECrbnVmmAOwxKQuhGMT7xXHrkYIBMBcTiOqNWhv5KbJIboKR5STXxNXl32hllnvKaffzFaWQg=="
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.1.tgz",
+      "integrity": "sha512-Hq+6QZ6kgmloCg8Kgrix+4F0HtvLqVK3FZAnlAoS0eonaDemHe1Km4kwjSWRE3JNpJNcKxFHF+jsZrYo0SxWoQ=="
     },
     "@next/swc-android-arm-eabi": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
-      "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.1.tgz",
+      "integrity": "sha512-Yua7mUpEd1wzIT6Jjl3dpRizIfGp9NR4F2xeRuQv+ae+SDI1Em2WyM9m46UL+oeW5GpMiEHoaBagr47RScZFmQ==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
-      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.1.tgz",
+      "integrity": "sha512-Bifcr2f6VwInOdq1uH/9lp8fH7Nf7XGkIx4XceVd32LPJqG2c6FZU8ZRBvTdhxzXVpt5TPtuXhOP4Ij9UPqsVw==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.1.6.tgz",
-      "integrity": "sha512-KKRQH4DDE4kONXCvFMNBZGDb499Hs+xcFAwvj+rfSUssIDrZOlyfJNy55rH5t2Qxed1e4K80KEJgsxKQN1/fyw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.1.tgz",
+      "integrity": "sha512-gvqm+fGMYxAkwBapH0Vvng5yrb6HTkIvZfY4oEdwwYrwuLdkjqnJygCMgpNqIFmAHSXgtlWxfYv1VC8sjN81Kw==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.6.tgz",
-      "integrity": "sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.1.tgz",
+      "integrity": "sha512-HGqVqmaZWj6zomqOZUVbO5NhlABL0iIaxTmd0O5B0MoMa5zpDGoaHSG+fxgcWMXcGcxmUNchv1NfNOYiTKoHOg==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.6.tgz",
-      "integrity": "sha512-qaEALZeV7to6weSXk3Br80wtFQ7cFTpos/q+m9XVRFggu+8Ib895XhMWdJBzew6aaOcMvYR6KQ6JmHA2/eMzWw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.1.tgz",
+      "integrity": "sha512-N/a4JarAq+E+g+9K2ywJUmDIgU2xs2nA+BBldH0oq4zYJMRiUhL0iaN9G4e72VmGOJ61L/3W6VN8RIUOwTLoqQ==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.6.tgz",
-      "integrity": "sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.1.tgz",
+      "integrity": "sha512-WaFoerF/eRbhbE57TaIGJXbQAERADZ/RZ45u6qox9beb5xnWsyYgzX+WuN7Tkhyvga0/aMuVYFzS9CEay7D+bw==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.6.tgz",
-      "integrity": "sha512-yCH+yDr7/4FDuWv6+GiYrPI9kcTAO3y48UmaIbrKy8ZJpi7RehJe3vIBRUmLrLaNDH3rY1rwoHi471NvR5J5NQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.1.tgz",
+      "integrity": "sha512-R+Jhc1/RJTnncE9fkePboHDNOCm1WJ8daanWbjKhfPySMyeniKYRwGn5SLYW3S8YlRS0QVdZaaszDSZWgUcsmA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.6.tgz",
-      "integrity": "sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.1.tgz",
+      "integrity": "sha512-oI1UfZPidGAVddlL2eOTmfsuKV9EaT1aktIzVIxIAgxzQSdwsV371gU3G55ggkurzfdlgF3GThFePDWF0d8dmw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.6.tgz",
-      "integrity": "sha512-GT5w2mruk90V/I5g6ScuueE7fqj/d8Bui2qxdw6lFxmuTgMeol5rnzAv4uAoVQgClOUO/MULilzlODg9Ib3Y4Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.1.tgz",
+      "integrity": "sha512-PCygPwrQmS+7WUuAWWioWMZCzZm4PG91lfRxToLDg7yIm/3YfAw5N2EK2TaM9pzlWdvHQAqRMX/oLvv027xUiA==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.6.tgz",
-      "integrity": "sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.1.tgz",
+      "integrity": "sha512-sUAKxo7CFZYGHNxheGh9nIBElLYBM6md/liEGfOTwh/xna4/GTTcmkGWkF7PdnvaYNgcPIQgHIMYiAa6yBKAVw==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.6.tgz",
-      "integrity": "sha512-OwertslIiGQluFvHyRDzBCIB07qJjqabAmINlXUYt7/sY7Q7QPE8xVi5beBxX/rxTGPIbtyIe3faBE6Z2KywhQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.1.tgz",
+      "integrity": "sha512-qDmyEjDBpl/vBXxuOOKKWmPQOcARcZIMach1s7kjzaien0SySut/PHRlj56sosa81Wt4hTGhfhZ1R7g1n7+B8w==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.6.tgz",
-      "integrity": "sha512-g8zowiuP8FxUR9zslPmlju7qYbs2XBtTLVSxVikPtUDQedhcls39uKYLvOOd1JZg0ehyhopobRoH1q+MHlIN/w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.1.tgz",
+      "integrity": "sha512-2joqFQ81ZYPg6DcikIzQn3DgjKglNhPAozx6dL5sCNkr1CPMD0YIkJgT3CnYyMHQ04Qi3Npv0XX3MD6LJO8OCA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.6.tgz",
-      "integrity": "sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.1.tgz",
+      "integrity": "sha512-r3+0fSaIZT6N237iMzwUhfNwjhAFvXjqB+4iuW+wcpxW+LHm1g/IoxN8eSRcb8jPItC86JxjAxpke0QL97qd6g==",
       "optional": true
     },
     "@swc/helpers": {
@@ -536,24 +540,24 @@
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "next": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.1.6.tgz",
-      "integrity": "sha512-hHlbhKPj9pW+Cymvfzc15lvhaOZ54l+8sXDXJWm3OBNBzgrVj6hwGPmqqsXg40xO1Leq+kXpllzRPuncpC0Phw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.1.tgz",
+      "integrity": "sha512-qhgJlDtG0xidNViJUPeQHLGJJoT4zDj/El7fP3D3OzpxJDUfxsm16cK4WTMyvSX1ciIfAq05u+0HqFAa+VJ+Hg==",
       "requires": {
-        "@next/env": "13.1.6",
-        "@next/swc-android-arm-eabi": "13.1.6",
-        "@next/swc-android-arm64": "13.1.6",
-        "@next/swc-darwin-arm64": "13.1.6",
-        "@next/swc-darwin-x64": "13.1.6",
-        "@next/swc-freebsd-x64": "13.1.6",
-        "@next/swc-linux-arm-gnueabihf": "13.1.6",
-        "@next/swc-linux-arm64-gnu": "13.1.6",
-        "@next/swc-linux-arm64-musl": "13.1.6",
-        "@next/swc-linux-x64-gnu": "13.1.6",
-        "@next/swc-linux-x64-musl": "13.1.6",
-        "@next/swc-win32-arm64-msvc": "13.1.6",
-        "@next/swc-win32-ia32-msvc": "13.1.6",
-        "@next/swc-win32-x64-msvc": "13.1.6",
+        "@next/env": "13.2.1",
+        "@next/swc-android-arm-eabi": "13.2.1",
+        "@next/swc-android-arm64": "13.2.1",
+        "@next/swc-darwin-arm64": "13.2.1",
+        "@next/swc-darwin-x64": "13.2.1",
+        "@next/swc-freebsd-x64": "13.2.1",
+        "@next/swc-linux-arm-gnueabihf": "13.2.1",
+        "@next/swc-linux-arm64-gnu": "13.2.1",
+        "@next/swc-linux-arm64-musl": "13.2.1",
+        "@next/swc-linux-x64-gnu": "13.2.1",
+        "@next/swc-linux-x64-musl": "13.2.1",
+        "@next/swc-win32-arm64-msvc": "13.2.1",
+        "@next/swc-win32-ia32-msvc": "13.2.1",
+        "@next/swc-win32-x64-msvc": "13.2.1",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",

--- a/test/instrumentation/modules/next/a-nextjs-app/package.json
+++ b/test/instrumentation/modules/next/a-nextjs-app/package.json
@@ -11,7 +11,7 @@
   "keywords": [],
   "license": "BSD-2-Clause",
   "dependencies": {
-    "next": "^13.1.6",
+    "next": "^13.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/test/instrumentation/modules/next/next.test.js
+++ b/test/instrumentation/modules/next/next.test.js
@@ -29,6 +29,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const tape = require('tape')
+const treekill = require('tree-kill')
 
 const { MockAPMServer } = require('../../../_mock_apm_server')
 const { formatForTComment } = require('../../../_utils')
@@ -774,7 +775,7 @@ tape.test('-- dev server tests --', suite => {
       waitForServerReady(t, waitErr => {
         if (waitErr) {
           t.fail(`error waiting for Next.js server to be ready: ${waitErr.message}`)
-          nextServerProc.kill('SIGKILL')
+          treekill(nextServerProc.pid, 'SIGKILL')
           nextServerProc = null
         } else {
           t.comment('Next.js server is ready')
@@ -814,7 +815,7 @@ tape.test('-- dev server tests --', suite => {
       t.end()
     })
     setTimeout(() => {
-      nextServerProc.kill('SIGTERM')
+      treekill(nextServerProc.pid, 'SIGTERM')
     }, 4000) // 2x ELASTIC_APM_API_REQUEST_TIME set above
   })
 


### PR DESCRIPTION
Before this change internal changes in next@13.2.0 resulted in
transactions for Next.js API routes being `{method} unknown route`.
