### PR TITLE
Add awaitable option for flush

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -658,13 +658,27 @@ Agent.prototype.handleUncaughtExceptions = function (cb) {
 // - Delete the ID from the set when sent to the transport (`.sendSpan(...)` et
 //   al) or when dropping the event (e.g. because of a filter):
 //      inflightEvents.delete(id)
-Agent.prototype.flush = function (cb) {
+Agent.prototype.flush = async function (cb) {
   // This 1s timeout is a subjective balance between "long enough for spans
   // and errors to reasonably encode" and "short enough to not block data
   // being reported to APM server".
   const DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS = 1000
 
-  return this._flush({ inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS }, cb)
+  // If a callback is given, use the callback-based flush implementation.
+  if (cb) {
+    return this._flush({ inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS }, cb)
+  }
+
+  // If no callback is given, return a promise wrapping the callback-based flush implementation.
+  return new Promise((resolve, reject) => {
+    this._flush({ inflightTimeoutMs: DEFAULT_INFLIGHT_FLUSH_TIMEOUT_MS }, (err, result) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(result)
+      }
+    })
+  })
 }
 
 // The internal-use `.flush()` that supports some options not exposed to the

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -1148,6 +1148,21 @@ test('#flush()', function (t) {
     })
   })
 
+  t.test('flush async', function (t) {
+    const agent = new Agent().start(filterAgentOpts)
+    agent.startTransaction('transaction-name')
+    agent.endTransaction()
+    const p = agent.flush()
+    t.ok(p instanceof Promise, 'should return a promise')
+    p.then(() => {
+      apmServer.clear()
+      agent.destroy()
+    }).catch(err => {
+      t.fail('should not reject')
+    })
+    t.end()
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
As per #2857 add promise return if no callback is given.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
