### PR TITLE
test, ci: some small changes

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -11,8 +11,8 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
-      - '**.asciidoc'
+      - '**/**.md'
+      - '**/**.asciidoc'
       - 'docs/**'
       - 'examples/**'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,15 +7,15 @@ on:
     branches:
     - main
     paths-ignore:
-    - '*.md'
-    - '*.asciidoc'
+    - '**/*.md'
+    - '**/*.asciidoc'
     - 'docs/**'
   pull_request:
     branches:
     - main
     paths-ignore:
-    - '*.md'
-    - '*.asciidoc'
+    - '**/*.md'
+    - '**/*.asciidoc'
     - 'docs/**'
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,16 @@ on:
     branches:
     - main
     paths-ignore:
-    - '*.md'
-    - '*.asciidoc'
+    - '**/*.md'
+    - '**/*.asciidoc'
     - 'docs/**'
     - 'examples/**'
   pull_request:
     branches:
     - main
     paths-ignore:
-    - '*.md'
-    - '*.asciidoc'
+    - '**/*.md'
+    - '**/*.asciidoc'
     - 'docs/**'
     - 'examples/**'
 

--- a/examples/trace-redis.js
+++ b/examples/trace-redis.js
@@ -9,9 +9,8 @@
 // A small example showing Elastic APM tracing the 'redis' package.
 //
 // This assumes a Redis server running on localhost. You can use:
-//    npm run docker:start
-// to start an Redis docker container (and other containers used for
-// testing of this project). Then `npm run docker:stop` to stop them.
+//    npm run docker:start redis
+// to start an Redis docker container. Then `npm run docker:stop` to stop it.
 
 const apm = require('../').start({ // elastic-apm-node
   serviceName: 'example-trace-redis4',

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -161,7 +161,7 @@ apm.addMetadataFilter(filter1)
 apm.addMetadataFilter(filter2)
 apm.addMetadataFilter(filter3)
 
-apm.flush()
+apm.flush().finally(() => {})
 apm.flush(() => {})
 
 apm.destroy()


### PR DESCRIPTION
- Avoid test, lint, & edge CI workflows for .md and .asciidoc changes in
  any subdir.
- Tweak the "types" test (npm run test:types) to catch the case of
  `apm.flush()` with no callback returning a promise.
