### PR TITLE
3.43.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,8 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
+[[release-notes-3.43.0]]
+==== 3.43.0 2023/03/02
 
 [float]
 ===== Breaking changes
@@ -52,7 +53,9 @@ Notes:
 * Extend Lambda instrumentation to capture details for Lambda function URL
   and ELB-triggered Lambdas. ({issues}2901[#2901])
 
-* Make `Agent.flush()` return a `Promise` if no callback is passed as param. ({issues}2857(#2857))
+* Make `Agent.flush()` return a `Promise` if no callback is passed as param.
+  This means that flush is now `await`able: `await apm.flush()`.
+  ({issues}2857(#2857))
 
 [float]
 ===== Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.42.0",
+  "version": "3.43.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.42.0",
+      "version": "3.43.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.42.0",
+  "version": "3.43.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Notable:
- Trace-context propagation for outgoing SQS and SNS messages.
- Add support for mongodb@5.
- Lambda instrumentation captures details for Lambda function URL and ELB (ALB) triggered functions.
- `await apm.flush()` support.
- Fix instrumentation of API routes for Next.js 13.2.x.