### PR TITLE
ci: drop max-parallel for GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,6 @@ jobs:
           - nodelocalstackdata:/var/lib/localstack
 
     strategy:
-      # max-parallel to attempt to avoid 429s from many concurrent
-      # 'actions/checkout'. Try to have a value high enough to not more than
-      # double the time to execute all jobs.
-      max-parallel: 15
       matrix:
         node:
           - '19'


### PR DESCRIPTION
Earlier in #3180 we added max-parallel:15 as an attempted workaround
errors in the "actions/checkout@v2" (#3179). We also changed to
"actions/checkout@v3" in that change.
https://github.com/actions/checkout/issues/417 suggests that the update
to v3 is sufficient to fix, so let's get the parallelism back.

Refs: #3179
