### PR TITLE
updatecli: fix title since it caused errors

### DIFF
--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -1,5 +1,6 @@
 name: update-jsons-specs
 pipelineid: update-json-specs
+title: Synchronize json specs
 
 scms:
   default:
@@ -53,10 +54,10 @@ sources:
       file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/wildcard_matcher_tests.json
 actions:
   pr:
+    title: '[Automation] Update JSON specs'
     kind: "github/pullrequest"
     scmid: default
     spec:
-      title: Update JSON specs
       automerge: false
       draft: false
       labels:

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -1,5 +1,5 @@
 name: update-specs
-
+pipelineid: update-specs
 title: synchronize schema specs
 
 scms:
@@ -47,6 +47,7 @@ sources:
 actions:
   pr:
     kind: "github/pullrequest"
+    title: '[Automation] Update JSON specs'
     scmid: default
     sourceid: sha
     spec:


### PR DESCRIPTION
### What

Updatecli pipelines were misconfigured hence the automation failed with

```

ACTIONS
========

WARNING: **Fallback** Please add a title to you configuration using the field 'title: <your pipeline>'
Pipeline "update-jsons-specs" failed
Skipping due to:
	action stage:	"Title is too long (maximum is 256 characters)"

```

I also changed the PR title to be within the kind definition rather than within the specs.
