### PR TITLE
test: workaround spurious test failures in http2 tests with node v8

### DIFF
--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -27,6 +27,11 @@ var mockClient = require('../../_mock_http_client')
 var findObjInArray = require('../../_utils').findObjInArray
 const constants = require('../../../lib/constants')
 
+if (semver.satisfies(process.version, '8.x')) {
+  console.log('# SKIP http2 testing on node v8.x is crashy in CI')
+  process.exit()
+}
+
 var isSecure = [false, true]
 isSecure.forEach(secure => {
   var method = secure ? 'createSecureServer' : 'createServer'


### PR DESCRIPTION
Closes: #2409

---

The http2 tests have been occasionally crashy in CI for a long time.. and more so in GH Actions of late. Let's just skip these tests. The need to run them is very low.