### PR TITLE
ci: do NOT fail-fast on test matrix; test windows with node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,7 @@ jobs:
           - nodelocalstackdata:/var/lib/localstack
 
     strategy:
+      fail-fast: false
       matrix:
         node:
           - '19'
@@ -157,7 +158,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 14
+        # What Node.js version to test on Windows is a balance between which
+        # is the current LTS version (https://github.com/nodejs/release) and
+        # which version more of our users are using.
+        node-version: 16
         cache: 'npm'
     - run: npm install
     - run: npm ls --all || true


### PR DESCRIPTION
With `fail-fast: false` we get the useful information for whether a
particular test fails only for certain node versions (or other matrix
params) and passes on others. It can also help show if a particular
failure may be flakey (one failure, but many successes for other
versions).  The "fail-fast" default for our tests results in less useful
information

Bump Windows testing to node 16 to get closer to the current node LTS.
