### PR TITLE
ci: remove notification and leftovers Jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -30,6 +30,16 @@ pipeline {
     */
     stage('Checkout') {
       options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        allOf {
+          anyOf {
+            branch 'main'
+            expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
+          }
+          expression { return params.bench_ci }
+        }
+      }
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
@@ -82,11 +92,6 @@ pipeline {
           }
         }
       }
-    }
-  }
-  post {
-    cleanup {
-      notifyBuildResult()
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Remove GitHub build message in Jenkins. CI has been migrated to GH actions, but the micro-benchmarking 
that will happen eventually.

Move filter `when` to happen earlier in the pipeline

GH build message might be re-done to support GitHub actions, but for now the GH command is not accurate. Hence it's removed.