### PR TITLE
feat: update @opentelemetry/api dep to 1.4.x for OpenTelemetry Bridge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "elastic/apm-agent-node-js"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/opentelemetry-bridge"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "elastic/apm-agent-node-js"

--- a/.github/workflows/tav.yml
+++ b/.github/workflows/tav.yml
@@ -40,6 +40,7 @@ jobs:
           - '@elastic/elasticsearch-canary'
           - '@hapi/hapi'
           - '@koa/router'
+          - '@opentelemetry/api'
           - apollo-server-express
           - aws-sdk
           - bluebird

--- a/.tav.yml
+++ b/.tav.yml
@@ -528,3 +528,14 @@ undici:
   versions: '>=4.7.1 <6'
   commands: node test/instrumentation/modules/undici/undici.test.js
   node: '>=12.18'
+
+"@opentelemetry/api":
+  versions: '>=1.0.0 <1.5.0'
+  node: '>=8.0.0'
+  commands:
+    - node test/opentelemetry-bridge/OTelBridgeNonRecordingSpan.test.js
+    - node test/opentelemetry-bridge/OTelBridgeRunContext.test.js
+    - node test/opentelemetry-bridge/active-span-and-context-interop.test.js
+    - node test/opentelemetry-bridge/fixtures.test.js
+    - node test/opentelemetry-bridge/interface-ContextManager.test.js
+    - node test/opentelemetry-bridge/otel-bridge-feature.test.js

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,23 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+* Update the <<opentelemetry-bridge>> supported version of `@opentelemetry/api`
+  to version 1.4.x.
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
 
 [[release-notes-3.43.0]]
 ==== 3.43.0 2023/03/02

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,7 +40,7 @@ Notes:
 ===== Features
 
 * Update the <<opentelemetry-bridge>> supported version of `@opentelemetry/api`
-  to version 1.4.x.
+  to version 1.4.x. ({pull}3239[#3239])
 
 [float]
 ===== Bug fixes

--- a/dev-utils/bitrot.js
+++ b/dev-utils/bitrot.js
@@ -192,6 +192,8 @@ function loadSupportedDoc () {
         moduleNames = ['next']
       } else if (match[2] === '@hapi/hapi') {
         moduleNames = [match[2]]
+      } else if (match[2] === '@opentelemetry/api') {
+        moduleNames = [match[2]]
       } else if (match[1] === 'koa') {
         moduleNames = ['koa-router', '@koa/router']
       } else if (match[1] === 'azure-functions') {

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -24,7 +24,9 @@ without any vendor lock-in from adding manual tracing using the APM agent's own
 
 The goal of the OpenTelemetry bridge is to allow using the OpenTelemetry API
 with the APM agent. ① First, you will need to add those dependencies to your
-project. The minimum required OpenTelemetry API version is 1.0.0. For example:
+project. The minimum required OpenTelemetry API version is 1.0.0; see
+<<compatibility-opentelemetry,the OpenTelemetry compatibility section>> for the
+current maximum supported API version. For example:
 
 [source,bash]
 ----

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -130,10 +130,11 @@ The Metrics API is currently not supported.
 
 [float]
 [[otel-span-links]]
-===== Span Links
+===== Span Link Attributes
+
 Adding links when
 https://open-telemetry.github.io/opentelemetry-js-api/interfaces/tracer.html[starting a span]
-are not currently supported. Any given links will be silently dropped.
+*is* currently supported, but any span link *attributes are silently dropped*.
 
 [float]
 [[otel-span-events]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -99,6 +99,20 @@ These are the frameworks that we officially support:
 |=======================================================================
 
 [float]
+[[compatibility-opentelemetry]]
+=== OpenTelemetry
+
+The Node.js Elastic APM agent supports usage of the OpenTelemetry Tracing API
+via its <<opentelemetry-bridge>>.
+
+[options="header"]
+|=======================================================================
+| Framework                                   | Version
+| <<opentelemetry-bridge,@opentelemetry/api>> | >=1.0.0 <1.5.0
+|=======================================================================
+
+
+[float]
 [[compatibility-custom-transactions]]
 === Custom Transactions
 

--- a/examples/opentelemetry-bridge/README.md
+++ b/examples/opentelemetry-bridge/README.md
@@ -8,6 +8,8 @@ Setup dependencies via:
 
 To run a script using the **Elastic Node.js APM Agent** use:
 
+    export ELASTIC_APM_SERVER_URL=https://...  # your Elastic APM Server URL
+    export ELASTIC_APM_SECRET_TOKEN=...
     export ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED=true
     node -r elastic-apm-node/start.js THE-SCRIPT.js
 

--- a/examples/opentelemetry-bridge/package.json
+++ b/examples/opentelemetry-bridge/package.json
@@ -7,12 +7,12 @@
     "trace-https-request": "ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED=true node -r elastic-apm-node/start.js trace-https-request.js"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/core": "^1.2.0",
-    "@opentelemetry/instrumentation": "^0.28.0",
-    "@opentelemetry/instrumentation-http": "^0.28.0",
-    "@opentelemetry/sdk-trace-base": "^1.2.0",
-    "@opentelemetry/sdk-trace-node": "^1.2.0",
+    "@opentelemetry/api": "^1.4.0",
+    "@opentelemetry/core": "^1.11.0",
+    "@opentelemetry/instrumentation": "^0.36.0",
+    "@opentelemetry/instrumentation-http": "^0.36.0",
+    "@opentelemetry/sdk-trace-base": "^1.11.0",
+    "@opentelemetry/sdk-trace-node": "^1.11.0",
     "elastic-apm-node": "file:../.."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",
-        "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/api": "^1.4.1",
         "after-all-results": "^2.0.0",
         "async-cache": "^1.1.0",
         "async-value-promise": "^1.1.1",
@@ -3417,9 +3417,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -18033,9 +18033,9 @@
       "dev": true
     },
     "@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
   "dependencies": {
     "@elastic/ecs-pino-format": "^1.2.0",
-    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/api": "^1.4.1",
     "after-all-results": "^2.0.0",
     "async-cache": "^1.1.0",
     "async-value-promise": "^1.1.1",

--- a/test/opentelemetry-bridge/active-span-and-context-interop.test.js
+++ b/test/opentelemetry-bridge/active-span-and-context-interop.test.js
@@ -22,7 +22,10 @@ const apm = require('../..').start({
 })
 
 const otel = require('@opentelemetry/api')
+const semver = require('semver')
 const tape = require('tape')
+
+const supportsGetActiveSpan = semver.satisfies(require('@opentelemetry/api/package.json').version, '>=1.2.0')
 
 const tracer = otel.trace.getTracer()
 
@@ -43,6 +46,13 @@ tape.test('curr Elastic span is contained in OTel Context', t => {
   const t1 = apm.startTransaction('t1')
   const otelSpan = otel.trace.getSpan(otel.context.active())
   t.strictEqual(otelSpan._span, t1, 'active OTel span contains the Elastic API-started transaction')
+
+  if (supportsGetActiveSpan) {
+    // Also test the `otel.trace.getActiveSpan()` added in @opentelemetry/api@1.2.0.
+    t.strictEqual(otel.trace.getActiveSpan()._span, t1,
+      'active OTel span (retrieved from getActiveSpan()) contains the Elastic API-started transaction')
+  }
+
   t1.end()
   t.end()
 })


### PR DESCRIPTION
- Bump the dep.
- Update examples/opentelemetry-bridge/ and get dependabot to handle this in
  the future.
- Add an OTel section to the supported-technologies page.
- Add TAV testing of supported @opentelemetry/api versions.
- Add a test for the added `otel.trace.getActiveSpan()` in v1.2.0 of the API.
  This is implemented in the API, so no need for *implementation* changes.

Supersedes: #3211
