### PR TITLE
3.44.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,10 +32,8 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-3.44.0]]
+==== 3.44.0 2023/04/03
 
 [float]
 ===== Features
@@ -49,9 +47,6 @@ Notes:
 * Ensure `metadata.service.agent.activation_method` is only sent for APM
   server version 8.7.1 or later. APM server 8.7.0 included a bug where
   receiving `activation_method` is harmful. ({issues}3230[#3230])
-
-[float]
-===== Chores
 
 
 [[release-notes-3.43.0]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.43.0",
+  "version": "3.44.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.43.0",
+      "version": "3.44.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.43.0",
+  "version": "3.44.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Changelog entries:

```asciidoc
[float]
===== Features

* Update the <<opentelemetry-bridge>> supported version of `@opentelemetry/api`
  to version 1.4.x. ({pull}3239[#3239])

[float]
===== Bug fixes

* Ensure `metadata.service.agent.activation_method` is only sent for APM
  server version 8.7.1 or later. APM server 8.7.0 included a bug where
  receiving `activation_method` is harmful. ({issues}3230[#3230])
```