### PR TITLE
chore: limit Next.js instrumentation to <13.3.0 for now

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,18 +43,15 @@ Notes:
 [float]
 ===== Bug fixes
 
-[float]
-===== Chores
-
-- Restrict Next.js instrumentation to `<13.3.0` for now, because of a known
-  issue with instrumentating the `next@13.3.0` dev server. ({issues}3263[#3263])
-
 * Fix an edge case in instrumentation of `http.request()` and `https.request()`
   with node v19.9.0 and recently nightly builds of node v20.
   ({issues}3261[#3261])
 
 [float]
 ===== Chores
+
+* Restrict Next.js instrumentation to `<13.3.0` for now, because of a known
+  issue with instrumentating the `next@13.3.0` dev server. ({issues}3263[#3263])
 
 
 [[release-notes-3.44.1]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,24 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+- Restrict Next.js instrumentation to `<13.3.0` for now, because of a known
+  issue with instrumentating the `next@13.3.0` dev server. ({issues}3263[#3263])
+
+
 [[release-notes-3.44.1]]
 ==== 3.44.1 2023/04/06
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -94,7 +94,7 @@ These are the frameworks that we officially support:
 | <<hapi,@hapi/hapi>>   | >=17.9.0 <22.0.0 |
 | <<hapi,hapi>>         | >=9.0.0 <19.0.0 | Deprecated. No longer tested.
 | <<koa,Koa>> via koa-router or @koa/router | >=5.2.0 <13.0.0 | Koa doesn't have a built in router, so we can't support Koa directly since we rely on router information for full support. We currently support the most popular Koa router called https://github.com/koajs/koa-router[koa-router].
-| <<nextjs,Next.js>>    | >=11.1.0 <14.0.0 | (Technical Preview) This instruments Next.js routing to name transactions for incoming HTTP transactions; and reports errors in user pages. It supports the Next.js production server (`next start`) and development server (`next dev`). See the <<nextjs,Getting Started document>>.
+| <<nextjs,Next.js>>    | >=11.1.0 <13.3.0 | (Technical Preview) This instruments Next.js routing to name transactions for incoming HTTP transactions; and reports errors in user pages. It supports the Next.js production server (`next start`) and development server (`next dev`). See the <<nextjs,Getting Started document>>.
 | <<restify,Restify>>   | >=5.2.0 <12.0.0 |
 |=======================================================================
 

--- a/lib/instrumentation/modules/next/dist/server/next.js
+++ b/lib/instrumentation/modules/next/dist/server/next.js
@@ -14,7 +14,7 @@ module.exports = function (mod, agent, { version, enabled }) {
   if (!enabled) {
     return mod
   }
-  if (!semver.satisfies(version, '>=11.1.0 <14.0.0', { includePrerelease: true })) {
+  if (!semver.satisfies(version, '>=11.1.0 <13.3.0', { includePrerelease: true })) {
     agent.logger.debug('next version %s not supported, skipping', version)
     return mod
   }

--- a/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
+++ b/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
@@ -31,7 +31,6 @@ next-12:
 next:
   name: next
   versions: '>=13.0.0 <13.3.0'
-  # versions: '>=13.0.0 <14'
   node: '>=14.6.0'
   commands: node ../next.test.js
   peerDependencies:

--- a/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
+++ b/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
@@ -10,6 +10,8 @@
 #      NODE_OPTIONS=--openssl-legacy-provider ...
 #   See https://github.com/vercel/next.js/issues/30078 for details. There isn't
 #   much value in testing this old Next.js version with newer Node versions.
+# - For the latest version, we guard on the *minor* version, because 13.2 and
+#   13.3 releases have both broken our instrumentation.
 next-11:
   name: next
   versions: '11.1.0 || 11.1.4'
@@ -28,7 +30,8 @@ next-12:
     - "react-dom@^18.2.0"
 next:
   name: next
-  versions: '>=13.0.0 <14'
+  versions: '>=13.0.0 <13.3.0'
+  # versions: '>=13.0.0 <14'
   node: '>=14.6.0'
   commands: node ../next.test.js
   peerDependencies:


### PR DESCRIPTION
Refs: #3263
