### PR TITLE
feat: add S3 Bucket and Key params in instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,10 @@ Notes:
 [float]
 ===== Features
 
+* Add `aws.s3.bucket` and `aws.s3.key` attributes for OpenTelemetry in S3 instrumentation.
+  Spec https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435
+  ({issues}3150[#3150]).
+
 [float]
 ===== Bug fixes
 

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -246,13 +246,18 @@ GenericSpan.prototype._serializeOTel = function (payload) {
     payload.otel = {
       span_kind: this._otelKind
     }
-    if (this._otelAttributes) {
-      // Though the spec allows it ("MAY"), we are opting *not* to report OTel
-      // span attributes as labels for older (<7.16) versions of APM server.
-      // This is to avoid the added complexity of guarding allowed attribute
-      // value types to those supported by the APM server intake API.
-      payload.otel.attributes = this._otelAttributes
+  }
+
+  if (this._otelAttributes) {
+    // Though the spec allows it ("MAY"), we are opting *not* to report OTel
+    // span attributes as labels for older (<7.16) versions of APM server.
+    // This is to avoid the added complexity of guarding allowed attribute
+    // value types to those supported by the APM server intake API.
+    if (!payload.otel) {
+      payload.otel = {}
     }
+
+    payload.otel.attributes = this._otelAttributes
   }
 }
 

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -13,23 +13,22 @@ const constants = require('../../../constants')
 const TYPE = 'storage'
 const SUBTYPE = 's3'
 
-// Control wicho operations can send the Key OTel attribute
-// https://github.com/open-telemetry/opentelemetry-specification/blob/90007a192ae8b06d40ee8c15f56256d69a330321/semantic_conventions/trace/instrumentation/aws-sdk.yml#L458
-const OPERATIONS_WITH_KEY = [
-  'copyObject',
-  'deleteObject',
-  'getObject',
-  'headObject',
-  'putObject',
-  'restoreObject',
-  'selectObjectContent',
-  'abortMultipartUpload',
-  'completeMultipartUpload',
-  'createMultipartUpload',
-  'listParts',
-  'uploadPart',
-  'uploadPartCopy'
-]
+// Control which operations can send the Key OTel attribute
+const OPERATIONS_WITH_KEY = {
+  copyObject: true,
+  deleteObject: true,
+  getObject: true,
+  headObject: true,
+  putObject: true,
+  restoreObject: true,
+  selectObjectContent: true,
+  abortMultipartUpload: true,
+  completeMultipartUpload: true,
+  createMultipartUpload: true,
+  listParts: true,
+  uploadPart: true,
+  uploadPartCopy: true
+}
 
 // Return the PascalCase operation name from `request.operation` by undoing to
 // `lowerFirst()` from
@@ -85,27 +84,11 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
     return orig.apply(request, origArguments)
   }
 
-  if (params) {
-    const attrs = {}
-    // I guess we have to check that params correspond to operation
-    // because maybe consumers can append params arbitrarily
-    // https://github.com/open-telemetry/opentelemetry-specification/blob/90007a192ae8b06d40ee8c15f56256d69a330321/semantic_conventions/trace/instrumentation/aws-sdk.yml#L448
-    if (params.Bucket && request.operation !== 'listBuckets') {
-      attrs['aws.s3.bucket'] = bucket
-    }
-
-    if (params.Key && OPERATIONS_WITH_KEY.indexOf(request.operation) !== -1) {
-      attrs['aws.s3.key'] = request.params.Key
-    }
-
-    // span._getOTelAttributes() initialises the object so we have to make sure there is
-    // something to put inside and not increase the span payload for nothing
-    const attrKeys = Object.keys(attrs)
-    if (attrKeys.length > 0) {
-      const otelAttrs = span._getOTelAttributes()
-      attrKeys.forEach(function (key) {
-        otelAttrs[key] = attrs[key]
-      })
+  if (bucket) {
+    const otelAttrs = span._getOTelAttributes()
+    otelAttrs['aws.s3.bucket'] = bucket
+    if (params.Key && request.operation in OPERATIONS_WITH_KEY) {
+      otelAttrs['aws.s3.key'] = params.Key
     }
   }
 

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -13,23 +13,6 @@ const constants = require('../../../constants')
 const TYPE = 'storage'
 const SUBTYPE = 's3'
 
-// Control which operations can send the Key OTel attribute
-const OPERATIONS_WITH_KEY = {
-  copyObject: true,
-  deleteObject: true,
-  getObject: true,
-  headObject: true,
-  putObject: true,
-  restoreObject: true,
-  selectObjectContent: true,
-  abortMultipartUpload: true,
-  completeMultipartUpload: true,
-  createMultipartUpload: true,
-  listParts: true,
-  uploadPart: true,
-  uploadPartCopy: true
-}
-
 // Return the PascalCase operation name from `request.operation` by undoing to
 // `lowerFirst()` from
 // https://github.com/aws/aws-sdk-js/blob/c0c44b8a4e607aae521686898f39a3e359f727e4/lib/model/api.js#L63-L65
@@ -84,12 +67,14 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
     return orig.apply(request, origArguments)
   }
 
+  const otelAttrs = span._getOTelAttributes()
+
   if (bucket) {
-    const otelAttrs = span._getOTelAttributes()
     otelAttrs['aws.s3.bucket'] = bucket
-    if (params.Key && request.operation in OPERATIONS_WITH_KEY) {
-      otelAttrs['aws.s3.key'] = params.Key
-    }
+  }
+
+  if (params.Key) {
+    otelAttrs['aws.s3.key'] = params.Key
   }
 
   const onComplete = function (response) {

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -67,6 +67,7 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
     return orig.apply(request, origArguments)
   }
 
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435
   const otelAttrs = span._getOTelAttributes()
 
   if (bucket) {

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -13,6 +13,24 @@ const constants = require('../../../constants')
 const TYPE = 'storage'
 const SUBTYPE = 's3'
 
+// Control wicho operations can send the Key OTel attribute
+// https://github.com/open-telemetry/opentelemetry-specification/blob/90007a192ae8b06d40ee8c15f56256d69a330321/semantic_conventions/trace/instrumentation/aws-sdk.yml#L458
+const OPERATIONS_WITH_KEY = [
+  'copyObject',
+  'deleteObject',
+  'getObject',
+  'headObject',
+  'putObject',
+  'restoreObject',
+  'selectObjectContent',
+  'abortMultipartUpload',
+  'completeMultipartUpload',
+  'createMultipartUpload',
+  'listParts',
+  'uploadPart',
+  'uploadPartCopy'
+]
+
 // Return the PascalCase operation name from `request.operation` by undoing to
 // `lowerFirst()` from
 // https://github.com/aws/aws-sdk-js/blob/c0c44b8a4e607aae521686898f39a3e359f727e4/lib/model/api.js#L63-L65
@@ -52,8 +70,10 @@ function resourceFromBucket (bucket) {
 // @param {AWS.Request} request https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html
 function instrumentationS3 (orig, origArguments, request, AWS, agent, { version, enabled }) {
   const opName = opNameFromOperation(request.operation)
+  const params = request.params
+  const bucket = params && params.Bucket
+  const resource = resourceFromBucket(bucket)
   let name = 'S3 ' + opName
-  const resource = resourceFromBucket(request.params && request.params.Bucket)
   if (resource) {
     name += ' ' + resource
   }
@@ -63,6 +83,30 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
   const span = ins.createSpan(name, TYPE, SUBTYPE, opName, { exitSpan: true })
   if (!span) {
     return orig.apply(request, origArguments)
+  }
+
+  if (params) {
+    const attrs = {}
+    // I guess we have to check that params correspond to operation
+    // because maybe consumers can append params arbitrarily
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/90007a192ae8b06d40ee8c15f56256d69a330321/semantic_conventions/trace/instrumentation/aws-sdk.yml#L448
+    if (params.Bucket && request.operation !== 'listBuckets') {
+      attrs['aws.s3.bucket'] = bucket
+    }
+
+    if (params.Key && OPERATIONS_WITH_KEY.indexOf(request.operation) !== -1) {
+      attrs['aws.s3.key'] = request.params.Key
+    }
+
+    // span._getOTelAttributes() initialises the object so we have to make sure there is
+    // something to put inside and not increase the span payload for nothing
+    const attrKeys = Object.keys(attrs)
+    if (attrKeys.length > 0) {
+      const otelAttrs = span._getOTelAttributes()
+      attrKeys.forEach(function (key) {
+        otelAttrs[key] = attrs[key]
+      })
+    }
   }
 
   const onComplete = function (response) {

--- a/lib/instrumentation/modules/aws-sdk/s3.js
+++ b/lib/instrumentation/modules/aws-sdk/s3.js
@@ -67,15 +67,17 @@ function instrumentationS3 (orig, origArguments, request, AWS, agent, { version,
     return orig.apply(request, origArguments)
   }
 
+  // As for now OTel spec defines attributes for operations that require a Bucket
+  // if that changes we should review this guard
   // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435
-  const otelAttrs = span._getOTelAttributes()
-
   if (bucket) {
-    otelAttrs['aws.s3.bucket'] = bucket
-  }
+    const otelAttrs = span._getOTelAttributes()
 
-  if (params.Key) {
-    otelAttrs['aws.s3.key'] = params.Key
+    otelAttrs['aws.s3.bucket'] = bucket
+
+    if (params.Key) {
+      otelAttrs['aws.s3.key'] = params.Key
+    }
   }
 
   const onComplete = function (response) {

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -118,6 +118,7 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 200, response: { encoded_body_size: 205 } }
           },
+          otel: { attributes: {} },
           outcome: 'success'
         }, 'listAllBuckets produced expected span')
 

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -136,6 +136,9 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 200, response: { encoded_body_size: 177 } }
           },
+          otel: {
+            attributes: { 'aws.s3.bucket': 'elasticapmtest-bucket-1' }
+          },
           outcome: 'success'
         }, 'createTheBucketIfNecessary produced expected span')
 
@@ -153,6 +156,9 @@ tape.test('simple S3 usage scenario', function (t) {
               service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200 }
+          },
+          otel: {
+            attributes: { 'aws.s3.bucket': 'elasticapmtest-bucket-1' }
           },
           outcome: 'success'
         }, 'waitForBucketToExist produced expected span')
@@ -172,6 +178,12 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 200 }
           },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt'
+            }
+          },
           outcome: 'success'
         }, 'createObj produced expected span')
 
@@ -189,6 +201,12 @@ tape.test('simple S3 usage scenario', function (t) {
               service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 200 }
+          },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt'
+            }
           },
           outcome: 'success'
         }, 'waitForObjectToExist produced expected span')
@@ -208,6 +226,12 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 200, response: { encoded_body_size: 8 } }
           },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt'
+            }
+          },
           outcome: 'success'
         }, 'getObj produced expected span')
 
@@ -225,6 +249,12 @@ tape.test('simple S3 usage scenario', function (t) {
               service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 304 }
+          },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt'
+            }
           },
           outcome: 'success'
         }, 'getObjConditionalGet produced expected span')
@@ -244,6 +274,12 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 200, response: { encoded_body_size: 8 } }
           },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt'
+            }
+          },
           outcome: 'success'
         }, 'getObjUsingPromise produced expected span')
 
@@ -262,6 +298,12 @@ tape.test('simple S3 usage scenario', function (t) {
               service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 404, response: { encoded_body_size: 207 } }
+          },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt-does-not-exist'
+            }
           },
           outcome: 'failure'
         }, 'getObjNonExistantObject produced expected span')
@@ -285,6 +327,12 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 204 }
           },
+          otel: {
+            attributes: {
+              'aws.s3.bucket': 'elasticapmtest-bucket-1',
+              'aws.s3.key': 'aDir/aFile.txt'
+            }
+          },
           outcome: 'success'
         }, 'deleteTheObj produced expected span')
 
@@ -302,6 +350,9 @@ tape.test('simple S3 usage scenario', function (t) {
               service: { type: '', name: '', resource: 's3/elasticapmtest-bucket-1' }
             },
             http: { status_code: 204 }
+          },
+          otel: {
+            attributes: { 'aws.s3.bucket': 'elasticapmtest-bucket-1' }
           },
           outcome: 'success'
         }, 'deleteTheBucketIfCreatedIt produced expected span')

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -118,7 +118,6 @@ tape.test('simple S3 usage scenario', function (t) {
             },
             http: { status_code: 200, response: { encoded_body_size: 205 } }
           },
-          otel: { attributes: {} },
           outcome: 'success'
         }, 'listAllBuckets produced expected span')
 

--- a/test/integration/api-schema/apm-server-schema/span.json
+++ b/test/integration/api-schema/apm-server-schema/span.json
@@ -659,7 +659,23 @@
           "type": [
             "null",
             "object"
-          ]
+          ],
+          "properties": {
+            "aws.s3.bucket": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "The S3 bucket name the request refers to. Corresponds to the `--bucket` parameter of the S3 API"
+            },
+            "aws.s3.key": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "The S3 object key the request refers to. Corresponds to the `--key` parameter of the S3 API"
+            }
+          }
         },
         "span_kind": {
           "description": "SpanKind holds the incoming OpenTelemetry span kind.",

--- a/test/integration/api-schema/apm-server-schema/span.json
+++ b/test/integration/api-schema/apm-server-schema/span.json
@@ -659,23 +659,7 @@
           "type": [
             "null",
             "object"
-          ],
-          "properties": {
-            "aws.s3.bucket": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "description": "The S3 bucket name the request refers to. Corresponds to the `--bucket` parameter of the S3 API"
-            },
-            "aws.s3.key": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "description": "The S3 object key the request refers to. Corresponds to the `--key` parameter of the S3 API"
-            }
-          }
+          ]
         },
         "span_kind": {
           "description": "SpanKind holds the incoming OpenTelemetry span kind.",


### PR DESCRIPTION
Extract the parameters `Bucket` and `Key` from the instrumented requests to S3. Parameters are added into OTel attributes of the span following [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/90007a192ae8b06d40ee8c15f56256d69a330321/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435)

### Checklist

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)

Closes: #3150 