### PR TITLE
chore: update versions tested now that Node.js v20 is out

### DIFF
--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -1,5 +1,6 @@
 {
-  "versions": [ "19", "18", "16", "14", "12", "10", "8" ],
+  "// todo": "We want versions=['20','19','18','16','14','12','10','8'], but versions*modules needs to be <256 for the GH Actions jobs limit",
+  "versions": [ "20", "18", "16", "14", "12", "10", "8" ],
   "modules": [
     "@elastic/elasticsearch",
     "@elastic/elasticsearch-canary",

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ "20" ]
+        node: [ "21" ]
         contextManager: [ 'patch', '' ]
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
         env:
           ELASTIC_APM_CONTEXT_MANAGER: ${{ matrix.contextManager }}
 
-  # This should list all active Node.js major versions listed at:
+  # This should list all the Node.js major versions listed at:
   # https://nodejs.org/en/about/releases/
   #
   # The node.js project *sometimes* produces "rc" builds leading up to a new
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
+          - "20"
           - "19"
           - "18"
           - "16"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
+          - '20'
           - '19'
           - '18'
           - '18.0'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": "^8.6.0 || 10 || 12 || 14 || 16 || 17 || 18 || 19"
+    "node": ">=8.6.0"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
Node v20.0.0 is out (https://nodejs.org/en/blog/release/v20.0.0).   This updates to support that.

1. Change "engines" to just be `>=8.6.0` instead of explicitly listing all the even and current releases. This means that we'll avoid users getting this "npm WARN EBADENGINE" when a new release comes out:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'elastic-apm-node@3.44.1',
npm WARN EBADENGINE   required: { node: '^8.6.0 || 10 || 12 || 14 || 16 || 17 || 18 || 19' },
npm WARN EBADENGINE   current: { node: 'v20.0.0', npm: '9.6.4' }
npm WARN EBADENGINE }
```

at the cost of users of older elastic-apm-node versions perhaps assuming it supports all future Node.js releases.

In practice, I don't see any other npm packages using "engines" the way we have been doing. In typical practice it is, at best, used as a hint for the minimum node version supported. 


2. Update test workflows as appropriate for a v20 release.

On fall out here is that our full TAV test matrix is now greater than the GH Actions limit of 256 jobs for a workflow (8 node versions times 36 modules = 288). So for now I'm sacrificing testing against node v19. Node.js v19 will be EOL at 2023-06-01.