### PR TITLE
ci: allow the 'test.yml' CI to be run manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 # https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/2
 on:
+  workflow_dispatch:
   push:
     branches:
     - main


### PR DESCRIPTION
To be able to trigger a workflow manually requires `on: workflow_dispatch`.
Let's do that for the main "test" workflow. Then we can:

```
gh workflow run test.yml
```

Eventually it might be nice to have input params to limit the node versions run, etc. but that can be done separately.