### PR TITLE
test: workaround Azure Functions test failures on node >=18.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       - "elastic/apm-agent-node-js"
 
   - package-ecosystem: "npm"
+    directory: "/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "elastic/apm-agent-node-js"
+
+  - package-ecosystem: "npm"
     directory: "/test/instrumentation/modules/next/a-nextjs-app"
     schedule:
       interval: "weekly"

--- a/test/instrumentation/azure-functions/azure-functions.test.js
+++ b/test/instrumentation/azure-functions/azure-functions.test.js
@@ -20,7 +20,10 @@ const treekill = require('tree-kill')
 const { MockAPMServer } = require('../../_mock_apm_server')
 const { formatForTComment } = require('../../_utils')
 
-if (!semver.satisfies(process.version, '>=14 <19')) {
+if (semver.satisfies(process.version, '>=18')) {
+  console.log(`# SKIP azure-functions-core-tools is currently busted for node >=18.x (currently running node ${process.version}): see https://github.com/elastic/apm-agent-nodejs/issues/3279 and https://github.com/Azure/azure-functions-core-tools/issues/3335`)
+  process.exit()
+} else if (!semver.satisfies(process.version, '>=14 <19')) {
   console.log(`# SKIP Azure Functions runtime ~4 does not support node ${process.version} (https://aka.ms/functions-node-versions)`)
   process.exit()
 } else if (os.platform() === 'win32') {

--- a/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp/package-lock.json
+++ b/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp/package-lock.json
@@ -7,13 +7,13 @@
     "": {
       "version": "1.0.0",
       "devDependencies": {
-        "azure-functions-core-tools": "^4.0.4915"
+        "azure-functions-core-tools": "^4.0.5095"
       }
     },
     "node_modules/azure-functions-core-tools": {
-      "version": "4.0.4915",
-      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.4915.tgz",
-      "integrity": "sha512-z+dQHEfnOScDDlihOlTXn7hmvxjaqtOdEcTEmIRNR8N4nP9zqY8RHfKp3Z86pmh5PfXODnN+buCpJJM/iux9CA==",
+      "version": "4.0.5095",
+      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.5095.tgz",
+      "integrity": "sha512-BGBzxa03NnOz6hdTRYrBvYwVvKK14emsFCz3oj0buAaE91BiKo4KozzjYNGc9G1tB/cjBr7JU+B21dm+FHVfkA==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
@@ -489,9 +489,9 @@
   },
   "dependencies": {
     "azure-functions-core-tools": {
-      "version": "4.0.4915",
-      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.4915.tgz",
-      "integrity": "sha512-z+dQHEfnOScDDlihOlTXn7hmvxjaqtOdEcTEmIRNR8N4nP9zqY8RHfKp3Z86pmh5PfXODnN+buCpJJM/iux9CA==",
+      "version": "4.0.5095",
+      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.5095.tgz",
+      "integrity": "sha512-BGBzxa03NnOz6hdTRYrBvYwVvKK14emsFCz3oj0buAaE91BiKo4KozzjYNGc9G1tB/cjBr7JU+B21dm+FHVfkA==",
       "dev": true,
       "requires": {
         "chalk": "3.0.0",

--- a/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp/package.json
+++ b/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp/package.json
@@ -7,8 +7,7 @@
     "start": "func start",
     "test": "echo \"No tests yet...\""
   },
-  "dependencies": {},
   "devDependencies": {
-    "azure-functions-core-tools": "^4.0.4915"
+    "azure-functions-core-tools": "^4.0.5095"
   }
 }


### PR DESCRIPTION
Just skip them until https://github.com/Azure/azure-functions-core-tools/issues/3335
is resolved.

This also bumps the azure-functions-core-tools dep and sets up
dependabot for that package.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3279

