### PR TITLE
fix: do not log.warn when passing null args to span.setServiceTarget(...)

### DIFF
--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -290,7 +290,7 @@ Span.prototype.setServiceTarget = function (type, name) {
     } else {
       this._serviceTarget.type = type
     }
-  } else {
+  } else if (type != null) {
     this._agent.logger.warn('"type" argument to Span#setServiceTarget must be of type "string", got type "%s": ignoring', typeof type)
   }
   if (typeof name === 'string') {
@@ -300,7 +300,7 @@ Span.prototype.setServiceTarget = function (type, name) {
     } else {
       this._serviceTarget.name = name
     }
-  } else {
+  } else if (name != null) {
     this._agent.logger.warn('"name" argument to Span#setServiceTarget must be of type "string", got type "%s": ignoring', typeof name)
   }
 }


### PR DESCRIPTION
This method allows null arguments to indicate "no value":

    setServiceTarget(type?: string | null, name?: string | null): void;

Before this change it would warn if null or undefined was passed, e.g.:

    WARN (elastic-apm-node): "name" argument to Span#setServiceTarget must be of type "string", got type "object": ignoring
