### PR TITLE
fix: crash in Lambda handler with ELB or API Gateway event with no 'headers'

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -144,7 +144,7 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
         : undefined),
       method: requestContext.http.method,
       url: event.rawPath + (event.rawQueryString ? '?' + event.rawQueryString : ''),
-      headers: event.normedHeaders,
+      headers: event.normedHeaders || {},
       socket: { remoteAddress: requestContext.http.sourceIp },
       body: event.body
     }
@@ -162,7 +162,7 @@ function setApiGatewayData (agent, trans, event, context, faasId, isColdStart) {
       url: requestContext.path + (event.queryStringParameters
         ? '?' + querystring.encode(event.queryStringParameters)
         : ''),
-      headers: event.normedHeaders,
+      headers: event.normedHeaders || {},
       socket: { remoteAddress: requestContext.identity && requestContext.identity.sourceIp },
       // Limitation: Note that `getContextFromRequest` does *not* use this body,
       // because API Gateway payload format 1.0 does not include the
@@ -264,7 +264,7 @@ function setElbData (agent, trans, event, context, faasId, isColdStart) {
       event.queryStringParameters && Object.keys(event.queryStringParameters) > 0
         ? '?' + querystring.encode(event.queryStringParameters)
         : ''),
-    headers: event.normedHeaders,
+    headers: event.normedHeaders || {},
     body: event.body,
     bodyIsBase64Encoded: event.isBase64Encoded
   }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -28,6 +28,7 @@ const {
  *    However, some cases (e.g. Lambda and Azure Functions instrumentation)
  *    create a pseudo-req object that matches well enough for this function.
  *    Some relevant fields: (TODO: document all used fields)
+ *    - `headers` - Required. An object.
  *    - `body` - The incoming request body, if available. The `json` and
  *      `payload` fields are also checked to accomodate some web frameworks.
  *    - `bodyIsBase64Encoded` - An optional boolean. If `true`, then the `body`
@@ -109,9 +110,21 @@ function getContextFromResponse (res, conf, isError) {
   return context
 }
 
+/**
+ * Extract appropriate `{transaction,error}.context.user` from an HTTP
+ * request object.
+ *
+ * @param {Object} req - Typically `req` is a Node.js `http.IncomingMessage`.
+ *    However, some cases (e.g. Lambda and Azure Functions instrumentation)
+ *    create a pseudo-req object that matches well enough for this function.
+ *    Some relevant fields: (TODO: document all used fields)
+ *    - `headers` - Required. An object.
+ */
 function getUserContextFromRequest (req) {
   var user = req.user || basicAuth(req) || req.session
-  if (!user) return
+  if (!user) {
+    return
+  }
 
   var context = {}
 


### PR DESCRIPTION
If the lambda handler object for an ELB- or API Gateway-triggered Lambda
invocation did not have a 'headers' field, then the Lambda
instrumentation would crash. I'm not sure how to get an event with no
'headers' field, but we should still be defensive here.

Fixes: https://github.com/elastic/apm-agent-nodejs/issues/3286
