### PR TITLE
test: skip testing fastify 4.16.0 - 4.16.2 inclusive, they are broken releases

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -456,6 +456,7 @@ restify-v10-v12:
 # https://www.fastify.io/docs/latest/LTS/
 # - #1086 suggests fastify@2.4.0 was a broken release, skip it.
 # - fastify@4.0.1 is broken: https://github.com/fastify/fastify/issues/3998#issuecomment-1153662513
+# - fastify@4.16.0 - 4.16.2 (inclusive) are broken releases
 fastify-v1:
   name: fastify
   versions: '1.x'
@@ -482,7 +483,7 @@ fastify-v3:
     - node test/instrumentation/modules/fastify/set-framework.test.js
 fastify:
   name: fastify
-  versions: '>=4 <4.0.1 || >4.0.1'
+  versions: '>=4 <4.0.1 || >4.0.1 <4.16.0 || >4.16.2'
   node: '>=14.6.0'
   commands:
     - node test/instrumentation/modules/fastify/fastify.test.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
         "express-queue": "^0.0.13",
-        "fastify": "^4.0.2",
+        "fastify": "^4.16.3",
         "finalhandler": "^1.1.2",
         "generic-pool": "^3.7.1",
         "get-port": "^5.1.1",
@@ -2387,12 +2387,12 @@
       "dev": true
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.2.0.tgz",
-      "integrity": "sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
       "dev": true,
       "dependencies": {
-        "fast-json-stringify": "^5.0.0"
+        "fast-json-stringify": "^5.7.0"
       }
     },
     "node_modules/@fastify/fast-json-stringify-compiler/node_modules/ajv": {
@@ -2412,9 +2412,9 @@
       }
     },
     "node_modules/@fastify/fast-json-stringify-compiler/node_modules/fast-json-stringify": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.6.2.tgz",
-      "integrity": "sha512-F6xkRrXvtGbAiDSEI5Rk7qk2P63Y9kc8bO6Dnsd3Rt6sBNr2QxNFWs0JbKftgiyOfGxnJaRoHe4SizCTqeAyrA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
+      "integrity": "sha512-sBVPTgnAZseLu1Qgj6lUbQ0HfjFhZWXAmpZ5AaSGkyLh5gAXBga/uPJjQPHpDFjC9adWIpdOcCLSDTgrZ7snoQ==",
       "dev": true,
       "dependencies": {
         "@fastify/deepmerge": "^1.0.0",
@@ -7404,17 +7404,18 @@
       "dev": true
     },
     "node_modules/fastify": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.15.0.tgz",
-      "integrity": "sha512-m/CaRN8nf5uyYdrDe2qqq+0z3oGyE+A++qlKQoLJTI4WI0nWK9D6R3FxXQ3MVwt/md977GMR4F43pE9oqrS2zw==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.16.3.tgz",
+      "integrity": "sha512-W45bWZdjAcVxFUBubzkmiMp3VrIRpsqUP6D0NS2Qb1BjTSNNT1NxAubzM8tdMyC5mIBymtvPE3B+DYmItc1rlQ==",
       "dev": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^3.5.0",
         "@fastify/error": "^3.0.0",
-        "@fastify/fast-json-stringify-compiler": "^4.2.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^8.2.0",
         "fast-content-type-parse": "^1.0.0",
+        "fast-json-stringify": "^5.7.0",
         "find-my-way": "^7.6.0",
         "light-my-request": "^5.6.1",
         "pino": "^8.5.0",
@@ -7423,7 +7424,7 @@
         "rfdc": "^1.3.0",
         "secure-json-parse": "^2.5.0",
         "semver": "^7.3.7",
-        "tiny-lru": "^10.0.0"
+        "tiny-lru": "^11.0.1"
       }
     },
     "node_modules/fastify-plugin": {
@@ -7431,6 +7432,36 @@
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.2.1.tgz",
       "integrity": "sha512-dlGKiwLzRBKkEf5J5ho0uAD/Jdv8GQVUbriB3tAX3ehRUXE4gTV3lRd5inEg9li1aLzb0EGj8y2K4/8g1TN06g==",
       "dev": true
+    },
+    "node_modules/fastify/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
+      "integrity": "sha512-sBVPTgnAZseLu1Qgj6lUbQ0HfjFhZWXAmpZ5AaSGkyLh5gAXBga/uPJjQPHpDFjC9adWIpdOcCLSDTgrZ7snoQ==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
+      }
     },
     "node_modules/fastify/node_modules/pino": {
       "version": "8.6.1",
@@ -14402,12 +14433,12 @@
       }
     },
     "node_modules/tiny-lru": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
-      "integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.0.1.tgz",
+      "integrity": "sha512-iNgFugVuQgBKrqeO/mpiTTgmBsTP0WL6yeuLfLs/Ctf0pI/ixGqIRm8sDCwMcXGe9WWvt2sGXI5mNqZbValmJg==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/tmp": {
@@ -16998,12 +17029,12 @@
       "dev": true
     },
     "@fastify/fast-json-stringify-compiler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.2.0.tgz",
-      "integrity": "sha512-ypZynRvXA3dibfPykQN3RB5wBdEUgSGgny8Qc6k163wYPLD4mEGEDkACp+00YmqkGvIm8D/xYoHajwyEdWD/eg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
       "dev": true,
       "requires": {
-        "fast-json-stringify": "^5.0.0"
+        "fast-json-stringify": "^5.7.0"
       },
       "dependencies": {
         "ajv": {
@@ -17019,9 +17050,9 @@
           }
         },
         "fast-json-stringify": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.6.2.tgz",
-          "integrity": "sha512-F6xkRrXvtGbAiDSEI5Rk7qk2P63Y9kc8bO6Dnsd3Rt6sBNr2QxNFWs0JbKftgiyOfGxnJaRoHe4SizCTqeAyrA==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
+          "integrity": "sha512-sBVPTgnAZseLu1Qgj6lUbQ0HfjFhZWXAmpZ5AaSGkyLh5gAXBga/uPJjQPHpDFjC9adWIpdOcCLSDTgrZ7snoQ==",
           "dev": true,
           "requires": {
             "@fastify/deepmerge": "^1.0.0",
@@ -21154,17 +21185,18 @@
       "dev": true
     },
     "fastify": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.15.0.tgz",
-      "integrity": "sha512-m/CaRN8nf5uyYdrDe2qqq+0z3oGyE+A++qlKQoLJTI4WI0nWK9D6R3FxXQ3MVwt/md977GMR4F43pE9oqrS2zw==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.16.3.tgz",
+      "integrity": "sha512-W45bWZdjAcVxFUBubzkmiMp3VrIRpsqUP6D0NS2Qb1BjTSNNT1NxAubzM8tdMyC5mIBymtvPE3B+DYmItc1rlQ==",
       "dev": true,
       "requires": {
         "@fastify/ajv-compiler": "^3.5.0",
         "@fastify/error": "^3.0.0",
-        "@fastify/fast-json-stringify-compiler": "^4.2.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^8.2.0",
         "fast-content-type-parse": "^1.0.0",
+        "fast-json-stringify": "^5.7.0",
         "find-my-way": "^7.6.0",
         "light-my-request": "^5.6.1",
         "pino": "^8.5.0",
@@ -21173,9 +21205,35 @@
         "rfdc": "^1.3.0",
         "secure-json-parse": "^2.5.0",
         "semver": "^7.3.7",
-        "tiny-lru": "^10.0.0"
+        "tiny-lru": "^11.0.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-json-stringify": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
+          "integrity": "sha512-sBVPTgnAZseLu1Qgj6lUbQ0HfjFhZWXAmpZ5AaSGkyLh5gAXBga/uPJjQPHpDFjC9adWIpdOcCLSDTgrZ7snoQ==",
+          "dev": true,
+          "requires": {
+            "@fastify/deepmerge": "^1.0.0",
+            "ajv": "^8.10.0",
+            "ajv-formats": "^2.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^2.1.0",
+            "rfdc": "^1.2.0"
+          }
+        },
         "pino": {
           "version": "8.6.1",
           "resolved": "https://registry.npmjs.org/pino/-/pino-8.6.1.tgz",
@@ -26619,9 +26677,9 @@
       "dev": true
     },
     "tiny-lru": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
-      "integrity": "sha512-Vst+6kEsWvb17Zpz14sRJV/f8bUWKhqm6Dc+v08iShmIJ/WxqWytHzCTd6m88pS33rE2zpX34TRmOpAJPloNCA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.0.1.tgz",
+      "integrity": "sha512-iNgFugVuQgBKrqeO/mpiTTgmBsTP0WL6yeuLfLs/Ctf0pI/ixGqIRm8sDCwMcXGe9WWvt2sGXI5mNqZbValmJg==",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "express-queue": "^0.0.13",
-    "fastify": "^4.0.2",
+    "fastify": "^4.16.3",
     "finalhandler": "^1.1.2",
     "generic-pool": "^3.7.1",
     "get-port": "^5.1.1",


### PR DESCRIPTION
Also update our dev dep to the current latest fastify release.

---

TAV tests for fastify v4.x started failing in the last day. E.g.: https://github.com/elastic/apm-agent-nodejs/actions/runs/4821512259/jobs/8587501136

<details>
<summary>test failure excerpt</summary>

```
node_tests_1  | > tav --quiet && (cd test/instrumentation/modules/next/a-nextjs-app && tav --quiet)
node_tests_1  | 
node_tests_1  | -- required packages ["fastify@4.17.0"]
node_tests_1  | -- installing ["fastify@4.17.0"]
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/fastify.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/async-await.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/set-framework.test.js" with fastify
node_tests_1  | -- required packages ["fastify@4.16.3"]
node_tests_1  | -- installing ["fastify@4.16.3"]
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/fastify.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/async-await.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/set-framework.test.js" with fastify
node_tests_1  | -- required packages ["fastify@4.16.2"]
node_tests_1  | -- installing ["fastify@4.16.2"]
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/fastify.test.js" with fastify
node_tests_1  | node:internal/modules/cjs/loader:1078
node_tests_1  |   throw err;
node_tests_1  |   ^
node_tests_1  | 
node_tests_1  | Error: Cannot find module 'fast-json-stringify/lib/standalone'
node_tests_1  | Require stack:
node_tests_1  | - /app/node_modules/fastify/lib/error-serializer.js
node_tests_1  | - /app/node_modules/fastify/lib/error-handler.js
node_tests_1  | - /app/node_modules/fastify/lib/reply.js
node_tests_1  | - /app/node_modules/fastify/fastify.js
node_tests_1  | - /app/test/instrumentation/modules/fastify/fastify.test.js
node_tests_1  |     at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
node_tests_1  |     at Module._load (node:internal/modules/cjs/loader:920:27)
node_tests_1  |     at Module.require (node:internal/modules/cjs/loader:1141:19)
```

</details>


There were a few broken releases in the last day or so:

```
  '4.15.0': '2023-03-20T09:13:03.060Z',
  '4.16.0': '2023-04-25T22:13:11.730Z',
  '4.16.1': '2023-04-26T07:17:36.805Z',
  '4.16.2': '2023-04-26T07:44:28.532Z',
  '4.16.3': '2023-04-26T08:02:35.518Z',
  '4.17.0': '2023-04-27T08:28:22.806Z'
```

This changes our TAV config to skip those broken releases.