### PR TITLE
chore: update nvm

### DIFF
--- a/.ci/docker/node-edge-container/Dockerfile
+++ b/.ci/docker/node-edge-container/Dockerfile
@@ -21,7 +21,7 @@ ENV NVM_NODEJS_ORG_MIRROR=${NVM_NODEJS_ORG_MIRROR}
 ENV ELASTIC_APM_CONTEXT_MANAGER=${ELASTIC_APM_CONTEXT_MANAGER}
 
 # nvm environment variables
-ENV NVM_VERSION v0.34.0
+ENV NVM_VERSION v0.39.3
 ENV NVM_DIR /usr/local/nvm
 RUN mkdir $NVM_DIR
 RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash

--- a/.ci/scripts/prepare-benchmarks-env.sh
+++ b/.ci/scripts/prepare-benchmarks-env.sh
@@ -15,7 +15,7 @@ if [[ -z "$NODE_VERSION" ]]; then
 fi
 
 # This particular configuration is required to be installed in the baremetal
-curl -sS -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+curl -sS -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 set +x  # Disable xtrace because output using nvm.sh is huge.
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
We use nvm to install specific versions of node for "Edge tests"
and benchmarks. v0.34.0 was from 2019.
