### PR TITLE
test: fix @aws-sdk/client-s3 TAV test failures

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -213,7 +213,7 @@ elif [[ -n "${TAV_MODULE}" ]]; then
     memcached)
       DOCKER_COMPOSE_FILE=docker-compose-memcached.yml
       ;;
-    aws-sdk)
+    aws-sdk|@aws-sdk/client-s3)
       DOCKER_COMPOSE_FILE=docker-compose-localstack.yml
       ;;
     *)

--- a/.tav.yml
+++ b/.tav.yml
@@ -539,7 +539,7 @@ aws-sdk:
 
 '@aws-sdk/client-s3':
   # We want this version range:
-  #   versions: '>=3 <4'
+  #   versions: '>=3.15.0 <4'
   # However, @awk-sdk/client-s3 releases *very* frequently (almost every day) and there
   # is no need to test *all* those releases. Instead we statically list a subset
   # of versions to test.
@@ -547,8 +547,8 @@ aws-sdk:
   # Maintenance note: This should be updated periodically using:
   #   ./dev-utils/aws-sdk-s3-client-tav-versions.sh
   #
-  # Test v3.0.0, every N=41 of 210 releases, and current latest
-  versions: '3.0.0 || 3.36.0 || 3.86.0 || 3.171.0 || 3.245.0 || 3.315.0 || 3.321.1 || >3.321.1 <4'
+  # Test v3.15.0, every N=37 of 191 releases, and current latest.
+  versions: '3.15.0 || 3.48.0 || 3.112.0 || 3.188.0 || 3.257.0 || 3.315.0 || 3.325.0 || >3.325.0 <4'
   commands:
     - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
   node: '>=14'

--- a/dev-utils/aws-sdk-s3-client-tav-versions.sh
+++ b/dev-utils/aws-sdk-s3-client-tav-versions.sh
@@ -2,7 +2,7 @@
 #
 # Calculate and emit the "versions:" block of ".tav.yml" for aws-sdk.
 # This will include:
-# - the first supported release (2.858.0)
+# - the first supported release
 # - the latest current release
 # - and ~5 releases in between
 
@@ -14,9 +14,9 @@ npm info -j @aws-sdk/client-s3 | node -e '
         .on("data", (chunk) => { chunks.push(chunk) })
         .on("end", () => {
             var input = JSON.parse(chunks.join(""));
-            var vers = input.versions.filter(v => semver.satisfies(v, ">=3 <4"));
+            var vers = input.versions.filter(v => semver.satisfies(v, ">=3.15.0 <4"));
             var modulus = Math.floor((vers.length - 2) / 5);
-            console.log("  # Test v3.0.0, every N=%d of %d releases, and current latest.", modulus, vers.length);
+            console.log("  # Test v3.15.0, every N=%d of %d releases, and current latest.", modulus, vers.length);
             vers = vers.filter((v, idx, arr) => idx % modulus === 0 || idx === arr.length - 1);
             console.log("  versions: '\''%s || >%s <4'\''", vers.join(" || "), vers[vers.length-1])
         })

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -139,7 +139,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 |=======================================================================
 |Module |Version |Note
 |https://www.npmjs.com/package/aws-sdk[aws-sdk] |>1 <3 |Will instrument SQS send/receive/delete messages, all S3 methods, all DynamoDB methods, and the SNS publish method
-|https://www.npmjs.com/package/@aws-sdk/client-s3[@aws-sdk/client-s3] |>=3 <4 |Will instrument all S3 methods
+|https://www.npmjs.com/package/@aws-sdk/client-s3[@aws-sdk/client-s3] |>=3.15.0 <4 |Will instrument all S3 methods
 |https://www.npmjs.com/package/cassandra-driver[cassandra-driver] |>=3.0.0 <5 |Will instrument all queries
 |https://www.npmjs.com/package/elasticsearch[elasticsearch] |>=8.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/@elastic/elasticsearch[@elastic/elasticsearch] |>=7.0.0 <9.0.0 |Will instrument all queries

--- a/test/instrumentation/modules/@aws-sdk/client-s3.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-s3.test.js
@@ -77,8 +77,8 @@ tape.test('simple S3 V3 usage scenario', function (t) {
         // Sort the events by timestamp, then work through each expected span.
         const events = server.events.slice(1)
         events.sort((a, b) => {
-          const aTimestamp = (a.transaction || a.span || {}).timestamp
-          const bTimestamp = (b.transaction || b.span || {}).timestamp
+          const aTimestamp = (a.transaction || a.span || a.error || {}).timestamp
+          const bTimestamp = (b.transaction || b.span || b.error || {}).timestamp
           return aTimestamp < bTimestamp ? -1 : 1
         })
 

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -68,8 +68,8 @@ tape.test('simple S3 usage scenario', function (t) {
         // Sort the events by timestamp, then work through each expected span.
         const events = server.events.slice(1)
         events.sort((a, b) => {
-          const aTimestamp = (a.transaction || a.span || {}).timestamp
-          const bTimestamp = (b.transaction || b.span || {}).timestamp
+          const aTimestamp = (a.transaction || a.span || a.error || {}).timestamp
+          const bTimestamp = (b.transaction || b.span || b.error || {}).timestamp
           return aTimestamp < bTimestamp ? -1 : 1
         })
 


### PR DESCRIPTION
- Fix for bad selection of docker compose file to run tests on module `@aws-sdk/client-s3`. Test script was selecting the default one instead of using one with localstack.
- Bump the min supported client-s3 version to v3.15.0.
- Also a small fix in intake event sorting for tests 

Fixes: #3311

### Checklist

- [x] Implement code (in CI scripts)
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
