### PR TITLE
test: fix fastify TAV test failures

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -468,6 +468,9 @@ restify-v10-v12:
 # - #1086 suggests fastify@2.4.0 was a broken release, skip it.
 # - fastify@4.0.1 is broken: https://github.com/fastify/fastify/issues/3998#issuecomment-1153662513
 # - fastify@4.16.0 - 4.16.2 (inclusive) are broken releases
+# - Do not run "test/sanitize-field-names/fastify.test.js" for older fastify,
+#   because the test file uses '@fastify/formbody', which only has versions
+#   for fastify >=3.
 fastify-v1:
   name: fastify
   versions: '1.x'
@@ -476,7 +479,6 @@ fastify-v1:
     - node test/instrumentation/modules/fastify/fastify.test.js
     - node test/instrumentation/modules/fastify/async-await.test.js
     - node test/instrumentation/modules/fastify/set-framework.test.js
-    - node test/sanitize-field-names/fastify.test.js
 fastify-v2:
   name: fastify
   versions: '>=2.0.0 <2.4.0 || >2.4.0 <3'
@@ -485,10 +487,10 @@ fastify-v2:
     - node test/instrumentation/modules/fastify/fastify.test.js
     - node test/instrumentation/modules/fastify/async-await.test.js
     - node test/instrumentation/modules/fastify/set-framework.test.js
-    - node test/sanitize-field-names/fastify.test.js
 fastify-v3:
   name: fastify
   versions: '>=3.0.0 <4'
+  peerDependencies: '@fastify/formbody@^6.0.1'
   node: '>=10'
   commands:
     - node test/instrumentation/modules/fastify/fastify.test.js
@@ -498,6 +500,7 @@ fastify-v3:
 fastify:
   name: fastify
   versions: '>=4 <4.0.1 || >4.0.1 <4.16.0 || >4.16.2'
+  peerDependencies: '@fastify/formbody@^7'
   node: '>=14.6.0'
   commands:
     - node test/instrumentation/modules/fastify/fastify.test.js


### PR DESCRIPTION
The TAV tests were failing on fastify@3 with this error:
    FastifyError [FST_ERR_PLUGIN_VERSION_MISMATCH]: fastify-plugin: @fastify/formbody - expected '4.x' fastify version, '3.29.5' is installed

The '@fastify/formbody' dep used in the sanitize-field-names/fastify.test.js
test file needs to match the fastify major version.

I am somewhat hesitant to add this change, because I think it might
make the fastify TAV tests much longer to run. Each version tested will
be doing an additional npm install step, which is slow.

---

<details>
<summary>Test failure log output</summary>

From https://github.com/elastic/apm-agent-nodejs/actions/runs/4871077219/jobs/8687616639

```
...
node_tests_1  | -- installing ["fastify@4.0.0"]
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/fastify.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/async-await.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/set-framework.test.js" with fastify
node_tests_1  | -- running test "node test/sanitize-field-names/fastify.test.js" with fastify
node_tests_1  | -- required packages ["fastify@3.29.5"]
node_tests_1  | -- installing ["fastify@3.29.5"]
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/fastify.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/async-await.test.js" with fastify
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/set-framework.test.js" with fastify
node_tests_1  | -- running test "node test/sanitize-field-names/fastify.test.js" with fastify
node_tests_1  |
node_tests_1  | /app/node_modules/fastify/lib/pluginUtils.js:107
node_tests_1  |   if (!semver.satisfies(this.version, requiredVersion)) throw new FST_ERR_PLUGIN_VERSION_MISMATCH(meta.name, requiredVersion, this.version)
node_tests_1  |                                                               ^
node_tests_1  | FastifyError [FST_ERR_PLUGIN_VERSION_MISMATCH]: fastify-plugin: @fastify/formbody - expected '4.x' fastify version, '3.29.5' is installed
node_tests_1  |     at Object.checkVersion (/app/node_modules/fastify/lib/pluginUtils.js:107:63)
node_tests_1  |     at Object.registerPlugin (/app/node_modules/fastify/lib/pluginUtils.js:121:16)
node_tests_1  |     at Boot.override (/app/node_modules/fastify/lib/pluginOverride.js:28:57)
node_tests_1  |     at Plugin.exec (/app/node_modules/avvio/plugin.js:80:33)
node_tests_1  |     at Boot.loadPlugin (/app/node_modules/avvio/plugin.js:274:10)
node_tests_1  |     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
node_tests_1  |   code: 'FST_ERR_PLUGIN_VERSION_MISMATCH',
node_tests_1  |   statusCode: 500
node_tests_1  | }
node_tests_1  |
node_tests_1  | Node.js v18.16.0
```

</details>

Repro:

```
% npm install --no-save fastify@3

% node test/sanitize-field-names/fastify.test.js
TAP version 13
# Running fixtures with fastify
# tests default wildcard handling, with urlencode bodyparsing

/Users/trentm/el/apm-agent-nodejs14/node_modules/fastify/lib/pluginUtils.js:107
  if (!semver.satisfies(this.version, requiredVersion)) throw new FST_ERR_PLUGIN_VERSION_MISMATCH(meta.name, requiredVersion, this.version)
                                                              ^
FastifyError [FST_ERR_PLUGIN_VERSION_MISMATCH]: fastify-plugin: @fastify/formbody - expected '4.x' fastify version, '3.29.5' is installed
    at Object.checkVersion (/Users/trentm/el/apm-agent-nodejs14/node_modules/fastify/lib/pluginUtils.js:107:63)
    at Object.registerPlugin (/Users/trentm/el/apm-agent-nodejs14/node_modules/fastify/lib/pluginUtils.js:121:16)
    at Boot.override (/Users/trentm/el/apm-agent-nodejs14/node_modules/fastify/lib/pluginOverride.js:28:57)
    at Plugin.exec (/Users/trentm/el/apm-agent-nodejs14/node_modules/avvio/plugin.js:80:33)
    at Boot.loadPlugin (/Users/trentm/el/apm-agent-nodejs14/node_modules/avvio/plugin.js:274:10)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  code: 'FST_ERR_PLUGIN_VERSION_MISMATCH',
  statusCode: 500
}
```
