### PR TITLE
test: fix running fastify.test.js with node v8

### DIFF
--- a/test/instrumentation/modules/fastify/fastify.test.js
+++ b/test/instrumentation/modules/fastify/fastify.test.js
@@ -101,11 +101,11 @@ test('captureBody', function (t) {
     // an argument to the callback
     const port = fastify.server.address().port
     const cReq = http.request(
-      'http://localhost:' + port + '/postSomeData',
       {
         method: 'POST',
         hostname: 'localhost',
         port,
+        path: '/postSomeData',
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(postData)


### PR DESCRIPTION
`http.request(url, options, cb)` didn't exist until node v10.

---

This is to resolve this `test-tav (8, fastify)` test failure:

https://github.com/elastic/apm-agent-nodejs/actions/runs/4876452824/jobs/8700775255#step:3:158

```
node_tests_1  | -- required packages ["fastify@2.15.3"]
node_tests_1  | -- installing ["fastify@2.15.3"]
node_tests_1  | -- running test "node test/instrumentation/modules/fastify/fastify.test.js" with fastify
node_tests_1  | events.js:340
node_tests_1  |     throw new TypeError('"listener" argument must be a function');
node_tests_1  |     ^
node_tests_1  | 
node_tests_1  | TypeError: "listener" argument must be a function
node_tests_1  |     at ClientRequest.once (events.js:340:11)
node_tests_1  |     at new ClientRequest (_http_client.js:174:10)
node_tests_1  |     at Object.request (http.js:39:10)
node_tests_1  |     at Object.request (/app/lib/instrumentation/http-shared.js:257:21)
node_tests_1  |     at /app/test/instrumentation/modules/fastify/fastify.test.js:103:23
node_tests_1  |     at Server.wrap (/app/node_modules/fastify/lib/server.js:75:9)
node_tests_1  |     at Object.onceWrapper (events.js:313:30)
node_tests_1  |     at emitNone (events.js:106:13)
node_tests_1  |     at Server.emit (events.js:208:7)
node_tests_1  |     at Server.emit (/app/lib/instrumentation/http-shared.js:139:19)
node_tests_1  |     at emitListeningNT (net.js:1387:10)
node_tests_1  |     at _combinedTickCallback (internal/process/next_tick.js:136:11)
node_tests_1  |     at process._tickCallback (internal/process/next_tick.js:181:9)
node_tests_1  | -- detected failing command, flushing stdout...
node_tests_1  | TAP version 13
node_tests_1  | # transaction name
node_tests_1  | ok 1 null
node_tests_1  | ok 2 has a transaction
node_tests_1  | ok 3 transaction name is GET /hello/:name
node_tests_1  | ok 4 transaction type is request
node_tests_1  | ok 5 got correct body
node_tests_1  | # captureBody
node_tests_1  | ok 6 null
node_tests_1  | 
node_tests_1  | -- fatal: Test exited with code 1
node_tests_1  | npm ERR! code ELIFECYCLE
node_tests_1  | npm ERR! errno 1
node_tests_1  | npm ERR! elastic-apm-node@3.45.0 test:tav: `(cd test/opentelemetry-metrics/fixtures && tav --quiet) && (cd test/opentelemetry-bridge && tav --quiet) && (cd test/instrumentation/modules/next/a-nextjs-app && tav --quiet) && tav --quiet`
node_tests_1  | npm ERR! Exit status 1
node_tests_1  | npm ERR! 
node_tests_1  | npm ERR! Failed at the elastic-apm-node@3.45.0 test:tav script.
node_tests_1  | npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
node_tests_1  | 
node_tests_1  | npm ERR! A complete log of this run can be found in:
node_tests_1  | npm ERR!     /tmp/.npm/_logs/2023-05-03T22_37_24_343Z-debug.log
docker_node_tests_1 exited with code 1
1
```