### PR TITLE
docs: add section about unhandled rejections in config docs

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -588,6 +588,11 @@ Another side-effect is that the APM agent does not log the uncaught exception
 to stderr by default. Use <<log-uncaught-exceptions, `logUncaughtExceptions: true`>>
 to have the agent print the exception to stderr before exiting.
 
+Unhandled rejections (https://nodejs.org/api/process.html#event-unhandledrejection[`unhandledRejection`])
+will also be captured if your node process starts with `--unhandled-rejections` mode set to
+`strict` or `throw`. If your application run on Node.js 15+ you don't need to explitcitly set the mode
+since `throw` is the default (https://nodejs.org/api/cli.html#--unhandled-rejectionsmode[reference]).
+
 [[log-uncaught-exceptions]]
 ==== `logUncaughtExceptions`
 


### PR DESCRIPTION
# Description

Unhandled rejections are captured by the agent in NodeJS v15+ environments but there was no mention of it in the docs.

Fixes #2366

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
