### PR TITLE
fix: correct supported versions of knex to exclude 0.9.0

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -171,10 +171,10 @@ bluebird:
 # - knex 0.18.0 min supported node is v8
 # - knex 0.21.0 min supported node is v10
 # - knex 1.0.0 min supported node is v12
-knex-v0.9-v0.17:
+knex-v0.10-v0.17:
   name: knex
   # Latest 0.16 release was in 2019, therefore only test first and last in this range.
-  versions: '0.9.0 || 0.16.5'
+  versions: '0.10.0 || 0.16.5'
   commands: node test/instrumentation/modules/pg/knex.test.js
 knex-v0.17-v0.21:
   name: knex

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -189,7 +189,7 @@ please create a new topic in the https://discuss.elastic.co/c/apm[Elastic APM di
 [options="header"]
 |=================================================
 |Module |Version |Note
-|https://www.npmjs.com/package/knex[knex] |>=0.9.0 <1.0.0 | Provides better span stack traces for 'pg' and 'mysql' spans. Instrumentation of Knex >=0.95.0 is not supported when using the deprecated <<context-manager,`contextManager=patch`>> configuration option.
+|https://www.npmjs.com/package/knex[knex] |>=0.10.0 <1.0.0 | Provides better span stack traces for 'pg' and 'mysql' spans. Instrumentation of Knex >=0.95.0 is not supported when using the deprecated <<context-manager,`contextManager=patch`>> configuration option.
 |=================================================
 
 [float]


### PR DESCRIPTION
Our knex instrumentation only ever supported '>0.9.0', but the docs for
it accidentally stated '>=0.9.0'. Then in a recent change to .tav.yml we
actually started testing with '0.9.0', the result being that the tests
hang.  This change corrects and restates the range to be '>=0.10.0
<1.0.0'.

Dropping a documented supported version might in general be worthy of
changelog, docs, and even a breaking change. However, instrumenting
0.9.0 never worked and it was released 2015.

---

This fixes recent hangs in knex TAV tests, e.g.:
https://github.com/elastic/apm-agent-nodejs/actions/runs/4895356707
