### PR TITLE
chore, test: bump @elastic/elasticsearch-canary dep, drop its TAV testing, bump ES server version

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       retries: 30
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="

--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -5,7 +5,6 @@
     "@apollo/server",
     "@aws-sdk/client-s3",
     "@elastic/elasticsearch",
-    "@elastic/elasticsearch-canary",
     "@hapi/hapi",
     "@opentelemetry/api",
     "@opentelemetry/sdk-metrics",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
           - nodemssqldata:/var/opt/mssql
 
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.2.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
         env:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
           network.host: ''

--- a/.tav.yml
+++ b/.tav.yml
@@ -313,16 +313,6 @@ elasticsearch:
   node: '>=14.0.0'
   commands: node test/instrumentation/modules/@elastic/elasticsearch.test.js
 
-# @elastic/elasticsearch-canary *sometimes* gets releases in advance of
-# '@elastic/elasticsearch'. It is only the latest such release that
-# might matter. The point in testing it is to try to make sure the agent is
-# updated for coming changes to the non-canary package.
-'@elastic/elasticsearch-canary':
-  name: '@elastic/elasticsearch-canary'
-  versions: '>=8.2.0-canary.2'
-  node: '>=14'
-  commands: node test/instrumentation/modules/@elastic/elasticsearch-canary.test.js
-
 handlebars:
   versions: '*'
   commands: node test/instrumentation/modules/handlebars.test.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@babel/core": "^7.8.4",
         "@babel/preset-env": "^7.8.4",
         "@elastic/elasticsearch": "^8.6.0",
-        "@elastic/elasticsearch-canary": "^8.2.0-canary.2",
+        "@elastic/elasticsearch-canary": "^8.8.0-canary.2",
         "@fastify/formbody": "^7.0.1",
         "@hapi/hapi": "^21.0.0",
         "@koa/router": "^12.0.0",
@@ -4030,16 +4030,16 @@
       }
     },
     "node_modules/@elastic/elasticsearch-canary": {
-      "version": "8.2.0-canary.2",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.2.0-canary.2.tgz",
-      "integrity": "sha512-Ki2lQ3/UlOnBaf5EjNw0WmCdXiW+J020aYtdVnIuCNhPSLoNPKoM7P+MlggdfeRnENvINlStrMy4bkYF/h6Vbw==",
+      "version": "8.8.0-canary.2",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.8.0-canary.2.tgz",
+      "integrity": "sha512-UxH8YUxcsqHXGh4t2PjuL0q03XunF9vCLHPAs9r+fQcaPXpNbEuv9jbNGXv/9TLyeAKYEgcq9Xm0p0Nk/Mh0lQ==",
       "dev": true,
       "dependencies": {
-        "@elastic/transport": "^8.0.2",
-        "tslib": "^2.3.0"
+        "@elastic/transport": "^8.3.1",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@elastic/transport": {
@@ -20200,13 +20200,13 @@
       }
     },
     "@elastic/elasticsearch-canary": {
-      "version": "8.2.0-canary.2",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.2.0-canary.2.tgz",
-      "integrity": "sha512-Ki2lQ3/UlOnBaf5EjNw0WmCdXiW+J020aYtdVnIuCNhPSLoNPKoM7P+MlggdfeRnENvINlStrMy4bkYF/h6Vbw==",
+      "version": "8.8.0-canary.2",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.8.0-canary.2.tgz",
+      "integrity": "sha512-UxH8YUxcsqHXGh4t2PjuL0q03XunF9vCLHPAs9r+fQcaPXpNbEuv9jbNGXv/9TLyeAKYEgcq9Xm0p0Nk/Mh0lQ==",
       "dev": true,
       "requires": {
-        "@elastic/transport": "^8.0.2",
-        "tslib": "^2.3.0"
+        "@elastic/transport": "^8.3.1",
+        "tslib": "^2.4.0"
       }
     },
     "@elastic/transport": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
     "@elastic/elasticsearch": "^8.6.0",
-    "@elastic/elasticsearch-canary": "^8.2.0-canary.2",
+    "@elastic/elasticsearch-canary": "^8.8.0-canary.2",
     "@fastify/formbody": "^7.0.1",
     "@hapi/hapi": "^21.0.0",
     "@koa/router": "^12.0.0",

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       retries: 30
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="


### PR DESCRIPTION
- bump the elasticsearch-canary dep to the latest version
- Drop TAV testing of elasticsearch-canary, because it doesn't work with
  TAV: `tav` doesn't support ranges of *pre*releases (its internal usage
  of node-semver does not use or support using `{includePrerelease: true}`, 
  so our current .tav.yml block does not test the *latest*
  canary release, only the exact version specified. Testing an older
  canary release is pointless.
- Bump the Elasticsearch service version we use to the latest (8.7.1).
