### PR TITLE
chore: extract normalizers to its own module

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,11 +16,27 @@ const REDACTED = require('./constants').REDACTED
 var logging = require('./logging')
 var version = require('../package').version
 
-const { WildcardMatcher } = require('./wildcard-matcher')
 const { CloudMetadata } = require('./cloud-metadata')
 const { NoopTransport } = require('./noop-transport')
 const { isLambdaExecutionEnvironment } = require('./lambda')
 const { isAzureFunctionsEnvironment, getAzureFunctionsExtraMetadata } = require('./instrumentation/azure-functions')
+
+const {
+  normalizeArrays,
+  normalizeBools,
+  normalizeBytes,
+  normalizeDurationOptions,
+  normalizeIgnoreOptions,
+  normalizeInfinity,
+  normalizeKeyValuePairs,
+  normalizeNumbers,
+  normalizeElasticsearchCaptureBodyUrls,
+  normalizeDisableMetrics,
+  normalizeSanitizeFieldNames,
+  normalizeCloudProvider,
+  normalizeCustomMetricsHistogramBoundaries,
+  normalizeTransactionSampleRate
+} = require('./config/normalizers')
 
 let confFile = loadConfigFile()
 
@@ -764,19 +780,20 @@ function serviceVersionFromPackageJson () {
 }
 
 function normalize (opts, logger) {
-  normalizeKeyValuePairs(opts)
-  normalizeNumbers(opts)
-  normalizeBytes(opts)
-  normalizeArrays(opts)
-  normalizeDurationOptions(opts, logger)
-  normalizeBools(opts, logger)
+  normalizeKeyValuePairs(opts, KEY_VALUE_OPTS, DEFAULTS, logger)
+  normalizeNumbers(opts, NUM_OPTS, DEFAULTS, logger)
+  normalizeInfinity(opts, MINUS_ONE_EQUAL_INFINITY, DEFAULTS, logger)
+  normalizeBytes(opts, BYTES_OPTS, DEFAULTS, logger)
+  normalizeArrays(opts, ARRAY_OPTS, DEFAULTS, logger)
+  normalizeDurationOptions(opts, DURATION_OPTS, DEFAULTS, logger)
+  normalizeBools(opts, BOOL_OPTS, DEFAULTS, logger)
   normalizeIgnoreOptions(opts)
   normalizeElasticsearchCaptureBodyUrls(opts)
   normalizeDisableMetrics(opts)
   normalizeSanitizeFieldNames(opts)
   normalizeContextManager(opts, logger) // Must be after normalizeBools().
-  normalizeCloudProvider(opts, logger)
-  normalizeTransactionSampleRate(opts, logger)
+  normalizeCloudProvider(opts, [], DEFAULTS, logger)
+  normalizeTransactionSampleRate(opts, [], DEFAULTS, logger)
   normalizeTraceContinuationStrategy(opts, logger)
   normalizeCustomMetricsHistogramBoundaries(opts, logger)
 
@@ -786,41 +803,6 @@ function normalize (opts, logger) {
   normalizeSpanStackTraceMinDuration(opts, logger)
 
   truncateOptions(opts)
-}
-
-// `customMetricsHistogramBoundaries` must be a sorted array of numbers,
-// without duplicates.
-function normalizeCustomMetricsHistogramBoundaries (opts, logger) {
-  if (!('customMetricsHistogramBoundaries' in opts)) {
-    return
-  }
-  let val = opts.customMetricsHistogramBoundaries
-  if (typeof val === 'string') {
-    val = val.split(',').map(v => Number(v.trim()))
-  }
-  let errReason = null
-  if (!Array.isArray(val)) {
-    errReason = 'value is not an array'
-  } else if (val.some(el => typeof el !== 'number' || isNaN(el))) {
-    errReason = 'array includes non-numbers'
-  } else {
-    for (let i = 0; i < val.length - 1; i++) {
-      if (val[i] === val[i + 1]) {
-        errReason = 'array has duplicate values'
-        break
-      } else if (val[i] > val[i + 1]) {
-        errReason = 'array is not sorted'
-        break
-      }
-    }
-  }
-  if (errReason) {
-    logger.warn('Invalid "customMetricsHistogramBoundaries" config value %j, %s; falling back to default',
-      opts.customMetricsHistogramBoundaries, errReason)
-    opts.customMetricsHistogramBoundaries = DEFAULTS.customMetricsHistogramBoundaries
-  } else {
-    opts.customMetricsHistogramBoundaries = val
-  }
 }
 
 const ALLOWED_TRACE_CONTINUATION_STRATEGY = {
@@ -948,319 +930,9 @@ function normalizeContextManager (opts, logger) {
   }
 }
 
-// transactionSampleRate is specified to be:
-// - in the range [0,1]
-// - rounded to 4 decimal places of precision (e.g. 0.0001, 0.5678, 0.9999)
-// - with the special case that a value in the range (0, 0.0001] should be
-//   rounded to 0.0001 -- to avoid a small value being rounded to zero.
-//
-// https://github.com/elastic/apm/blob/main/specs/agents/tracing-sampling.md
-function normalizeTransactionSampleRate (opts, logger) {
-  if ('transactionSampleRate' in opts) {
-    // The value was already run through `Number(...)` in `normalizeNumbers`.
-    const rate = opts.transactionSampleRate
-    if (isNaN(rate) || rate < 0 || rate > 1) {
-      opts.transactionSampleRate = DEFAULTS.transactionSampleRate
-      logger.warn('Invalid "transactionSampleRate" config value %s, falling back to default %s',
-        rate, opts.transactionSampleRate)
-    } else if (rate > 0 && rate < 0.0001) {
-      opts.transactionSampleRate = 0.0001
-    } else {
-      opts.transactionSampleRate = Math.round(rate * 10000) / 10000
-    }
-  }
-}
-
-function normalizeSanitizeFieldNames (opts) {
-  if (opts.sanitizeFieldNames) {
-    opts.sanitizeFieldNamesRegExp = []
-    const wildcard = new WildcardMatcher()
-    for (const ptn of opts.sanitizeFieldNames) {
-      const re = wildcard.compile(ptn)
-      opts.sanitizeFieldNamesRegExp.push(re)
-    }
-  }
-}
-
-function normalizeDisableMetrics (opts) {
-  if (opts.disableMetrics) {
-    const wildcard = new WildcardMatcher()
-    for (const ptn of opts.disableMetrics) {
-      const re = wildcard.compile(ptn)
-      opts.disableMetricsRegExp.push(re)
-    }
-  }
-}
-
-function normalizeCloudProvider (opts, logger) {
-  if ('cloudProvider' in opts) {
-    const allowedValues = ['auto', 'gcp', 'azure', 'aws', 'none']
-    if (allowedValues.indexOf(opts.cloudProvider) === -1) {
-      logger.warn('Invalid "cloudProvider" config value %s, falling back to default %s',
-        opts.cloudProvider, DEFAULTS.cloudProvider)
-      opts.cloudProvider = DEFAULTS.cloudProvider
-    }
-  }
-}
-
-function normalizeIgnoreOptions (opts) {
-  if (opts.transactionIgnoreUrls) {
-    opts.transactionIgnoreUrlRegExp = []
-    const wildcard = new WildcardMatcher()
-    for (const ptn of opts.transactionIgnoreUrls) {
-      const re = wildcard.compile(ptn)
-      opts.transactionIgnoreUrlRegExp.push(re)
-    }
-  }
-
-  if (opts.ignoreUrls) {
-    opts.ignoreUrlStr = []
-    opts.ignoreUrlRegExp = []
-    for (const ptn of opts.ignoreUrls) {
-      if (typeof ptn === 'string') {
-        opts.ignoreUrlStr.push(ptn)
-      } else {
-        opts.ignoreUrlRegExp.push(ptn)
-      }
-    }
-    delete opts.ignoreUrls
-  }
-
-  if (opts.ignoreUserAgents) {
-    opts.ignoreUserAgentStr = []
-    opts.ignoreUserAgentRegExp = []
-    for (const ptn of opts.ignoreUserAgents) {
-      if (typeof ptn === 'string') {
-        opts.ignoreUserAgentStr.push(ptn)
-      } else {
-        opts.ignoreUserAgentRegExp.push(ptn)
-      }
-    }
-    delete opts.ignoreUserAgents
-  }
-
-  if (opts.ignoreMessageQueues) {
-    opts.ignoreMessageQueuesRegExp = []
-    const wildcard = new WildcardMatcher()
-    for (const ptn of opts.ignoreMessageQueues) {
-      const re = wildcard.compile(ptn)
-      opts.ignoreMessageQueuesRegExp.push(re)
-    }
-  }
-}
-
-function normalizeElasticsearchCaptureBodyUrls (opts) {
-  if (opts.elasticsearchCaptureBodyUrls) {
-    opts.elasticsearchCaptureBodyUrlsRegExp = []
-    const wildcard = new WildcardMatcher()
-    for (const ptn of opts.elasticsearchCaptureBodyUrls) {
-      const re = wildcard.compile(ptn)
-      opts.elasticsearchCaptureBodyUrlsRegExp.push(re)
-    }
-  }
-}
-
-function normalizeNumbers (opts) {
-  for (const key of NUM_OPTS) {
-    if (key in opts) opts[key] = Number(opts[key])
-  }
-
-  for (const key of MINUS_ONE_EQUAL_INFINITY) {
-    if (opts[key] === -1) opts[key] = Infinity
-  }
-}
-
-function normalizeBytes (opts) {
-  for (const key of BYTES_OPTS) {
-    if (key in opts) opts[key] = bytes(String(opts[key]))
-  }
-}
-
-function normalizeDurationOptions (opts, logger) {
-  for (const optSpec of DURATION_OPTS) {
-    const key = optSpec.name
-    if (key in opts) {
-      const val = secondsFromDuration(opts[key], optSpec.defaultUnit,
-        optSpec.allowedUnits, optSpec.allowNegative)
-      if (val === null) {
-        if (key in DEFAULTS) {
-          const def = DEFAULTS[key]
-          logger.warn('invalid duration value "%s" for "%s" config option: using default "%s"',
-            opts[key], key, def)
-          opts[key] = secondsFromDuration(def, optSpec.defaultUnit,
-            optSpec.allowedUnits, optSpec.allowNegative)
-        } else {
-          logger.warn('invalid duration value "%s" for "%s" config option: ignoring this option',
-            opts[key], key)
-          delete opts[key]
-        }
-      } else {
-        opts[key] = val
-      }
-    }
-  }
-}
-
-// Array config vars are either already an array of strings, or a
-// comma-separated string (whitespace is trimmed):
-//    'foo, bar' => ['foo', 'bar']
-function normalizeArrays (opts) {
-  for (const key of ARRAY_OPTS) {
-    if (key in opts && typeof opts[key] === 'string') {
-      opts[key] = opts[key].split(',').map(v => v.trim())
-    }
-  }
-}
-
-// KeyValuePairs config vars are either an object or a comma-separated string
-// of key=value pairs (whitespace around the "key=value" strings is trimmed):
-//    {'foo': 'bar', 'eggs': 'spam'} => [['foo', 'bar'], ['eggs', 'spam']]
-//    foo=bar, eggs=spam             => [['foo', 'bar'], ['eggs', 'spam']]
-function normalizeKeyValuePairs (opts) {
-  for (const key of KEY_VALUE_OPTS) {
-    if (key in opts) {
-      if (typeof opts[key] === 'object' && !Array.isArray(opts[key])) {
-        opts[key] = Object.entries(opts[key])
-        return
-      }
-
-      if (!Array.isArray(opts[key]) && typeof opts[key] === 'string') {
-        opts[key] = opts[key].split(',').map(v => v.trim())
-      }
-
-      if (Array.isArray(opts[key])) {
-        // Note: Currently this assumes no '=' in the value. Also this does not
-        // trim whitespace.
-        opts[key] = opts[key].map(
-          value => typeof value === 'string' ? value.split('=') : value)
-      }
-    }
-  }
-}
-
-function normalizeBools (opts, logger) {
-  for (const key of BOOL_OPTS) {
-    if (key in opts) opts[key] = strictBool(logger, key, opts[key])
-  }
-}
-
 function truncateOptions (opts) {
   if (opts.serviceVersion) opts.serviceVersion = truncate(String(opts.serviceVersion), INTAKE_STRING_MAX_SIZE)
   if (opts.hostname) opts.hostname = truncate(String(opts.hostname), INTAKE_STRING_MAX_SIZE)
-}
-
-// Translate a string byte size, e.g. '10kb', into an integer number of bytes.
-function bytes (input) {
-  const matches = input.match(/^(\d+)(b|kb|mb|gb)$/i)
-  if (!matches) return Number(input)
-
-  const suffix = matches[2].toLowerCase()
-  let value = Number(matches[1])
-
-  if (!suffix || suffix === 'b') {
-    return value
-  }
-
-  value *= 1024
-  if (suffix === 'kb') {
-    return value
-  }
-
-  value *= 1024
-  if (suffix === 'mb') {
-    return value
-  }
-
-  value *= 1024
-  if (suffix === 'gb') {
-    return value
-  }
-}
-
-// Convert a given duration config option into a number of seconds.
-// If the given duration is invalid, this returns `null`.
-// Units are *case-sensitive*.
-//
-// @param {String|Number} duration - Typically a string of the form `<num><unit>`,
-//    for example `30s`, `-1ms`, `2m`. The `defaultUnit` is used if a unit is
-//    not part of the string, or if duration is a number. If given as a string,
-//    decimal ('1.5s') and exponential-notation ('1e-3s') values are not allowed.
-// @param {String} defaultUnit
-// @param {Array} allowedUnits - An array of the allowed unit strings. This
-//    array may include any number of `us`, `ms`, `s`, and `m`.
-// @param {Boolean} allowNegative - Whether a negative number is allowed.
-//
-// Examples:
-//    secondsFromDuration('30s', 's', ['ms', 's', 'm'], false) // => 30
-//    secondsFromDuration('-1s', 's', ['ms', 's', 'm'], false) // => null
-//    secondsFromDuration('-1ms', 's', ['ms', 's', 'm'], true) // => -0.001
-//    secondsFromDuration(500, 'ms', ['us', 'ms', 's', 'm'], false) // => 0.5
-//
-function secondsFromDuration (duration, defaultUnit, allowedUnits, allowNegative) {
-  let val
-  let unit
-  if (typeof duration === 'string') {
-    let match
-    if (allowNegative) {
-      match = /^(-?\d+)(\w+)?$/.exec(duration)
-    } else {
-      match = /^(\d+)(\w+)?$/.exec(duration)
-    }
-    if (!match) {
-      return null
-    }
-    val = Number(match[1])
-    if (isNaN(val) || !Number.isFinite(val)) {
-      return null
-    }
-    unit = match[2] || defaultUnit
-    if (!allowedUnits.includes(unit)) {
-      return null
-    }
-  } else if (typeof duration === 'number') {
-    if (isNaN(duration)) {
-      return null
-    } else if (duration < 0 && !allowNegative) {
-      return null
-    }
-    val = duration
-    unit = defaultUnit
-  } else {
-    return null
-  }
-
-  // Scale to seconds.
-  switch (unit) {
-    case 'us':
-      val /= 1e6
-      break
-    case 'ms':
-      val /= 1e3
-      break
-    case 's':
-      break
-    case 'm':
-      val *= 60
-      break
-    default:
-      throw new Error(`unknown unit "${unit}" from "${duration}"`)
-  }
-
-  return val
-}
-
-function strictBool (logger, key, value) {
-  if (typeof value === 'boolean') {
-    return value
-  }
-  // This will return undefined for unknown inputs, resulting in them being skipped.
-  switch (value) {
-    case 'false': return false
-    case 'true': return true
-    default: {
-      logger.warn('unrecognized boolean value "%s" for "%s"', value, key)
-    }
-  }
 }
 
 function maybePairsToObject (pairs) {
@@ -1449,7 +1121,6 @@ module.exports = {
   CENTRAL_CONFIG_OPTS,
   DEFAULTS,
   DURATION_OPTS,
-  secondsFromDuration,
   userAgentFromConf,
   ENV_TABLE
 }

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -1,0 +1,488 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+const { WildcardMatcher } = require('../wildcard-matcher')
+
+// TODO: move this typedef to logger.js
+/**
+ * @typedef {Object} Logger
+ * @property {function(any, any, any, any): undefined} log
+ * @property {function(any, any, any, any): undefined} info
+ * @property {function(any, any, any, any): undefined} warn
+ * @property {function(any, any, any, any): undefined} error
+ */
+
+/**
+ * Normalizes the key/value pairs properties of the config options object
+ * KeyValuePairs config vars are either an object or a comma-separated string
+ * of key=value pairs (whitespace around the "key=value" strings is trimmed):
+ *    {'foo': 'bar', 'eggs': 'spam'} => [['foo', 'bar'], ['eggs', 'spam']]
+ *    foo=bar, eggs=spam             => [['foo', 'bar'], ['eggs', 'spam']]
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as key/value pair
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeKeyValuePairs (opts, fields, defaults, logger) {
+  for (const key of fields) {
+    if (key in opts) {
+      if (typeof opts[key] === 'object' && !Array.isArray(opts[key])) {
+        opts[key] = Object.entries(opts[key])
+        return
+      }
+
+      if (!Array.isArray(opts[key]) && typeof opts[key] === 'string') {
+        opts[key] = opts[key].split(',').map(v => v.trim())
+      }
+
+      if (Array.isArray(opts[key])) {
+        // Note: Currently this assumes no '=' in the value. Also this does not
+        // trim whitespace.
+        opts[key] = opts[key].map(
+          value => typeof value === 'string' ? value.split('=') : value)
+      }
+    }
+  }
+}
+
+/**
+ * Normalizes the number properties of the config options object
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as number
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeNumbers (opts, fields, defaults, logger) {
+  for (const key of fields) {
+    if (key in opts) opts[key] = Number(opts[key])
+  }
+}
+
+/**
+ * Normalizes the number properties of the config options object
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as number
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeInfinity (opts, fields, defaults, logger) {
+  for (const key of fields) {
+    if (opts[key] === -1) opts[key] = Infinity
+  }
+}
+
+/**
+ * Translates a string byte size, e.g. '10kb', into an integer number of bytes.
+ *
+ * @param {string} input
+ * @returns {number|undefined}
+ */
+function bytes (input) {
+  const matches = input.match(/^(\d+)(b|kb|mb|gb)$/i)
+  if (!matches) return Number(input)
+
+  const suffix = matches[2].toLowerCase()
+  let value = Number(matches[1])
+
+  if (!suffix || suffix === 'b') {
+    return value
+  }
+
+  value *= 1024
+  if (suffix === 'kb') {
+    return value
+  }
+
+  value *= 1024
+  if (suffix === 'mb') {
+    return value
+  }
+
+  value *= 1024
+  if (suffix === 'gb') {
+    return value
+  }
+}
+
+/**
+ * Normalizes the byte properties of the config options object
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as bytes
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeBytes (opts, fields, defaults, logger) {
+  for (const key of fields) {
+    if (key in opts) opts[key] = bytes(String(opts[key]))
+  }
+}
+
+/**
+ * Convert a given duration config option into a number of seconds.
+ * If the given duration is invalid, this returns `null`.
+ * Units are *case-sensitive*.
+ *
+ * Examples:
+ *   secondsFromDuration('30s', 's', ['ms', 's', 'm'], false) // => 30
+ *   secondsFromDuration('-1s', 's', ['ms', 's', 'm'], false) // => null
+ *   secondsFromDuration('-1ms', 's', ['ms', 's', 'm'], true) // => -0.001
+ *   secondsFromDuration(500, 'ms', ['us', 'ms', 's', 'm'], false) // => 0.5
+ *
+ * @param {string|number} duration - Typically a string of the form `<num><unit>`,
+ *    for example `30s`, `-1ms`, `2m`. The `defaultUnit` is used if a unit is
+ *    not part of the string, or if duration is a number. If given as a string,
+ *    decimal ('1.5s') and exponential-notation ('1e-3s') values are not allowed.
+ * @param {string} defaultUnit
+ * @param {Array<string>} allowedUnits - An array of the allowed unit strings. This
+ *    array may include any number of `us`, `ms`, `s`, and `m`.
+ * @param {Boolean} allowNegative - Whether a negative number is allowed.
+ * @returns {number|null}
+ */
+function secondsFromDuration (duration, defaultUnit, allowedUnits, allowNegative) {
+  let val
+  let unit
+  if (typeof duration === 'string') {
+    let match
+    if (allowNegative) {
+      match = /^(-?\d+)(\w+)?$/.exec(duration)
+    } else {
+      match = /^(\d+)(\w+)?$/.exec(duration)
+    }
+    if (!match) {
+      return null
+    }
+    val = Number(match[1])
+    if (isNaN(val) || !Number.isFinite(val)) {
+      return null
+    }
+    unit = match[2] || defaultUnit
+    if (!allowedUnits.includes(unit)) {
+      return null
+    }
+  } else if (typeof duration === 'number') {
+    if (isNaN(duration)) {
+      return null
+    } else if (duration < 0 && !allowNegative) {
+      return null
+    }
+    val = duration
+    unit = defaultUnit
+  } else {
+    return null
+  }
+
+  // Scale to seconds.
+  switch (unit) {
+    case 'us':
+      val /= 1e6
+      break
+    case 'ms':
+      val /= 1e3
+      break
+    case 's':
+      break
+    case 'm':
+      val *= 60
+      break
+    default:
+      throw new Error(`unknown unit "${unit}" from "${duration}"`)
+  }
+
+  return val
+}
+
+/**
+ * Normalizes the duration properties of the config options object
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {Array<Object>} fields the list of fields to normalize as duration (with name, defaultUnit, allowedUnits, allowNegative)
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeDurationOptions (opts, fields, defaults, logger) {
+  for (const optSpec of fields) {
+    const key = optSpec.name
+    if (key in opts) {
+      const val = secondsFromDuration(opts[key], optSpec.defaultUnit,
+        optSpec.allowedUnits, optSpec.allowNegative)
+      if (val === null) {
+        if (key in defaults) {
+          const def = defaults[key]
+          logger.warn('invalid duration value "%s" for "%s" config option: using default "%s"',
+            opts[key], key, def)
+          opts[key] = secondsFromDuration(def, optSpec.defaultUnit,
+            optSpec.allowedUnits, optSpec.allowNegative)
+        } else {
+          logger.warn('invalid duration value "%s" for "%s" config option: ignoring this option',
+            opts[key], key)
+          delete opts[key]
+        }
+      } else {
+        opts[key] = val
+      }
+    }
+  }
+}
+
+/**
+ * Normalizes the array properties of the config options object
+ * Array config vars are either already an array of strings, or a
+ * comma-separated string (whitespace is trimmed):
+ *    'foo, bar' => ['foo', 'bar']
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as arrays
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeArrays (opts, fields, defaults, logger) {
+  for (const key of fields) {
+    if (key in opts && typeof opts[key] === 'string') {
+      opts[key] = opts[key].split(',').map(v => v.trim())
+    }
+  }
+}
+
+/**
+ * Parses "true"|"false" to boolean if not a boolean already and returns it. Returns undefined otherwise
+ *
+ * @param {Logger} logger
+ * @param {string} key
+ * @param {any} value
+ * @returns {boolean|undefined}
+ */
+function strictBool (logger, key, value) {
+  if (typeof value === 'boolean') {
+    return value
+  }
+  // This will return undefined for unknown inputs, resulting in them being skipped.
+  switch (value) {
+    case 'false': return false
+    case 'true': return true
+    default: {
+      logger.warn('unrecognized boolean value "%s" for "%s"', value, key)
+    }
+  }
+}
+
+/**
+ * Normalizes the boolean properties of the config options object
+ * Boolean config vars are either already a boolean, or a string
+ * representation of the boolean value: `true` or `false`
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as boolean
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeBools (opts, fields, defaults, logger) {
+  for (const key of fields) {
+    if (key in opts) opts[key] = strictBool(logger, key, opts[key])
+  }
+}
+
+/**
+ * Normalizes the ignore options and places them in specific properties for string and RegExp values
+ *
+ * Ignore config vars are either an array of wildcard expressions or an array of strings and RegExps:
+ * of key=value pairs (whitespace around the "key=value" strings is trimmed):
+ *    ['*foo', 'bar*']          => [ /^.*foo/, /^bar.*$/ ] (result goes to another property)
+ *    ['foo', /url/pathname$/]  => ['foo'] (strings are placed into a specific config option)
+ *                              => [/url/pathname$/] (RegExps are placed into a specific config option)
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as boolean
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeIgnoreOptions (opts, fields, defaults, logger) { // Params are meant to be used in upcoming changes
+  if (opts.transactionIgnoreUrls) {
+    opts.transactionIgnoreUrlRegExp = []
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.transactionIgnoreUrls) {
+      const re = wildcard.compile(ptn)
+      opts.transactionIgnoreUrlRegExp.push(re)
+    }
+  }
+
+  if (opts.ignoreUrls) {
+    opts.ignoreUrlStr = []
+    opts.ignoreUrlRegExp = []
+    for (const ptn of opts.ignoreUrls) {
+      if (typeof ptn === 'string') {
+        opts.ignoreUrlStr.push(ptn)
+      } else {
+        opts.ignoreUrlRegExp.push(ptn)
+      }
+    }
+    delete opts.ignoreUrls
+  }
+
+  if (opts.ignoreUserAgents) {
+    opts.ignoreUserAgentStr = []
+    opts.ignoreUserAgentRegExp = []
+    for (const ptn of opts.ignoreUserAgents) {
+      if (typeof ptn === 'string') {
+        opts.ignoreUserAgentStr.push(ptn)
+      } else {
+        opts.ignoreUserAgentRegExp.push(ptn)
+      }
+    }
+    delete opts.ignoreUserAgents
+  }
+
+  if (opts.ignoreMessageQueues) {
+    opts.ignoreMessageQueuesRegExp = []
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.ignoreMessageQueues) {
+      const re = wildcard.compile(ptn)
+      opts.ignoreMessageQueuesRegExp.push(re)
+    }
+  }
+}
+
+/**
+ * Normalizes the wildcard matchers of sanitizeFieldNames and thansforms the into RegExps
+ *
+ * TODO: we are doing the same to some ignoreOptions
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ */
+function normalizeSanitizeFieldNames (opts) {
+  if (opts.sanitizeFieldNames) {
+    opts.sanitizeFieldNamesRegExp = []
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.sanitizeFieldNames) {
+      const re = wildcard.compile(ptn)
+      opts.sanitizeFieldNamesRegExp.push(re)
+    }
+  }
+}
+
+// TODO: this is the same as normalizeSanitizeFieldNames
+// maybe create a normalizeWildcardOptions???
+function normalizeDisableMetrics (opts) {
+  if (opts.disableMetrics) {
+    opts.disableMetricsRegExp = [] // This line was not in the original code but raised an exception in the tests
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.disableMetrics) {
+      const re = wildcard.compile(ptn)
+      opts.disableMetricsRegExp.push(re)
+    }
+  }
+}
+
+// TODO: same as above
+function normalizeElasticsearchCaptureBodyUrls (opts) {
+  if (opts.elasticsearchCaptureBodyUrls) {
+    opts.elasticsearchCaptureBodyUrlsRegExp = []
+    const wildcard = new WildcardMatcher()
+    for (const ptn of opts.elasticsearchCaptureBodyUrls) {
+      const re = wildcard.compile(ptn)
+      opts.elasticsearchCaptureBodyUrlsRegExp.push(re)
+    }
+  }
+}
+
+/**
+ * Makes sure the cloudProvider options is valid othherwise it set the default value.
+ *
+ * @param {Record<string, unknown>} opts the configuration options to normalize
+ * @param {String[]} fields the list of fields to normalize as duration
+ * @param {Record<string, unknown>} defaults the configuration defaults
+ * @param {Logger} logger
+ */
+function normalizeCloudProvider (opts, fields, defaults, logger) {
+  if ('cloudProvider' in opts) {
+    const allowedValues = ['auto', 'gcp', 'azure', 'aws', 'none']
+    if (allowedValues.indexOf(opts.cloudProvider) === -1) {
+      logger.warn('Invalid "cloudProvider" config value %s, falling back to default %s',
+        opts.cloudProvider, defaults.cloudProvider)
+      opts.cloudProvider = defaults.cloudProvider
+    }
+  }
+}
+
+// `customMetricsHistogramBoundaries` must be a sorted array of numbers,
+// without duplicates.
+function normalizeCustomMetricsHistogramBoundaries (opts, fields, defaults, logger) {
+  if (!('customMetricsHistogramBoundaries' in opts)) {
+    return
+  }
+  let val = opts.customMetricsHistogramBoundaries
+  if (typeof val === 'string') {
+    val = val.split(',').map(v => Number(v.trim()))
+  }
+  let errReason = null
+  if (!Array.isArray(val)) {
+    errReason = 'value is not an array'
+  } else if (val.some(el => typeof el !== 'number' || isNaN(el))) {
+    errReason = 'array includes non-numbers'
+  } else {
+    for (let i = 0; i < val.length - 1; i++) {
+      if (val[i] === val[i + 1]) {
+        errReason = 'array has duplicate values'
+        break
+      } else if (val[i] > val[i + 1]) {
+        errReason = 'array is not sorted'
+        break
+      }
+    }
+  }
+  if (errReason) {
+    logger.warn('Invalid "customMetricsHistogramBoundaries" config value %j, %s; falling back to default',
+      opts.customMetricsHistogramBoundaries, errReason)
+    opts.customMetricsHistogramBoundaries = defaults.customMetricsHistogramBoundaries
+  } else {
+    opts.customMetricsHistogramBoundaries = val
+  }
+}
+
+// transactionSampleRate is specified to be:
+// - in the range [0,1]
+// - rounded to 4 decimal places of precision (e.g. 0.0001, 0.5678, 0.9999)
+// - with the special case that a value in the range (0, 0.0001] should be
+//   rounded to 0.0001 -- to avoid a small value being rounded to zero.
+//
+// https://github.com/elastic/apm/blob/main/specs/agents/tracing-sampling.md
+function normalizeTransactionSampleRate (opts, fields, defaults, logger) {
+  if ('transactionSampleRate' in opts) {
+    // The value was already run through `Number(...)` in `normalizeNumbers`.
+    const rate = opts.transactionSampleRate
+    if (isNaN(rate) || rate < 0 || rate > 1) {
+      opts.transactionSampleRate = defaults.transactionSampleRate
+      logger.warn('Invalid "transactionSampleRate" config value %s, falling back to default %s',
+        rate, opts.transactionSampleRate)
+    } else if (rate > 0 && rate < 0.0001) {
+      opts.transactionSampleRate = 0.0001
+    } else {
+      opts.transactionSampleRate = Math.round(rate * 10000) / 10000
+    }
+  }
+}
+
+module.exports = {
+  normalizeArrays,
+  normalizeBools,
+  normalizeBytes,
+  normalizeCloudProvider,
+  normalizeCustomMetricsHistogramBoundaries,
+  normalizeDisableMetrics,
+  normalizeDurationOptions,
+  normalizeElasticsearchCaptureBodyUrls,
+  normalizeIgnoreOptions,
+  normalizeInfinity,
+  normalizeKeyValuePairs,
+  normalizeNumbers,
+  normalizeSanitizeFieldNames,
+  normalizeTransactionSampleRate,
+  secondsFromDuration
+}

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -23,6 +23,7 @@ const Agent = require('../lib/agent')
 const { MockAPMServer } = require('./_mock_apm_server')
 const { NoopTransport } = require('../lib/noop-transport')
 const { safeGetPackageVersion, findObjInArray } = require('./_utils')
+const { secondsFromDuration } = require('../lib/config/normalizers')
 const config = require('../lib/config')
 var Instrumentation = require('../lib/instrumentation')
 var apmVersion = require('../package').version
@@ -478,7 +479,7 @@ config.DURATION_OPTS.forEach(function (optSpec) {
 
   let def
   if (key in config.DEFAULTS) {
-    def = config.secondsFromDuration(config.DEFAULTS[key],
+    def = secondsFromDuration(config.DEFAULTS[key],
       optSpec.defaultUnit, optSpec.allowedUnits, optSpec.allowNegative)
   } else if (key === 'spanStackTraceMinDuration') {
     // Because of special handling in normalizeSpanStackTraceMinDuration()

--- a/test/config/_mock_logger.js
+++ b/test/config/_mock_logger.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+/**
+ * @typedef {object} LogEntry
+ * @property {string} type
+ * @property {string} message
+ * @property {Array<any>} message
+ */
+
+/**
+ * SomeClass is an example class for my question.
+ * @class
+ * @constructor
+ * @public
+ */
+class MockLogger {
+  constructor () {
+    /**
+     * someProperty is an example property that is set to `true`
+     * @type {Array<LogEntry>}
+     * @public
+     */
+    this.calls = []
+  }
+
+  _log (type, message, interpolation) {
+    this.calls.push({
+      type,
+      message,
+      interpolation
+    })
+  }
+
+  // fatal (message) { this._log('fatal', message) }
+  // error (message) { this._log('error', message) }
+  // warn (message) { this._log('warn', message) }
+  // info (message) { this._log('info', message) }
+  // debug (message) { this._log('debug', message) }
+  // trace (message) { this._log('trace', message) }
+  fatal () { this._log('fatal', arguments[0], [].slice.call(arguments, 1)) }
+  error () { this._log('error', arguments[0], [].slice.call(arguments, 1)) }
+  warn () { this._log('warn', arguments[0], [].slice.call(arguments, 1)) }
+  info () { this._log('info', arguments[0], [].slice.call(arguments, 1)) }
+  debug () { this._log('debug', arguments[0], [].slice.call(arguments, 1)) }
+  trace () { this._log('trace', arguments[0], [].slice.call(arguments, 1)) }
+}
+
+module.exports = MockLogger

--- a/test/config/normalizers.test.js
+++ b/test/config/normalizers.test.js
@@ -1,0 +1,388 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Test the normalizer functions
+const test = require('tape')
+const MockLogger = require('./_mock_logger')
+
+const {
+  normalizeArrays,
+  normalizeBools,
+  normalizeBytes,
+  normalizeDurationOptions,
+  normalizeIgnoreOptions,
+  normalizeInfinity,
+  normalizeKeyValuePairs,
+  normalizeNumbers,
+  normalizeElasticsearchCaptureBodyUrls,
+  normalizeDisableMetrics,
+  normalizeSanitizeFieldNames,
+  normalizeCloudProvider,
+  normalizeCustomMetricsHistogramBoundaries,
+  normalizeTransactionSampleRate
+} = require('../../lib/config/normalizers')
+
+test('#normalizeArrays()', function (t) {
+  const opts = { arrayOpt: ['a', 'b'], stringOpt: '1,2,3', numberOpt: 2 }
+
+  normalizeArrays(opts, ['arrayOpt', 'stringOpt'])
+
+  t.deepEqual(opts, { arrayOpt: ['a', 'b'], stringOpt: ['1', '2', '3'], numberOpt: 2 })
+  t.end()
+})
+
+test('#normalizeBools()', function (t) {
+  const logger = new MockLogger()
+  const fields = ['boolTrue', 'boolFalse', 'strTrue', 'strFalse', 'badWithDefault', 'badWithoutDefault']
+  const defaults = { badWithDefault: false }
+  const opts = {
+    boolTrue: true,
+    boolFalse: false,
+    strTrue: 'true',
+    strFalse: 'false',
+    badWithDefault: 'not-a-bool',
+    badWithoutDefault: 'not-a-bool',
+    nonBoolProperty: 25
+  }
+
+  normalizeBools(opts, fields, defaults, logger)
+
+  t.deepEqual(opts, {
+    boolTrue: true,
+    boolFalse: false,
+    strTrue: true,
+    strFalse: false,
+    badWithDefault: undefined,
+    badWithoutDefault: undefined,
+    nonBoolProperty: 25
+  })
+
+  const warnings = logger.calls
+  t.ok(warnings.length === 2, 'we got warnings for bad boolean options')
+  t.deepEqual(warnings[0].interpolation, ['not-a-bool', 'badWithDefault'])
+  t.deepEqual(warnings[1].interpolation, ['not-a-bool', 'badWithoutDefault'])
+  t.end()
+})
+
+test('#normalizeBytes()', function (t) {
+  const logger = new MockLogger()
+  const fields = ['bytes', 'kiloBytes', 'megaBytes', 'gigaBytes', 'numberBytes', 'badWithDefault', 'badWithoutDefault']
+  const defaults = { badWithDefault: '25kb' }
+  const opts = {
+    bytes: '1000b',
+    kiloBytes: '100kb',
+    megaBytes: '10mb',
+    gigaBytes: '1gb',
+    numberBytes: 12345678,
+    badWithDefault: 'not-bytes',
+    badWithoutDefault: 'not-bytes',
+    anotherProperty: 25
+  }
+
+  normalizeBytes(opts, fields, defaults, logger)
+
+  t.deepEqual(opts, {
+    bytes: 1000,
+    kiloBytes: 102400,
+    megaBytes: 10485760,
+    gigaBytes: 1073741824,
+    numberBytes: 12345678,
+    badWithDefault: NaN,
+    badWithoutDefault: NaN,
+    anotherProperty: 25
+  })
+
+  t.ok(logger.calls.length === 0, 'we got no warnings for bad byte options')
+  t.end()
+})
+
+test('#normalizeDurationOptions()', function (t) {
+  const logger = new MockLogger()
+  const fields = [
+    { name: 'withoutUnit', defaultUnit: 'ms', allowedUnits: ['us', 'ms', 's', 'm'], allowNegative: true },
+    { name: 'withUnit', defaultUnit: 'ms', allowedUnits: ['us', 'ms', 's', 'm'], allowNegative: true },
+    { name: 'notAllowedUnit', defaultUnit: 's', allowedUnits: ['s', 'm'], allowNegative: true },
+    { name: 'notAllowedNegative', defaultUnit: 's', allowedUnits: ['s', 'm'], allowNegative: false },
+    { name: 'badWithDefault', defaultUnit: 's', allowedUnits: ['s', 'm'], allowNegative: false },
+    { name: 'badWithoutDefault', defaultUnit: 's', allowedUnits: ['s', 'm'], allowNegative: false }
+
+  ]
+  const defaults = { badWithDefault: '25s' }
+  const opts = {
+    withoutUnit: '200',
+    withUnit: '2m',
+    notAllowedUnit: '20us',
+    notAllowedNegative: '-1s',
+    badWithDefault: 'not-duration',
+    badWithoutDefault: 'not-duration',
+    anotherProperty: 25
+  }
+
+  normalizeDurationOptions(opts, fields, defaults, logger)
+
+  t.deepEqual(opts, {
+    // TODO: this normalized deletes keys whose values are not valid (because format or contraint)
+    // other normalizers keep the property as is. Should we remove as well?
+    withoutUnit: 0.2,
+    withUnit: 120,
+    badWithDefault: 25,
+    anotherProperty: 25
+  })
+
+  const warnings = logger.calls
+  t.ok(warnings.length === 4, 'we got warnings for bad duration options')
+  t.ok(warnings[0].message.indexOf('ignoring this option') !== -1, 'ignores not allowed unit')
+  t.deepEqual(warnings[0].interpolation, ['20us', 'notAllowedUnit'])
+  t.ok(warnings[1].message.indexOf('ignoring this option') !== -1, 'ignores not allowed negative value')
+  t.deepEqual(warnings[1].interpolation, ['-1s', 'notAllowedNegative'])
+  t.ok(warnings[2].message.indexOf('using default') !== -1, 'uses default value')
+  t.deepEqual(warnings[2].interpolation, ['not-duration', 'badWithDefault', '25s'])
+  t.ok(warnings[3].message.indexOf('ignoring this option') !== -1, 'ignores bad value without default')
+  t.deepEqual(warnings[3].interpolation, ['not-duration', 'badWithoutDefault'])
+  t.end()
+})
+
+test('#normalizeIgnoreOptions()', function (t) {
+  const logger = new MockLogger()
+  const defaults = {}
+  const opts = {
+    transactionIgnoreUrls: ['*path*'],
+    ignoreUrls: ['str/path/ignore', /path\/to\/secret/],
+    ignoreUserAgents: ['Mozilla', /Safari/],
+    ignoreMessageQueues: ['*topic*']
+  }
+
+  normalizeIgnoreOptions(opts, Object.keys(opts), defaults, logger)
+
+  t.deepEqual(opts, {
+    transactionIgnoreUrls: ['*path*'],
+    transactionIgnoreUrlRegExp: [/^.*path.*$/i],
+    ignoreUrlStr: ['str/path/ignore'],
+    ignoreUrlRegExp: [/path\/to\/secret/],
+    ignoreUserAgentStr: ['Mozilla'],
+    ignoreUserAgentRegExp: [/Safari/],
+    ignoreMessageQueues: ['*topic*'],
+    ignoreMessageQueuesRegExp: [/^.*topic.*$/i]
+  })
+
+  t.ok(logger.calls.length === 0, 'we got no warnings for bad ignore options')
+  t.end()
+})
+
+test('#normalizeInfinity()', function (t) {
+  const logger = new MockLogger()
+  const fields = ['minusOne']
+  const defaults = {}
+  const opts = {
+    positiveNumber: 100,
+    negativeNumber: -100,
+    minusOne: -1,
+    anotherProperty: 'value'
+  }
+
+  normalizeInfinity(opts, fields, defaults, logger)
+
+  t.deepEqual(opts, {
+    positiveNumber: 100,
+    negativeNumber: -100,
+    minusOne: Infinity,
+    anotherProperty: 'value'
+  })
+
+  t.ok(logger.calls.length === 0, 'we got no warnings for bad ignore options')
+  t.end()
+})
+
+test.skip('#normalizeKeyValuePairs()', function (t) {
+  const logger = new MockLogger()
+  const defaults = {}
+  const opts = {
+    objectProperty: { foo: 'bar', eggs: 'spam' },
+    stringProperty: 'foo=bar, eggs=spam',
+    arrayProperty: ['foo=bar', 'eggs=spam'],
+    badWithDefault: 234,
+    badWithoutDefault: 234
+  }
+
+  normalizeKeyValuePairs(opts, Object.keys(opts), defaults, logger)
+
+  // TODO: they should all be in the same format, shouldn't they?
+  t.deepEqual(opts, {
+    objectProperty: [['foo', 'bar'], ['eggs', 'spam']],
+    stringProperty: [['foo', 'bar'], ['eggs', 'spam']],
+    arrayProperty: [['foo', 'bar'], ['eggs', 'spam']],
+    badWithDefault: 234,
+    badWithoutDefault: 234
+  })
+
+  t.ok(logger.calls.length === 0, 'we got no warnings for bad key/value options')
+  t.end()
+})
+
+test('#normalizeNumbers()', function (t) {
+  const logger = new MockLogger()
+  const defaults = {}
+  const opts = {
+    numberProperty: 100,
+    stringProperty: '200',
+    badWithDefault: 'not-a-number',
+    badWithoutDefault: 'not-a-number'
+  }
+
+  normalizeNumbers(opts, Object.keys(opts), defaults, logger)
+
+  t.deepEqual(opts, {
+    numberProperty: 100,
+    stringProperty: 200,
+    badWithDefault: NaN,
+    badWithoutDefault: NaN
+  })
+
+  t.ok(logger.calls.length === 0, 'we got no warnings for bad number options')
+  t.end()
+})
+
+test('#normalizeElasticsearchCaptureBodyUrls()', function (t) {
+  const logger = new MockLogger()
+  const defaults = {}
+  const opts = {
+    elasticsearchCaptureBodyUrls: ['*body*']
+  }
+
+  normalizeElasticsearchCaptureBodyUrls(opts, Object.keys(opts), defaults, logger)
+
+  t.deepEqual(opts, {
+    elasticsearchCaptureBodyUrls: ['*body*'],
+    elasticsearchCaptureBodyUrlsRegExp: [/^.*body.*$/i]
+  })
+  t.end()
+})
+
+test('#normalizeDisableMetrics()', function (t) {
+  const logger = new MockLogger()
+  const defaults = {}
+  const opts = {
+    disableMetrics: ['*metric*']
+  }
+
+  normalizeDisableMetrics(opts, Object.keys(opts), defaults, logger)
+
+  t.deepEqual(opts, {
+    disableMetrics: ['*metric*'],
+    disableMetricsRegExp: [/^.*metric.*$/i]
+  })
+  t.end()
+})
+
+test('#normalizeSanitizeFieldNames()', function (t) {
+  const logger = new MockLogger()
+  const defaults = {}
+  const opts = {
+    sanitizeFieldNames: ['*secret*']
+  }
+
+  normalizeSanitizeFieldNames(opts, Object.keys(opts), defaults, logger)
+
+  t.deepEqual(opts, {
+    sanitizeFieldNames: ['*secret*'],
+    sanitizeFieldNamesRegExp: [/^.*secret.*$/i]
+  })
+  t.end()
+})
+
+test('#normalizeCloudProvider()', function (t) {
+  const logger = new MockLogger()
+  const allowedValues = ['auto', 'gcp', 'azure', 'aws', 'none']
+  const defaults = { cloudProvider: 'auto' }
+  const opts = { cloudProvider: '' }
+
+  for (const value of allowedValues) {
+    opts.cloudProvider = value
+    normalizeCloudProvider(opts, Object.keys(opts), defaults, logger)
+
+    t.deepEqual(opts, { cloudProvider: value })
+  }
+
+  opts.cloudProvider = 'unknown'
+  normalizeCloudProvider(opts, Object.keys(opts), defaults, logger)
+
+  t.deepEqual(opts, { cloudProvider: defaults.cloudProvider })
+  const warnings = logger.calls
+  t.ok(warnings.length === 1, 'we got warnings for bad cloudProvider options')
+  t.ok(warnings[0].message.indexOf('Invalid "cloudProvider" config value') !== -1, 'warns about invalid value')
+  t.deepEqual(warnings[0].interpolation, ['unknown', 'auto'])
+  t.end()
+})
+
+test('#normalizeCustomMetricsHistogramBoundaries()', function (t) {
+  const logger = new MockLogger()
+  const warnings = logger.calls
+  const defaults = { customMetricsHistogramBoundaries: [1, 2, 3, 4] }
+  const opts = {}
+
+  const badInputs = [
+    { val: 2, errReason: 'value is not an array' },
+    { val: 'test', errReason: 'array includes non-numbers' },
+    { val: [1, 'test'], errReason: 'array includes non-numbers' },
+    { val: [1, 0], errReason: 'array is not sorted' },
+    { val: [1, 2, 2], errReason: 'array has duplicate values' }
+  ]
+
+  for (const input of badInputs) {
+    opts.customMetricsHistogramBoundaries = input.val
+    normalizeCustomMetricsHistogramBoundaries(opts, [], defaults, logger)
+    t.deepEqual(opts.customMetricsHistogramBoundaries, [1, 2, 3, 4])
+    const lastWarnig = warnings.pop()
+    t.ok(typeof lastWarnig !== 'undefined', 'we got warnings for "' + input.errReason + '"')
+    t.deepEqual(lastWarnig.interpolation, [input.val, input.errReason])
+  }
+
+  const goodInputs = [
+    { val: [1, 2, 3] },
+    { val: '1,2,3' }
+  ]
+
+  for (const input of goodInputs) {
+    opts.customMetricsHistogramBoundaries = input.val
+    normalizeCustomMetricsHistogramBoundaries(opts, [], defaults, logger)
+    t.deepEqual(opts.customMetricsHistogramBoundaries, [1, 2, 3])
+    const lastWarnig = warnings.pop()
+    t.ok(typeof lastWarnig === 'undefined', 'we got no warnings')
+  }
+  t.end()
+})
+
+test('#normalizeTransactionSampleRate()', function (t) {
+  const logger = new MockLogger()
+  const defaults = { transactionSampleRate: 0.5 }
+  const opts = {}
+
+  const badValues = [2, -1, NaN]
+  for (const value of badValues) {
+    opts.transactionSampleRate = value
+    normalizeTransactionSampleRate(opts, [], defaults, logger)
+
+    t.deepEqual(opts, { transactionSampleRate: 0.5 })
+    const warning = logger.calls[logger.calls.length - 1]
+    t.ok(warning.message.indexOf('Invalid "transactionSampleRate"') !== -1)
+  }
+
+  const goodValues = [0, 0.8, 1]
+  for (const value of goodValues) {
+    opts.transactionSampleRate = value
+    normalizeTransactionSampleRate(opts, [], defaults, logger)
+    t.deepEqual(opts, { transactionSampleRate: value })
+  }
+
+  // Special case for really small numbers
+  opts.transactionSampleRate = 0.000001
+  normalizeTransactionSampleRate(opts, [], defaults, logger)
+  t.deepEqual(opts, { transactionSampleRate: 0.0001 })
+
+  t.end()
+})


### PR DESCRIPTION
# Description

This is the 1st of a short series of PRs with the intent of have better organisation of the code and set the grounds for:
- tackle the issue #3060 
- a possible refactoring in the short/mid term

Normalization logic is quite straightforward and does not depend much on any context. This PR:
- extract the normalization functions into a specific module
- adds unit tests on these extracted methods
- require & use the functions inside `config.js` file


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update ~TypeScript~ typings (internal)
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
