### PR TITLE
test: enable tests for knex versions >1 <2

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -187,7 +187,11 @@ knex-v0.21-v1:
   node: '>=10.22.0'
   versions: '0.21.21 || 0.95.15' # latest minors subset of '>=0.21 <1'
   commands: node test/instrumentation/modules/pg/knex.test.js
-
+knex-v1-v2:
+  name: knex
+  node: '>=12.0.0'
+  versions: '>=1 <2'
+  commands: node test/instrumentation/modules/pg/knex.test.js
 ws-old:
   name: ws
   versions: '>=1 <7'

--- a/dev-utils/tav-versions.js
+++ b/dev-utils/tav-versions.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+const { execSync } = require('child_process')
+const semver = require('semver')
+
+// Prints versions fot TAV for the given package and version range
+function main (packageName, versionRange) {
+  // Validation
+  if (!packageName || !versionRange) {
+    console.error('package or version range not defined')
+    return
+  }
+  if (!semver.validRange(versionRange)) {
+    console.error('version range %s is not valid', versionRange)
+    return
+  }
+
+  // Try to get versions
+  let info
+  try {
+    info = JSON.parse(execSync('npm info -j ' + packageName, { encoding: 'utf-8' }))
+    const versions = info.versions.filter(v => semver.satisfies(v, versionRange))
+    const modulus = Math.floor((versions.length - 2) / 5)
+    const vers = versions.filter((v, idx, arr) => idx % modulus === 0 || idx === arr.length - 1)
+    console.log('  # Test v%s, every N=%d of %d releases, and current latest.', versions[0], modulus, versions.length)
+    console.log("  versions: '%s || >%s' # subset of '%s'", vers.join(' || '), vers[vers.length - 1], versionRange)
+  } catch (e) {
+    console.error('package %s not found or cannot be fetched')
+  }
+}
+
+// Run
+main(process.argv[2], process.argv[3])

--- a/lib/instrumentation/modules/knex.js
+++ b/lib/instrumentation/modules/knex.js
@@ -24,8 +24,12 @@ module.exports = function (Knex, agent, { version, enabled }) {
       agent._conf.spanStackTraceMinDuration)
     return Knex
   }
-  if (semver.gte(version, '1.0.0')) {
+  if (semver.gte(version, '2.0.0')) {
     agent.logger.debug('knex version %s not supported - aborting...', version)
+    return Knex
+  }
+  if (semver.gte(version, '1.0.0') && semver.lt(process.version, '12.0.0')) {
+    agent.logger.debug('knex version %s does not support node %s - aborting...', version, process.version)
     return Knex
   }
   if (semver.gte(version, '0.95.0') && agent._conf.contextManager === 'patch') {

--- a/test/instrumentation/modules/pg/knex.test.js
+++ b/test/instrumentation/modules/pg/knex.test.js
@@ -28,7 +28,8 @@ var semver = require('semver')
 
 // knex 0.18.0 min supported node is v8, knex 0.21.0 min supported node is v10
 if ((semver.gte(knexVersion, '0.18.0') && semver.lt(process.version, '8.6.0')) ||
-  (semver.gte(knexVersion, '0.21.0') && semver.lt(process.version, '10.22.0'))) {
+  (semver.gte(knexVersion, '0.21.0') && semver.lt(process.version, '10.22.0')) ||
+  (semver.gte(knexVersion, '1.0.0') && semver.lt(process.version, '12.0.0'))) {
   console.log(`# SKIP knex@${knexVersion} does not support node ${process.version}`)
   process.exit()
 }


### PR DESCRIPTION
# Description

Enabling knex intsrumentation and tests for version range `>1 <2`. 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] ~Add~ Enable tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
