### PR TITLE
chore: move config.js to its own module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,9 +28,9 @@ Notes:
         ==== x.x.x - YYYY/MM/DD
 ////
 
-
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
+
 
 [[release-notes-3.46.0]]
 ==== 3.46.0 - 2023/05/15

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,24 +32,6 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
-
-[float]
-===== Bug fixes
-
-[float]
-===== Chores
-
-* Move configuration to its own module and add normalizer tests.
-  ({pull}3358[#3358])
-
-
 
 [[release-notes-3.46.0]]
 ==== 3.46.0 - 2023/05/15

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,6 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
-
 [[release-notes-3.46.0]]
 ==== 3.46.0 - 2023/05/15
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,8 +28,27 @@ Notes:
         ==== x.x.x - YYYY/MM/DD
 ////
 
+
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
+
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+* Move configuration to its own module and add normalizer tests.
+  ({pull}3358[#3358])
+
 
 
 [[release-notes-3.46.0]]

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -13,7 +13,8 @@ var isError = require('core-util-is').isError
 var Filters = require('object-filter-sequence')
 
 const { agentActivationMethodFromStartStack } = require('./activation-method')
-var config = require('./config')
+const { CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS, CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES } = require('./config/schema')
+var config = require('./config/config')
 var connect = require('./middleware/connect')
 const constants = require('./constants')
 var errors = require('./errors')
@@ -534,8 +535,8 @@ Agent.prototype.captureError = function (err, opts, cb) {
   // As an added feature, for *some* cases, we capture a stacktrace at the point
   // this `captureError` was called. This is added to `error.log.stacktrace`.
   if (handled &&
-      (agent._conf.captureErrorLogStackTraces === config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS ||
-       (!errIsError && agent._conf.captureErrorLogStackTraces === config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES))
+      (agent._conf.captureErrorLogStackTraces === CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS ||
+       (!errIsError && agent._conf.captureErrorLogStackTraces === CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES))
   ) {
     callSiteLoc = {}
     Error.captureStackTrace(callSiteLoc, Agent.prototype.captureError)

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -12,14 +12,28 @@ var path = require('path')
 var ElasticAPMHttpClient = require('elastic-apm-http-client')
 var truncate = require('unicode-byte-truncate')
 
-const REDACTED = require('./constants').REDACTED
-var logging = require('./logging')
-var version = require('../package').version
+const REDACTED = require('../constants').REDACTED
+var logging = require('../logging')
+var version = require('../../package').version
 
-const { CloudMetadata } = require('./cloud-metadata')
-const { NoopTransport } = require('./noop-transport')
-const { isLambdaExecutionEnvironment } = require('./lambda')
-const { isAzureFunctionsEnvironment, getAzureFunctionsExtraMetadata } = require('./instrumentation/azure-functions')
+const { CloudMetadata } = require('../cloud-metadata')
+const { NoopTransport } = require('../noop-transport')
+const { isLambdaExecutionEnvironment } = require('../lambda')
+const { isAzureFunctionsEnvironment, getAzureFunctionsExtraMetadata } = require('../instrumentation/azure-functions')
+
+const {
+  INTAKE_STRING_MAX_SIZE,
+  CENTRAL_CONFIG_OPTS,
+  BOOL_OPTS,
+  NUM_OPTS,
+  DURATION_OPTS,
+  BYTES_OPTS,
+  MINUS_ONE_EQUAL_INFINITY,
+  ARRAY_OPTS,
+  KEY_VALUE_OPTS,
+  ENV_TABLE,
+  DEFAULTS
+} = require('./schema')
 
 const {
   normalizeArrays,
@@ -35,324 +49,13 @@ const {
   normalizeSanitizeFieldNames,
   normalizeCloudProvider,
   normalizeCustomMetricsHistogramBoundaries,
-  normalizeTransactionSampleRate
-} = require('./config/normalizers')
+  normalizeTransactionSampleRate,
+  normalizeTraceContinuationStrategy,
+  normalizeContextManager,
+  normalizeSpanStackTraceMinDuration
+} = require('./normalizers')
 
 let confFile = loadConfigFile()
-
-const INTAKE_STRING_MAX_SIZE = 1024
-const CAPTURE_ERROR_LOG_STACK_TRACES_NEVER = 'never'
-const CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES = 'messages'
-const CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS = 'always'
-const CONTEXT_MANAGER_PATCH = 'patch'
-const CONTEXT_MANAGER_ASYNCHOOKS = 'asynchooks'
-const CONTEXT_MANAGER_ASYNCLOCALSTORAGE = 'asynclocalstorage'
-const TRACE_CONTINUATION_STRATEGY_CONTINUE = 'continue'
-const TRACE_CONTINUATION_STRATEGY_RESTART = 'restart'
-const TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL = 'restart_external'
-
-var DEFAULTS = {
-  abortedErrorThreshold: '25s',
-  active: true,
-  addPatch: undefined,
-  apiRequestSize: '768kb',
-  apiRequestTime: '10s',
-  breakdownMetrics: true,
-  captureBody: 'off',
-  captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
-  captureExceptions: true,
-  captureHeaders: true,
-  centralConfig: true,
-  cloudProvider: 'auto',
-  containerId: undefined,
-  // 'contextManager' and 'asyncHooks' are explicitly *not* included in DEFAULTS
-  // because normalizeContextManager() needs to know if a value was provided by
-  // the user.
-  contextPropagationOnly: false,
-  // Exponential powers-of-2 bucket boundaries, rounded to 6 significant figures.
-  //    2**N for N in [-8, -7.5, -7, ..., 16, 16.5, 17]
-  // https://github.com/elastic/apm/blob/main/specs/agents/metrics-otel.md#histogram-aggregation
-  customMetricsHistogramBoundaries: [
-    0.00390625, 0.00552427, 0.0078125, 0.0110485,
-    0.015625, 0.0220971, 0.03125, 0.0441942,
-    0.0625, 0.0883883, 0.125, 0.176777,
-    0.25, 0.353553, 0.5, 0.707107,
-    1, 1.41421, 2, 2.82843,
-    4, 5.65685, 8, 11.3137,
-    16, 22.6274, 32, 45.2548,
-    64, 90.5097, 128, 181.019,
-    256, 362.039, 512, 724.077,
-    1024, 1448.15, 2048, 2896.31,
-    4096, 5792.62, 8192, 11585.2,
-    16384, 23170.5, 32768, 46341,
-    65536, 92681.9, 131072
-  ],
-  disableInstrumentations: [],
-  disableMetrics: [],
-  disableSend: false,
-  elasticsearchCaptureBodyUrls: [
-    '*/_search', '*/_search/template', '*/_msearch', '*/_msearch/template',
-    '*/_async_search', '*/_count', '*/_sql', '*/_eql/search'
-  ],
-  environment: process.env.NODE_ENV || 'development',
-  errorOnAbortedRequests: false,
-  exitSpanMinDuration: '0ms',
-  // Deprecated: already filtered with `sanitizeFieldNames` defaults
-  // TODO: https://github.com/elastic/apm-agent-nodejs/issues/3332
-  filterHttpHeaders: true,
-  globalLabels: undefined,
-  ignoreMessageQueues: [],
-  instrument: true,
-  instrumentIncomingHTTPRequests: true,
-  kubernetesNamespace: undefined,
-  kubernetesNodeName: undefined,
-  kubernetesPodName: undefined,
-  kubernetesPodUID: undefined,
-  logLevel: 'info',
-  logUncaughtExceptions: false, // TODO: Change to `true` in the v4.0.0
-  longFieldMaxLength: 10000,
-  // Rough equivalent of the Java Agent's max_queue_size:
-  // https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-max-queue-size
-  maxQueueSize: 1024,
-  metricsInterval: '30s',
-  metricsLimit: 1000,
-  opentelemetryBridgeEnabled: false,
-  sanitizeFieldNames: [
-    // These patterns are specified in the shared APM specs:
-    // https://github.com/elastic/apm/blob/main/specs/agents/sanitization.md
-    'password', 'passwd', 'pwd', 'secret', '*key', '*token*',
-    '*session*', '*credit*', '*card*', '*auth*', 'set-cookie', '*principal*',
-    // These are default patterns only in the Node.js APM agent, historically
-    // from when the "is-secret" dependency was used.
-    'pw', 'pass', 'connect.sid'
-  ],
-  serviceNodeName: undefined,
-  serverTimeout: '30s',
-  serverUrl: 'http://127.0.0.1:8200',
-  sourceLinesErrorAppFrames: 5,
-  sourceLinesErrorLibraryFrames: 5,
-  sourceLinesSpanAppFrames: 0,
-  sourceLinesSpanLibraryFrames: 0,
-  spanCompressionEnabled: true,
-  spanCompressionExactMatchMaxDuration: '50ms',
-  spanCompressionSameKindMaxDuration: '0ms',
-  // 'spanStackTraceMinDuration' is explicitly *not* included in DEFAULTS
-  // because normalizeSpanStackTraceMinDuration() needs to know if a value
-  // was provided by the user.
-  stackTraceLimit: 50,
-  traceContinuationStrategy: TRACE_CONTINUATION_STRATEGY_CONTINUE,
-  transactionIgnoreUrls: [],
-  transactionMaxSpans: 500,
-  transactionSampleRate: 1.0,
-  useElasticTraceparentHeader: true,
-  usePathAsTransactionName: false,
-  verifyServerCert: true
-}
-
-var ENV_TABLE = {
-  abortedErrorThreshold: 'ELASTIC_APM_ABORTED_ERROR_THRESHOLD',
-  active: 'ELASTIC_APM_ACTIVE',
-  addPatch: 'ELASTIC_APM_ADD_PATCH',
-  apiKey: 'ELASTIC_APM_API_KEY',
-  apiRequestSize: 'ELASTIC_APM_API_REQUEST_SIZE',
-  apiRequestTime: 'ELASTIC_APM_API_REQUEST_TIME',
-  asyncHooks: 'ELASTIC_APM_ASYNC_HOOKS',
-  breakdownMetrics: 'ELASTIC_APM_BREAKDOWN_METRICS',
-  captureBody: 'ELASTIC_APM_CAPTURE_BODY',
-  captureErrorLogStackTraces: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
-  captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
-  captureHeaders: 'ELASTIC_APM_CAPTURE_HEADERS',
-  captureSpanStackTraces: 'ELASTIC_APM_CAPTURE_SPAN_STACK_TRACES',
-  centralConfig: 'ELASTIC_APM_CENTRAL_CONFIG',
-  cloudProvider: 'ELASTIC_APM_CLOUD_PROVIDER',
-  containerId: 'ELASTIC_APM_CONTAINER_ID',
-  contextManager: 'ELASTIC_APM_CONTEXT_MANAGER',
-  contextPropagationOnly: 'ELASTIC_APM_CONTEXT_PROPAGATION_ONLY',
-  customMetricsHistogramBoundaries: 'ELASTIC_APM_CUSTOM_METRICS_HISTOGRAM_BOUNDARIES',
-  disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
-  disableMetrics: 'ELASTIC_APM_DISABLE_METRICS',
-  disableSend: 'ELASTIC_APM_DISABLE_SEND',
-  environment: 'ELASTIC_APM_ENVIRONMENT',
-  exitSpanMinDuration: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
-  ignoreMessageQueues: ['ELASTIC_IGNORE_MESSAGE_QUEUES', 'ELASTIC_APM_IGNORE_MESSAGE_QUEUES'],
-  elasticsearchCaptureBodyUrls: 'ELASTIC_APM_ELASTICSEARCH_CAPTURE_BODY_URLS',
-  errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
-  errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
-  // Deprecated: already filtered with `sanitizeFieldNames` defaults
-  // TODO: https://github.com/elastic/apm-agent-nodejs/issues/3332
-  filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',
-  frameworkName: 'ELASTIC_APM_FRAMEWORK_NAME',
-  frameworkVersion: 'ELASTIC_APM_FRAMEWORK_VERSION',
-  globalLabels: 'ELASTIC_APM_GLOBAL_LABELS',
-  hostname: 'ELASTIC_APM_HOSTNAME',
-  instrument: 'ELASTIC_APM_INSTRUMENT',
-  instrumentIncomingHTTPRequests: 'ELASTIC_APM_INSTRUMENT_INCOMING_HTTP_REQUESTS',
-  kubernetesNamespace: ['ELASTIC_APM_KUBERNETES_NAMESPACE', 'KUBERNETES_NAMESPACE'],
-  kubernetesNodeName: ['ELASTIC_APM_KUBERNETES_NODE_NAME', 'KUBERNETES_NODE_NAME'],
-  kubernetesPodName: ['ELASTIC_APM_KUBERNETES_POD_NAME', 'KUBERNETES_POD_NAME'],
-  kubernetesPodUID: ['ELASTIC_APM_KUBERNETES_POD_UID', 'KUBERNETES_POD_UID'],
-  logLevel: 'ELASTIC_APM_LOG_LEVEL',
-  logUncaughtExceptions: 'ELASTIC_APM_LOG_UNCAUGHT_EXCEPTIONS',
-  longFieldMaxLength: 'ELASTIC_APM_LONG_FIELD_MAX_LENGTH',
-  maxQueueSize: 'ELASTIC_APM_MAX_QUEUE_SIZE',
-  metricsInterval: 'ELASTIC_APM_METRICS_INTERVAL',
-  metricsLimit: 'ELASTIC_APM_METRICS_LIMIT',
-  opentelemetryBridgeEnabled: 'ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED',
-  payloadLogFile: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
-  sanitizeFieldNames: ['ELASTIC_SANITIZE_FIELD_NAMES', 'ELASTIC_APM_SANITIZE_FIELD_NAMES'],
-  serverCaCertFile: 'ELASTIC_APM_SERVER_CA_CERT_FILE',
-  secretToken: 'ELASTIC_APM_SECRET_TOKEN',
-  serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT',
-  serverUrl: 'ELASTIC_APM_SERVER_URL',
-  serviceName: 'ELASTIC_APM_SERVICE_NAME',
-  serviceNodeName: 'ELASTIC_APM_SERVICE_NODE_NAME',
-  serviceVersion: 'ELASTIC_APM_SERVICE_VERSION',
-  sourceLinesErrorAppFrames: 'ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES',
-  sourceLinesErrorLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES',
-  sourceLinesSpanAppFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
-  sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
-  spanCompressionEnabled: 'ELASTIC_APM_SPAN_COMPRESSION_ENABLED',
-  spanCompressionExactMatchMaxDuration: 'ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION',
-  spanCompressionSameKindMaxDuration: 'ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION',
-  spanStackTraceMinDuration: 'ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION',
-  spanFramesMinDuration: 'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION',
-  stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
-  traceContinuationStrategy: 'ELASTIC_APM_TRACE_CONTINUATION_STRATEGY',
-  transactionIgnoreUrls: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
-  transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
-  transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
-  useElasticTraceparentHeader: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
-  usePathAsTransactionName: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
-  verifyServerCert: 'ELASTIC_APM_VERIFY_SERVER_CERT'
-}
-
-var CENTRAL_CONFIG_OPTS = {
-  log_level: 'logLevel',
-  transaction_sample_rate: 'transactionSampleRate',
-  transaction_max_spans: 'transactionMaxSpans',
-  capture_body: 'captureBody',
-  transaction_ignore_urls: 'transactionIgnoreUrls',
-  sanitize_field_names: 'sanitizeFieldNames',
-  ignore_message_queues: 'ignoreMessageQueues',
-  span_stack_trace_min_duration: 'spanStackTraceMinDuration',
-  trace_continuation_strategy: 'traceContinuationStrategy',
-  exit_span_min_duration: 'exitSpanMinDuration'
-}
-
-var BOOL_OPTS = [
-  'active',
-  'asyncHooks',
-  'breakdownMetrics',
-  'captureExceptions',
-  'captureHeaders',
-  'captureSpanStackTraces',
-  'centralConfig',
-  'contextPropagationOnly',
-  'disableSend',
-  'errorOnAbortedRequests',
-  'filterHttpHeaders',
-  'instrument',
-  'instrumentIncomingHTTPRequests',
-  'logUncaughtExceptions',
-  'opentelemetryBridgeEnabled',
-  'spanCompressionEnabled',
-  'usePathAsTransactionName',
-  'verifyServerCert'
-]
-
-var NUM_OPTS = [
-  'longFieldMaxLength',
-  'maxQueueSize',
-  'metricsLimit',
-  'sourceLinesErrorAppFrames',
-  'sourceLinesErrorLibraryFrames',
-  'sourceLinesSpanAppFrames',
-  'sourceLinesSpanLibraryFrames',
-  'stackTraceLimit',
-  'transactionMaxSpans',
-  'transactionSampleRate'
-]
-
-var DURATION_OPTS = [
-  {
-    name: 'abortedErrorThreshold',
-    defaultUnit: 's',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    name: 'apiRequestTime',
-    defaultUnit: 's',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    name: 'exitSpanMinDuration',
-    defaultUnit: 'ms',
-    allowedUnits: ['us', 'ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    name: 'metricsInterval',
-    defaultUnit: 's',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    name: 'serverTimeout',
-    defaultUnit: 's',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    name: 'spanCompressionExactMatchMaxDuration',
-    defaultUnit: 'ms',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    name: 'spanCompressionSameKindMaxDuration',
-    defaultUnit: 'ms',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: false
-  },
-  {
-    // Deprecated: use `spanStackTraceMinDuration`.
-    name: 'spanFramesMinDuration',
-    defaultUnit: 's',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: true
-  },
-  {
-    name: 'spanStackTraceMinDuration',
-    defaultUnit: 'ms',
-    allowedUnits: ['ms', 's', 'm'],
-    allowNegative: true
-  }
-]
-
-var BYTES_OPTS = [
-  'apiRequestSize',
-  'errorMessageMaxLength'
-]
-
-var MINUS_ONE_EQUAL_INFINITY = [
-  'transactionMaxSpans'
-]
-
-var ARRAY_OPTS = [
-  'disableInstrumentations',
-  'disableMetrics',
-  'elasticsearchCaptureBodyUrls',
-  'sanitizeFieldNames',
-  'transactionIgnoreUrls',
-  'ignoreMessageQueues'
-]
-
-var KEY_VALUE_OPTS = [
-  'addPatch',
-  'globalLabels'
-]
 
 // Configure a logger for the agent.
 //
@@ -791,143 +494,18 @@ function normalize (opts, logger) {
   normalizeElasticsearchCaptureBodyUrls(opts)
   normalizeDisableMetrics(opts)
   normalizeSanitizeFieldNames(opts)
-  normalizeContextManager(opts, logger) // Must be after normalizeBools().
+  normalizeContextManager(opts, [], DEFAULTS, logger) // Must be after normalizeBools().
   normalizeCloudProvider(opts, [], DEFAULTS, logger)
   normalizeTransactionSampleRate(opts, [], DEFAULTS, logger)
-  normalizeTraceContinuationStrategy(opts, logger)
-  normalizeCustomMetricsHistogramBoundaries(opts, logger)
+  normalizeTraceContinuationStrategy(opts, [], DEFAULTS, logger)
+  normalizeCustomMetricsHistogramBoundaries(opts, [], DEFAULTS, logger)
 
   // This must be after `normalizeDurationOptions()` and `normalizeBools()`
   // because it synthesizes the deprecated `spanFramesMinDuration` and
   // `captureSpanStackTraces` options into `spanStackTraceMinDuration`.
-  normalizeSpanStackTraceMinDuration(opts, logger)
+  normalizeSpanStackTraceMinDuration(opts, [], DEFAULTS, logger)
 
   truncateOptions(opts)
-}
-
-const ALLOWED_TRACE_CONTINUATION_STRATEGY = {
-  [TRACE_CONTINUATION_STRATEGY_CONTINUE]: true,
-  [TRACE_CONTINUATION_STRATEGY_RESTART]: true,
-  [TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL]: true
-}
-function normalizeTraceContinuationStrategy (opts, logger) {
-  if ('traceContinuationStrategy' in opts &&
-      !(opts.traceContinuationStrategy in ALLOWED_TRACE_CONTINUATION_STRATEGY)) {
-    logger.warn('Invalid "traceContinuationStrategy" config value %j, falling back to default %j',
-      opts.traceContinuationStrategy, DEFAULTS.traceContinuationStrategy)
-    opts.traceContinuationStrategy = DEFAULTS.traceContinuationStrategy
-  }
-}
-
-// Normalize provided values for `spanFramesMinDuration` (deprecated),
-// `captureSpanStackTraces` (deprecated) and `spanStackTraceMinDuration` into
-// a final value for `spanStackTraceMinDuration` that is used by the agent.
-//
-// This function expects `normalizeDurationOptions()` and `normalizeBools()`
-// to have already been called.
-//
-// | spanStackTraceMinDuration | captureSpanStackTraces | spanFramesMinDuration   | resultant spanStackTraceMinDuration |
-// | ------------------------- | ---------------------- | ----------------------- | ----------------------------------- |
-// | -                         | -                      | -                       | `-1ms` (no span stacktraces)        |
-// | `-1ms` (negative value)   | (any value is ignored) | (any value is ignored)  | `-1ms` (no span stacktraces)        |
-// | `0ms` (zero value)        | (any value is ignored) | (any value is ignored)  | `0ms` (stacktraces for all spans)   |
-// | `5ms` (positive value)    | (any value is ignored) | (any value is ignored)  | `5ms`                               |
-// | -                         | `false`                | (any value)             | `-1ms` (no span stacktraces)        |
-// | -                         | `true`                 | -                       | `10ms` (backwards compatible value) |
-// | -                         | `true` or unspecified  | `0ms` (zero value)      | `-1ms` (no span stacktraces)        |
-// | -                         | `true` or unspecified  | `-1ms` (negative value) | `0ms` (stacktraces for all spans)   |
-// | -                         | `true` or unspecified  | `5ms` (positive value)  | `5ms`                               |
-function normalizeSpanStackTraceMinDuration (opts, logger) {
-  const before = {}
-  if (opts.captureSpanStackTraces !== undefined) before.captureSpanStackTraces = opts.captureSpanStackTraces
-  if (opts.spanFramesMinDuration !== undefined) before.spanFramesMinDuration = opts.spanFramesMinDuration
-  if (opts.spanStackTraceMinDuration !== undefined) before.spanStackTraceMinDuration = opts.spanStackTraceMinDuration
-
-  if ('spanStackTraceMinDuration' in opts) {
-    // If the new option was specified, then use it and ignore the old two.
-  } else if (opts.captureSpanStackTraces === false) {
-    opts.spanStackTraceMinDuration = -1 // Turn off span stacktraces.
-  } else if ('spanFramesMinDuration' in opts) {
-    if (opts.spanFramesMinDuration === 0) {
-      opts.spanStackTraceMinDuration = -1 // Turn off span stacktraces.
-    } else if (opts.spanFramesMinDuration < 0) {
-      opts.spanStackTraceMinDuration = 0 // Stacktraces for all spans.
-    } else {
-      opts.spanStackTraceMinDuration = opts.spanFramesMinDuration
-    }
-  } else if (opts.captureSpanStackTraces === true) {
-    // For backwards compat, use the default `spanFramesMinDuration` value
-    // from before `spanStackTraceMinDuration` was introduced.
-    opts.spanStackTraceMinDuration = 10 / 1e3 // 10ms
-  } else {
-    // None of the three options was specified.
-    opts.spanStackTraceMinDuration = -1 // Turn off span stacktraces.
-  }
-  delete opts.captureSpanStackTraces
-  delete opts.spanFramesMinDuration
-
-  // Log if something potentially interesting happened here.
-  if (Object.keys(before).length > 0) {
-    const after = { spanStackTraceMinDuration: opts.spanStackTraceMinDuration }
-    logger.trace({ before, after }, 'normalizeSpanStackTraceMinDuration')
-  }
-}
-
-const ALLOWED_CONTEXT_MANAGER = {
-  [CONTEXT_MANAGER_PATCH]: true,
-  [CONTEXT_MANAGER_ASYNCHOOKS]: true,
-  [CONTEXT_MANAGER_ASYNCLOCALSTORAGE]: true
-}
-
-/**
- * Normalize and validate the given values for `contextManager`, and the
- * deprecated `asyncHooks` that it replaces.
- *
- * - `contextManager=patch` means use the "patch-async" technique. I.e., do
- *   limited monkey patching of Node.js core async methods to do limited context
- *   tracking).
- * - `contextManager=asynchooks` means use the "async_hooks.createHook()"
- *   technique. This works in all supported versions of node, but can have
- *   significant performance overhead for Promise-heavy apps.
- * - `contextManager=asynclocalstorage` means use the "AsyncLocalStorage"
- *   technique *if supported in the version of node* (>=14.5 || ^12.19.0).
- *   Otherwise, this will warn and fallback to "asynchooks".
- * - The `asyncHooks` config var is now deprecated. It is translated to the
- *   equivalent `contextManager` value.
- *    - `asyncHooks=false` -> `contextManager=patch`
- *    - `asyncHooks=true` -> leaves the `contextManager` value empty to get
- *      the default behavior: the best async technique.
- * - No specified option means use the best async technique.
- */
-function normalizeContextManager (opts, logger) {
-  // Treat the empty string, e.g. `ELASTIC_APM_CONTEXT_MANAGER=`, as if it had
-  // not been specified.
-  if (opts.contextManager === '') {
-    delete opts.contextManager
-  }
-
-  if ('contextManager' in opts && !(opts.contextManager in ALLOWED_CONTEXT_MANAGER)) {
-    logger.warn('Invalid "contextManager" config value %j, falling back to default behavior',
-      opts.contextManager)
-    delete opts.contextManager
-  }
-
-  if ('asyncHooks' in opts) {
-    if ('contextManager' in opts) {
-      logger.warn({ asyncHooks: opts.asyncHooks, contextManager: opts.contextManager },
-        'both `asyncHooks` and `contextManager` config options were specified: the `asyncHooks` value will be ignored')
-      delete opts.asyncHooks
-    } else if (opts.asyncHooks === false) {
-      logger.warn('the `asyncHooks` config option is deprecated; instead of `asyncHooks: false` option, use `contextManager: "patch"`')
-      opts.contextManager = 'patch'
-      delete opts.asyncHooks
-    } else if (opts.asyncHooks === true) {
-      logger.warn('the `asyncHooks` config option is deprecated; `asyncHooks: true` is the default behavior')
-      delete opts.asyncHooks
-    } else {
-      delete opts.asyncHooks // Some bogus value.
-    }
-  }
 }
 
 function truncateOptions (opts) {
@@ -1106,21 +684,5 @@ module.exports = {
   configLogger,
   initialConfig,
   createConfig,
-  INTAKE_STRING_MAX_SIZE,
-  CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
-  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
-  CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS,
-  CONTEXT_MANAGER_PATCH,
-  CONTEXT_MANAGER_ASYNCHOOKS,
-  CONTEXT_MANAGER_ASYNCLOCALSTORAGE,
-  TRACE_CONTINUATION_STRATEGY_CONTINUE,
-  TRACE_CONTINUATION_STRATEGY_RESTART,
-  TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL,
-
-  // The following are exported for tests.
-  CENTRAL_CONFIG_OPTS,
-  DEFAULTS,
-  DURATION_OPTS,
-  userAgentFromConf,
-  ENV_TABLE
+  userAgentFromConf
 }

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -7,6 +7,15 @@
 'use strict'
 
 const { WildcardMatcher } = require('../wildcard-matcher')
+const {
+  DEFAULTS,
+  TRACE_CONTINUATION_STRATEGY_CONTINUE,
+  TRACE_CONTINUATION_STRATEGY_RESTART,
+  TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL,
+  CONTEXT_MANAGER_PATCH,
+  CONTEXT_MANAGER_ASYNCHOOKS,
+  CONTEXT_MANAGER_ASYNCLOCALSTORAGE
+} = require('./schema')
 
 // TODO: move this typedef to logger.js
 /**
@@ -472,6 +481,131 @@ function normalizeTransactionSampleRate (opts, fields, defaults, logger) {
   }
 }
 
+const ALLOWED_TRACE_CONTINUATION_STRATEGY = {
+  [TRACE_CONTINUATION_STRATEGY_CONTINUE]: true,
+  [TRACE_CONTINUATION_STRATEGY_RESTART]: true,
+  [TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL]: true
+}
+function normalizeTraceContinuationStrategy (opts, fields, defaults, logger) {
+  if ('traceContinuationStrategy' in opts &&
+      !(opts.traceContinuationStrategy in ALLOWED_TRACE_CONTINUATION_STRATEGY)) {
+    logger.warn('Invalid "traceContinuationStrategy" config value %j, falling back to default %j',
+      opts.traceContinuationStrategy, DEFAULTS.traceContinuationStrategy)
+    opts.traceContinuationStrategy = DEFAULTS.traceContinuationStrategy
+  }
+}
+
+const ALLOWED_CONTEXT_MANAGER = {
+  [CONTEXT_MANAGER_PATCH]: true,
+  [CONTEXT_MANAGER_ASYNCHOOKS]: true,
+  [CONTEXT_MANAGER_ASYNCLOCALSTORAGE]: true
+}
+
+/**
+ * Normalize and validate the given values for `contextManager`, and the
+ * deprecated `asyncHooks` that it replaces.
+ *
+ * - `contextManager=patch` means use the "patch-async" technique. I.e., do
+ *   limited monkey patching of Node.js core async methods to do limited context
+ *   tracking).
+ * - `contextManager=asynchooks` means use the "async_hooks.createHook()"
+ *   technique. This works in all supported versions of node, but can have
+ *   significant performance overhead for Promise-heavy apps.
+ * - `contextManager=asynclocalstorage` means use the "AsyncLocalStorage"
+ *   technique *if supported in the version of node* (>=14.5 || ^12.19.0).
+ *   Otherwise, this will warn and fallback to "asynchooks".
+ * - The `asyncHooks` config var is now deprecated. It is translated to the
+ *   equivalent `contextManager` value.
+ *    - `asyncHooks=false` -> `contextManager=patch`
+ *    - `asyncHooks=true` -> leaves the `contextManager` value empty to get
+ *      the default behavior: the best async technique.
+ * - No specified option means use the best async technique.
+ */
+function normalizeContextManager (opts, fields, defaults, logger) {
+  // Treat the empty string, e.g. `ELASTIC_APM_CONTEXT_MANAGER=`, as if it had
+  // not been specified.
+  if (opts.contextManager === '') {
+    delete opts.contextManager
+  }
+
+  if ('contextManager' in opts && !(opts.contextManager in ALLOWED_CONTEXT_MANAGER)) {
+    logger.warn('Invalid "contextManager" config value %j, falling back to default behavior',
+      opts.contextManager)
+    delete opts.contextManager
+  }
+
+  if ('asyncHooks' in opts) {
+    if ('contextManager' in opts) {
+      logger.warn({ asyncHooks: opts.asyncHooks, contextManager: opts.contextManager },
+        'both `asyncHooks` and `contextManager` config options were specified: the `asyncHooks` value will be ignored')
+      delete opts.asyncHooks
+    } else if (opts.asyncHooks === false) {
+      logger.warn('the `asyncHooks` config option is deprecated; instead of `asyncHooks: false` option, use `contextManager: "patch"`')
+      opts.contextManager = 'patch'
+      delete opts.asyncHooks
+    } else if (opts.asyncHooks === true) {
+      logger.warn('the `asyncHooks` config option is deprecated; `asyncHooks: true` is the default behavior')
+      delete opts.asyncHooks
+    } else {
+      delete opts.asyncHooks // Some bogus value.
+    }
+  }
+}
+
+// Normalize provided values for `spanFramesMinDuration` (deprecated),
+// `captureSpanStackTraces` (deprecated) and `spanStackTraceMinDuration` into
+// a final value for `spanStackTraceMinDuration` that is used by the agent.
+//
+// This function expects `normalizeDurationOptions()` and `normalizeBools()`
+// to have already been called.
+//
+// | spanStackTraceMinDuration | captureSpanStackTraces | spanFramesMinDuration   | resultant spanStackTraceMinDuration |
+// | ------------------------- | ---------------------- | ----------------------- | ----------------------------------- |
+// | -                         | -                      | -                       | `-1ms` (no span stacktraces)        |
+// | `-1ms` (negative value)   | (any value is ignored) | (any value is ignored)  | `-1ms` (no span stacktraces)        |
+// | `0ms` (zero value)        | (any value is ignored) | (any value is ignored)  | `0ms` (stacktraces for all spans)   |
+// | `5ms` (positive value)    | (any value is ignored) | (any value is ignored)  | `5ms`                               |
+// | -                         | `false`                | (any value)             | `-1ms` (no span stacktraces)        |
+// | -                         | `true`                 | -                       | `10ms` (backwards compatible value) |
+// | -                         | `true` or unspecified  | `0ms` (zero value)      | `-1ms` (no span stacktraces)        |
+// | -                         | `true` or unspecified  | `-1ms` (negative value) | `0ms` (stacktraces for all spans)   |
+// | -                         | `true` or unspecified  | `5ms` (positive value)  | `5ms`                               |
+function normalizeSpanStackTraceMinDuration (opts, fields, defaults, logger) {
+  const before = {}
+  if (opts.captureSpanStackTraces !== undefined) before.captureSpanStackTraces = opts.captureSpanStackTraces
+  if (opts.spanFramesMinDuration !== undefined) before.spanFramesMinDuration = opts.spanFramesMinDuration
+  if (opts.spanStackTraceMinDuration !== undefined) before.spanStackTraceMinDuration = opts.spanStackTraceMinDuration
+
+  if ('spanStackTraceMinDuration' in opts) {
+    // If the new option was specified, then use it and ignore the old two.
+  } else if (opts.captureSpanStackTraces === false) {
+    opts.spanStackTraceMinDuration = -1 // Turn off span stacktraces.
+  } else if ('spanFramesMinDuration' in opts) {
+    if (opts.spanFramesMinDuration === 0) {
+      opts.spanStackTraceMinDuration = -1 // Turn off span stacktraces.
+    } else if (opts.spanFramesMinDuration < 0) {
+      opts.spanStackTraceMinDuration = 0 // Stacktraces for all spans.
+    } else {
+      opts.spanStackTraceMinDuration = opts.spanFramesMinDuration
+    }
+  } else if (opts.captureSpanStackTraces === true) {
+    // For backwards compat, use the default `spanFramesMinDuration` value
+    // from before `spanStackTraceMinDuration` was introduced.
+    opts.spanStackTraceMinDuration = 10 / 1e3 // 10ms
+  } else {
+    // None of the three options was specified.
+    opts.spanStackTraceMinDuration = -1 // Turn off span stacktraces.
+  }
+  delete opts.captureSpanStackTraces
+  delete opts.spanFramesMinDuration
+
+  // Log if something potentially interesting happened here.
+  if (Object.keys(before).length > 0) {
+    const after = { spanStackTraceMinDuration: opts.spanStackTraceMinDuration }
+    logger.trace({ before, after }, 'normalizeSpanStackTraceMinDuration')
+  }
+}
+
 module.exports = {
   normalizeArrays,
   normalizeBools,
@@ -487,5 +621,8 @@ module.exports = {
   normalizeNumbers,
   normalizeSanitizeFieldNames,
   normalizeTransactionSampleRate,
-  secondsFromDuration
+  secondsFromDuration,
+  normalizeTraceContinuationStrategy,
+  normalizeContextManager,
+  normalizeSpanStackTraceMinDuration
 }

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -1,0 +1,350 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+const INTAKE_STRING_MAX_SIZE = 1024
+const CAPTURE_ERROR_LOG_STACK_TRACES_NEVER = 'never'
+const CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES = 'messages'
+const CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS = 'always'
+const CONTEXT_MANAGER_PATCH = 'patch'
+const CONTEXT_MANAGER_ASYNCHOOKS = 'asynchooks'
+const CONTEXT_MANAGER_ASYNCLOCALSTORAGE = 'asynclocalstorage'
+const TRACE_CONTINUATION_STRATEGY_CONTINUE = 'continue'
+const TRACE_CONTINUATION_STRATEGY_RESTART = 'restart'
+const TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL = 'restart_external'
+
+const DEFAULTS = {
+  abortedErrorThreshold: '25s',
+  active: true,
+  addPatch: undefined,
+  apiRequestSize: '768kb',
+  apiRequestTime: '10s',
+  breakdownMetrics: true,
+  captureBody: 'off',
+  captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
+  captureExceptions: true,
+  captureHeaders: true,
+  centralConfig: true,
+  cloudProvider: 'auto',
+  containerId: undefined,
+  // 'contextManager' and 'asyncHooks' are explicitly *not* included in DEFAULTS
+  // because normalizeContextManager() needs to know if a value was provided by
+  // the user.
+  contextPropagationOnly: false,
+  // Exponential powers-of-2 bucket boundaries, rounded to 6 significant figures.
+  //    2**N for N in [-8, -7.5, -7, ..., 16, 16.5, 17]
+  // https://github.com/elastic/apm/blob/main/specs/agents/metrics-otel.md#histogram-aggregation
+  customMetricsHistogramBoundaries: [
+    0.00390625, 0.00552427, 0.0078125, 0.0110485,
+    0.015625, 0.0220971, 0.03125, 0.0441942,
+    0.0625, 0.0883883, 0.125, 0.176777,
+    0.25, 0.353553, 0.5, 0.707107,
+    1, 1.41421, 2, 2.82843,
+    4, 5.65685, 8, 11.3137,
+    16, 22.6274, 32, 45.2548,
+    64, 90.5097, 128, 181.019,
+    256, 362.039, 512, 724.077,
+    1024, 1448.15, 2048, 2896.31,
+    4096, 5792.62, 8192, 11585.2,
+    16384, 23170.5, 32768, 46341,
+    65536, 92681.9, 131072
+  ],
+  disableInstrumentations: [],
+  disableMetrics: [],
+  disableSend: false,
+  elasticsearchCaptureBodyUrls: [
+    '*/_search', '*/_search/template', '*/_msearch', '*/_msearch/template',
+    '*/_async_search', '*/_count', '*/_sql', '*/_eql/search'
+  ],
+  environment: process.env.NODE_ENV || 'development',
+  errorOnAbortedRequests: false,
+  exitSpanMinDuration: '0ms',
+  // Deprecated: already filtered with `sanitizeFieldNames` defaults
+  // TODO: https://github.com/elastic/apm-agent-nodejs/issues/3332
+  filterHttpHeaders: true,
+  globalLabels: undefined,
+  ignoreMessageQueues: [],
+  instrument: true,
+  instrumentIncomingHTTPRequests: true,
+  kubernetesNamespace: undefined,
+  kubernetesNodeName: undefined,
+  kubernetesPodName: undefined,
+  kubernetesPodUID: undefined,
+  logLevel: 'info',
+  logUncaughtExceptions: false, // TODO: Change to `true` in the v4.0.0
+  longFieldMaxLength: 10000,
+  // Rough equivalent of the Java Agent's max_queue_size:
+  // https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-max-queue-size
+  maxQueueSize: 1024,
+  metricsInterval: '30s',
+  metricsLimit: 1000,
+  opentelemetryBridgeEnabled: false,
+  sanitizeFieldNames: [
+    // These patterns are specified in the shared APM specs:
+    // https://github.com/elastic/apm/blob/main/specs/agents/sanitization.md
+    'password', 'passwd', 'pwd', 'secret', '*key', '*token*',
+    '*session*', '*credit*', '*card*', '*auth*', 'set-cookie', '*principal*',
+    // These are default patterns only in the Node.js APM agent, historically
+    // from when the "is-secret" dependency was used.
+    'pw', 'pass', 'connect.sid'
+  ],
+  serviceNodeName: undefined,
+  serverTimeout: '30s',
+  serverUrl: 'http://127.0.0.1:8200',
+  sourceLinesErrorAppFrames: 5,
+  sourceLinesErrorLibraryFrames: 5,
+  sourceLinesSpanAppFrames: 0,
+  sourceLinesSpanLibraryFrames: 0,
+  spanCompressionEnabled: true,
+  spanCompressionExactMatchMaxDuration: '50ms',
+  spanCompressionSameKindMaxDuration: '0ms',
+  // 'spanStackTraceMinDuration' is explicitly *not* included in DEFAULTS
+  // because normalizeSpanStackTraceMinDuration() needs to know if a value
+  // was provided by the user.
+  stackTraceLimit: 50,
+  traceContinuationStrategy: TRACE_CONTINUATION_STRATEGY_CONTINUE,
+  transactionIgnoreUrls: [],
+  transactionMaxSpans: 500,
+  transactionSampleRate: 1.0,
+  useElasticTraceparentHeader: true,
+  usePathAsTransactionName: false,
+  verifyServerCert: true
+}
+
+const ENV_TABLE = {
+  abortedErrorThreshold: 'ELASTIC_APM_ABORTED_ERROR_THRESHOLD',
+  active: 'ELASTIC_APM_ACTIVE',
+  addPatch: 'ELASTIC_APM_ADD_PATCH',
+  apiKey: 'ELASTIC_APM_API_KEY',
+  apiRequestSize: 'ELASTIC_APM_API_REQUEST_SIZE',
+  apiRequestTime: 'ELASTIC_APM_API_REQUEST_TIME',
+  asyncHooks: 'ELASTIC_APM_ASYNC_HOOKS',
+  breakdownMetrics: 'ELASTIC_APM_BREAKDOWN_METRICS',
+  captureBody: 'ELASTIC_APM_CAPTURE_BODY',
+  captureErrorLogStackTraces: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
+  captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
+  captureHeaders: 'ELASTIC_APM_CAPTURE_HEADERS',
+  captureSpanStackTraces: 'ELASTIC_APM_CAPTURE_SPAN_STACK_TRACES',
+  centralConfig: 'ELASTIC_APM_CENTRAL_CONFIG',
+  cloudProvider: 'ELASTIC_APM_CLOUD_PROVIDER',
+  containerId: 'ELASTIC_APM_CONTAINER_ID',
+  contextManager: 'ELASTIC_APM_CONTEXT_MANAGER',
+  contextPropagationOnly: 'ELASTIC_APM_CONTEXT_PROPAGATION_ONLY',
+  customMetricsHistogramBoundaries: 'ELASTIC_APM_CUSTOM_METRICS_HISTOGRAM_BOUNDARIES',
+  disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
+  disableMetrics: 'ELASTIC_APM_DISABLE_METRICS',
+  disableSend: 'ELASTIC_APM_DISABLE_SEND',
+  environment: 'ELASTIC_APM_ENVIRONMENT',
+  exitSpanMinDuration: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
+  ignoreMessageQueues: ['ELASTIC_IGNORE_MESSAGE_QUEUES', 'ELASTIC_APM_IGNORE_MESSAGE_QUEUES'],
+  elasticsearchCaptureBodyUrls: 'ELASTIC_APM_ELASTICSEARCH_CAPTURE_BODY_URLS',
+  errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
+  errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
+  // Deprecated: already filtered with `sanitizeFieldNames` defaults
+  // TODO: https://github.com/elastic/apm-agent-nodejs/issues/3332
+  filterHttpHeaders: 'ELASTIC_APM_FILTER_HTTP_HEADERS',
+  frameworkName: 'ELASTIC_APM_FRAMEWORK_NAME',
+  frameworkVersion: 'ELASTIC_APM_FRAMEWORK_VERSION',
+  globalLabels: 'ELASTIC_APM_GLOBAL_LABELS',
+  hostname: 'ELASTIC_APM_HOSTNAME',
+  instrument: 'ELASTIC_APM_INSTRUMENT',
+  instrumentIncomingHTTPRequests: 'ELASTIC_APM_INSTRUMENT_INCOMING_HTTP_REQUESTS',
+  kubernetesNamespace: ['ELASTIC_APM_KUBERNETES_NAMESPACE', 'KUBERNETES_NAMESPACE'],
+  kubernetesNodeName: ['ELASTIC_APM_KUBERNETES_NODE_NAME', 'KUBERNETES_NODE_NAME'],
+  kubernetesPodName: ['ELASTIC_APM_KUBERNETES_POD_NAME', 'KUBERNETES_POD_NAME'],
+  kubernetesPodUID: ['ELASTIC_APM_KUBERNETES_POD_UID', 'KUBERNETES_POD_UID'],
+  logLevel: 'ELASTIC_APM_LOG_LEVEL',
+  logUncaughtExceptions: 'ELASTIC_APM_LOG_UNCAUGHT_EXCEPTIONS',
+  longFieldMaxLength: 'ELASTIC_APM_LONG_FIELD_MAX_LENGTH',
+  maxQueueSize: 'ELASTIC_APM_MAX_QUEUE_SIZE',
+  metricsInterval: 'ELASTIC_APM_METRICS_INTERVAL',
+  metricsLimit: 'ELASTIC_APM_METRICS_LIMIT',
+  opentelemetryBridgeEnabled: 'ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED',
+  payloadLogFile: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
+  sanitizeFieldNames: ['ELASTIC_SANITIZE_FIELD_NAMES', 'ELASTIC_APM_SANITIZE_FIELD_NAMES'],
+  serverCaCertFile: 'ELASTIC_APM_SERVER_CA_CERT_FILE',
+  secretToken: 'ELASTIC_APM_SECRET_TOKEN',
+  serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT',
+  serverUrl: 'ELASTIC_APM_SERVER_URL',
+  serviceName: 'ELASTIC_APM_SERVICE_NAME',
+  serviceNodeName: 'ELASTIC_APM_SERVICE_NODE_NAME',
+  serviceVersion: 'ELASTIC_APM_SERVICE_VERSION',
+  sourceLinesErrorAppFrames: 'ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES',
+  sourceLinesErrorLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES',
+  sourceLinesSpanAppFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
+  sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
+  spanCompressionEnabled: 'ELASTIC_APM_SPAN_COMPRESSION_ENABLED',
+  spanCompressionExactMatchMaxDuration: 'ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION',
+  spanCompressionSameKindMaxDuration: 'ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION',
+  spanStackTraceMinDuration: 'ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION',
+  spanFramesMinDuration: 'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION',
+  stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
+  traceContinuationStrategy: 'ELASTIC_APM_TRACE_CONTINUATION_STRATEGY',
+  transactionIgnoreUrls: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
+  transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
+  transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
+  useElasticTraceparentHeader: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
+  usePathAsTransactionName: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
+  verifyServerCert: 'ELASTIC_APM_VERIFY_SERVER_CERT'
+}
+
+const CENTRAL_CONFIG_OPTS = {
+  log_level: 'logLevel',
+  transaction_sample_rate: 'transactionSampleRate',
+  transaction_max_spans: 'transactionMaxSpans',
+  capture_body: 'captureBody',
+  transaction_ignore_urls: 'transactionIgnoreUrls',
+  sanitize_field_names: 'sanitizeFieldNames',
+  ignore_message_queues: 'ignoreMessageQueues',
+  span_stack_trace_min_duration: 'spanStackTraceMinDuration',
+  trace_continuation_strategy: 'traceContinuationStrategy',
+  exit_span_min_duration: 'exitSpanMinDuration'
+}
+
+const BOOL_OPTS = [
+  'active',
+  'asyncHooks',
+  'breakdownMetrics',
+  'captureExceptions',
+  'captureHeaders',
+  'captureSpanStackTraces',
+  'centralConfig',
+  'contextPropagationOnly',
+  'disableSend',
+  'errorOnAbortedRequests',
+  'filterHttpHeaders',
+  'instrument',
+  'instrumentIncomingHTTPRequests',
+  'logUncaughtExceptions',
+  'opentelemetryBridgeEnabled',
+  'spanCompressionEnabled',
+  'usePathAsTransactionName',
+  'verifyServerCert'
+]
+
+const NUM_OPTS = [
+  'longFieldMaxLength',
+  'maxQueueSize',
+  'metricsLimit',
+  'sourceLinesErrorAppFrames',
+  'sourceLinesErrorLibraryFrames',
+  'sourceLinesSpanAppFrames',
+  'sourceLinesSpanLibraryFrames',
+  'stackTraceLimit',
+  'transactionMaxSpans',
+  'transactionSampleRate'
+]
+
+const DURATION_OPTS = [
+  {
+    name: 'abortedErrorThreshold',
+    defaultUnit: 's',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'apiRequestTime',
+    defaultUnit: 's',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'exitSpanMinDuration',
+    defaultUnit: 'ms',
+    allowedUnits: ['us', 'ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'metricsInterval',
+    defaultUnit: 's',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'serverTimeout',
+    defaultUnit: 's',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'spanCompressionExactMatchMaxDuration',
+    defaultUnit: 'ms',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    name: 'spanCompressionSameKindMaxDuration',
+    defaultUnit: 'ms',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: false
+  },
+  {
+    // Deprecated: use `spanStackTraceMinDuration`.
+    name: 'spanFramesMinDuration',
+    defaultUnit: 's',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: true
+  },
+  {
+    name: 'spanStackTraceMinDuration',
+    defaultUnit: 'ms',
+    allowedUnits: ['ms', 's', 'm'],
+    allowNegative: true
+  }
+]
+
+const BYTES_OPTS = [
+  'apiRequestSize',
+  'errorMessageMaxLength'
+]
+
+const MINUS_ONE_EQUAL_INFINITY = [
+  'transactionMaxSpans'
+]
+
+const ARRAY_OPTS = [
+  'disableInstrumentations',
+  'disableMetrics',
+  'elasticsearchCaptureBodyUrls',
+  'sanitizeFieldNames',
+  'transactionIgnoreUrls',
+  'ignoreMessageQueues'
+]
+
+const KEY_VALUE_OPTS = [
+  'addPatch',
+  'globalLabels'
+]
+
+// Exports.
+module.exports = {
+  // Constant values
+  INTAKE_STRING_MAX_SIZE,
+  CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
+  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
+  CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS,
+  CONTEXT_MANAGER_PATCH,
+  CONTEXT_MANAGER_ASYNCHOOKS,
+  CONTEXT_MANAGER_ASYNCLOCALSTORAGE,
+  TRACE_CONTINUATION_STRATEGY_CONTINUE,
+  TRACE_CONTINUATION_STRATEGY_RESTART,
+  TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL,
+
+  // Options
+  CENTRAL_CONFIG_OPTS,
+  BOOL_OPTS,
+  NUM_OPTS,
+  DURATION_OPTS,
+  BYTES_OPTS,
+  MINUS_ONE_EQUAL_INFINITY,
+  ARRAY_OPTS,
+  KEY_VALUE_OPTS,
+
+  // The following are exported for tests.
+  DEFAULTS,
+  ENV_TABLE
+}

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -8,7 +8,7 @@
 
 const truncate = require('unicode-byte-truncate')
 
-const config = require('../config')
+const { INTAKE_STRING_MAX_SIZE } = require('../config/schema')
 const constants = require('../constants')
 const { SpanCompression } = require('./span-compression')
 const Timer = require('./timer')
@@ -132,7 +132,7 @@ GenericSpan.prototype.setLabel = function (key, value, stringify = true) {
       return value
     }
 
-    return truncate(String(value), config.INTAKE_STRING_MAX_SIZE)
+    return truncate(String(value), INTAKE_STRING_MAX_SIZE)
   }
 
   if (!key) return false

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -12,7 +12,11 @@ var path = require('path')
 const Hook = require('require-in-the-middle')
 const semver = require('semver')
 
-const config = require('../config')
+const {
+  CONTEXT_MANAGER_PATCH,
+  CONTEXT_MANAGER_ASYNCHOOKS,
+  CONTEXT_MANAGER_ASYNCLOCALSTORAGE
+} = require('../config/schema')
 var { Ids } = require('./ids')
 var NamedArray = require('./named-array')
 var Transaction = require('./transaction')
@@ -203,15 +207,15 @@ Instrumentation.prototype.start = function (runContextClass) {
 
   // Select the appropriate run-context manager.
   const confContextManager = this._agent._conf.contextManager
-  if (confContextManager === config.CONTEXT_MANAGER_PATCH) {
+  if (confContextManager === CONTEXT_MANAGER_PATCH) {
     this._runCtxMgr = new BasicRunContextManager(this._log, runContextClass)
     require('./patch-async')(this)
-  } else if (confContextManager === config.CONTEXT_MANAGER_ASYNCHOOKS) {
+  } else if (confContextManager === CONTEXT_MANAGER_ASYNCHOOKS) {
     this._runCtxMgr = new AsyncHooksRunContextManager(this._log, runContextClass)
   } else if (nodeSupportsAsyncLocalStorage) {
     this._runCtxMgr = new AsyncLocalStorageRunContextManager(this._log, runContextClass)
   } else {
-    if (confContextManager === config.CONTEXT_MANAGER_ASYNCLOCALSTORAGE) {
+    if (confContextManager === CONTEXT_MANAGER_ASYNCLOCALSTORAGE) {
       this._log.warn(`config includes 'contextManager="${confContextManager}"', but node ${process.version} does not support AsyncLocalStorage for run-context management: falling back to using async_hooks`)
     }
     this._runCtxMgr = new AsyncHooksRunContextManager(this._log, runContextClass)

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -21,7 +21,7 @@ const {
   TRACE_CONTINUATION_STRATEGY_CONTINUE,
   TRACE_CONTINUATION_STRATEGY_RESTART,
   TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL
-} = require('../config')
+} = require('../config/config')
 var { TransactionIds } = require('./ids')
 const TraceState = require('../tracecontext/tracestate')
 

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -21,7 +21,7 @@ const {
   TRACE_CONTINUATION_STRATEGY_CONTINUE,
   TRACE_CONTINUATION_STRATEGY_RESTART,
   TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL
-} = require('../config/config')
+} = require('../config/schema')
 var { TransactionIds } = require('./ids')
 const TraceState = require('../tracecontext/tracestate')
 

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -25,7 +25,6 @@ const {
   CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
   DEFAULTS
 } = require('../lib/config/schema')
-const config = require('../lib/config/config')
 const { findObjInArray } = require('./_utils')
 const { MockAPMServer } = require('./_mock_apm_server')
 const { NoopTransport } = require('../lib/noop-transport')

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -19,7 +19,13 @@ var os = require('os')
 var test = require('tape')
 
 const Agent = require('../lib/agent')
-var config = require('../lib/config')
+const {
+  CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS,
+  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
+  CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
+  DEFAULTS
+} = require('../lib/config/schema')
+const config = require('../lib/config/config')
 const { findObjInArray } = require('./_utils')
 const { MockAPMServer } = require('./_mock_apm_server')
 const { NoopTransport } = require('../lib/noop-transport')
@@ -1291,7 +1297,7 @@ test('#captureError()', function (t) {
       function () {
         t.equal(apmServer.events.length, 2, 'APM server got 2 events')
         const data = apmServer.events[1].error
-        t.strictEqual(data.exception.stacktrace.length, config.DEFAULTS.stackTraceLimit)
+        t.strictEqual(data.exception.stacktrace.length, DEFAULTS.stackTraceLimit)
         t.strictEqual(data.exception.stacktrace[0].context_line.trim(), 'return new Error()')
 
         apmServer.clear()
@@ -1349,7 +1355,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_NEVER }
     ))
     agent.captureError(new Error('foo'),
       function () {
@@ -1370,7 +1376,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_NEVER }
     ))
     agent.captureError('foo',
       function () {
@@ -1391,7 +1397,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_NEVER }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_NEVER }
     ))
     agent.captureError({ message: 'Hello %s', params: ['World'] },
       function () {
@@ -1412,7 +1418,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES }
     ))
     agent.captureError(new Error('foo'),
       function () {
@@ -1433,7 +1439,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES }
     ))
     agent.captureError('foo',
       function () {
@@ -1454,7 +1460,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES }
     ))
     agent.captureError({ message: 'Hello %s', params: ['World'] },
       function () {
@@ -1475,7 +1481,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS }
     ))
     agent.captureError(new Error('foo'),
       function () {
@@ -1497,7 +1503,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS }
     ))
     agent.captureError('foo',
       function () {
@@ -1518,7 +1524,7 @@ test('#captureError()', function (t) {
     const agent = new Agent().start(Object.assign(
       {},
       ceAgentOpts,
-      { captureErrorLogStackTraces: config.CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS }
+      { captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS }
     ))
     agent.captureError({ message: 'Hello %s', params: ['World'] },
       function () {

--- a/test/central-config-enabled.test.js
+++ b/test/central-config-enabled.test.js
@@ -14,7 +14,7 @@ const http = require('http')
 const test = require('tape')
 
 const Agent = require('./_agent')
-const { CENTRAL_CONFIG_OPTS } = require('../lib/config/config')
+const { CENTRAL_CONFIG_OPTS } = require('../lib/config/schema')
 
 const runTestsWithServer = (t, updates, expect) => {
   let agent

--- a/test/central-config-enabled.test.js
+++ b/test/central-config-enabled.test.js
@@ -14,7 +14,7 @@ const http = require('http')
 const test = require('tape')
 
 const Agent = require('./_agent')
-const { CENTRAL_CONFIG_OPTS } = require('../lib/config')
+const { CENTRAL_CONFIG_OPTS } = require('../lib/config/config')
 
 const runTestsWithServer = (t, updates, expect) => {
   let agent

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -24,7 +24,14 @@ const { MockAPMServer } = require('./_mock_apm_server')
 const { NoopTransport } = require('../lib/noop-transport')
 const { safeGetPackageVersion, findObjInArray } = require('./_utils')
 const { secondsFromDuration } = require('../lib/config/normalizers')
-const config = require('../lib/config')
+const {
+  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
+  DEFAULTS,
+  DURATION_OPTS,
+  ENV_TABLE
+} = require('../lib/config/schema')
+const config = require('../lib/config/config')
+
 var Instrumentation = require('../lib/instrumentation')
 var apmVersion = require('../package').version
 var apmName = require('../package').name
@@ -121,12 +128,12 @@ var optionFixtures = [
   ['apiRequestSize', 'API_REQUEST_SIZE', 768 * 1024],
   ['apiRequestTime', 'API_REQUEST_TIME', 10],
   ['captureBody', 'CAPTURE_BODY', 'off'],
-  ['captureErrorLogStackTraces', 'CAPTURE_ERROR_LOG_STACK_TRACES', config.CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES],
+  ['captureErrorLogStackTraces', 'CAPTURE_ERROR_LOG_STACK_TRACES', CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES],
   ['captureExceptions', 'CAPTURE_EXCEPTIONS', true],
   ['centralConfig', 'CENTRAL_CONFIG', true],
   ['containerId', 'CONTAINER_ID'],
   ['contextPropagationOnly', 'CONTEXT_PROPAGATION_ONLY', false],
-  ['customMetricsHistogramBoundaries', 'CUSTOM_METRICS_HISTOGRAM_BOUNDARIES', config.DEFAULTS.customMetricsHistogramBoundaries.slice()],
+  ['customMetricsHistogramBoundaries', 'CUSTOM_METRICS_HISTOGRAM_BOUNDARIES', DEFAULTS.customMetricsHistogramBoundaries.slice()],
   ['disableSend', 'DISABLE_SEND', false],
   ['disableInstrumentations', 'DISABLE_INSTRUMENTATIONS', []],
   ['environment', 'ENVIRONMENT', 'development'],
@@ -468,7 +475,7 @@ bytesValues.forEach(function (key) {
   })
 })
 
-config.DURATION_OPTS.forEach(function (optSpec) {
+DURATION_OPTS.forEach(function (optSpec) {
   const key = optSpec.name
 
   // Skip the deprecated `spanFramesMinDuration` because config normalization
@@ -478,12 +485,12 @@ config.DURATION_OPTS.forEach(function (optSpec) {
   }
 
   let def
-  if (key in config.DEFAULTS) {
-    def = secondsFromDuration(config.DEFAULTS[key],
+  if (key in DEFAULTS) {
+    def = secondsFromDuration(DEFAULTS[key],
       optSpec.defaultUnit, optSpec.allowedUnits, optSpec.allowNegative)
   } else if (key === 'spanStackTraceMinDuration') {
     // Because of special handling in normalizeSpanStackTraceMinDuration()
-    // `spanStackTraceMinDuration` is not listed in `config.DEFAULTS`.
+    // `spanStackTraceMinDuration` is not listed in `DEFAULTS`.
     def = -1
   } else {
     def = undefined
@@ -1855,7 +1862,7 @@ test('contextManager', suite => {
 
 test('env variable names', suite => {
   // flatten
-  const names = [].concat(...Object.values(config.ENV_TABLE))
+  const names = [].concat(...Object.values(ENV_TABLE))
 
   // list of names we keep around for backwards compatability
   // but that don't conform to the ELASTIC_APM name

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -24,7 +24,7 @@ const agent = require('../../../..').start({
 
 const { URL } = require('url')
 
-const config = require('../../../../lib/config')
+const config = require('../../../../lib/config/config')
 const { safeGetPackageVersion } = require('../../../_utils')
 
 // Support running these tests with a different package name -- typically

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -24,7 +24,7 @@ const agent = require('../../../..').start({
 
 const { URL } = require('url')
 
-const config = require('../../../../lib/config/config')
+const { CONTEXT_MANAGER_PATCH } = require('../../../../lib/config/schema')
 const { safeGetPackageVersion } = require('../../../_utils')
 
 // Support running these tests with a different package name -- typically
@@ -398,7 +398,7 @@ if (semver.gte(process.version, '10.0.0')) {
   // clients. Also cannot test with contextManager="patch", because of the
   // limitation described in "modules/@elastic/elasticsearch.js".)
   if (semver.satisfies(esVersion, '>=8') &&
-      agent._conf.contextManager !== config.CONTEXT_MANAGER_PATCH) {
+      agent._conf.contextManager !== CONTEXT_MANAGER_PATCH) {
     test('cluster name from "x-found-handling-cluster"', function (t) {
       // Create a mock Elasticsearch server that mimics a search response from
       // a cloud instance.
@@ -986,7 +986,7 @@ function checkDataAndEnd (t, expectedName, expectedHttpUrl, expectedStatusCode, 
     // a limitation such that some HTTP context fields cannot be captured.
     // (See "Limitations" section in the instrumentation code.)
     if (semver.satisfies(esVersion, '>=8', { includePrerelease: true }) &&
-          agent._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+          agent._conf.contextManager === CONTEXT_MANAGER_PATCH) {
       t.comment('skip span.context.http.{status_code,response} check because of contextManager="patch" + esVersion>=8 limitation')
     } else {
       t.equal(esSpan.context.http.status_code, expectedStatusCode, 'context.http.status_code')

--- a/test/instrumentation/modules/http/ignore-url-does-not-leak-trans.test.js
+++ b/test/instrumentation/modules/http/ignore-url-does-not-leak-trans.test.js
@@ -27,9 +27,9 @@ const apm = require('../../../..').start({
   }
 })
 
-const config = require('../../../../lib/config')
+const { CONTEXT_MANAGER_PATCH } = require('../../../../lib/config/schema')
 if (Number(process.versions.node.split('.')[0]) <= 8 &&
-    apm._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+    apm._conf.contextManager === CONTEXT_MANAGER_PATCH) {
   // With node v8 and contextManager="patch", i.e. relying on patch-async.js, we
   // do not support this test as written. Given node v8 support *and* arguably
   // patch-async.js support are near EOL, it isn't worth rewriting this test

--- a/test/traceContinuationStrategy.test.js
+++ b/test/traceContinuationStrategy.test.js
@@ -20,7 +20,7 @@ const http = require('http')
 const semver = require('semver')
 const tape = require('tape')
 
-const config = require('../lib/config')
+const { CONTEXT_MANAGER_PATCH } = require('../lib/config/schema')
 
 // Ensure that, by default, an HTTP request with a valid traceparent to an
 // instrumented HTTP server *uses* that traceparent.
@@ -67,7 +67,7 @@ tape.test('traceContinuationStrategy=continue', t => {
   })
   server.listen(function () {
     if (semver.satisfies(process.version, '<=8') &&
-        apm._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+        apm._conf.contextManager === CONTEXT_MANAGER_PATCH) {
       // There is some bug in node v8 and lower and with contextManager="patch"
       // instrumentation where this listener callback takes the run context of
       // the preceding test's transaction. Hack it back.
@@ -109,7 +109,7 @@ tape.test('traceContinuationStrategy=restart', t => {
   })
   server.listen(function () {
     if (semver.satisfies(process.version, '<=8') &&
-        apm._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+        apm._conf.contextManager === CONTEXT_MANAGER_PATCH) {
       // There is some bug in node v8 and lower and with contextManager="patch"
       // instrumentation where this listener callback takes the run context of
       // the preceding test's transaction. Hack it back.
@@ -155,7 +155,7 @@ tape.test('traceContinuationStrategy=restart_external (no tracestate)', t => {
   })
   server.listen(function () {
     if (semver.satisfies(process.version, '<=8') &&
-        apm._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+        apm._conf.contextManager === CONTEXT_MANAGER_PATCH) {
       // There is some bug in node v8 and lower and with contextManager="patch"
       // instrumentation where this listener callback takes the run context of
       // the preceding test's transaction. Hack it back.
@@ -200,7 +200,7 @@ tape.test('traceContinuationStrategy=restart_external (tracestate without "es")'
   })
   server.listen(function () {
     if (semver.satisfies(process.version, '<=8') &&
-        apm._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+        apm._conf.contextManager === CONTEXT_MANAGER_PATCH) {
       // There is some bug in node v8 and lower and with contextManager="patch"
       // instrumentation where this listener callback takes the run context of
       // the preceding test's transaction. Hack it back.
@@ -244,7 +244,7 @@ tape.test('traceContinuationStrategy=restart_external (tracestate with "es")', t
   })
   server.listen(function () {
     if (semver.satisfies(process.version, '<=8') &&
-        apm._conf.contextManager === config.CONTEXT_MANAGER_PATCH) {
+        apm._conf.contextManager === CONTEXT_MANAGER_PATCH) {
       // There is some bug in node v8 and lower and with contextManager="patch"
       // instrumentation where this listener callback takes the run context of
       // the preceding test's transaction. Hack it back.


### PR DESCRIPTION
# Description

This is a continuation from a previous one (#3343) which aim for better organisation of the config logic without changing the behavior. What's don in this PR:
- move constant and defaults to `schema.js`. This file will contain in the future a schema object for easier config definitions (object shape to be discussed with \@trentm)
- moved last normalizers left in config file and added tests for them
- move `config.js` file in its own module alongside with `schema.js` and `normalizers.js` files
-  update `require` calls of the dependant modules

Relates to #3060 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
