### PR TITLE
chore: ignore mimic-response updates since they are not instrumented

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "elastic/apm-agent-node-js"
+    ignore:
+      # For mimic-response, ignore all versions https://github.com/elastic/apm-agent-nodejs/pull/3349#issuecomment-1549517238
+      - dependency-name: "mimic-response"
 
   - package-ecosystem: "npm"
     directory: "/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp"


### PR DESCRIPTION
# Description

Update `dependabot.yml` to ignore updates of `mimic-response` package. Reason behind this is the agent does not instrument any version higher than `1.0.0`

Sample dependabot PR trying to update the package https://github.com/elastic/apm-agent-nodejs/pull/3349

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
