### PR TITLE
chore: add tedious v16 in tav tests and agent checks

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -392,7 +392,7 @@ tedious-v15-v16:
   commands: node test/instrumentation/modules/tedious.test.js
 tedious:
   name: tedious
-  node: '>=15'
+  node: '>=16'
   versions: '16.0.0 || 16.1.0 || 16.1.0 <17' # first and last majors subset of '16.x'
   commands: node test/instrumentation/modules/tedious.test.js
 

--- a/.tav.yml
+++ b/.tav.yml
@@ -393,7 +393,7 @@ tedious-v15-v16:
 tedious:
   name: tedious
   node: '>=16'
-  versions: '16.0.0 || 16.1.0 || 16.1.0 <17' # first and last majors subset of '16.x'
+  versions: '16.0.0 || 16.1.0 || >16.1.0 <17' # first and last majors subset of '16.x'
   commands: node test/instrumentation/modules/tedious.test.js
 
 

--- a/.tav.yml
+++ b/.tav.yml
@@ -385,11 +385,17 @@ tedious-v12-v15:
   # first and last majors subset of '12.x || 13.x || 14.x'
   versions: '12.0.0 || 12.3.0 || 13.0.0 || 13.2.0 || 14.0.0 || 14.7.0 || >14.7.0 <15'
   commands: node test/instrumentation/modules/tedious.test.js
-tedious:
+tedious-v15-v16:
   name: tedious
   node: '>=14'
   versions: '15.0.0 || 15.1.3 || >15.1.3 <16' # first and last majors subset of '15.x'
   commands: node test/instrumentation/modules/tedious.test.js
+tedious:
+  name: tedious
+  node: '>=15'
+  versions: '16.0.0 || 16.1.0 || 16.1.0 <17' # first and last majors subset of '16.x'
+  commands: node test/instrumentation/modules/tedious.test.js
+
 
 cassandra-driver:
   # 3.1.0 is broken

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,12 +39,11 @@ Notes:
 [float]
 ===== Features
 
+* Add `tedious@16.x` support
+  ({pull}3366[#3366])
+
 [float]
 ===== Bug fixes
-
-* Fix a new case in instrumentation of `tedious` since new version 16 drops support
-  of node v14. Agent should guard instrumentation of a version mismatch.
-  ({issues}3365[#3365])
 
 [float]
 ===== Chores

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,24 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix a new case in instrumentation of `tedious` since new version 16 drops support
+  of node v14. Agent should guard instrumentation of a version mismatch.
+  ({issues}3365[#3365])
+
+[float]
+===== Chores
+
 
 [[release-notes-3.46.0]]
 ==== 3.46.0 - 2023/05/15

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -161,7 +161,7 @@ so those should be supported as well.
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <4.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/redis[redis] |>=2.0.0 <5.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <16.0.0 | (Excluding v4.0.0.) Will instrument all queries
+|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <17.0.0 | (Excluding v4.0.0.) Will instrument all queries
 |https://www.npmjs.com/package/undici[undici] | >=4.7.1 <6 | Will instrument undici HTTP requests, except HTTP CONNECT. Requires node v14.17.0 or later, or the user to have installed the https://www.npmjs.com/package/diagnostics_channel['diagnostics_channel' polyfill].
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages
 |=======================================================================

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -14,7 +14,7 @@ var { getDBDestination } = require('../context')
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious
-  if (!semver.satisfies(version, '>=1.9.0 <17')) {
+  if (version === '4.0.0' || !semver.satisfies(version, '>=1.9.0 <17')) {
     agent.logger.debug('tedious version %s not supported - aborting...', version)
     return tedious
   }

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -14,7 +14,7 @@ var { getDBDestination } = require('../context')
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious
-  if (!semver.satisfies(version, '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x || 15.x || 16.x')) {
+  if (!semver.satisfies(version, '>=1.9.0 <17')) {
     agent.logger.debug('tedious version %s not supported - aborting...', version)
     return tedious
   }

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -14,7 +14,7 @@ var { getDBDestination } = require('../context')
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious
-  if (!semver.satisfies(version, '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x || 15.x')) {
+  if (!semver.satisfies(version, '^1.9.0 || 2.x || 3.x || ^4.0.1 || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x || 15.x || 16.x')) {
     agent.logger.debug('tedious version %s not supported - aborting...', version)
     return tedious
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "rimraf": "^3.0.2",
         "tap-junit": "^5.0.1",
         "tape": "^5.0.0",
-        "tedious": "^15.1.0",
+        "tedious": "^16.1.0",
         "test-all-versions": "^4.1.1",
         "thunky": "^1.1.0",
         "tree-kill": "^1.2.2",
@@ -5426,15 +5426,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
-    },
-    "node_modules/@types/es-aggregate-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.2.tgz",
-      "integrity": "sha512-erqUpFXksaeR2kejKnhnjZjbFxUpGZx4Z7ydNL9ie8tEhXPiZTsLeUDJ6aR1F8j5wWUAtOAQWUqkc7givBJbBA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/express": {
       "version": "4.17.14",
@@ -16030,27 +16021,26 @@
       }
     },
     "node_modules/tedious": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.0.tgz",
-      "integrity": "sha512-D96Z8SL4ALE/rS6rOAfzWd/x+RD9vWbnNT3w5KZ0e0Tdh5FX1bKEODS+1oemSQM2ok5SktLHqSJqYQRx4yu3WA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.1.0.tgz",
+      "integrity": "sha512-5W+shTkUoAyrB/Bbx89k6Q8Cb400OHzS6XDXQdsTp/obe1cFyOhNc1KI4FI6TOzklDGJWyLnEEfUSBVMpugnjA==",
       "dev": true,
       "dependencies": {
         "@azure/identity": "^2.0.4",
         "@azure/keyvault-keys": "^4.4.0",
         "@js-joda/core": "^5.2.0",
-        "@types/es-aggregate-error": "^1.0.2",
         "bl": "^5.0.0",
         "es-aggregate-error": "^1.0.8",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "punycode": "^2.1.0",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/tedious/node_modules/bl": {
@@ -21508,15 +21498,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
-    },
-    "@types/es-aggregate-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.2.tgz",
-      "integrity": "sha512-erqUpFXksaeR2kejKnhnjZjbFxUpGZx4Z7ydNL9ie8tEhXPiZTsLeUDJ6aR1F8j5wWUAtOAQWUqkc7givBJbBA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/express": {
       "version": "4.17.14",
@@ -29826,22 +29807,21 @@
       "dev": true
     },
     "tedious": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.0.tgz",
-      "integrity": "sha512-D96Z8SL4ALE/rS6rOAfzWd/x+RD9vWbnNT3w5KZ0e0Tdh5FX1bKEODS+1oemSQM2ok5SktLHqSJqYQRx4yu3WA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.1.0.tgz",
+      "integrity": "sha512-5W+shTkUoAyrB/Bbx89k6Q8Cb400OHzS6XDXQdsTp/obe1cFyOhNc1KI4FI6TOzklDGJWyLnEEfUSBVMpugnjA==",
       "dev": true,
       "requires": {
         "@azure/identity": "^2.0.4",
         "@azure/keyvault-keys": "^4.4.0",
         "@js-joda/core": "^5.2.0",
-        "@types/es-aggregate-error": "^1.0.2",
         "bl": "^5.0.0",
         "es-aggregate-error": "^1.0.8",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "punycode": "^2.1.0",
         "sprintf-js": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "rimraf": "^3.0.2",
     "tap-junit": "^5.0.1",
     "tape": "^5.0.0",
-    "tedious": "^15.1.0",
+    "tedious": "^16.1.0",
     "test-all-versions": "^4.1.1",
     "thunky": "^1.1.0",
     "tree-kill": "^1.2.2",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1061,7 +1061,7 @@ test('disableInstrumentations', function (t) {
     // https://github.com/restify/node-restify/issues/1888
     modules.delete('restify')
   }
-  if (semver.lt(process.version, '14.0.0')) {
+  if (semver.lt(process.version, '16.0.0')) {
     modules.delete('tedious')
   }
   if (semver.lt(process.version, '12.18.0')) {

--- a/test/instrumentation/modules/tedious.test.js
+++ b/test/instrumentation/modules/tedious.test.js
@@ -22,7 +22,8 @@ const agent = require('../../../').start({
 
 const tediousVer = require('../../../node_modules/tedious/package.json').version
 const semver = require('semver')
-if ((semver.gte(tediousVer, '15.0.0') && semver.lt(process.version, '14.0.0')) ||
+if ((semver.gte(tediousVer, '16.0.0') && semver.lt(process.version, '15.0.0')) ||
+    (semver.gte(tediousVer, '15.0.0') && semver.lt(process.version, '14.0.0')) ||
     (semver.gte(tediousVer, '12.0.0') && semver.lt(process.version, '12.3.0')) ||
     (semver.gte(tediousVer, '11.0.0') && semver.lt(process.version, '10.17.0'))) {
   console.log(`# SKIP tedious@${tediousVer} does not support node ${process.version}`)

--- a/test/instrumentation/modules/tedious.test.js
+++ b/test/instrumentation/modules/tedious.test.js
@@ -22,7 +22,7 @@ const agent = require('../../../').start({
 
 const tediousVer = require('../../../node_modules/tedious/package.json').version
 const semver = require('semver')
-if ((semver.gte(tediousVer, '16.0.0') && semver.lt(process.version, '15.0.0')) ||
+if ((semver.gte(tediousVer, '16.0.0') && semver.lt(process.version, '16.0.0')) ||
     (semver.gte(tediousVer, '15.0.0') && semver.lt(process.version, '14.0.0')) ||
     (semver.gte(tediousVer, '12.0.0') && semver.lt(process.version, '12.3.0')) ||
     (semver.gte(tediousVer, '11.0.0') && semver.lt(process.version, '10.17.0'))) {


### PR DESCRIPTION
# Description

Enable instrumentation of `tedious@16.x` and update `tav` tests according node versions supported by this new release.

Closes #3365 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
