### PR TITLE
test: fix Elasticsearch service setup, 8.7.1 requires a 'network.host' value

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "network.host="
+      - "network.host=_site_"
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=false"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
         env:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
-          network.host: ''
+          network.host: '_site_'
           transport.host: '127.0.0.1'
           http.host: '0.0.0.0'
           xpack.security.enabled: 'false'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "network.host="
+      - "network.host=_site_"
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=false"


### PR DESCRIPTION
Since the bump in Elasticsearch version in #3341, Elasticsearch TAV
tests in CI have been failing, because the ES service never comes up.
It is failing with:
    Exception in thread "main" org.elasticsearch.ElasticsearchParseException: null-valued setting found for key [network.host] found at line number [2], column number [14]

Special values are defined here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#network-interface-values

Refs: #3341
