### PR TITLE
Fix broken links from APM-Server 10874

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -164,7 +164,7 @@ apm.addMetadataFilter(function dropArgv(metadata) {
 
 Warning: It is the responsibility of the author to ensure the returned object
 conforms to the
-{apm-guide-ref}/metadata-api.html#metadata-schema[metadata schema]
+{apm-guide-ref}/metadata-api.html[metadata schema]
 otherwise all APM data injest will fail. A metadata filter that breaks the
 metadata will result in error logging from the agent, something like:
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -164,7 +164,7 @@ apm.addMetadataFilter(function dropArgv(metadata) {
 
 Warning: It is the responsibility of the author to ensure the returned object
 conforms to the
-{apm-guide-ref}/metadata-api.html[metadata schema]
+{apm-guide-ref}/api-metadata.html[metadata schema]
 otherwise all APM data injest will fail. A metadata filter that breaks the
 metadata will result in error logging from the agent, something like:
 


### PR DESCRIPTION
This is an attempt to fix some broken links in the current docs build:

```
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/3.x/agent-api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/metadata-api.html#metadata-schema
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/current/agent-api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/metadata-api.html#metadata-schema
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/nodejs/master/agent-api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/metadata-api.html#metadata-schema
```

The change would need to be backported from `main` and `3.x`.