### PR TITLE
docs: fix broken links to APM docs

### DIFF
--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -84,7 +84,7 @@ containing the data about to be sent to the APM Server.
 
 The format of the payload depends on the event type being sent.
 For details about the different formats,
-see the {apm-guide-ref}/intake-api.html[APM Server intake API documentation].
+see the {apm-guide-ref}/api-events.html[events intake API docs].
 
 The filter function is synchronous and should return the manipulated payload object.
 If a filter function doesn't return any value or returns a falsy value,
@@ -144,7 +144,7 @@ but the `fn` will only be called with span payloads.
 [small]#Added in: v3.14.0#
 
 Use `addMetadataFilter(fn)` to supply a filter function for the
-{apm-guide-ref}/metadata-api.html[metadata object]
+{apm-guide-ref}/api-metadata.html#api-metadata-schema[metadata object]
 sent to the APM Server. This will allow you to manipulate the data being
 sent, for instance to remove possibly sensitive information.
 
@@ -164,7 +164,7 @@ apm.addMetadataFilter(function dropArgv(metadata) {
 
 Warning: It is the responsibility of the author to ensure the returned object
 conforms to the
-{apm-guide-ref}/metadata-api.html#metadata-schema[metadata schema]
+{apm-guide-ref}/api-metadata.html#api-metadata-schema[metadata schema]
 otherwise all APM data injest will fail. A metadata filter that breaks the
 metadata will result in error logging from the agent, something like:
 
@@ -230,7 +230,7 @@ the context from the active transaction is used as context for the captured erro
 and any custom context given as the 2nd argument to <<apm-capture-error,`apm.captureError`>> takes precedence and is shallow merged on top.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 [[apm-set-label]]
 ==== `apm.setLabel(name, value[, stringify = true])`
@@ -255,7 +255,7 @@ it will also get tagged with the same label.
 TIP: Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable
 (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 Before using custom labels, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
@@ -285,7 +285,7 @@ it will also get tagged with the same labels.
 TIP: Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable
 (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 Before using custom labels, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
@@ -304,7 +304,7 @@ Extends the <<global-labels>> configuration. It allows setting labels that are a
 TIP: Labels are key/value pairs that are indexed by Elasticsearch and therefore searchable
 (as opposed to data set via <<apm-set-custom-context,`apm.setCustomContext()`>>).
 Before using custom labels, ensure you understand the different types of
-{apm-guide-ref}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
@@ -404,7 +404,7 @@ To ease debugging it's possible to send some extra data with each error you send
 The APM Server intake API supports a lot of different metadata fields,
 most of which are automatically managed by the Elastic APM Node.js Agent.
 But if you wish you can supply some extra details using `user` or `custom`.
-For more details on the properties accepted by the events intake API see the {apm-guide-ref}/events-api.html[events intake API docs].
+For more details on the properties accepted by the events intake API see the {apm-guide-ref}/api-events.html[events intake API docs].
 
 To supply any of these extra fields,
 use the optional options argument when calling `apm.captureError()`.

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -18,5 +18,5 @@ Using your favorite logging framework, you'd then need to inject this informatio
 
 When your logs contain the appropriate identifiers, the final step is to ingest them into the same
 Elasticsearch instance that contains your APM data. See
-link:https://www.elastic.co/guide/en/apm/guide/master/log-correlation.html#ingest-logs-in-es[Ingest your logs into Elasticsearch]
+{apm-guide-ref}/log-correlation.html#ingest-logs-in-es[Ingest your logs into Elasticsearch]
 for more information.

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -36,7 +36,7 @@ npm install elastic-apm-node elastic-apm-node-opentracing --save
 [[ot-terminologies]]
 === OpenTracing vs Elastic APM terminologies
 
-Elastic APM differentiates between {apm-guide-ref}/transactions.html[transactions] and {apm-guide-ref}/transaction-spans.html[spans].
+Elastic APM differentiates between {apm-guide-ref}/data-model-transactions.html[transactions] and {apm-guide-ref}/data-model-spans.html[spans].
 In the context of OpenTracing, a transaction can be thought of as a special kind of span.
 
 Because OpenTracing natively only has the concept of spans,
@@ -166,7 +166,7 @@ Baggage items are silently dropped.
 
 Only error logging is supported.
 Logging an Error object on the OpenTracing span will create an Elastic APM
-{apm-guide-ref}/errors.html[error].
+{apm-guide-ref}/data-model-errors.html[error].
 Example:
 
 [source,js]


### PR DESCRIPTION
Some PRs cannot pass the docs generation check. The logs reveal som broken links
https://elasticsearch-ci.elastic.co/job/elastic+apm-agent-nodejs+pull-request+build-docs/2604/console

This PRs fix the broken links. Once passed there should be another similar PR for `3.x` branch

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
