### PR TITLE
fix: sanitize field names shouldn't mutate the original object

### DIFF
--- a/lib/filters/sanitize-field-names.js
+++ b/lib/filters/sanitize-field-names.js
@@ -30,7 +30,7 @@ function redactKeysFromPostedFormVariables (body, requestHeaders, regexes) {
   // if body is a string, use querystring to create object,
   // pass to redactKeysFromObject, and reserialize as string
   if (typeof body === 'string') {
-    const objBody = redactKeysFromObject(querystring.parse(body), regexes);
+    const objBody = redactKeysFromObject(querystring.parse(body), regexes)
     return querystring.stringify(objBody)
   }
 

--- a/lib/filters/sanitize-field-names.js
+++ b/lib/filters/sanitize-field-names.js
@@ -30,31 +30,25 @@ function redactKeysFromPostedFormVariables (body, requestHeaders, regexes) {
   // if body is a string, use querystring to create object,
   // pass to redactKeysFromObject, and reserialize as string
   if (typeof body === 'string') {
-    const objBody = querystring.parse(body)
-    redactKeysFromObject(objBody, regexes)
+    const objBody = redactKeysFromObject(querystring.parse(body), regexes);
     return querystring.stringify(objBody)
   }
 
   return body
 }
 
-function redactKeyFromObject (obj, regex) {
-  for (const [key] of Object.entries(obj)) {
-    if (regex.test(key)) {
-      obj[key] = REDACTED
-    }
-  }
-  return obj
-}
-
 function redactKeysFromObject (obj, regexes) {
   if (!obj || !Array.isArray(regexes)) {
     return obj
   }
-  for (const [, regex] of regexes.entries()) {
-    redactKeyFromObject(obj, regex)
-  }
-  return obj
+
+  const result = {}
+  Object.keys(obj).forEach((key) => {
+    const shouldRedact = regexes.some((regex) => regex.test(key))
+    result[key] = shouldRedact ? REDACTED : obj[key]
+  })
+
+  return result
 }
 
 module.exports = {

--- a/test/sanitize-field-names/main.test.js
+++ b/test/sanitize-field-names/main.test.js
@@ -21,20 +21,20 @@ test('redactKeysFromObject tests', function (t) {
     three: 'four',
     five: 'six'
   }
-  redactKeysFromObject(obj1, [/th.*ee/])
-  t.equals(obj1.three, '[REDACTED]', 'key three redacted')
-  t.equals(obj1.one, 'two', 'key one remains in ibject')
-  t.equals(obj1.five, 'six', 'key five remains in object')
+  const redactedObj1 = redactKeysFromObject(obj1, [/th.*ee/])
+  t.equals(redactedObj1.three, '[REDACTED]', 'key three redacted')
+  t.equals(redactedObj1.one, 'two', 'key one remains in ibject')
+  t.equals(redactedObj1.five, 'six', 'key five remains in object')
 
   const obj2 = {
     one: 'two',
     three: 'four',
     five: 'six'
   }
-  redactKeysFromObject(obj2, [/th.*ee/, /three/, /.*five/])
-  t.equals(obj2.three, '[REDACTED]', 'key three redacted')
-  t.equals(obj2.one, 'two', 'key one remains in ibject')
-  t.equals(obj2.five, '[REDACTED]', 'key five redacted')
+  const redactedObj2 = redactKeysFromObject(obj2, [/th.*ee/, /three/, /.*five/])
+  t.equals(redactedObj2.three, '[REDACTED]', 'key three redacted')
+  t.equals(redactedObj2.one, 'two', 'key one remains in ibject')
+  t.equals(redactedObj2.five, '[REDACTED]', 'key five redacted')
 
   t.end()
 })


### PR DESCRIPTION
### Description
This PR changes the sanitize field name (redactKeysFromObject / redactKeysFromPostedFormVariables) to not mutate the original object

#### Current status

redactKeysFromObject / redactKeysFromPostedFormVariables mutate the original object which sanitized the original request / response  headers

For example, our stack running in the AWS Lambda functions it sanitized www-authenticate response header
<img width="495" alt="Screenshot 2023-05-26 at 10 47 21" src="https://github.com/elastic/apm-agent-nodejs/assets/788101/93b01e26-c8ac-4586-8ebf-baaa8b4699e1">


#### After this PR

redactKeysFromObject / redactKeysFromPostedFormVariables will return the new copy of the original object

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
