### PR TITLE
fix: do not start the Agent in "start.js" when in a Worker thread

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,18 +39,31 @@ Notes:
 [float]
 ===== Features
 
-* Add support for 'knex' version v1 and v2
-  ({pull}3355[#3355])
-* Add `tedious@16.x` support
-  ({pull}3366[#3366])
+* Add support for 'knex' version v1 and v2. ({pull}3355[#3355])
+* Add `tedious@16.x` support. ({pull}3366[#3366])
 
 [float]
 ===== Bug fixes
 
+* Change the "start.js" export to *not* start the APM agent inside a
+  https://nodejs.org/api/worker_threads.html[Node.js Worker thread].
++
+One way to start the APM agent is via `node -r elastic-apm-node/start.js ...` or
+`NODE_OPTIONS='-r elastic-apm-node/start.js`.  When a Node.js Worker thread is
+started, it inherits the `process.execArgv` and environment, which results in
+"start.js" being run in the context of the new thread. Starting an additional
+APM agent in each new Worker is arguably surprising. For now, "start.js" will
+avoid starting in a thread. The exact behavior may change in future versions.
++
+One undesirable effect of this change is that explicit use of "start.js" in
+code (`import 'elastic-apm-node/start.js'` or `require('elastic-apm-node/start.js')`)
+in a Worker will *not* start the APM agent. Instead, one must use:
+`require('elastic-apm-node').start()` or equivalent.
+
 [float]
 ===== Chores
 
-* Extract configuration's transport property to new `apm-client` module
+* Refactor transport handling to new internal `apm-client` module.
   ({pull}3372[#3372])
 
 

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -93,22 +93,24 @@ This start method exists for those that use a tool like Babel or esbuild to tran
 
 [source,js]
 ----
-import 'elastic-apm-node/start';
+import 'elastic-apm-node/start.js';
 
 // Application main code goes here.
 ----
 
 A limitation of this approach is that you cannot configure the agent with an options object, but instead have to rely on <<configuring-the-agent,one of the other methods of configuration>>, such as setting `ELASTIC_APM_...` environment variables.
 
+Note: As of elastic-apm-node version REPLACEME, the "elastic-apm-node/start.js" will *not start the agent in a Node.js Worker thread.*
+
 
 [[start-option-node-require-opt]]
-===== `node -r elastic-apm-node/start ...`
+===== `node -r elastic-apm-node/start.js ...`
 
-Another way to start the agent is with the `-r elastic-apm-node/start` https://nodejs.org/api/cli.html#-r---require-module[command line option to `node`]. This will import and start the APM agent before your application code starts. This method allows you to enable the agent _without touching any code_. This is the recommended start method for <<lambda,monitoring AWS Lambda functions>> and for tracing <<nextjs,a Next.js server>>.
+Another way to start the agent is with the `-r elastic-apm-node/start.js` https://nodejs.org/api/cli.html#-r---require-module[command line option to `node`]. This will load and start the APM agent before your application code starts. This method allows you to enable the agent _without touching any code_. This is the recommended start method for <<lambda,monitoring AWS Lambda functions>> and for tracing <<nextjs,a Next.js server>>.
 
 [source,bash]
 ----
-node -r elastic-apm-node/start app.js
+node -r elastic-apm-node/start.js app.js
 ----
 
 The `-r, --require` option can also be specified via the https://nodejs.org/api/cli.html#node_optionsoptions[`NODE_OPTIONS` environment variable]:
@@ -116,9 +118,11 @@ The `-r, --require` option can also be specified via the https://nodejs.org/api/
 [source,bash]
 ----
 # export ELASTIC_APM_...  # Configure the agent with envvars.
-export NODE_OPTIONS='-r elastic-apm-node/start'
+export NODE_OPTIONS='-r elastic-apm-node/start.js'
 node app.js
 ----
+
+Note: As of elastic-apm-node version REPLACEME, the "elastic-apm-node/start.js" will *not start the agent in a https://nodejs.org/api/worker_threads.html[Node.js Worker thread].* New Worker threads inherit the `process.execArgv` and environment, so "elastic-apm-node/start.js" is executed again. Starting a new APM agent in each Worker thread because of "start.js" is deemed surprise, so is disabled for now.
 
 
 [[start-option-separate-init-module]]

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -56,6 +56,14 @@ const {
   normalizeSpanStackTraceMinDuration
 } = require('./normalizers')
 
+let threadId
+try {
+  const workerThreads = require('worker_threads')
+  threadId = workerThreads.threadId
+} catch (_err) {
+  // pass
+}
+
 const EXCLUDE_FIELDS = {
   logger: true,
   transport: true
@@ -483,12 +491,12 @@ function loadConfigFile (filePath) {
  * @returns {Object} Object with agent, environment, and configuration data.
  */
 function getLoggingPreambleData (config, sources, configFilePath) {
-  // const optsFromSources = sources.reduce((prev, s) => Object.assign({}, s.opts, prev), {})
   const optsFromSources = sources.reduceRight((prev, s) => Object.assign(prev, s.opts), {})
   const result = {
     agentVersion: AGENT_VERSION,
     env: {
       pid: process.pid,
+      tid: threadId, // worker_threads docs do *not* specify if the main thread is always tid 0
       proctitle: process.title,
       // For darwin: https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history
       os: `${os.platform()} ${os.release()}`,

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -56,14 +56,6 @@ const {
   normalizeSpanStackTraceMinDuration
 } = require('./normalizers')
 
-let threadId
-try {
-  const workerThreads = require('worker_threads')
-  threadId = workerThreads.threadId
-} catch (_err) {
-  // pass
-}
-
 const EXCLUDE_FIELDS = {
   logger: true,
   transport: true
@@ -496,7 +488,6 @@ function getLoggingPreambleData (config, sources, configFilePath) {
     agentVersion: AGENT_VERSION,
     env: {
       pid: process.pid,
-      tid: threadId, // worker_threads docs do *not* specify if the main thread is always tid 0
       proctitle: process.title,
       // For darwin: https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history
       os: `${os.platform()} ${os.release()}`,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:tav": "./dev-utils/lint-tav-json.js",
     "coverage": "COVERAGE=true ./test/script/run_tests.sh",
     "test": "./test/script/run_tests.sh",
-    "test:deps": "dependency-check index.js start.js start-next.js 'lib/**/*.js' 'test/**/*.js' '!test/activation-method/fixtures' '!test/instrumentation/azure-functions/fixtures' '!test/instrumentation/modules/next/a-nextjs-app' '!test/opentelemetry-bridge' '!test/opentelemetry-metrics/fixtures' --no-dev -i async_hooks -i perf_hooks -i node:http -i @azure/functions-core",
+    "test:deps": "dependency-check index.js start.js start-next.js 'lib/**/*.js' 'test/**/*.js' '!test/activation-method/fixtures' '!test/instrumentation/azure-functions/fixtures' '!test/instrumentation/modules/next/a-nextjs-app' '!test/opentelemetry-bridge' '!test/opentelemetry-metrics/fixtures' --no-dev -i async_hooks -i perf_hooks -i node:http -i @azure/functions-core -i worker_threads",
     "test:tav": "(cd test/opentelemetry-metrics/fixtures && tav --quiet) && (cd test/opentelemetry-bridge && tav --quiet) && (cd test/instrumentation/modules/next/a-nextjs-app && tav --quiet) && tav --quiet",
     "test:types": "tsc --project test/types/tsconfig.json && tsc --project test/types/transpile/tsconfig.json && node test/types/transpile/index.js && tsc --project test/types/transpile-default/tsconfig.json && node test/types/transpile-default/index.js  # requires node >=14.17",
     "test:babel": "babel test/babel/src.js --out-file test/babel/out.js && cd test/babel && node out.js",

--- a/start-next.js
+++ b/start-next.js
@@ -9,19 +9,21 @@
 // Use this module via `node --require=elastic-apm-node/start-next.js ...`
 // to monitor a Next.js app with Elastic APM.
 
-const apm = require('./').start()
+const apm = require('./start.js')
 
+if (apm.isStarted()) {
 // Flush APM data on server process termination.
 // https://nextjs.org/docs/deployment#manual-graceful-shutdowns
 // Note: Support for NEXT_MANUAL_SIG_HANDLE was added in next@12.1.7-canary.7,
 // so this `apm.flush()` will only happen in that and later versions.
-process.env.NEXT_MANUAL_SIG_HANDLE = 1
-function flushApmAndExit () {
-  apm.flush(() => {
-    process.exit(0)
-  })
+  process.env.NEXT_MANUAL_SIG_HANDLE = 1
+  const flushApmAndExit = () => {
+    apm.flush(() => {
+      process.exit(0)
+    })
+  }
+  process.on('SIGTERM', flushApmAndExit)
+  process.on('SIGINT', flushApmAndExit)
 }
-process.on('SIGTERM', flushApmAndExit)
-process.on('SIGINT', flushApmAndExit)
 
 module.exports = apm

--- a/start.js
+++ b/start.js
@@ -19,6 +19,7 @@ try {
   var workerThreads = require('worker_threads')
   isMainThread = workerThreads.isMainThread
 } catch (_importErr) {
+  // worker_threads were added in node 12 and behind a flag in node ^10.5.0.
   isMainThread = true
 }
 if (isMainThread) {

--- a/start.js
+++ b/start.js
@@ -6,4 +6,23 @@
 
 'use strict'
 
-module.exports = require('./').start()
+// Load and start the APM agent.
+//
+// Note: Currently this will *not* start the agent in Worker threads because
+// that is arguably not desired default behavior when using:
+//    node --require=elastic-apm-node/start.js ...
+
+const apm = require('./')
+
+var isMainThread
+try {
+  var workerThreads = require('worker_threads')
+  isMainThread = workerThreads.isMainThread
+} catch (_importErr) {
+  isMainThread = true
+}
+if (isMainThread) {
+  apm.start()
+}
+
+module.exports = apm


### PR DESCRIPTION
This avoids the, arguably, surprise case of an additional APM agent
being started whenever a new Worker is created (see Node.js
`worker_thread` docs) if `node -r elastic-apm-node/start.js ...`
or `import 'elastic-apm-node/start.js'` is being used.

The former is especially surprising when using a loader with node v20:
    node --experimental-loader=elastic-apm-node/loader.mjs -r elastic-apm-node/start.js ...
because Node v20 has moved loader processing to a Worker... so the
"start.js" is executed again in that worker. The visible side-effect
is that the logging preamble is printed twice.

This change isn't ideal because an explicit use of
    import 'elastic-apm-node/start.js'
in TypeScript or ESM code for a worker does *not* start the APM agent.
That's a subtlety that we rely on documentation to explain away.

---

This is the first of a couple smaller PRs extracting changes from my ESM PR (https://github.com/elastic/apm-agent-nodejs/pull/3381).
