### PR TITLE
3.47.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,7 +44,7 @@ Notes:
 
 
 [[release-notes-3.47.0]]
-==== 3.46.0 - 2023/06/15
+==== 3.47.0 - 2023/06/15
 
 [float]
 ===== Breaking changes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,9 +47,6 @@ Notes:
 ==== 3.47.0 - 2023/06/15
 
 [float]
-===== Breaking changes
-
-[float]
 ===== Features
 
 * Add support for `knex` version v1 and v2. ({pull}3355[#3355])

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,7 @@ Notes:
 === Node.js Agent version 3.x
 
 [[release-notes-3.47.0]]
-==== 3.47.0 - 2023/06/15
+==== 3.47.0 - 2023/06/14
 
 [float]
 ===== Features

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,7 +44,7 @@ Notes:
 
 
 [[release-notes-3.47.0]]
-=== Node.js Agent version 3.47.0
+==== 3.46.0 - 2023/06/15
 
 [float]
 ===== Breaking changes
@@ -52,7 +52,7 @@ Notes:
 [float]
 ===== Features
 
-* Add support for 'knex' version v1 and v2. ({pull}3355[#3355])
+* Add support for `knex` version v1 and v2. ({pull}3355[#3355])
 
 * Add `tedious@16.x` support. ({pull}3366[#3366])
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,20 +28,8 @@ Notes:
         ==== x.x.x - YYYY/MM/DD
 ////
 
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
-
-[float]
-===== Bug fixes
-
-[float]
-===== Chores
-
+[[release-notes-3.x]]
+=== Node.js Agent version 3.x
 
 [[release-notes-3.47.0]]
 ==== 3.47.0 - 2023/06/15

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,8 +40,6 @@ Notes:
 * Add support for `knex` version v1 and v2. ({pull}3355[#3355])
 
 * Add `tedious@16.x` support. ({pull}3366[#3366])
-* Add `apm.setGlobalLabel()` to dynamically extend the `globalLabels` set in the initial config.
-  Refer to <<apm-set-global-label>> for details. ({pull}3337[#3337])
 
 * Add `apm.setGlobalLabel()` to dynamically extend the `globalLabels` set in
   the initial config. Refer to <<apm-set-global-label>> for details. ({pull}3337[#3337])

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,9 +28,6 @@ Notes:
         ==== x.x.x - YYYY/MM/DD
 ////
 
-[[release-notes-3.x]]
-=== Node.js Agent version 3.x
-
 ==== Unreleased
 
 [float]
@@ -39,8 +36,28 @@ Notes:
 [float]
 ===== Features
 
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+
+[[release-notes-3.47.0]]
+=== Node.js Agent version 3.47.0
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
 * Add support for 'knex' version v1 and v2. ({pull}3355[#3355])
+
 * Add `tedious@16.x` support. ({pull}3366[#3366])
+
+* Add `apm.setGlobalLabel()` to dynamically extend the `globalLabels` set in
+  the initial config. Refer to <<apm-set-global-label>> for details. ({pull}3337[#3337])
 
 [float]
 ===== Bug fixes
@@ -99,8 +116,6 @@ in a Worker will *not* start the APM agent. Instead, one must use:
   metrics to APM server. As well, you may use the OpenTelemetry Metrics SDK
   and the APM agent will automatically add a MetricReader to ship metrics to
   APM server. See the <<opentelemetry-bridge>> for details. ({pull}3152[#3152])
-
-* Add `apm.setGlobalLabel()` to dynamically extend the `globalLabels` set in the initial config. Refer to <<apm-set-global-label>> for details. ({pull}3337[#3337])
 
 [float]
 ===== Chores

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -294,7 +294,7 @@ Defining too many unique fields in an index is a condition that can lead to a
 [[apm-set-global-label]]
 ==== `apm.setGlobalLabel(name, value)`
 
-[small]#Added in: REPLACEME#
+[small]#Added in: 3.47.0#
 
 * `name` +{type-string}+
 * `value` +{type-string}+ | +{type-number}+ | +{type-boolean}+

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -294,7 +294,7 @@ Defining too many unique fields in an index is a condition that can lead to a
 [[apm-set-global-label]]
 ==== `apm.setGlobalLabel(name, value)`
 
-[small]#Added in: 3.47.0#
+[small]#Added in: v3.47.0#
 
 * `name` +{type-string}+
 * `value` +{type-string}+ | +{type-number}+ | +{type-boolean}+

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -100,7 +100,7 @@ import 'elastic-apm-node/start.js';
 
 A limitation of this approach is that you cannot configure the agent with an options object, but instead have to rely on <<configuring-the-agent,one of the other methods of configuration>>, such as setting `ELASTIC_APM_...` environment variables.
 
-Note: As of elastic-apm-node version REPLACEME, the "elastic-apm-node/start.js" will *not start the agent in a Node.js Worker thread.*
+Note: As of elastic-apm-node version 3.47.0, the "elastic-apm-node/start.js" will *not start the agent in a Node.js Worker thread.*
 
 
 [[start-option-node-require-opt]]
@@ -122,7 +122,7 @@ export NODE_OPTIONS='-r elastic-apm-node/start.js'
 node app.js
 ----
 
-Note: As of elastic-apm-node version REPLACEME, the "elastic-apm-node/start.js" will *not start the agent in a https://nodejs.org/api/worker_threads.html[Node.js Worker thread].* New Worker threads inherit the `process.execArgv` and environment, so "elastic-apm-node/start.js" is executed again. Starting a new APM agent in each Worker thread because of "start.js" is deemed surprise, so is disabled for now.
+Note: As of elastic-apm-node version 3.47.0, the "elastic-apm-node/start.js" will *not start the agent in a https://nodejs.org/api/worker_threads.html[Node.js Worker thread].* New Worker threads inherit the `process.execArgv` and environment, so "elastic-apm-node/start.js" is executed again. Starting a new APM agent in each Worker thread because of "start.js" is deemed surprise, so is disabled for now.
 
 
 [[start-option-separate-init-module]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.46.0",
+  "version": "3.47.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.46.0",
+      "version": "3.47.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.46.0",
+  "version": "3.47.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Release to get out some features, in particular the new `setGlobalLabel` API so our colleagues form the Kibana team can try it. this release is targeted for next Wednesday

### Highlights

- Add support for `knex` version v1 and v2.
- Add `tedious@16.x` support.
- Add `apm.setGlobalLabel()` to dynamically extend the `globalLabels` set in
  the initial config. Refer to [apm-set-global-label](https://www.elastic.co/guide/en/apm/agent/nodejs/master/agent-api.html#apm-set-global-label) for details.
- Change the `start.js` export to *not* start the APM agent inside a [Node.js Worker thread](https://nodejs.org/api/worker_threads.html)

### Checklist

- [x] Fix changelog entry for https://github.com/elastic/apm-agent-nodejs/pull/3337
- [x] merge https://github.com/elastic/apm-agent-nodejs/pull/3427
