### PR TITLE
fix: Started Supporting response.writableEnded in transaction's context.

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -115,7 +115,7 @@ function getContextFromResponse (res, conf, isError) {
 
   if (isError) {
     context.headers_sent = res.headersSent
-    context.finished = res.finished
+    context.finished = res.finished || res.writableEnded
   }
 
   return context

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -115,7 +115,11 @@ function getContextFromResponse (res, conf, isError) {
 
   if (isError) {
     context.headers_sent = res.headersSent
-    context.finished = Boolean(res.finished || res.writableEnded)
+    if (typeof res.finished === 'boolean') {
+      context.finished = res.finished
+    } else {
+      context.finished = res.writableEnded
+    }
   }
 
   return context

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -115,7 +115,7 @@ function getContextFromResponse (res, conf, isError) {
 
   if (isError) {
     context.headers_sent = res.headersSent
-    context.finished = res.finished || res.writableEnded
+    context.finished = Boolean(res.finished || res.writableEnded)
   }
 
   return context


### PR DESCRIPTION
Since response.finished property is deprecated as of the newer node versions and another property i.e. response.writableEnded is currently used in place of it. So started supporting the response.writableEnded in transaction's context. Also, the change is backward compatible as the response.finished is not removed yet. 
Fixes: #3428

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Update documentation
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
