### PR TITLE
test: fix a flaky test that was relying on www.google.com:81 behaviour

### DIFF
--- a/test/http-request.test.js
+++ b/test/http-request.test.js
@@ -10,6 +10,7 @@ var test = require('tape')
 
 const http = require('http')
 const { httpRequest } = require('../lib/http-request')
+const shimmer = require('../lib/instrumentation/shimmer')
 
 test('httpRequest - no timeouts', function (t) {
   const server = http.createServer(function onReq (_req, res) {
@@ -68,32 +69,56 @@ test('httpRequest - get timeout', function (t) {
 })
 
 test('httpRequest - get connectTimeout', function (t) {
-  // 1. Google firewalls port 81 such that it drops TCP SYN packets, so we
-  //    expect a *connection* timeout.
-  const req = httpRequest('http://www.google.com:81', {
-    connectTimeout: 100,
-    timeout: 5000
-  }, function onRes (res) {
-    t.fail('got client response, but did not expect it')
-  })
+  // A torturous Node.js http client Agent that breaks all socket connections
+  // by throwing away the 'connect' event on any created sockets.
+  class MyHttpAgent extends http.Agent {
+    createConnection (opts, cb) {
+      const socket = super.createConnection(opts, cb)
+      shimmer.wrap(socket, 'emit', function (origEmit) {
+        return function wrappedEmit (name) {
+          if (name === 'connect') {
+            return
+          }
+          return origEmit.call(this, ...arguments)
+        }
+      })
+      return socket
+    }
+  }
 
-  req.on('timeout', function () {
-    t.fail('got timeout, but did not expect it')
+  const server = http.createServer((req, res) => {
+    res.end('hi')
   })
+  server.listen(0, () => {
+    // 1. Send a request to a normal server, using a client HTTP agent that
+    // makes all connections time out.
+    const req = httpRequest(`http://127.0.0.1:${server.address().port}`, {
+      connectTimeout: 100,
+      timeout: 5000,
+      agent: new MyHttpAgent()
+    }, function onRes (res) {
+      t.fail('got client response, but did not expect it')
+    })
 
-  // 2. Get a 'connectTimeout' event.
-  req.on('connectTimeout', function () {
-    t.pass('got connectTimeout event, as expected')
-    // 3. It is the responsibility of the caller to clean up the request.
-    req.destroy(new Error('cleaning up after connectTimeout'))
+    req.on('timeout', function () {
+      t.fail('got timeout, but did not expect it')
+    })
+
+    // 2. Get a 'connectTimeout' event.
+    req.on('connectTimeout', function () {
+      t.pass('got connectTimeout event, as expected')
+      // 3. It is the responsibility of the caller to clean up the request.
+      req.destroy(new Error('cleaning up after connectTimeout'))
+    })
+
+    // 4. We expect an 'error' event from our self-called `res.destroy()`.
+    req.on('error', function (err) {
+      t.ok(err)
+      t.equal(err.message, 'cleaning up after connectTimeout')
+      t.end()
+      server.close()
+    })
+
+    req.end()
   })
-
-  // 5. We expect an 'error' event from our self-called `res.destroy()`.
-  req.on('error', function (err) {
-    t.ok(err)
-    t.equal(err.message, 'cleaning up after connectTimeout')
-    t.end()
-  })
-
-  req.end()
 })


### PR DESCRIPTION
The test was using www.google.com:81 behaviour of firewalling requests
to that port such that establishing a *connection* would hang long
enough for the code under test to emit a "connectionTimeout" event.
Recently a number of tests on unrelated PRs were getting an ECONNREFUSED
instead.
See https://github.com/elastic/apm-agent-nodejs/issues/3313#issuecomment-1591932919 for an example.

This changes the test to not rely on an external server, but uses a
custom http.Agent that drops socket "connect" events, there by
simulating a connection hang and timeout.
