### PR TITLE
fix: set the transaction parent for an incoming HTTP/2 request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ See <<esm>> for full details.
 
 * Ensure `apm.setGlobalLabel(...)` does not throw an error when apm is inactive.
   ({issues}3442[#3442])
+* Set the transaction parent for an incoming HTTP/2 request ({issues}1830[#1830])
 
 [float]
 ===== Chores

--- a/lib/instrumentation/modules/http2.js
+++ b/lib/instrumentation/modules/http2.js
@@ -61,7 +61,12 @@ module.exports = function (http2, agent, { enabled }) {
 
         agent.logger.debug('intercepted stream event call to http2.Server.prototype.emit')
 
-        const trans = agent.startTransaction()
+        const traceparent = headers.traceparent || headers['elastic-apm-traceparent']
+        const tracestate = headers.tracestate
+        const trans = agent.startTransaction(null, null, {
+          childOf: traceparent,
+          tracestate: tracestate
+        })
         trans.type = 'request'
         // `trans.req` and `trans.res` are fake representations of Node.js's
         // core `http.IncomingMessage` and `http.ServerResponse` objects,
@@ -105,8 +110,8 @@ module.exports = function (http2, agent, { enabled }) {
 
         agent.logger.debug('intercepted request event call to http2.Server.prototype.emit for %s', req.url)
 
-        var traceparent = req.headers.traceparent || req.headers['elastic-apm-traceparent']
-        var tracestate = req.headers.tracestate
+        const traceparent = req.headers.traceparent || req.headers['elastic-apm-traceparent']
+        const tracestate = req.headers.tracestate
         const trans = agent.startTransaction(null, null, {
           childOf: traceparent,
           tracestate: tracestate


### PR DESCRIPTION
With distributed tracing incoming http2 requests have no parent ids. This behavior can be observed using grpc/js module which is using http2 transport.

The change extracts parent ids and state from the request headers the similar way as it is done for http/1.

This fixes https://github.com/elastic/apm-agent-nodejs/issues/1830

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
