### PR TITLE
fix: @aws-sdk/client-s3 instrumentation was broken with 3.363.0 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,9 @@ See <<esm>> for full details.
 * Set the trace-context for an incoming HTTP/2 request. Contributed by @paulish.
   ({issues}1830[#1830])
 
+* Fix aws-sdk v3 instrumentation (currently just `@aws-sdk/client-s3`) for
+  versions 3.363.0 and later. ({pull}3455[#3455])
+
 [float]
 ===== Chores
 

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -37,7 +37,7 @@ const nodeHasInstrumentableFetch = typeof (global.fetch) === 'function'
 
 var MODULES = [
   '@apollo/server',
-  '@aws-sdk/smithy-client', // Instrument the base client which all AWS-SDK v3 clients extends
+  ['@aws-sdk/smithy-client', '@smithy/smithy-client'], // Instrument the base client which all AWS-SDK v3 clients extends.
   ['@elastic/elasticsearch', '@elastic/elasticsearch-canary'],
   '@opentelemetry/api',
   '@opentelemetry/sdk-metrics',
@@ -430,7 +430,7 @@ Instrumentation.prototype._patchModule = function (modExports, name, version, en
         continue
       }
 
-      modExports = patch(modExports, this._agent, { version, enabled, isImportMod })
+      modExports = patch(modExports, this._agent, { name, version, enabled, isImportMod })
     }
   }
   return modExports

--- a/lib/instrumentation/modules/@aws-sdk/smithy-client.js
+++ b/lib/instrumentation/modules/@aws-sdk/smithy-client.js
@@ -5,6 +5,7 @@
  */
 
 'use strict'
+
 const semver = require('semver')
 const shimmer = require('../../shimmer')
 const elasticAPMMiddlewares = Symbol('elasticAPMMiddlewares')
@@ -57,11 +58,15 @@ const clientsConfig = {
   }
 }
 
-module.exports = function (mod, agent, { version, enabled }) {
+module.exports = function (mod, agent, { name, version, enabled }) {
   if (!enabled) return mod
 
-  // We have to do this check since npm view reveals RC versions below 3
-  if (!semver.satisfies(version, '>=3 <4')) {
+  // As of `@aws-sdk/*@3.363.0` the underlying smithy-client is under the
+  // `@smithy/` npm org and is 1.x.
+  if (name === '@smithy/smithy-client' && !semver.satisfies(version, '>=1 <2')) {
+    agent.logger.debug('cannot instrument @aws-sdk/client-*: @smithy/smithy-client version %s not supported', version)
+    return mod
+  } else if (name === '@aws-sdk/smithy-client' && !semver.satisfies(version, '>=3 <4')) {
     agent.logger.debug('cannot instrument @aws-sdk/client-*: @aws-sdk/smithy-client version %s not supported', version)
     return mod
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       },
       "devDependencies": {
         "@apollo/server": "^4.2.2",
-        "@aws-sdk/client-s3": "^3.319.0",
+        "@aws-sdk/client-s3": "^3.363.0",
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.8.4",
         "@babel/preset-env": "^7.8.4",
@@ -787,19 +787,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
-      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/chunked-blob-reader": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
@@ -810,64 +797,64 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.328.0.tgz",
-      "integrity": "sha512-jYHukdhiICj8aiCg3DqjIeKkZs1xOmwXta/kjCbHQlaF17Rl43VLI3nT4rzXB6ixtqUW3I7Wvx61F9S+EOVl3A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.363.0.tgz",
+      "integrity": "sha512-LNnfg/t8wG5Fqj6l+PSV/t+IXDq9r3Kj9jEHn84513+p7bewXYSSreSpmLjG8OcKuMfHc9EJGNQ3DkMyFaLoWg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.328.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.328.0",
-        "@aws-sdk/eventstream-serde-browser": "3.310.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
-        "@aws-sdk/eventstream-serde-node": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-blob-browser": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/hash-stream-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/md5-js": "3.310.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-expect-continue": "3.325.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.326.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-location-constraint": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-sdk-s3": "3.326.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/middleware-ssec": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4-multi-region": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-stream-browser": "3.310.0",
-        "@aws-sdk/util-stream-node": "3.328.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.310.0",
+        "@aws-sdk/client-sts": "3.363.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/hash-blob-browser": "3.357.0",
+        "@aws-sdk/hash-stream-node": "3.357.0",
+        "@aws-sdk/md5-js": "3.357.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.363.0",
+        "@aws-sdk/middleware-expect-continue": "3.363.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-location-constraint": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-sdk-s3": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-ssec": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/signature-v4-multi-region": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/eventstream-serde-browser": "^1.0.1",
+        "@smithy/eventstream-serde-config-resolver": "^1.0.1",
+        "@smithy/eventstream-serde-node": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-stream": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "@smithy/util-waiter": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -875,42 +862,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.328.0.tgz",
-      "integrity": "sha512-IneVwc4j3bCXwCdNAALQ8VVrfFTFAb2f3FxerHv4DLx8OlMTvZiraDDJisfO+cXLl2WCJOJAzpAJTgrPA50LCg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
+      "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -918,42 +906,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.328.0.tgz",
-      "integrity": "sha512-2T6Snri7ovx9+q/iw/wZ1YHzz/SsxPuJOhgbJipCFW9f1IEPBIEKVZtywcKYzE1nYjyc6YanAqQMn6U2SPhW4A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
+      "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -961,61 +950,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.328.0.tgz",
-      "integrity": "sha512-Eedz24H7zLuTjJoCtNQEGOKbIlhibqyasFFwWsds6ds24hRF4fVrCKLwZWENZwawtJjjEdRESQe4dwpV5lWqtw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
+      "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.328.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-sdk-sts": "3.326.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-sdk-sts": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.1",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1023,29 +998,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
-      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
+      "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
-      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1053,19 +1013,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.328.0.tgz",
-      "integrity": "sha512-tOHzfWQUaQif1IciWs57MFM7bFc+693pnEhFCgT3wjzwjKGkq1QsNzfRlOp1QP4Glw6qV+kAAemEZj8mGth8Bg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
+      "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.328.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1073,20 +1034,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.328.0.tgz",
-      "integrity": "sha512-/omjTxrC8Vv6OPAK+66KNnjVmMZWyEQnQp8e8Y+RZvsuVaeQNJT5UQKSqrYtmqTX2T+yqJY7eVpx5CXBCGjc2g==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
+      "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.328.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.328.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-ini": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1094,14 +1056,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
-      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
+      "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1109,16 +1072,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.328.0.tgz",
-      "integrity": "sha512-6lSfA3AcoqNt+OYJoBimWmPmqUYVCHkE0Y+4HFN7JaXCyUknsO9/71P5zo/pp8Q7/yxP/aRyzjael82G5thj0A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
+      "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.328.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/token-providers": "3.328.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso": "3.363.0",
+        "@aws-sdk/token-providers": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1126,147 +1090,43 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
-      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
+      "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.310.0.tgz",
-      "integrity": "sha512-clIeSgWbZbxwtsxZ/yoedNM0/kJFSIjjHPikuDGhxhqc+vP6TN3oYyVMFrYwFaTFhk2+S5wZcWYMw8Op1pWo+A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.310.0.tgz",
-      "integrity": "sha512-3S6ziuQVALgEyz0TANGtYDVeG8ArK4Y05mcgrs8qUTmsvlDIXX37cR/DvmVbNB76M4IrsZeSAIajL9644CywkA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8s1Qdn9STj+sV75nUp9yt0W6fHS4BZ2jTm4Z/1Pcbvh2Gqs0WjH5n2StS+pDW5Y9J/HSGBl0ogmUr5lC5bXFHg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.310.0.tgz",
-      "integrity": "sha512-kSnRomCgW43K9TmQYuwN9+AoYPnhyOKroanUMyZEzJk7rpCPMj4OzaUpXfDYOvznFNYn7NLaH6nHLJAr0VPlJA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.310.0.tgz",
-      "integrity": "sha512-Qyjt5k/waV5cDukpgT824ISZAz5U0pwzLz5ztR409u85AGNkF/9n7MS+LSyBUBSb0WJ5pUeSD47WBk+nLq9Nhw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
-      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.310.0.tgz",
-      "integrity": "sha512-OoR8p0cbypToysLT0v3o2oyjy6+DKrY7GNCAzHOHJK9xmqXCt+DsjKoPeiY7o1sWX2aN6Plmvubj/zWxMKEn/A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.357.0.tgz",
+      "integrity": "sha512-RDd6UgrGHDmleTnXM9LRSSVa69euSAG2mlNhZMEDWk3OFseXVYqBDaqroVbQ01rM2UAe8MeBFchlV9OmxuVgvw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/chunked-blob-reader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
-      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.310.0.tgz",
-      "integrity": "sha512-ZoXdybNgvMz1Hl6k/e32xVL3jmG5p2IEk5mTtLfFEuskTJ74Z+VMYKkkF1whyy7KQfH83H+TQGnsGtlRCchQKw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.357.0.tgz",
+      "integrity": "sha512-KZjN1VAw1KHNp+xKVOWBGS+MpaYQTjZFD5f+7QQqW4TfbAkFFwIAEYIHq5Q8Gw+jVh0h61OrV/LyW3J2PVzc+w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
-      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
@@ -1282,56 +1142,27 @@
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.310.0.tgz",
-      "integrity": "sha512-x5sRBUrEfLWAS1EhwbbDQ7cXq6uvBxh3qR2XAsnGvFFceTeAadk7cVogWxlk3PC+OCeeym7c3/6Bv2HQ2f1YyQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.357.0.tgz",
+      "integrity": "sha512-to42sFAL7KgV/X9X40LLfEaNMHMGQL6/7mPMVCL/W2BZf3zw5OTl3lAaNyjXA+gO5Uo4lFEiQKAQVKNbr8b8Nw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.310.0.tgz",
-      "integrity": "sha512-uJJfHI7v4AgbJZRLtyI8ap2QRWkBokGc3iyUoQ+dVNT3/CE2ZCu694A6W+H0dRqg79dIE+f9CRNdtLGa/Ehhvg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.363.0.tgz",
+      "integrity": "sha512-kR8+0X50zslpzRW29q4JbpPMadE1z39ZfGwPaBLKpoWvSGt4x+75FaoK71TH7urPPoFyD2Y+XKGA6YRYTUNHSQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
-      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
-      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-config-provider": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1339,13 +1170,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.325.0.tgz",
-      "integrity": "sha512-Hj4D+zeet4gdUpSiMeHZfIzcnXkZI2krGyUw4U1psPzCqOp7WP5307g+1NWXOlVu3H3tF5r3rEgthQOQj2zNfA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.363.0.tgz",
+      "integrity": "sha512-I88xneZp6jRwySmIl9uI7eZCcTsqRVnTDfUr1JiXt7zonqNNm80PVYMs6pwaw7t97ec1AQJcsONjuXZyCMnu5g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1353,17 +1185,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.326.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.326.0.tgz",
-      "integrity": "sha512-MtcvSU+wKu4/a/trIJmb4Tfb682U9uP5YYA5aXzdhxOxG11wj86uBIeQrdbUxhtTXMgmvwn1193dvTi91EUEaQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.363.0.tgz",
+      "integrity": "sha512-FBYmrMRX01uNximNN0WLgpf97GN4xNTLaKsDlkjYRWKJ+J97ICkvLG0FcSu7+SNCpCdJJBeQ5tRVOPVpUu6nmA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/is-array-buffer": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1371,13 +1204,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
-      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
+      "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1385,12 +1219,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.325.0.tgz",
-      "integrity": "sha512-T2OrpXXY9I1nHvIGSlQD6qj1FDG3WDFSu65+Bh4pMl+zVh0IqIEajiK++TfrdQl+sJxRGQd/euoeXXL4JYw9JA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.363.0.tgz",
+      "integrity": "sha512-piNzpNNI/fChSGOZxcq/2msN2qFUSEAbhqs91zbcpv8CEPekVLc4W9laXCG764BEMyfG97ZU8MtzwHeMhELhBA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1398,12 +1233,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
-      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
+      "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1411,46 +1247,30 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
-      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
+      "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.327.0.tgz",
-      "integrity": "sha512-LCG+oRIPc4XJ+DYqkSCgggavxWi4+hP3Rw40vHdHMNvJpCiUJMwVJ+dULEywEP/WZvr4AEkWiRrHmJVpSLeZ+Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/service-error-classification": "3.327.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.326.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.326.0.tgz",
-      "integrity": "sha512-IyonHEiDMn0fdYWxA/TAnNj8M/xG5EJWvoOKcakl891f+JPaWeRsV2oE1fIjqM/waM3jqNXLDTrm06QfAYmgBQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.363.0.tgz",
+      "integrity": "sha512-npC8vLCero+vULizrK0QPjNanWbgH4A/2Llc1nO8N005uvUe7co6WglILF2W3guZrFk/0uGEdX67OnLxUD97pw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1458,26 +1278,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.326.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.326.0.tgz",
-      "integrity": "sha512-suOkuXxyAfOH0hznK63ZU10EoytKX5YPs9amO416VbgYFtuIeliCmntYfnl1jUvutp0fctGGpEGE9OnoYI+fhw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
+      "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
-      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1485,16 +1293,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
-      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
+      "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1502,24 +1311,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.325.0.tgz",
-      "integrity": "sha512-hxmvvWVfVrbfUw8pDEPlsR6Sb+IUdhq0cOJc7SL5XO9ddRXJ5DjT2Z2ao9FB424hJgAcOrqIO5ECjdIRs+O4FQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.363.0.tgz",
+      "integrity": "sha512-pN+QN1rMShYpJnTJSCIYnNRhD0S8xSZsTn6ThgcO559Xiwz5LMHFOfOXUCEyxtbVW5kMHLUh3w101AMUKae99A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
-      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
-      "dev": true,
-      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1527,138 +1325,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.327.0.tgz",
-      "integrity": "sha512-4rDSNY1xhlqfRcY97CQKcgs6AOe4ovtiRdCAjg2InnLOZHRVFoHhOIDxWNK2W1K2Pl65z4EGH6RXmB1t0srJHA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
+      "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
-      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.328.0.tgz",
-      "integrity": "sha512-zxXdNfdSGi6w/1bopllxAYAufCGDNG2eLenR3Tjj/UVBGrvS4ME5NGInu6u4LirTdkSqYlZkqKMyfiZ6XxGfdQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
-      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
-      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
-      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
-      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.327.0.tgz",
-      "integrity": "sha512-bCWnw+uH3gI6yPxLi4a4WV71P1KlJU7Z4+iMBY1Gt4+ZsaPAJX9pAbuQcFhFH++4xTk/QaVMzSvD0uQ+u0B/NQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
-      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
-      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1666,14 +1341,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.310.0.tgz",
-      "integrity": "sha512-q8W+RIomTS/q85Ntgks/CoDElwqkC9+4OCicee5YznNHjQ4gtNWhUkYIyIRWRmXa/qx/AUreW9DM8FAecCOdng==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
+      "integrity": "sha512-iWamQSpaBKg88LKuiUq8xO/7iyxJ+ORkA3qDhAwUqyTJOg87ma47yFf4ycCKqINnflc3AIGLGzBHnkBc4cMF5g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1688,30 +1364,17 @@
         }
       }
     },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
-      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.328.0.tgz",
-      "integrity": "sha512-AWrRwa0RqSiz9CT3QKuMYuZsRXaeKCp8kMsx1CgrG5VUaag+NhDBBMYVbxgb0SyoqbsGC+wDUXtSCZctrE7Z3Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
+      "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.328.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso-oidc": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1719,66 +1382,21 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
-      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
-      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
       "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1800,69 +1418,13 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
-      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
-      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.327.0.tgz",
-      "integrity": "sha512-2+2jTfBzhXsfpOci61gzaoBUVdGhFWja7k5cLAfOaRROkK+m+Zv532+m3cCQZjBXJ6pJ952MbiAroRSjFq0/SQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dev": true,
-      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1881,91 +1443,27 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
-      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.327.0.tgz",
-      "integrity": "sha512-y15NLGTAT2vaLzA8klJ6Bo8NGjVAa3/njqc4iCbta/3GqKpQU0zbvw3Y5aWyHp8BhV4DSUTp088jWjaoZlSqgw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.327.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.310.0.tgz",
-      "integrity": "sha512-bysXZHwFwvbqOTCScCdCnoLk1K3GCo0HRIYEZuL7O7MHrQmfaYRXcaft/p22+GUv9VeFXS/eJJZ5r4u32az94w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.328.0.tgz",
-      "integrity": "sha512-9h8oji5OTmatXMfPIasAapL59QDO7TR0J/B5Y3ERwGxy2U373LEy8Uvs+mbPIIQV1ztCLwHWDxKQoTUj4hLxoQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
-      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
+      "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
-      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
+      "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2000,20 +1498,6 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
-      "integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
@@ -5497,6 +4981,589 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
+      "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-config-provider": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
+      "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
+      "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-1.0.1.tgz",
+      "integrity": "sha512-oc8vxe+AU2RzvXH/Ehh0TzM/Nsw3I3ywu7V3qaCzqdkBIntAwK9JGZqcSDsqTK0WxZKBRgFIEwopcuZ2slVnFQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.1.tgz",
+      "integrity": "sha512-TJwaXima0djnNY819utO1j93qZHaheFH1bhHxBkMrImtEOuXY48Tjma/L2m8swkIq8dy8jFC9hrYOkD0eYHkFA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-1.0.1.tgz",
+      "integrity": "sha512-JEj8w7IRs4l+kcwKxbv3pNuu8n7ORC4pMFrIOrM4rERzrRnI7vMNTRzvAPGYA53rqm/Y9tBA9dw4C+H6hLXcsA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-1.0.1.tgz",
+      "integrity": "sha512-c6m9DH7m6D2S93dof4wSxysaGSQdauO20TNcSePzrgHd4rkTnz5pqZ1a7Pt22q2SKf09SvTugq5cV2Sy4r8zHw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
+      "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-base64": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
+      "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-buffer-from": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
+      "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
+      "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.1.tgz",
+      "integrity": "sha512-XEHPq73PPm0sXul//5MRC8JKDwHTaNjV3myd9FJ5YoUT+QMJ27gqiwwAMVASJ6vC4ELHzgQdmoTZxVX83Jx17w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.2.tgz",
+      "integrity": "sha512-Osj+XsqJ67RuX1MLc3+7LDtlRz8eNVqr/Pim9yPAjRa03Xberu6ST3a3oV3NqRpcUgMTifxuaKVIciuPE3rTWA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/service-error-classification": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
+      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
+      "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
+      "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
+      "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
+      "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
+      "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-uri-escape": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
+      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.1.tgz",
+      "integrity": "sha512-EcFVOHFv4YZHUrJ6161tpPKXNlQsTAQKoKorODxuOQW1my14mgoyiiMXrlnSMaYRF//oaONYfFOQ2EMAUTC5DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
+      "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
+      "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^1.0.1",
+        "@smithy/is-array-buffer": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/util-uri-escape": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
+      "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-stream": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
+      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
+      "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
+      "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
+      "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
+      "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
+      "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
+      "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
+      "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
+      "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
+      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.2.tgz",
+      "integrity": "sha512-LqzAy1QzeAHpSZpsd2LtKZRbco7F5gF+Zpoa4TuuFq9f+CGmH6OuTCIN3I13LPEBa4zs2AgvGnXljvMbUw5WGw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
+      "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-buffer-from": "^1.0.1",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
+      "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
+      "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.0.1.tgz",
+      "integrity": "sha512-dsn8O0s3pFIgxFzySLe1dv0w4tEQizEP6UqbgZ4r/Kar4n8pSdrPi6DJg8BzXwkwEIZpMtV4/nhSeGZ7HksDXA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -9433,19 +9500,25 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastify": {
@@ -17695,16 +17768,6 @@
         }
       }
     },
-    "@aws-sdk/abort-controller": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
-      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
     "@aws-sdk/chunked-blob-reader": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
@@ -17715,408 +17778,302 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.328.0.tgz",
-      "integrity": "sha512-jYHukdhiICj8aiCg3DqjIeKkZs1xOmwXta/kjCbHQlaF17Rl43VLI3nT4rzXB6ixtqUW3I7Wvx61F9S+EOVl3A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.363.0.tgz",
+      "integrity": "sha512-LNnfg/t8wG5Fqj6l+PSV/t+IXDq9r3Kj9jEHn84513+p7bewXYSSreSpmLjG8OcKuMfHc9EJGNQ3DkMyFaLoWg==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.328.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.328.0",
-        "@aws-sdk/eventstream-serde-browser": "3.310.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
-        "@aws-sdk/eventstream-serde-node": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-blob-browser": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/hash-stream-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/md5-js": "3.310.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-expect-continue": "3.325.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.326.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-location-constraint": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-sdk-s3": "3.326.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/middleware-ssec": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4-multi-region": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-stream-browser": "3.310.0",
-        "@aws-sdk/util-stream-node": "3.328.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.310.0",
+        "@aws-sdk/client-sts": "3.363.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/hash-blob-browser": "3.357.0",
+        "@aws-sdk/hash-stream-node": "3.357.0",
+        "@aws-sdk/md5-js": "3.357.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.363.0",
+        "@aws-sdk/middleware-expect-continue": "3.363.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-location-constraint": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-sdk-s3": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-ssec": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/signature-v4-multi-region": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/eventstream-serde-browser": "^1.0.1",
+        "@smithy/eventstream-serde-config-resolver": "^1.0.1",
+        "@smithy/eventstream-serde-node": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-stream": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "@smithy/util-waiter": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.328.0.tgz",
-      "integrity": "sha512-IneVwc4j3bCXwCdNAALQ8VVrfFTFAb2f3FxerHv4DLx8OlMTvZiraDDJisfO+cXLl2WCJOJAzpAJTgrPA50LCg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
+      "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.328.0.tgz",
-      "integrity": "sha512-2T6Snri7ovx9+q/iw/wZ1YHzz/SsxPuJOhgbJipCFW9f1IEPBIEKVZtywcKYzE1nYjyc6YanAqQMn6U2SPhW4A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
+      "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.328.0.tgz",
-      "integrity": "sha512-Eedz24H7zLuTjJoCtNQEGOKbIlhibqyasFFwWsds6ds24hRF4fVrCKLwZWENZwawtJjjEdRESQe4dwpV5lWqtw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
+      "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.328.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.327.0",
-        "@aws-sdk/middleware-sdk-sts": "3.326.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.327.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-sdk-sts": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.1",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
-      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
+      "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
-      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.328.0.tgz",
-      "integrity": "sha512-tOHzfWQUaQif1IciWs57MFM7bFc+693pnEhFCgT3wjzwjKGkq1QsNzfRlOp1QP4Glw6qV+kAAemEZj8mGth8Bg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
+      "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.328.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.328.0.tgz",
-      "integrity": "sha512-/omjTxrC8Vv6OPAK+66KNnjVmMZWyEQnQp8e8Y+RZvsuVaeQNJT5UQKSqrYtmqTX2T+yqJY7eVpx5CXBCGjc2g==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
+      "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.328.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.328.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-ini": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
-      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
+      "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.328.0.tgz",
-      "integrity": "sha512-6lSfA3AcoqNt+OYJoBimWmPmqUYVCHkE0Y+4HFN7JaXCyUknsO9/71P5zo/pp8Q7/yxP/aRyzjael82G5thj0A==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
+      "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.328.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/token-providers": "3.328.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso": "3.363.0",
+        "@aws-sdk/token-providers": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
-      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
+      "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-codec": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.310.0.tgz",
-      "integrity": "sha512-clIeSgWbZbxwtsxZ/yoedNM0/kJFSIjjHPikuDGhxhqc+vP6TN3oYyVMFrYwFaTFhk2+S5wZcWYMw8Op1pWo+A==",
-      "dev": true,
-      "requires": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.310.0.tgz",
-      "integrity": "sha512-3S6ziuQVALgEyz0TANGtYDVeG8ArK4Y05mcgrs8qUTmsvlDIXX37cR/DvmVbNB76M4IrsZeSAIajL9644CywkA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8s1Qdn9STj+sV75nUp9yt0W6fHS4BZ2jTm4Z/1Pcbvh2Gqs0WjH5n2StS+pDW5Y9J/HSGBl0ogmUr5lC5bXFHg==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-serde-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.310.0.tgz",
-      "integrity": "sha512-kSnRomCgW43K9TmQYuwN9+AoYPnhyOKroanUMyZEzJk7rpCPMj4OzaUpXfDYOvznFNYn7NLaH6nHLJAr0VPlJA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.310.0.tgz",
-      "integrity": "sha512-Qyjt5k/waV5cDukpgT824ISZAz5U0pwzLz5ztR409u85AGNkF/9n7MS+LSyBUBSb0WJ5pUeSD47WBk+nLq9Nhw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/eventstream-codec": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
-      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.310.0.tgz",
-      "integrity": "sha512-OoR8p0cbypToysLT0v3o2oyjy6+DKrY7GNCAzHOHJK9xmqXCt+DsjKoPeiY7o1sWX2aN6Plmvubj/zWxMKEn/A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.357.0.tgz",
+      "integrity": "sha512-RDd6UgrGHDmleTnXM9LRSSVa69euSAG2mlNhZMEDWk3OFseXVYqBDaqroVbQ01rM2UAe8MeBFchlV9OmxuVgvw==",
       "dev": true,
       "requires": {
         "@aws-sdk/chunked-blob-reader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
-      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.310.0.tgz",
-      "integrity": "sha512-ZoXdybNgvMz1Hl6k/e32xVL3jmG5p2IEk5mTtLfFEuskTJ74Z+VMYKkkF1whyy7KQfH83H+TQGnsGtlRCchQKw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.357.0.tgz",
+      "integrity": "sha512-KZjN1VAw1KHNp+xKVOWBGS+MpaYQTjZFD5f+7QQqW4TfbAkFFwIAEYIHq5Q8Gw+jVh0h61OrV/LyW3J2PVzc+w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
-      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
@@ -18130,364 +18087,201 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.310.0.tgz",
-      "integrity": "sha512-x5sRBUrEfLWAS1EhwbbDQ7cXq6uvBxh3qR2XAsnGvFFceTeAadk7cVogWxlk3PC+OCeeym7c3/6Bv2HQ2f1YyQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.357.0.tgz",
+      "integrity": "sha512-to42sFAL7KgV/X9X40LLfEaNMHMGQL6/7mPMVCL/W2BZf3zw5OTl3lAaNyjXA+gO5Uo4lFEiQKAQVKNbr8b8Nw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.310.0.tgz",
-      "integrity": "sha512-uJJfHI7v4AgbJZRLtyI8ap2QRWkBokGc3iyUoQ+dVNT3/CE2ZCu694A6W+H0dRqg79dIE+f9CRNdtLGa/Ehhvg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.363.0.tgz",
+      "integrity": "sha512-kR8+0X50zslpzRW29q4JbpPMadE1z39ZfGwPaBLKpoWvSGt4x+75FaoK71TH7urPPoFyD2Y+XKGA6YRYTUNHSQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
-      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
-      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-config-provider": "^1.0.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.325.0.tgz",
-      "integrity": "sha512-Hj4D+zeet4gdUpSiMeHZfIzcnXkZI2krGyUw4U1psPzCqOp7WP5307g+1NWXOlVu3H3tF5r3rEgthQOQj2zNfA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.363.0.tgz",
+      "integrity": "sha512-I88xneZp6jRwySmIl9uI7eZCcTsqRVnTDfUr1JiXt7zonqNNm80PVYMs6pwaw7t97ec1AQJcsONjuXZyCMnu5g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.326.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.326.0.tgz",
-      "integrity": "sha512-MtcvSU+wKu4/a/trIJmb4Tfb682U9uP5YYA5aXzdhxOxG11wj86uBIeQrdbUxhtTXMgmvwn1193dvTi91EUEaQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.363.0.tgz",
+      "integrity": "sha512-FBYmrMRX01uNximNN0WLgpf97GN4xNTLaKsDlkjYRWKJ+J97ICkvLG0FcSu7+SNCpCdJJBeQ5tRVOPVpUu6nmA==",
       "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/is-array-buffer": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
-      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
+      "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.325.0.tgz",
-      "integrity": "sha512-T2OrpXXY9I1nHvIGSlQD6qj1FDG3WDFSu65+Bh4pMl+zVh0IqIEajiK++TfrdQl+sJxRGQd/euoeXXL4JYw9JA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.363.0.tgz",
+      "integrity": "sha512-piNzpNNI/fChSGOZxcq/2msN2qFUSEAbhqs91zbcpv8CEPekVLc4W9laXCG764BEMyfG97ZU8MtzwHeMhELhBA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
-      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
+      "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
-      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
+      "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.327.0.tgz",
-      "integrity": "sha512-LCG+oRIPc4XJ+DYqkSCgggavxWi4+hP3Rw40vHdHMNvJpCiUJMwVJ+dULEywEP/WZvr4AEkWiRrHmJVpSLeZ+Q==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/service-error-classification": "3.327.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-retry": "3.327.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.326.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.326.0.tgz",
-      "integrity": "sha512-IyonHEiDMn0fdYWxA/TAnNj8M/xG5EJWvoOKcakl891f+JPaWeRsV2oE1fIjqM/waM3jqNXLDTrm06QfAYmgBQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.363.0.tgz",
+      "integrity": "sha512-npC8vLCero+vULizrK0QPjNanWbgH4A/2Llc1nO8N005uvUe7co6WglILF2W3guZrFk/0uGEdX67OnLxUD97pw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.326.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.326.0.tgz",
-      "integrity": "sha512-suOkuXxyAfOH0hznK63ZU10EoytKX5YPs9amO416VbgYFtuIeliCmntYfnl1jUvutp0fctGGpEGE9OnoYI+fhw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
+      "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
-      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
-      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
+      "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.325.0.tgz",
-      "integrity": "sha512-hxmvvWVfVrbfUw8pDEPlsR6Sb+IUdhq0cOJc7SL5XO9ddRXJ5DjT2Z2ao9FB424hJgAcOrqIO5ECjdIRs+O4FQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.363.0.tgz",
+      "integrity": "sha512-pN+QN1rMShYpJnTJSCIYnNRhD0S8xSZsTn6ThgcO559Xiwz5LMHFOfOXUCEyxtbVW5kMHLUh3w101AMUKae99A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
-      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
-      "dev": true,
-      "requires": {
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.327.0.tgz",
-      "integrity": "sha512-4rDSNY1xhlqfRcY97CQKcgs6AOe4ovtiRdCAjg2InnLOZHRVFoHhOIDxWNK2W1K2Pl65z4EGH6RXmB1t0srJHA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
+      "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.327.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
-      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.328.0.tgz",
-      "integrity": "sha512-zxXdNfdSGi6w/1bopllxAYAufCGDNG2eLenR3Tjj/UVBGrvS4ME5NGInu6u4LirTdkSqYlZkqKMyfiZ6XxGfdQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
-      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
-      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
-      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
-      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.327.0.tgz",
-      "integrity": "sha512-bCWnw+uH3gI6yPxLi4a4WV71P1KlJU7Z4+iMBY1Gt4+ZsaPAJX9pAbuQcFhFH++4xTk/QaVMzSvD0uQ+u0B/NQ==",
-      "dev": true
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
-      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
-      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.310.0.tgz",
-      "integrity": "sha512-q8W+RIomTS/q85Ntgks/CoDElwqkC9+4OCicee5YznNHjQ4gtNWhUkYIyIRWRmXa/qx/AUreW9DM8FAecCOdng==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
+      "integrity": "sha512-iWamQSpaBKg88LKuiUq8xO/7iyxJ+ORkA3qDhAwUqyTJOg87ma47yFf4ycCKqINnflc3AIGLGzBHnkBc4cMF5g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
-      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.328.0.tgz",
-      "integrity": "sha512-AWrRwa0RqSiz9CT3QKuMYuZsRXaeKCp8kMsx1CgrG5VUaag+NhDBBMYVbxgb0SyoqbsGC+wDUXtSCZctrE7Z3Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
+      "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.328.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso-oidc": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
-      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
       "dev": true,
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
-      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
@@ -18495,34 +18289,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
       "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.5.0"
@@ -18538,57 +18304,13 @@
         "tslib": "^2.5.0"
       }
     },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
-      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
-      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
     "@aws-sdk/util-endpoints": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.327.0.tgz",
-      "integrity": "sha512-2+2jTfBzhXsfpOci61gzaoBUVdGhFWja7k5cLAfOaRROkK+m+Zv532+m3cCQZjBXJ6pJ952MbiAroRSjFq0/SQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dev": true,
-      "requires": {
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       }
     },
@@ -18601,79 +18323,27 @@
         "tslib": "^2.5.0"
       }
     },
-    "@aws-sdk/util-middleware": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
-      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.327.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.327.0.tgz",
-      "integrity": "sha512-y15NLGTAT2vaLzA8klJ6Bo8NGjVAa3/njqc4iCbta/3GqKpQU0zbvw3Y5aWyHp8BhV4DSUTp088jWjaoZlSqgw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.327.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-stream-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.310.0.tgz",
-      "integrity": "sha512-bysXZHwFwvbqOTCScCdCnoLk1K3GCo0HRIYEZuL7O7MHrQmfaYRXcaft/p22+GUv9VeFXS/eJJZ5r4u32az94w==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-stream-node": {
-      "version": "3.328.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.328.0.tgz",
-      "integrity": "sha512-9h8oji5OTmatXMfPIasAapL59QDO7TR0J/B5Y3ERwGxy2U373LEy8Uvs+mbPIIQV1ztCLwHWDxKQoTUj4hLxoQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/node-http-handler": "3.328.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
-      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
+      "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
-      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
+      "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -18694,17 +18364,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
-      "integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/xml-builder": {
@@ -21484,6 +21143,475 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true
+    },
+    "@smithy/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
+      "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-config-provider": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
+      "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
+      "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-1.0.1.tgz",
+      "integrity": "sha512-oc8vxe+AU2RzvXH/Ehh0TzM/Nsw3I3ywu7V3qaCzqdkBIntAwK9JGZqcSDsqTK0WxZKBRgFIEwopcuZ2slVnFQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-config-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.1.tgz",
+      "integrity": "sha512-TJwaXima0djnNY819utO1j93qZHaheFH1bhHxBkMrImtEOuXY48Tjma/L2m8swkIq8dy8jFC9hrYOkD0eYHkFA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-1.0.1.tgz",
+      "integrity": "sha512-JEj8w7IRs4l+kcwKxbv3pNuu8n7ORC4pMFrIOrM4rERzrRnI7vMNTRzvAPGYA53rqm/Y9tBA9dw4C+H6hLXcsA==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-1.0.1.tgz",
+      "integrity": "sha512-c6m9DH7m6D2S93dof4wSxysaGSQdauO20TNcSePzrgHd4rkTnz5pqZ1a7Pt22q2SKf09SvTugq5cV2Sy4r8zHw==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-codec": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
+      "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-base64": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
+      "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-buffer-from": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
+      "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
+      "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.1.tgz",
+      "integrity": "sha512-XEHPq73PPm0sXul//5MRC8JKDwHTaNjV3myd9FJ5YoUT+QMJ27gqiwwAMVASJ6vC4ELHzgQdmoTZxVX83Jx17w==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.2.tgz",
+      "integrity": "sha512-Osj+XsqJ67RuX1MLc3+7LDtlRz8eNVqr/Pim9yPAjRa03Xberu6ST3a3oV3NqRpcUgMTifxuaKVIciuPE3rTWA==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/service-error-classification": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
+      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
+      "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
+      "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+      "dev": true,
+      "requires": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
+      "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
+      "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
+      "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-uri-escape": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
+      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.1.tgz",
+      "integrity": "sha512-EcFVOHFv4YZHUrJ6161tpPKXNlQsTAQKoKorODxuOQW1my14mgoyiiMXrlnSMaYRF//oaONYfFOQ2EMAUTC5DQ==",
+      "dev": true
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
+      "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
+      "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-codec": "^1.0.1",
+        "@smithy/is-array-buffer": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/util-uri-escape": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
+      "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-stream": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
+      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+      "dev": true,
+      "requires": {
+        "@smithy/querystring-parser": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
+      "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
+      "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
+      "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
+      "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+      "dev": true,
+      "requires": {
+        "@smithy/is-array-buffer": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
+      "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
+      "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+      "dev": true,
+      "requires": {
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
+      "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+      "dev": true,
+      "requires": {
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
+      "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
+      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.2.tgz",
+      "integrity": "sha512-LqzAy1QzeAHpSZpsd2LtKZRbco7F5gF+Zpoa4TuuFq9f+CGmH6OuTCIN3I13LPEBa4zs2AgvGnXljvMbUw5WGw==",
+      "dev": true,
+      "requires": {
+        "@smithy/service-error-classification": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
+      "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+      "dev": true,
+      "requires": {
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-buffer-from": "^1.0.1",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
+      "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
+      "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^1.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.0.1.tgz",
+      "integrity": "sha512-dsn8O0s3pFIgxFzySLe1dv0w4tEQizEP6UqbgZ4r/Kar4n8pSdrPi6DJg8BzXwkwEIZpMtV4/nhSeGZ7HksDXA==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -24573,9 +24701,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "dev": true,
       "requires": {
         "strnum": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   },
   "devDependencies": {
     "@apollo/server": "^4.2.2",
-    "@aws-sdk/client-s3": "^3.319.0",
+    "@aws-sdk/client-s3": "^3.363.0",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1075,6 +1075,8 @@ test('disableInstrumentations', function (t) {
   modules.delete('@node-redis/client/dist/lib/client') // redis@4 supports node >=14
   modules.delete('@node-redis/client/dist/lib/client/commands-queue') // redis@4 supports node >=14
   modules.delete('mysql2')
+  modules.delete('@aws-sdk/smithy-client')
+  modules.delete('@smithy/smithy-client')
 
   function testSlice (t, name, selector) {
     var selection = selector(modules)


### PR DESCRIPTION
In https://github.com/aws/aws-sdk-js-v3/pull/4873 aws-sdk v3 moved
@aws-sdk/smithy-client to @smithy/smithy-client. This will now
instrument either package name.

Fixes: https://github.com/elastic/apm-agent-nodejs/issues/3454
