### PR TITLE
fix: `@aws-sdk/client-s3` instrumentation could cause `getSignedUrl` to crash

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -81,6 +81,9 @@ See <<esm>> for full details.
 * Fix aws-sdk v3 instrumentation (currently just `@aws-sdk/client-s3`) for
   versions 3.363.0 and later. ({pull}3455[#3455])
 
+* Fix a possible crash when using `getSignedUrl()` from `@aws-sdk/s3-request-presigner`
+  due to a bug in `@aws-sdk/client-s3` instrumentation. ({issues}3464[#3464])
+
 [float]
 ===== Chores
 

--- a/lib/instrumentation/modules/@aws-sdk/client-s3.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-s3.js
@@ -61,14 +61,15 @@ function s3MiddlewareFactory (client, agent) {
   return [
     {
       middleware: (next, context) => async (args) => {
+        // Ensure there is a span from the wrapped `client.send()`.
+        const span = agent._instrumentation.currSpan()
+        if (!span || !(span.type === TYPE && span.subtype === SUBTYPE)) {
+          return await next(args)
+        }
+
         const input = args.input
         const bucket = input && input.Bucket
         const resource = resourceFromBucket(bucket)
-        const span = agent._instrumentation.currSpan()
-
-        if (!span) {
-          return await next(args)
-        }
         // The given span comes with the operation name and we need to
         // add the resource if applies
         if (resource) {
@@ -152,17 +153,18 @@ function s3MiddlewareFactory (client, agent) {
 
           // Destination context.
           const destContext = {
-            address: context[elasticAPMStash].hostname,
-            port: context[elasticAPMStash].port,
             service: {
               name: SUBTYPE,
               type: TYPE
             }
           }
+          if (context[elasticAPMStash]) {
+            destContext.address = context[elasticAPMStash].hostname
+            destContext.port = context[elasticAPMStash].port
+          }
           if (resource) {
             destContext.service.resource = resource
           }
-
           if (region) {
             destContext.cloud = { region }
           }
@@ -190,7 +192,6 @@ function s3MiddlewareFactory (client, agent) {
         }
 
         context[elasticAPMStash] = {
-          protocol: req.protocol,
           hostname: req.hostname,
           port
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       "devDependencies": {
         "@apollo/server": "^4.2.2",
         "@aws-sdk/client-s3": "^3.363.0",
+        "@aws-sdk/s3-request-presigner": "^3.363.0",
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.8.4",
         "@babel/preset-env": "^7.8.4",
@@ -1340,6 +1341,25 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.363.0.tgz",
+      "integrity": "sha512-KbAa5mbBmSt2FEutOWUF2g8sW35I63726tnIO65Z7ej3bWoreHM1u+TCMzTiAUGW67lbsG8nTEbFz9yRrsNoLQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-format-url": "3.363.0",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.363.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
@@ -1425,6 +1445,21 @@
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.363.0.tgz",
+      "integrity": "sha512-lz3z4M5QPVJxALVUOU6a538CO+VPDLl9dgeAQCRF7fVjYP7nRGjm7Hc1oiEP7nYL3sAw/lQfbL7NlTPNXRwRlQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -18323,6 +18358,22 @@
         "tslib": "^2.5.0"
       }
     },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.363.0.tgz",
+      "integrity": "sha512-KbAa5mbBmSt2FEutOWUF2g8sW35I63726tnIO65Z7ej3bWoreHM1u+TCMzTiAUGW67lbsG8nTEbFz9yRrsNoLQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/signature-v4-multi-region": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-format-url": "3.363.0",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
     "@aws-sdk/signature-v4-multi-region": {
       "version": "3.363.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
@@ -18385,6 +18436,18 @@
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.363.0.tgz",
+      "integrity": "sha512-lz3z4M5QPVJxALVUOU6a538CO+VPDLl9dgeAQCRF7fVjYP7nRGjm7Hc1oiEP7nYL3sAw/lQfbL7NlTPNXRwRlQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/querystring-builder": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   "devDependencies": {
     "@apollo/server": "^4.2.2",
     "@aws-sdk/client-s3": "^3.363.0",
+    "@aws-sdk/s3-request-presigner": "^3.363.0",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",

--- a/test/instrumentation/modules/@aws-sdk/client-s3.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-s3.test.js
@@ -77,7 +77,7 @@ const testFixtures = [
         spans.length, 'all spans have sync=false')
       t.equal(spans.filter(s => s.sample_rate === 1).length,
         spans.length, 'all spans have sample_rate=1')
-      const failingSpanId = spans[7].id // index of `getObjNonExistantObject`
+      const failingSpanId = spans[8].id // index of `getObjNonExistantObject`
       spans.forEach(s => {
         // Remove variable and common fields to facilitate t.deepEqual below.
         delete s.id
@@ -223,6 +223,14 @@ const testFixtures = [
         },
         outcome: 'success'
       }, 'getObj produced expected span')
+
+      t.deepEqual(spans.shift(), {
+        name: 'get-signed-url',
+        type: 'custom',
+        subtype: null,
+        action: null,
+        outcome: 'success'
+      }, 'custom span for getSignedUrl call')
 
       t.deepEqual(spans.shift(), {
         name: 'S3 GetObject elasticapmtest-bucket-3',


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-nodejs/issues/3464
