### PR TITLE
feat: enable ESM support for Node v20

### DIFF
--- a/docs/esm.asciidoc
+++ b/docs/esm.asciidoc
@@ -70,7 +70,7 @@ As well, the APM agent must also be separately *started* -- for example via `--r
 
 Automatic instrumentation of ES modules is based on the experimental Node.js Loaders API. ESM support in the Elastic APM Node.js agent will remain *experimental* while the Loaders API is experimental.
 
-ESM auto-instrumentation is only supported for Node.js versions that match *`^12.20.0 || ^14.13.1 || ^16.0.0 || ^18.1.0 <20`*. Notably, in the current APM agent version, this _excludes Node.js v20_ because of changes in the Loaders API. The behavior when using `node --experimental-loader=elastic-apm-node/loader.mjs` with earlier Node.js versions is undefined and unsupported.
+ESM auto-instrumentation is only supported for Node.js versions that match *`^12.20.0 || ^14.13.1 || ^16.0.0 || >=18.1.0`*. The behavior when using `node --experimental-loader=elastic-apm-node/loader.mjs` with earlier Node.js versions is undefined and unsupported.
 
 
 [float]

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "escape-string-regexp": "^4.0.0",
         "fast-safe-stringify": "^2.0.7",
         "http-headers": "^3.0.2",
-        "import-in-the-middle": "1.3.5",
+        "import-in-the-middle": "1.4.1",
         "is-native": "^1.0.1",
         "lru-cache": "^6.0.0",
         "measured-reporting": "^1.51.1",
@@ -5895,6 +5895,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -7299,6 +7307,11 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -10768,11 +10781,25 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
+      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
       "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -21999,6 +22026,11 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
+    "acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA=="
+    },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -23070,6 +23102,11 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -25734,11 +25771,21 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
+      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
       "requires": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+          "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+        }
       }
     },
     "imurmurhash": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "escape-string-regexp": "^4.0.0",
     "fast-safe-stringify": "^2.0.7",
     "http-headers": "^3.0.2",
-    "import-in-the-middle": "1.3.5",
+    "import-in-the-middle": "1.4.1",
     "is-native": "^1.0.1",
     "lru-cache": "^6.0.0",
     "measured-reporting": "^1.51.1",

--- a/test/instrumentation/modules/fastify/fastify.test.js
+++ b/test/instrumentation/modules/fastify/fastify.test.js
@@ -48,7 +48,7 @@ const testFixtures = [
       ELASTIC_APM_CAPTURE_BODY: 'all'
     },
     versionRanges: {
-      node: '^14.13.1 || ^16.0.0 || ^18.1.0 <20', // NODE_VER_RANGE_IITM minus node v12 because top-level `await` is used
+      node: '^14.13.1 || ^16.0.0 || >=18.1.0', // NODE_VER_RANGE_IITM minus node v12 because top-level `await` is used
       // IITM and `import fastify from 'fastify'` fail without https://github.com/fastify/fastify/pull/2590
       // I would have thought the only failure would be with a named import,
       // so I don't completely understand the issue.

--- a/test/instrumentation/modules/http/http-esm.test.js
+++ b/test/instrumentation/modules/http/http-esm.test.js
@@ -92,7 +92,7 @@ const testFixtures = [
       ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME: 'true'
     },
     versionRanges: {
-      node: '^14.13.1 || ^16.0.0 || ^18.1.0 <20' // NODE_VER_RANGE_IITM minus node v12 because top-level `await` is used
+      node: '^14.13.1 || ^16.0.0 || >=18.1.0' // NODE_VER_RANGE_IITM minus node v12 because top-level `await` is used
     },
     verbose: false,
     checkApmServer: (t, apmServer) => {
@@ -113,7 +113,7 @@ const testFixtures = [
       NODE_NO_WARNINGS: '1' // skip warnings about --experimental-loader
     },
     versionRanges: {
-      node: '^14.13.1 || ^16.0.0 || ^18.1.0 <20' // NODE_VER_RANGE_IITM minus node v12 because top-level `await` is used
+      node: '^14.13.1 || ^16.0.0 || >=18.1.0' // NODE_VER_RANGE_IITM minus node v12 because top-level `await` is used
     },
     verbose: true
   }

--- a/test/testconsts.js
+++ b/test/testconsts.js
@@ -13,9 +13,7 @@
 //   fixes in the .1 minor release
 // - v18.1.0 fixes an issue in v18.0.0
 //   https://github.com/nodejs/node/pull/42881
-// - Current node v20 does not work with IITM
-//   https://github.com/DataDog/import-in-the-middle/pull/27
-const NODE_VER_RANGE_IITM = '^12.20.0 || ^14.13.1 || ^16.0.0 || ^18.1.0 <20'
+const NODE_VER_RANGE_IITM = '^12.20.0 || ^14.13.1 || ^16.0.0 || >=18.1.0'
 
 module.exports = {
   NODE_VER_RANGE_IITM


### PR DESCRIPTION
All the hard work was done in import-in-the-middle#28.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3445
