### PR TITLE
fix: identifying the "sp_prepare" stored procedure changed for tedious@16.2.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,24 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix tedious instrumentation to recognize "connection.prepare()" usage in
+  tedious@16.2.0 and later.
+
+[float]
+===== Chores
+
+
 [[release-notes-3.48.0]]
 ==== 3.48.0 - 2023/07/07
 

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -97,7 +97,11 @@ module.exports = function (tedious, agent, { version, enabled }) {
           // This looks for tedious instance with `RpcRequestPayload` started
           // since version >=v11.0.10, when RPC parameter handling was refactored
           // (https://github.com/tediousjs/tedious/pull/1275).
-          preparing = payload.procedure === 'sp_prepare'
+          preparing = (typeof payload.procedure === 'number'
+            // tedious@16.2.0 starts using stored procedure *IDs*
+            // (https://github.com/tediousjs/tedious/pull/1327)
+            ? payload.procedure === 11
+            : payload.procedure === 'sp_prepare')
           const stmtParam = (payload.parameters.find(({ name }) => name === 'statement') ||
             payload.parameters.find(({ name }) => name === 'stmt'))
           sql = stmtParam ? stmtParam.value : request.sqlTextOrProcedure


### PR DESCRIPTION
tedious@16.2.0 changed the "name" it uses internally for RpcRequestPayload objects, from a string to the SQL Server-defined numeric identifiers. For example, to identify a "prepare":

```diff
- new RpcRequestPayload('sp_prepare', ...);
+ new RpcRequestPayload(Procedures.Sp_Prepare, ...);
```

where that `Procedures.Sp_Prepare` is a hardcoded 11, corresponding to https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-prepare-transact-sql
