### PR TITLE
chore(deps): bump OpenTelemetry deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,3 +50,11 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "elastic/apm-agent-node-js"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/opentelemetry-metrics"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "elastic/apm-agent-node-js"

--- a/dev-utils/gen-notice.sh
+++ b/dev-utils/gen-notice.sh
@@ -78,6 +78,7 @@ npm ls --omit=dev --all --parseable \
         const fs = require("fs")
         const path = require("path")
         const knownLicTypes = {
+            "0BSD": true,
             "Apache-2.0": true,
             "BSD-2-Clause": true,
             "BSD-3-Clause": true,

--- a/examples/opentelemetry-metrics/package.json
+++ b/examples/opentelemetry-metrics/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@opentelemetry/api": "^1.4.1",
-    "@opentelemetry/exporter-prometheus": "^0.38.0",
+    "@opentelemetry/exporter-prometheus": "^0.41.0",
     "@opentelemetry/sdk-metrics": "^1.12.0",
     "elastic-apm-node": "file:../.."
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4884,11 +4884,12 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -4898,12 +4899,13 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
+      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -4913,13 +4915,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.14.0.tgz",
-      "integrity": "sha512-F0JXmLqT4LmsaiaE28fl0qMtc5w0YuMWTHt1hnANTNX8hxW4IKSv9+wrYG7BZd61HEbPm032Re7fXyzzNA6nIw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.0.tgz",
+      "integrity": "sha512-fFUnAcPvlXO39nlIduGuaeCuiZyFtSLCn9gW/0djFRO5DFst4m4gcT6+llXvNWuUvtGB49s56NP10B9IZRN0Rw==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "lodash.merge": "4.6.2"
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/resources": "1.15.0",
+        "lodash.merge": "^4.6.2",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -4929,9 +4932,12 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
+      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14"
       }
@@ -16638,8 +16644,7 @@
     "node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -21261,36 +21266,42 @@
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
     },
     "@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
+      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
       "requires": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.14.0.tgz",
-      "integrity": "sha512-F0JXmLqT4LmsaiaE28fl0qMtc5w0YuMWTHt1hnANTNX8hxW4IKSv9+wrYG7BZd61HEbPm032Re7fXyzzNA6nIw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.0.tgz",
+      "integrity": "sha512-fFUnAcPvlXO39nlIduGuaeCuiZyFtSLCn9gW/0djFRO5DFst4m4gcT6+llXvNWuUvtGB49s56NP10B9IZRN0Rw==",
       "requires": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "lodash.merge": "4.6.2"
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/resources": "1.15.0",
+        "lodash.merge": "^4.6.2",
+        "tslib": "^2.3.1"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
+      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -30471,8 +30482,7 @@
     "tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsscmp": {
       "version": "1.0.6",

--- a/test/instrumentation/drop-fast-exit-spans.test.js
+++ b/test/instrumentation/drop-fast-exit-spans.test.js
@@ -71,7 +71,7 @@ tape.test('end to end test', function (t) {
 // Test that a composite span faster than `exitSpanMinDuration` is dropped.
 tape.test('end to end test with compression', function (t) {
   resetAgent(function (data) {
-    t.equals(data.spans.length, 0, 'the composite span was dropped')
+    t.equals(data.spans.length, 0, `the composite span was dropped (exitSpanMinDuration=${agent._conf.exitSpanMinDuration * 1000}ms, data.spans=${JSON.stringify(data.spans)})`)
     t.end()
   })
 

--- a/test/opentelemetry-metrics/fixtures/package-lock.json
+++ b/test/opentelemetry-metrics/fixtures/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/exporter-prometheus": "^0.41.0",
-        "@opentelemetry/sdk-metrics": "^1.14.0"
+        "@opentelemetry/sdk-metrics": "^1.15.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/test/opentelemetry-metrics/fixtures/package.json
+++ b/test/opentelemetry-metrics/fixtures/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/exporter-prometheus": "^0.41.0",
-    "@opentelemetry/sdk-metrics": "^1.14.0"
+    "@opentelemetry/sdk-metrics": "^1.15.0"
   }
 }


### PR DESCRIPTION
This also adds the 0BSD license, used by the new tslib dep of
some OTel packages, to the list of known licenses for redist.

Obsoletes: #3478, #3483
