### PR TITLE
instrumentation of @aws-sdk/client-sns

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -213,7 +213,7 @@ elif [[ -n "${TAV_MODULE}" ]]; then
     memcached)
       DOCKER_COMPOSE_FILE=docker-compose-memcached.yml
       ;;
-    aws-sdk|@aws-sdk/client-s3)
+    aws-sdk|@aws-sdk/client-s3|@aws-sdk/client-sns)
       DOCKER_COMPOSE_FILE=docker-compose-localstack.yml
       ;;
     *)

--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -4,6 +4,7 @@
   "modules": [
     "@apollo/server",
     "@aws-sdk/client-s3",
+    "@aws-sdk/client-sns",
     "@elastic/elasticsearch",
     "@hapi/hapi",
     "@opentelemetry/api",

--- a/.tav.yml
+++ b/.tav.yml
@@ -528,6 +528,18 @@ aws-sdk:
     - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
   node: '>=14'
 
+
+'@aws-sdk/client-s3':
+  # Maintenance note: This should be updated periodically using:
+  #   node ./dev-utils/tav-versions.js @aws-sdk/client-sns ">=3.15.0 <4"
+  #
+  # Test v3.15.0, every N=40 of 205 releases, and current latest.
+  versions: '3.15.0 || 3.53.0 || 3.154.0 || 3.218.0 || 3.294.0 || 3.360.0 || 3.370.0 || >3.370.0 <4'
+  commands:
+    - node test/instrumentation/modules/@aws-sdk/client-sns.test.js
+  node: '>=14'
+
+
 # - undici@4.7.0 added its diagnostics_channel support.
 # - In undici@4.7.1 the `request.origin` property was added, which we need
 #   in the 'undici:request:create' diagnostic message.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,9 @@ Notes:
 [float]
 ===== Features
 
+* Add support for `@aws-sdk/client-sns`, one of the AWS SDK v3 clients.
+  ({pull}3500[#3500])
+
 [float]
 ===== Bug fixes
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -114,6 +114,7 @@ The Node.js agent will automatically instrument the following modules to give yo
 |Module |Version |Note
 |https://www.npmjs.com/package/aws-sdk[aws-sdk] |>=2.858.0 <3 |Will instrument SQS send/receive/delete messages, all S3 methods, all DynamoDB methods, and the SNS publish method
 |https://www.npmjs.com/package/@aws-sdk/client-s3[@aws-sdk/client-s3] |>=3.15.0 <4 |Will instrument all S3 methods
+|https://www.npmjs.com/package/@aws-sdk/client-s3[@aws-sdk/client-sns] |>=3.15.0 <4 |Will instrument the SNS publish method
 |https://www.npmjs.com/package/cassandra-driver[cassandra-driver] |>=3.0.0 <5 |Will instrument all queries
 |https://www.npmjs.com/package/elasticsearch[elasticsearch] |>=8.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/@elastic/elasticsearch[@elastic/elasticsearch] |>=7.0.0 <9.0.0 |Will instrument all queries

--- a/lib/instrumentation/modules/@aws-sdk/client-s3.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-s3.js
@@ -11,7 +11,6 @@ const { getHttpInfo, httpInfoMiddleware } = require('./http-info-middleware')
 const NAME = 'S3'
 const TYPE = 'storage'
 const SUBTYPE = 's3'
-const elasticAPMStash = Symbol('elasticAPMStash')
 
 /**
  * Gets the region from the ARN

--- a/lib/instrumentation/modules/@aws-sdk/client-s3.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-s3.js
@@ -178,13 +178,13 @@ function s3MiddlewareFactory (client, agent) {
 }
 
 /**
- * Tells if the command needs to be instrumented or not
+ * Tells if the command needs to be ingored
  * @param {import('@aws-sdk/types').Command} command the command sent by the SNS client
  * @param {any} config the agent configuration
- * @returns {boolean} true if the command should create a span
+ * @returns {boolean} false if the command should create a span
  */
-function s3CommandFilter (command, config) {
-  return true
+function s3ShouldIgnoreCommand (command, config) {
+  return false
 }
 
 module.exports = {
@@ -192,5 +192,5 @@ module.exports = {
   S3_TYPE: TYPE,
   S3_SUBTYPE: SUBTYPE,
   s3MiddlewareFactory,
-  s3CommandFilter
+  s3ShouldIgnoreCommand
 }

--- a/lib/instrumentation/modules/@aws-sdk/client-s3.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-s3.js
@@ -153,23 +153,16 @@ function s3MiddlewareFactory (client, agent) {
           }
 
           // Destination context.
-          const destContext = {
-            service: {
-              name: SUBTYPE,
-              type: TYPE
-            }
-          }
-          if (context[elasticAPMStash]) {
-            destContext.address = context[elasticAPMStash].hostname
-            destContext.port = context[elasticAPMStash].port
-          }
+          const service = { name: SUBTYPE, type: TYPE }
+          const destCtx = Object.assign({ service }, getHttpInfo(context))
+
           if (resource) {
-            destContext.service.resource = resource
+            destCtx.service.resource = resource
           }
           if (region) {
-            destContext.cloud = { region }
+            destCtx.cloud = { region }
           }
-          span._setDestinationContext(destContext)
+          span._setDestinationContext(destCtx)
 
           span.end()
         }

--- a/lib/instrumentation/modules/@aws-sdk/client-s3.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-s3.js
@@ -7,6 +7,7 @@
 'use strict'
 
 const constants = require('../../../constants')
+const { getHttpInfo, httpInfoMiddleware } = require('./http-info-middleware')
 const NAME = 'S3'
 const TYPE = 'storage'
 const SUBTYPE = 's3'
@@ -178,33 +179,26 @@ function s3MiddlewareFactory (client, agent) {
       options: { step: 'initialize', priority: 'high', name: 'elasticAPMSpan' }
     },
     {
-      middleware: (next, context) => async (args) => {
-        const req = args.request
-        let port = req.port
-
-        // Resolve port for HTTP(S) protocols
-        if (port === undefined) {
-          if (req.protocol === 'https:') {
-            port = 443
-          } else if (req.protocol === 'http:') {
-            port = 80
-          }
-        }
-
-        context[elasticAPMStash] = {
-          hostname: req.hostname,
-          port
-        }
-        return next(args)
-      },
+      middleware: httpInfoMiddleware,
       options: { step: 'finalizeRequest', name: 'elasticAPMHTTPInfo' }
     }
   ]
+}
+
+/**
+ * Tells if the command needs to be instrumented or not
+ * @param {import('@aws-sdk/types').Command} command the command sent by the SNS client
+ * @param {any} config the agent configuration
+ * @returns {boolean} true if the command should create a span
+ */
+function s3CommandFilter (command, config) {
+  return true
 }
 
 module.exports = {
   S3_NAME: NAME,
   S3_TYPE: TYPE,
   S3_SUBTYPE: SUBTYPE,
-  s3MiddlewareFactory
+  s3MiddlewareFactory,
+  s3CommandFilter
 }

--- a/lib/instrumentation/modules/@aws-sdk/client-sns.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sns.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+const constants = require('../../../constants')
+const NAME = 'SNS'
+const TYPE = 'messaging'
+const SUBTYPE = 'sns'
+const elasticAPMStash = Symbol('elasticAPMStash')
+const MAX_SNS_MESSAGE_ATTRIBUTES = 10
+
+/**
+ * Returns middlewares to instrument an S3Client instance
+ *
+ * @param {import('@aws-sdk/client-s3').SNSClient} client
+ * @param {any} agent
+ * @returns {import('./smithy-client').AWSMiddlewareEntry[]}
+ */
+function snsMiddlewareFactory (client, agent) {
+  return [
+    {
+      middleware: (next, context) => async (args) => {
+        const ins = agent._instrumentation
+        const log = agent.logger
+        const span = ins.currSpan()
+        const input = args.input
+
+        // TODO: trace-context propagation goes here
+        const runContext = ins.currRunContext()
+        const parentSpan = span || runContext.currSpan() || runContext.currTransaction()
+        const targetId = input && (input.TopicArn || input.TargetArn || input.PhoneNumber)
+
+        // Though our spec only mentions a 10-message-attribute limit for *SQS*, we'll
+        // do the same limit here, because
+        // https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
+        // mentions the 10-message-attribute limit for SQS subscriptions.
+        input.MessageAttributes = input.MessageAttributes || {}
+        if (input.MessageAttributes && Object.keys(input.MessageAttributes).length + 2 > MAX_SNS_MESSAGE_ATTRIBUTES) {
+          log.warn('cannot propagate trace-context with SNS message to %s, too many MessageAttributes', targetId)
+        } else {
+          parentSpan.propagateTraceContextHeaders(input.MessageAttributes, function (msgAttrs, name, value) {
+            if (name.startsWith('elastic-')) {
+              return
+            }
+            msgAttrs[name] = { DataType: 'String', StringValue: value }
+          })
+        }
+
+        // Ensure there is a span from the wrapped `client.send()`.
+        if (!span || !(span.type === TYPE && span.subtype === SUBTYPE)) {
+          return await next(args)
+        }
+
+        if (targetId) {
+          span.name += ' to ' + targetId
+        }
+
+        let err
+        let result
+        let response
+        let statusCode
+        try {
+          result = await next(args)
+          response = result && result.response
+          statusCode = response && response.statusCode
+        } catch (ex) {
+          // Save the error for use in `finally` below, but re-throw it to
+          // not impact code flow.
+          err = ex
+
+          // This code path happens with a GetObject conditional request
+          // that returns a 304 Not Modified.
+          statusCode = err && err.$metadata && err.$metadata.httpStatusCode
+          throw ex
+        } finally {
+          if (statusCode) {
+            span._setOutcomeFromHttpStatusCode(statusCode)
+          } else {
+            span._setOutcomeFromErrorCapture(constants.OUTCOME_FAILURE)
+          }
+          if (err && (!statusCode || statusCode >= 400)) {
+            agent.captureError(err, { skipOutcome: true })
+          }
+
+          // TODO: set context in the span
+          // const region = await config.region()
+
+          // Destination context.
+          // TODO: review this
+          const destContext = {
+            service: {
+              name: SUBTYPE,
+              type: TYPE
+            }
+          }
+          if (context[elasticAPMStash]) {
+            destContext.address = context[elasticAPMStash].hostname
+            destContext.port = context[elasticAPMStash].port
+          }
+          span._setDestinationContext(destContext)
+
+          span.end()
+        }
+
+        return result
+      },
+      options: { step: 'initialize', priority: 'high', name: 'elasticAPMSpan' }
+    },
+    {
+      middleware: (next, context) => async (args) => {
+        const req = args.request
+        let port = req.port
+
+        // Resolve port for HTTP(S) protocols
+        if (port === undefined) {
+          if (req.protocol === 'https:') {
+            port = 443
+          } else if (req.protocol === 'http:') {
+            port = 80
+          }
+        }
+
+        context[elasticAPMStash] = {
+          hostname: req.hostname,
+          port
+        }
+        return next(args)
+      },
+      options: { step: 'finalizeRequest', name: 'elasticAPMHTTPInfo' }
+    }
+  ]
+}
+
+/**
+ * Tells if the command needs to be instrumented or not
+ * @param {any} command the command sent by the SNS client
+ * @returns {boolean}
+ */
+function snsCommandFilter (command) {
+  return command.constructor.name === 'PublishCommand'
+}
+
+module.exports = {
+  SNS_NAME: NAME,
+  SNS_TYPE: TYPE,
+  SNS_SUBTYPE: SUBTYPE,
+  snsMiddlewareFactory,
+  snsCommandFilter
+}

--- a/lib/instrumentation/modules/@aws-sdk/client-sns.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sns.js
@@ -29,7 +29,7 @@ function snsMiddlewareFactory (client, agent) {
         const span = ins.currSpan()
         const input = args.input
 
-        // TODO: trace-context propagation goes here
+        // W3C trace-context propagation.
         const runContext = ins.currRunContext()
         const parentSpan = span || runContext.currSpan() || runContext.currTransaction()
         const targetId = input && (input.TopicArn || input.TargetArn || input.PhoneNumber)

--- a/lib/instrumentation/modules/@aws-sdk/client-sns.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sns.js
@@ -7,10 +7,10 @@
 'use strict'
 
 const constants = require('../../../constants')
+const { getHttpInfo, httpInfoMiddleware } = require('./http-info-middleware')
 const NAME = 'SNS'
 const TYPE = 'messaging'
 const SUBTYPE = 'sns'
-const elasticAPMStash = Symbol('elasticAPMStash')
 const MAX_SNS_MESSAGE_ATTRIBUTES = 10
 
 /**
@@ -55,8 +55,21 @@ function snsMiddlewareFactory (client, agent) {
           return await next(args)
         }
 
-        if (targetId) {
-          span.name += ' to ' + targetId
+        let queueName
+
+        if (input.PhoneNumber) {
+          queueName = '<PHONE_NUMBER>'
+        } else if (input.TopicArn) {
+          queueName = input.TopicArn.split(':').pop()
+        } else if (input.TargetArn) {
+          queueName = input.TargetArn.split(':').pop()
+          if (queueName.lastIndexOf('/') !== -1) {
+            queueName = queueName.substring(0, queueName.lastIndexOf('/'))
+          }
+        }
+
+        if (queueName) {
+          span.name += ' to ' + queueName
         }
 
         let err
@@ -86,22 +99,20 @@ function snsMiddlewareFactory (client, agent) {
             agent.captureError(err, { skipOutcome: true })
           }
 
-          // TODO: set context in the span
-          // const region = await config.region()
-
           // Destination context.
-          // TODO: review this
-          const destContext = {
-            service: {
-              name: SUBTYPE,
-              type: TYPE
-            }
+          const region = await client.config.region()
+          const service = { name: SUBTYPE, type: TYPE }
+          const destCtx = Object.assign({ service }, getHttpInfo(context))
+
+          if (region) {
+            destCtx.cloud = { region }
           }
-          if (context[elasticAPMStash]) {
-            destContext.address = context[elasticAPMStash].hostname
-            destContext.port = context[elasticAPMStash].port
+          span._setDestinationContext(destCtx)
+
+          // Message context
+          if (queueName) {
+            span.setMessageContext({ queue: { name: queueName } })
           }
-          span._setDestinationContext(destContext)
 
           span.end()
         }
@@ -111,25 +122,7 @@ function snsMiddlewareFactory (client, agent) {
       options: { step: 'initialize', priority: 'high', name: 'elasticAPMSpan' }
     },
     {
-      middleware: (next, context) => async (args) => {
-        const req = args.request
-        let port = req.port
-
-        // Resolve port for HTTP(S) protocols
-        if (port === undefined) {
-          if (req.protocol === 'https:') {
-            port = 443
-          } else if (req.protocol === 'http:') {
-            port = 80
-          }
-        }
-
-        context[elasticAPMStash] = {
-          hostname: req.hostname,
-          port
-        }
-        return next(args)
-      },
+      middleware: httpInfoMiddleware,
       options: { step: 'finalizeRequest', name: 'elasticAPMHTTPInfo' }
     }
   ]
@@ -137,11 +130,28 @@ function snsMiddlewareFactory (client, agent) {
 
 /**
  * Tells if the command needs to be instrumented or not
- * @param {any} command the command sent by the SNS client
- * @returns {boolean}
+ * @param {import('@aws-sdk/types').Command} command the command sent by the SNS client
+ * @param {any} config the agent configuration
+ * @returns {boolean} true if the command should create a span
  */
-function snsCommandFilter (command) {
-  return command.constructor.name === 'PublishCommand'
+function snsCommandFilter (command, config) {
+  if (command.constructor.name !== 'PublishCommand') {
+    return false
+  }
+
+  if (config.ignoreMessageQueuesRegExp) {
+    const input = command.input
+    const queueName = input && (input.TopicArn || input.TargetArn || input.PhoneNumber)
+    if (queueName) {
+      for (const rule of config.ignoreMessageQueuesRegExp) {
+        if (rule.test(queueName)) {
+          return false
+        }
+      }
+    }
+  }
+
+  return true
 }
 
 module.exports = {

--- a/lib/instrumentation/modules/@aws-sdk/client-sns.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sns.js
@@ -16,7 +16,7 @@ const MAX_SNS_MESSAGE_ATTRIBUTES = 10
 /**
  * Returns middlewares to instrument an S3Client instance
  *
- * @param {import('@aws-sdk/client-s3').SNSClient} client
+ * @param {import('@aws-sdk/client-sns').SNSClient} client
  * @param {any} agent
  * @returns {import('./smithy-client').AWSMiddlewareEntry[]}
  */
@@ -85,8 +85,7 @@ function snsMiddlewareFactory (client, agent) {
           // not impact code flow.
           err = ex
 
-          // This code path happens with a GetObject conditional request
-          // that returns a 304 Not Modified.
+          // This code path happens with a Publish command that returns a 404 Not Found.
           statusCode = err && err.$metadata && err.$metadata.httpStatusCode
           throw ex
         } finally {
@@ -129,14 +128,14 @@ function snsMiddlewareFactory (client, agent) {
 }
 
 /**
- * Tells if the command needs to be instrumented or not
+ * Tells if the command needs to be ingored
  * @param {import('@aws-sdk/types').Command} command the command sent by the SNS client
  * @param {any} config the agent configuration
- * @returns {boolean} true if the command should create a span
+ * @returns {boolean} false if the command should create a span
  */
-function snsCommandFilter (command, config) {
+function snsShouldIgnoreCommand (command, config) {
   if (command.constructor.name !== 'PublishCommand') {
-    return false
+    return true
   }
 
   if (config.ignoreMessageQueuesRegExp) {
@@ -145,13 +144,13 @@ function snsCommandFilter (command, config) {
     if (queueName) {
       for (const rule of config.ignoreMessageQueuesRegExp) {
         if (rule.test(queueName)) {
-          return false
+          return true
         }
       }
     }
   }
 
-  return true
+  return false
 }
 
 module.exports = {
@@ -159,5 +158,5 @@ module.exports = {
   SNS_TYPE: TYPE,
   SNS_SUBTYPE: SUBTYPE,
   snsMiddlewareFactory,
-  snsCommandFilter
+  snsShouldIgnoreCommand
 }

--- a/lib/instrumentation/modules/@aws-sdk/http-info-middleware.js
+++ b/lib/instrumentation/modules/@aws-sdk/http-info-middleware.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+const elasticHttpInfo = Symbol('elasticHttpInfo')
+
+/**
+ * Gets http information (address, port, ...) and stash it into the context for use in
+ * other middlewares
+ *
+ * @type {import('@aws-sdk/types').FinalizeRequestMiddleware}
+ */
+function httpInfoMiddleware (next, context) {
+  return function (args) {
+    const req = args.request
+    let port = req.port
+
+    // Resolve port for HTTP(S) protocols
+    if (port === undefined) {
+      if (req.protocol === 'https:') {
+        port = 443
+      } else if (req.protocol === 'http:') {
+        port = 80
+      }
+    }
+
+    context[elasticHttpInfo] = {
+      address: req.hostname,
+      port
+    }
+    return next(args)
+  }
+}
+
+/**
+ * Extracts stashed HTTP info from the context
+ * @param {any} context The context of the request
+ * @returns the HTTP info
+ */
+function getHttpInfo (context) {
+  if (context[elasticHttpInfo]) {
+    return {
+      address: context[elasticHttpInfo].address,
+      port: context[elasticHttpInfo].port
+    }
+  }
+  return {}
+}
+
+module.exports = {
+  elasticHttpInfo,
+  httpInfoMiddleware,
+  getHttpInfo
+}

--- a/lib/instrumentation/modules/@aws-sdk/smithy-client.js
+++ b/lib/instrumentation/modules/@aws-sdk/smithy-client.js
@@ -13,7 +13,8 @@ const {
   S3_NAME,
   S3_TYPE,
   S3_SUBTYPE,
-  s3MiddlewareFactory
+  s3MiddlewareFactory,
+  s3CommandFilter
 } = require('./client-s3')
 const {
   SNS_NAME,
@@ -56,17 +57,13 @@ function opNameFromCommandName (commandName) {
   }
 }
 
-function allCommandsFilter () {
-  return true
-}
-
 const clientsConfig = {
   S3Client: {
     NAME: S3_NAME,
     TYPE: S3_TYPE,
     SUBTYPE: S3_SUBTYPE,
     factory: s3MiddlewareFactory,
-    shouldInstrument: allCommandsFilter
+    shouldInstrument: s3CommandFilter
   },
   SNSClient: {
     NAME: SNS_NAME,
@@ -115,9 +112,8 @@ module.exports = function (mod, agent, { name, version, enabled }) {
 
       const command = arguments[0]
 
-      // Some instrumentations (like SNS) do not want to instrument all commands
       // TODO: test this
-      if (!clientConfig.shouldInstrument(command)) {
+      if (!clientConfig.shouldInstrument(command, agent._conf)) {
         return orig.apply(this, arguments)
       }
 

--- a/lib/instrumentation/modules/@aws-sdk/smithy-client.js
+++ b/lib/instrumentation/modules/@aws-sdk/smithy-client.js
@@ -14,14 +14,14 @@ const {
   S3_TYPE,
   S3_SUBTYPE,
   s3MiddlewareFactory,
-  s3CommandFilter
+  s3ShouldIgnoreCommand
 } = require('./client-s3')
 const {
   SNS_NAME,
   SNS_TYPE,
   SNS_SUBTYPE,
   snsMiddlewareFactory,
-  snsCommandFilter
+  snsShouldIgnoreCommand
 } = require('./client-sns')
 
 /**
@@ -63,14 +63,14 @@ const clientsConfig = {
     TYPE: S3_TYPE,
     SUBTYPE: S3_SUBTYPE,
     factory: s3MiddlewareFactory,
-    shouldInstrument: s3CommandFilter
+    shouldIgnoreCommand: s3ShouldIgnoreCommand
   },
   SNSClient: {
     NAME: SNS_NAME,
     TYPE: SNS_TYPE,
     SUBTYPE: SNS_SUBTYPE,
     factory: snsMiddlewareFactory,
-    shouldInstrument: snsCommandFilter
+    shouldIgnoreCommand: snsShouldIgnoreCommand
   }
 }
 
@@ -112,8 +112,7 @@ module.exports = function (mod, agent, { name, version, enabled }) {
 
       const command = arguments[0]
 
-      // TODO: test this
-      if (!clientConfig.shouldInstrument(command, agent._conf)) {
+      if (clientConfig.shouldIgnoreCommand(command, agent._conf)) {
         return orig.apply(this, arguments)
       }
 

--- a/lib/instrumentation/modules/@aws-sdk/smithy-client.js
+++ b/lib/instrumentation/modules/@aws-sdk/smithy-client.js
@@ -15,6 +15,13 @@ const {
   S3_SUBTYPE,
   s3MiddlewareFactory
 } = require('./client-s3')
+const {
+  SNS_NAME,
+  SNS_TYPE,
+  SNS_SUBTYPE,
+  snsMiddlewareFactory,
+  snsCommandFilter
+} = require('./client-sns')
 
 /**
  * We do alias them to a local type
@@ -49,12 +56,24 @@ function opNameFromCommandName (commandName) {
   }
 }
 
+function allCommandsFilter () {
+  return true
+}
+
 const clientsConfig = {
   S3Client: {
     NAME: S3_NAME,
     TYPE: S3_TYPE,
     SUBTYPE: S3_SUBTYPE,
-    factory: s3MiddlewareFactory
+    factory: s3MiddlewareFactory,
+    shouldInstrument: allCommandsFilter
+  },
+  SNSClient: {
+    NAME: SNS_NAME,
+    TYPE: SNS_TYPE,
+    SUBTYPE: SNS_SUBTYPE,
+    factory: snsMiddlewareFactory,
+    shouldInstrument: snsCommandFilter
   }
 }
 
@@ -95,6 +114,13 @@ module.exports = function (mod, agent, { name, version, enabled }) {
       }
 
       const command = arguments[0]
+
+      // Some instrumentations (like SNS) do not want to instrument all commands
+      // TODO: test this
+      if (!clientConfig.shouldInstrument(command)) {
+        return orig.apply(this, arguments)
+      }
+
       const opName = opNameFromCommandName(command.constructor.name)
       const name = clientConfig.NAME + ' ' + opName
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.48.0",
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@aws-sdk/client-sns": "^3.370.0",
         "@elastic/ecs-pino-format": "^1.2.0",
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/core": "^1.11.0",
@@ -37,7 +38,7 @@
         "original-url": "^1.2.3",
         "pino": "^6.11.2",
         "relative-microtime": "^2.0.0",
-        "require-in-the-middle": "^7.0.1",
+        "require-in-the-middle": "^7.1.1",
         "semver": "^6.3.1",
         "shallow-clone-shim": "^2.0.0",
         "source-map": "^0.8.0-beta.0",
@@ -651,7 +652,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -661,8 +661,7 @@
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "3.0.0",
@@ -685,7 +684,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -693,8 +691,7 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "3.0.0",
@@ -721,7 +718,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -736,14 +732,12 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -753,14 +747,12 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -768,14 +760,12 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -785,8 +775,7 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
       "version": "3.310.0",
@@ -860,6 +849,447 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.370.0.tgz",
+      "integrity": "sha512-qYMRShyFhX7bjd8p2XxtFWeqAyupUl6OhMadaC2BLEMYm+2cPIrOJZY7JajEI8Sqf1EFXQSkKjc+svpHLINguw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.370.0",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
+      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
+      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sts": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
+      "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-sdk-sts": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
+      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
+      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
+      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-ini": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
+      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
+      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.370.0",
+        "@aws-sdk/token-providers": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
+      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
+      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
+      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
+      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
+      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
+      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
+      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
+      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
+      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
+      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
+      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -1405,7 +1835,6 @@
       "version": "3.357.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
       "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1470,7 +1899,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1530,7 +1958,6 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -5117,7 +5544,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
       "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -5130,7 +5556,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
       "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "@smithy/util-config-provider": "^1.0.1",
@@ -5145,7 +5570,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
       "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
-      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^1.0.1",
         "@smithy/property-provider": "^1.0.1",
@@ -5161,7 +5585,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
       "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^1.1.0",
@@ -5228,7 +5651,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
       "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/querystring-builder": "^1.0.1",
@@ -5241,7 +5663,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
       "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "@smithy/util-buffer-from": "^1.0.1",
@@ -5256,7 +5677,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
       "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -5266,7 +5686,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
       "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5278,7 +5697,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
       "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/types": "^1.1.0",
@@ -5289,15 +5707,14 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.1.tgz",
-      "integrity": "sha512-XEHPq73PPm0sXul//5MRC8JKDwHTaNjV3myd9FJ5YoUT+QMJ27gqiwwAMVASJ6vC4ELHzgQdmoTZxVX83Jx17w==",
-      "dev": true,
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
+      "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
       "dependencies": {
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/middleware-serde": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/url-parser": "^1.0.2",
+        "@smithy/util-middleware": "^1.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5305,16 +5722,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.2.tgz",
-      "integrity": "sha512-Osj+XsqJ67RuX1MLc3+7LDtlRz8eNVqr/Pim9yPAjRa03Xberu6ST3a3oV3NqRpcUgMTifxuaKVIciuPE3rTWA==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
+      "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/service-error-classification": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
-        "@smithy/util-retry": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.1",
+        "@smithy/service-error-classification": "^1.0.3",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-middleware": "^1.0.2",
+        "@smithy/util-retry": "^1.0.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -5323,12 +5739,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
-      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
+      "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5339,7 +5754,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
       "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5351,7 +5765,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
       "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
-      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^1.0.1",
         "@smithy/shared-ini-file-loader": "^1.0.1",
@@ -5366,7 +5779,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
       "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
-      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^1.0.1",
         "@smithy/protocol-http": "^1.1.0",
@@ -5382,7 +5794,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
       "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -5392,12 +5803,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
+      "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5408,7 +5818,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
       "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "@smithy/util-uri-escape": "^1.0.1",
@@ -5419,12 +5828,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
-      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
+      "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5432,10 +5840,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.1.tgz",
-      "integrity": "sha512-EcFVOHFv4YZHUrJ6161tpPKXNlQsTAQKoKorODxuOQW1my14mgoyiiMXrlnSMaYRF//oaONYfFOQ2EMAUTC5DQ==",
-      "dev": true,
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
+      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5444,7 +5851,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
       "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -5457,7 +5863,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
       "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^1.0.1",
         "@smithy/is-array-buffer": "^1.0.1",
@@ -5476,7 +5881,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
       "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-stack": "^1.0.1",
         "@smithy/types": "^1.1.0",
@@ -5488,10 +5892,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
+      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5500,13 +5903,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
-      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
+      "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
       "dependencies": {
-        "@smithy/querystring-parser": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@smithy/querystring-parser": "^1.0.2",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -5514,7 +5916,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
       "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.1",
         "tslib": "^2.5.0"
@@ -5527,7 +5928,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
       "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -5536,7 +5936,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
       "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5548,7 +5947,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
       "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
-      "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^1.0.1",
         "tslib": "^2.5.0"
@@ -5561,7 +5959,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
       "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5573,7 +5970,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
       "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
-      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^1.0.1",
         "@smithy/types": "^1.1.0",
@@ -5588,7 +5984,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
       "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
-      "dev": true,
       "dependencies": {
         "@smithy/config-resolver": "^1.0.1",
         "@smithy/credential-provider-imds": "^1.0.1",
@@ -5605,7 +6000,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
       "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5614,10 +6008,9 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
-      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
+      "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5626,12 +6019,11 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.2.tgz",
-      "integrity": "sha512-LqzAy1QzeAHpSZpsd2LtKZRbco7F5gF+Zpoa4TuuFq9f+CGmH6OuTCIN3I13LPEBa4zs2AgvGnXljvMbUw5WGw==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
+      "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
       "dependencies": {
-        "@smithy/service-error-classification": "^1.0.1",
+        "@smithy/service-error-classification": "^1.0.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5642,7 +6034,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
       "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
-      "dev": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^1.0.1",
         "@smithy/node-http-handler": "^1.0.2",
@@ -5661,7 +6052,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
       "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5673,7 +6063,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
       "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.1",
         "tslib": "^2.5.0"
@@ -7074,8 +7463,7 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -9650,7 +10038,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
       "funding": [
         {
           "type": "paypal",
@@ -16046,8 +16433,7 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -16881,7 +17267,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -17767,7 +18152,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -17777,8 +18161,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -17805,7 +18188,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -17813,8 +18195,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -17845,7 +18226,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -17860,8 +18240,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -17869,7 +18248,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -17879,8 +18257,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -17888,7 +18265,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -17896,8 +18272,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -17905,7 +18280,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -17915,8 +18289,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -17989,6 +18362,381 @@
         "@smithy/util-waiter": "^1.0.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sns": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.370.0.tgz",
+      "integrity": "sha512-qYMRShyFhX7bjd8p2XxtFWeqAyupUl6OhMadaC2BLEMYm+2cPIrOJZY7JajEI8Sqf1EFXQSkKjc+svpHLINguw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.370.0",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
+          "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/middleware-host-header": "3.370.0",
+            "@aws-sdk/middleware-logger": "3.370.0",
+            "@aws-sdk/middleware-recursion-detection": "3.370.0",
+            "@aws-sdk/middleware-user-agent": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@aws-sdk/util-endpoints": "3.370.0",
+            "@aws-sdk/util-user-agent-browser": "3.370.0",
+            "@aws-sdk/util-user-agent-node": "3.370.0",
+            "@smithy/config-resolver": "^1.0.1",
+            "@smithy/fetch-http-handler": "^1.0.1",
+            "@smithy/hash-node": "^1.0.1",
+            "@smithy/invalid-dependency": "^1.0.1",
+            "@smithy/middleware-content-length": "^1.0.1",
+            "@smithy/middleware-endpoint": "^1.0.2",
+            "@smithy/middleware-retry": "^1.0.3",
+            "@smithy/middleware-serde": "^1.0.1",
+            "@smithy/middleware-stack": "^1.0.1",
+            "@smithy/node-config-provider": "^1.0.1",
+            "@smithy/node-http-handler": "^1.0.2",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/smithy-client": "^1.0.3",
+            "@smithy/types": "^1.1.0",
+            "@smithy/url-parser": "^1.0.1",
+            "@smithy/util-base64": "^1.0.1",
+            "@smithy/util-body-length-browser": "^1.0.1",
+            "@smithy/util-body-length-node": "^1.0.1",
+            "@smithy/util-defaults-mode-browser": "^1.0.1",
+            "@smithy/util-defaults-mode-node": "^1.0.1",
+            "@smithy/util-retry": "^1.0.3",
+            "@smithy/util-utf8": "^1.0.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
+          "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/middleware-host-header": "3.370.0",
+            "@aws-sdk/middleware-logger": "3.370.0",
+            "@aws-sdk/middleware-recursion-detection": "3.370.0",
+            "@aws-sdk/middleware-user-agent": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@aws-sdk/util-endpoints": "3.370.0",
+            "@aws-sdk/util-user-agent-browser": "3.370.0",
+            "@aws-sdk/util-user-agent-node": "3.370.0",
+            "@smithy/config-resolver": "^1.0.1",
+            "@smithy/fetch-http-handler": "^1.0.1",
+            "@smithy/hash-node": "^1.0.1",
+            "@smithy/invalid-dependency": "^1.0.1",
+            "@smithy/middleware-content-length": "^1.0.1",
+            "@smithy/middleware-endpoint": "^1.0.2",
+            "@smithy/middleware-retry": "^1.0.3",
+            "@smithy/middleware-serde": "^1.0.1",
+            "@smithy/middleware-stack": "^1.0.1",
+            "@smithy/node-config-provider": "^1.0.1",
+            "@smithy/node-http-handler": "^1.0.2",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/smithy-client": "^1.0.3",
+            "@smithy/types": "^1.1.0",
+            "@smithy/url-parser": "^1.0.1",
+            "@smithy/util-base64": "^1.0.1",
+            "@smithy/util-body-length-browser": "^1.0.1",
+            "@smithy/util-body-length-node": "^1.0.1",
+            "@smithy/util-defaults-mode-browser": "^1.0.1",
+            "@smithy/util-defaults-mode-node": "^1.0.1",
+            "@smithy/util-retry": "^1.0.3",
+            "@smithy/util-utf8": "^1.0.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
+          "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/credential-provider-node": "3.370.0",
+            "@aws-sdk/middleware-host-header": "3.370.0",
+            "@aws-sdk/middleware-logger": "3.370.0",
+            "@aws-sdk/middleware-recursion-detection": "3.370.0",
+            "@aws-sdk/middleware-sdk-sts": "3.370.0",
+            "@aws-sdk/middleware-signing": "3.370.0",
+            "@aws-sdk/middleware-user-agent": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@aws-sdk/util-endpoints": "3.370.0",
+            "@aws-sdk/util-user-agent-browser": "3.370.0",
+            "@aws-sdk/util-user-agent-node": "3.370.0",
+            "@smithy/config-resolver": "^1.0.1",
+            "@smithy/fetch-http-handler": "^1.0.1",
+            "@smithy/hash-node": "^1.0.1",
+            "@smithy/invalid-dependency": "^1.0.1",
+            "@smithy/middleware-content-length": "^1.0.1",
+            "@smithy/middleware-endpoint": "^1.0.2",
+            "@smithy/middleware-retry": "^1.0.3",
+            "@smithy/middleware-serde": "^1.0.1",
+            "@smithy/middleware-stack": "^1.0.1",
+            "@smithy/node-config-provider": "^1.0.1",
+            "@smithy/node-http-handler": "^1.0.2",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/smithy-client": "^1.0.3",
+            "@smithy/types": "^1.1.0",
+            "@smithy/url-parser": "^1.0.1",
+            "@smithy/util-base64": "^1.0.1",
+            "@smithy/util-body-length-browser": "^1.0.1",
+            "@smithy/util-body-length-node": "^1.0.1",
+            "@smithy/util-defaults-mode-browser": "^1.0.1",
+            "@smithy/util-defaults-mode-node": "^1.0.1",
+            "@smithy/util-retry": "^1.0.3",
+            "@smithy/util-utf8": "^1.0.1",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
+          "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
+          "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.370.0",
+            "@aws-sdk/credential-provider-process": "3.370.0",
+            "@aws-sdk/credential-provider-sso": "3.370.0",
+            "@aws-sdk/credential-provider-web-identity": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/credential-provider-imds": "^1.0.1",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/shared-ini-file-loader": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
+          "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.370.0",
+            "@aws-sdk/credential-provider-ini": "3.370.0",
+            "@aws-sdk/credential-provider-process": "3.370.0",
+            "@aws-sdk/credential-provider-sso": "3.370.0",
+            "@aws-sdk/credential-provider-web-identity": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/credential-provider-imds": "^1.0.1",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/shared-ini-file-loader": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
+          "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/shared-ini-file-loader": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
+          "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.370.0",
+            "@aws-sdk/token-providers": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/shared-ini-file-loader": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
+          "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
+          "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
+          "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
+          "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
+          "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
+          "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/signature-v4": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "@smithy/util-middleware": "^1.0.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
+          "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@aws-sdk/util-endpoints": "3.370.0",
+            "@smithy/protocol-http": "^1.1.0",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
+          "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.370.0",
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/property-provider": "^1.0.1",
+            "@smithy/shared-ini-file-loader": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+          "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+          "requires": {
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
+          "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
+          "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/types": "^1.1.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.370.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
+          "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
+          "requires": {
+            "@aws-sdk/types": "3.370.0",
+            "@smithy/node-config-provider": "^1.0.1",
+            "@smithy/types": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -18448,7 +19196,6 @@
       "version": "3.357.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
       "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -18498,7 +19245,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -18541,7 +19287,6 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -21390,7 +22135,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
       "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -21400,7 +22144,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
       "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "@smithy/util-config-provider": "^1.0.1",
@@ -21412,7 +22155,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
       "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
-      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^1.0.1",
         "@smithy/property-provider": "^1.0.1",
@@ -21425,7 +22167,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
       "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
-      "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^1.1.0",
@@ -21480,7 +22221,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
       "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
-      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/querystring-builder": "^1.0.1",
@@ -21493,7 +22233,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
       "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "@smithy/util-buffer-from": "^1.0.1",
@@ -21505,7 +22244,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
       "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -21515,7 +22253,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
       "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -21524,7 +22261,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
       "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
-      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/types": "^1.1.0",
@@ -21532,40 +22268,37 @@
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.1.tgz",
-      "integrity": "sha512-XEHPq73PPm0sXul//5MRC8JKDwHTaNjV3myd9FJ5YoUT+QMJ27gqiwwAMVASJ6vC4ELHzgQdmoTZxVX83Jx17w==",
-      "dev": true,
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
+      "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
       "requires": {
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-middleware": "^1.0.1",
+        "@smithy/middleware-serde": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/url-parser": "^1.0.2",
+        "@smithy/util-middleware": "^1.0.2",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.2.tgz",
-      "integrity": "sha512-Osj+XsqJ67RuX1MLc3+7LDtlRz8eNVqr/Pim9yPAjRa03Xberu6ST3a3oV3NqRpcUgMTifxuaKVIciuPE3rTWA==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
+      "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
       "requires": {
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/service-error-classification": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
-        "@smithy/util-retry": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.1",
+        "@smithy/service-error-classification": "^1.0.3",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-middleware": "^1.0.2",
+        "@smithy/util-retry": "^1.0.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
-      "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
+      "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
       "requires": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -21573,7 +22306,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
       "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -21582,7 +22314,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
       "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
-      "dev": true,
       "requires": {
         "@smithy/property-provider": "^1.0.1",
         "@smithy/shared-ini-file-loader": "^1.0.1",
@@ -21594,7 +22325,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
       "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
-      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^1.0.1",
         "@smithy/protocol-http": "^1.1.0",
@@ -21607,19 +22337,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
       "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
-      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
+      "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
       "requires": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -21627,7 +22355,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
       "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "@smithy/util-uri-escape": "^1.0.1",
@@ -21635,26 +22362,23 @@
       }
     },
     "@smithy/querystring-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
-      "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
+      "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
       "requires": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.1.tgz",
-      "integrity": "sha512-EcFVOHFv4YZHUrJ6161tpPKXNlQsTAQKoKorODxuOQW1my14mgoyiiMXrlnSMaYRF//oaONYfFOQ2EMAUTC5DQ==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
+      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA=="
     },
     "@smithy/shared-ini-file-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
       "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
-      "dev": true,
       "requires": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -21664,7 +22388,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
       "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
-      "dev": true,
       "requires": {
         "@smithy/eventstream-codec": "^1.0.1",
         "@smithy/is-array-buffer": "^1.0.1",
@@ -21680,7 +22403,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
       "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
-      "dev": true,
       "requires": {
         "@smithy/middleware-stack": "^1.0.1",
         "@smithy/types": "^1.1.0",
@@ -21689,22 +22411,20 @@
       }
     },
     "@smithy/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
+      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
-      "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
+      "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
       "requires": {
-        "@smithy/querystring-parser": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@smithy/querystring-parser": "^1.0.2",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -21712,7 +22432,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
       "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
-      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^1.0.1",
         "tslib": "^2.5.0"
@@ -21722,7 +22441,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
       "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -21731,7 +22449,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
       "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -21740,7 +22457,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
       "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
-      "dev": true,
       "requires": {
         "@smithy/is-array-buffer": "^1.0.1",
         "tslib": "^2.5.0"
@@ -21750,7 +22466,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
       "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -21759,7 +22474,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
       "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
-      "dev": true,
       "requires": {
         "@smithy/property-provider": "^1.0.1",
         "@smithy/types": "^1.1.0",
@@ -21771,7 +22485,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
       "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
-      "dev": true,
       "requires": {
         "@smithy/config-resolver": "^1.0.1",
         "@smithy/credential-provider-imds": "^1.0.1",
@@ -21785,27 +22498,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
       "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-middleware": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
-      "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
+      "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-retry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.2.tgz",
-      "integrity": "sha512-LqzAy1QzeAHpSZpsd2LtKZRbco7F5gF+Zpoa4TuuFq9f+CGmH6OuTCIN3I13LPEBa4zs2AgvGnXljvMbUw5WGw==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
+      "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
       "requires": {
-        "@smithy/service-error-classification": "^1.0.1",
+        "@smithy/service-error-classification": "^1.0.3",
         "tslib": "^2.5.0"
       }
     },
@@ -21813,7 +22523,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
       "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
-      "dev": true,
       "requires": {
         "@smithy/fetch-http-handler": "^1.0.1",
         "@smithy/node-http-handler": "^1.0.2",
@@ -21829,7 +22538,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
       "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -21838,7 +22546,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
       "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
-      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^1.0.1",
         "tslib": "^2.5.0"
@@ -22972,8 +23679,7 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -24955,7 +25661,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -29948,8 +30653,7 @@
     "strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -30604,8 +31308,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
   "dependencies": {
+    "@aws-sdk/client-sns": "^3.370.0",
     "@elastic/ecs-pino-format": "^1.2.0",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/core": "^1.11.0",

--- a/test/instrumentation/modules/@aws-sdk/client-sns.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sns.test.js
@@ -6,14 +6,11 @@
 
 'use strict'
 
-// Test S3 instrumentation of the '@aws-sdk/client-s3' module.
+// Test SNS instrumentation of the '@aws-sdk/client-sns' module.
 //
-// Note that this uses localstack for testing, which mimicks the S3 API but
+// Note that this uses localstack for testing, which mimicks the SNS API but
 // isn't identical. Some known limitations:
-// - It basically does nothing with regions, so testing bucket region discovery
-//   isn't possible.
-// - AFAIK localstack does not support Access Points, so access point ARNs
-//   cannot be tested.
+// TODO: check if there are limitations
 
 const semver = require('semver')
 if (process.env.GITHUB_ACTIONS === 'true' && process.platform === 'win32') {

--- a/test/instrumentation/modules/@aws-sdk/client-sns.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sns.test.js
@@ -45,7 +45,7 @@ const testFixtures = [
     env: {
       AWS_ACCESS_KEY_ID: 'fake',
       AWS_SECRET_ACCESS_KEY: 'fake',
-      TEST_BUCKET_NAME: 'elasticapmtest-topic-3',
+      TEST_TOPIC_NAME: 'elasticapmtest-topic-3',
       TEST_ENDPOINT: endpoint,
       TEST_REGION: 'us-east-2'
     },
@@ -158,7 +158,7 @@ const testFixtures = [
 
       // This is the Publish to a non-existant-topic, so we expect a failure.
       t.equal(errors.length, 1, 'got 1 error')
-      t.equal(errors[0].parent_id, failingSpanId, 'error is a child of the failing span from getObjNonExistantObject')
+      t.equal(errors[0].parent_id, failingSpanId, 'error is a child of the failing span from publish to a non existant topic')
       t.equal(errors[0].transaction_id, tx.id, 'error.transaction_id')
       t.equal(errors[0].exception.type, 'NotFoundException', 'error.exception.type')
 

--- a/test/instrumentation/modules/@aws-sdk/client-sns.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sns.test.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Test S3 instrumentation of the '@aws-sdk/client-s3' module.
+//
+// Note that this uses localstack for testing, which mimicks the S3 API but
+// isn't identical. Some known limitations:
+// - It basically does nothing with regions, so testing bucket region discovery
+//   isn't possible.
+// - AFAIK localstack does not support Access Points, so access point ARNs
+//   cannot be tested.
+
+const semver = require('semver')
+if (process.env.GITHUB_ACTIONS === 'true' && process.platform === 'win32') {
+  console.log('# SKIP: GH Actions do not support docker services on Windows')
+  process.exit(0)
+}
+if (process.env.ELASTIC_APM_CONTEXT_MANAGER === 'patch') {
+  console.log('# SKIP @aws-sdk/* instrumentation does not work with contextManager="patch"')
+  process.exit()
+}
+if (semver.lt(process.version, '14.0.0')) {
+  console.log(`# SKIP @aws-sdk min supported node is v14 (node ${process.version})`)
+  process.exit()
+}
+
+const test = require('tape')
+
+const { validateSpan } = require('../../../_validate_schema')
+const { runTestFixtures, sortApmEvents } = require('../../../_utils')
+// TODO: create use-client-sns.mjs
+// const { NODE_VER_RANGE_IITM } = require('../../../testconsts')
+
+const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost'
+const endpoint = 'http://' + LOCALSTACK_HOST + ':4566'
+
+const testFixtures = [
+  {
+    name: 'simple SNS V3 usage scenario',
+    script: 'fixtures/use-client-sns.js',
+    cwd: __dirname,
+    timeout: 20000, // sanity guard on the test hanging
+    maxBuffer: 10 * 1024 * 1024, // This is big, but I don't ever want this to be a failure reason.
+    env: {
+      AWS_ACCESS_KEY_ID: 'fake',
+      AWS_SECRET_ACCESS_KEY: 'fake',
+      TEST_BUCKET_NAME: 'elasticapmtest-topic-3',
+      TEST_ENDPOINT: endpoint,
+      TEST_REGION: 'us-east-2'
+    },
+    verbose: false,
+    checkApmServer: (t, apmServer) => {
+      t.ok(apmServer.events[0].metadata, 'metadata')
+      const events = sortApmEvents(apmServer.events)
+
+      // First the transaction.
+      t.ok(events[0].transaction, 'got the transaction')
+      const tx = events.shift().transaction
+      const errors = events.filter(e => e.error).map(e => e.error)
+
+      // Compare some common fields across all spans.
+      // ignore http/external spans
+      const spans = events.filter(e => e.span && e.span.type !== 'external')
+        .map(e => e.span)
+      spans.forEach(s => {
+        const errs = validateSpan(s)
+        t.equal(errs, null, 'span is valid (per apm-server intake schema)')
+      })
+      t.equal(spans.filter(s => s.trace_id === tx.trace_id).length,
+        spans.length, 'all spans have the same trace_id')
+      t.equal(spans.filter(s => s.transaction_id === tx.id).length,
+        spans.length, 'all spans have the same transaction_id')
+      t.equal(spans.filter(s => s.sync === false).length,
+        spans.length, 'all spans have sync=false')
+      t.equal(spans.filter(s => s.sample_rate === 1).length,
+        spans.length, 'all spans have sample_rate=1')
+      const failingSpanId = spans[3].id // index of `Publish` to a non exixtent topic
+      spans.forEach(s => {
+        // Remove variable and common fields to facilitate t.deepEqual below.
+        delete s.id
+        delete s.transaction_id
+        delete s.parent_id
+        delete s.trace_id
+        delete s.timestamp
+        delete s.duration
+        delete s.sync
+        delete s.sample_rate
+      })
+
+      t.deepEqual(spans.shift(), {
+        name: 'get-signed-url',
+        type: 'custom',
+        subtype: null,
+        action: null,
+        outcome: 'success'
+      }, 'custom span for getSignedUrl call')
+
+      t.deepEqual(spans.shift(), {
+        name: 'SNS Publish to <PHONE_NUMBER>',
+        type: 'messaging',
+        subtype: 'sns',
+        action: 'Publish',
+        context: {
+          service: {
+            target: { type: 'sns', name: '<PHONE_NUMBER>' }
+          },
+          destination: {
+            service: { name: '', type: '', resource: 'sns/<PHONE_NUMBER>' },
+            address: 'localhost',
+            port: 4566,
+            cloud: { region: 'us-east-2' }
+          },
+          message: { queue: { name: '<PHONE_NUMBER>' } }
+        },
+        outcome: 'success'
+      }, 'publish to PHONE_NUMBER produced expected span')
+
+      t.deepEqual(spans.shift(), {
+        name: 'SNS Publish to elasticapmtest-topic-3',
+        type: 'messaging',
+        subtype: 'sns',
+        action: 'Publish',
+        context: {
+          service: {
+            target: { type: 'sns', name: 'elasticapmtest-topic-3' }
+          },
+          destination: {
+            service: { name: '', type: '', resource: 'sns/elasticapmtest-topic-3' },
+            address: 'localhost',
+            port: 4566,
+            cloud: { region: 'us-east-2' }
+          },
+          message: { queue: { name: 'elasticapmtest-topic-3' } }
+        },
+        outcome: 'success'
+      }, 'publish to topic produced expected span')
+
+      t.deepEqual(spans.shift(), {
+        name: 'SNS Publish to elasticapmtest-topic-3-unexistent',
+        type: 'messaging',
+        subtype: 'sns',
+        action: 'Publish',
+        context: {
+          service: {
+            target: { type: 'sns', name: 'elasticapmtest-topic-3-unexistent' }
+          },
+          destination: {
+            service: { name: '', type: '', resource: 'sns/elasticapmtest-topic-3-unexistent' },
+            address: 'localhost',
+            port: 4566,
+            cloud: { region: 'us-east-2' }
+          },
+          message: { queue: { name: 'elasticapmtest-topic-3-unexistent' } }
+        },
+        outcome: 'failure'
+      }, 'publish to unexistent topic produced expected span')
+
+      // This is the Publish to a non-existant-topic, so we expect a failure.
+      t.equal(errors.length, 1, 'got 1 error')
+      t.equal(errors[0].parent_id, failingSpanId, 'error is a child of the failing span from getObjNonExistantObject')
+      t.equal(errors[0].transaction_id, tx.id, 'error.transaction_id')
+      t.equal(errors[0].exception.type, 'NotFoundException', 'error.exception.type')
+
+      t.equal(spans.length, 0, 'all spans accounted for')
+    }
+  }
+]
+
+test('@aws-sdk/client-sns fixtures', suite => {
+  runTestFixtures(suite, testFixtures)
+  suite.end()
+})

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -184,7 +184,7 @@ function main () {
   // Config vars.
   const region = process.env.TEST_REGION || 'us-east-2'
   const endpoint = process.env.TEST_ENDPOINT || null
-  const topicName = process.env.TEST_BUCKET_NAME || TEST_TOPIC_NAME_PREFIX + getTimestamp()
+  const topicName = process.env.TEST_TOPIC_NAME || TEST_TOPIC_NAME_PREFIX + getTimestamp()
 
   // Guard against any topic name being used because we will be publishing
   // messages in it, and potentially *deleting* the topic.

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -173,9 +173,8 @@ async function useClientSNS (snsClient, topicName) {
   log.info({ data }, 'deleteTopic')
 }
 
-// Return a timestamp of the form YYYYMMDDHHMMSS, which can be used in an S3
-// bucket name:
-// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+// Return a timestamp of the form YYYYMMDDHHMMSS, which can be used in an SNS
+// topic name:
 function getTimestamp () {
   return (new Date()).toISOString().split('.')[0].replace(/[^0-9]/g, '')
 }

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -101,7 +101,6 @@ async function useClientSNS (snsClient, topicName) {
   } else {
     topicArn = preexistingTopic.TopicArn
   }
-  console.log('topicArn', topicArn)
 
   // Get a signed URL.
   // This is interesting to test, because `getSignedUrl` uses the command

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// Run a single scenario of using the S3 client (callback style) with APM
+// enabled. This is used to test that the expected APM events are generated.
+// It writes log.info (in ecs-logging format, see
+// https://github.com/trentm/go-ecslog#install) for each S3 client API call.
+//
+// This script can also be used for manual testing of APM instrumentation of S3
+// against a real S3 account. This can be useful because tests are done against
+// https://github.com/localstack/localstack that *simulates* S3 with imperfect
+// fidelity.
+//
+// Auth note: By default this uses the AWS profile/configuration from the
+// environment. If you do not have that configured (i.e. do not have
+// "~/.aws/...") files, then you can still use localstack via setting:
+//    unset AWS_PROFILE
+//    export AWS_ACCESS_KEY_ID=fake
+//    export AWS_SECRET_ACCESS_KEY=fake
+// See also: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+//
+// Usage:
+//    # Run against the default configured AWS profile, creating a new bucket
+//    # and deleting it afterwards.
+//    node use-client-s3.js | ecslog
+//
+//    # Testing against localstack.
+//    docker run --rm -it -e SERVICES=s3 -p 4566:4566 localstack/localstack
+//    TEST_ENDPOINT=http://localhost:4566 node use-client-s3.js | ecslog
+//
+//    # Use TEST_BUCKET_NAME to re-use an existing bucket (and not delete it).
+//    # For safety the bucket name must start with "elasticapmtest-bucket-".
+//    TEST_BUCKET_NAME=elasticapmtest-bucket-3 node use-client-s3.js | ecslog
+//
+// Output from a sample run is here:
+// https://gist.github.com/trentm/c402bcab8c0571f26d879ec0bcf5759c
+
+const apm = require('../../../../..').start({
+  serviceName: 'use-client-s3',
+  captureExceptions: false,
+  centralConfig: false,
+  metricsInterval: 0,
+  cloudProvider: 'none',
+  stackTraceLimit: 4, // get it smaller for reviewing output
+  logLevel: 'info',
+  ignoreMessageQueues: [
+    'arn:aws:sns:us-west-2:111111111111:ignore-name'
+  ]
+})
+
+const assert = require('assert')
+const {
+  SNSClient,
+  ListTopicsCommand,
+  CreateTopicCommand,
+  DeleteTopicCommand,
+  PublishCommand
+} = require('@aws-sdk/client-sns')
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner')
+
+const TEST_TOPIC_NAME_PREFIX = 'elasticapmtest-topic-'
+
+// https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/
+async function useClientSNS (snsClient, topicName) {
+  const region = await snsClient.config.region()
+  const log = apm.logger.child({
+    'event.module': 'app',
+    endpoint: snsClient.config.endpoint,
+    topicName,
+    region
+  })
+
+  let command
+  let data
+
+  // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/ListTopicsCommand/
+  // for testing purposes, shouldn't be instrumented
+  command = new ListTopicsCommand({})
+  data = await snsClient.send(command)
+  assert(apm.currentSpan === null,
+    'SNS span (or its HTTP span) should not be currentSpan after awaiting the task')
+  log.info({ data }, 'listTopics')
+
+  let topicArn
+  const preexistingTopic = data.Topics.find(t => t.TopicArn.split(':').pop() === topicName)
+
+  if (!preexistingTopic) {
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/CreateTopicCommand/
+    // for testing purposes, shouldn't be instrumented
+    command = new CreateTopicCommand({ Name: topicName })
+    data = await snsClient.send(command)
+    assert(apm.currentSpan === null,
+      'SNS span (or its HTTP span) should not be currentSpan after awaiting the task')
+    log.info({ data }, 'createTopic')
+    topicArn = data.TopicArn
+  } else {
+    topicArn = preexistingTopic.TopicArn
+  }
+  console.log('topicArn', topicArn)
+
+  // Get a signed URL.
+  // This is interesting to test, because `getSignedUrl` uses the command
+  // `middlewareStack` -- including our added middleware -- **without** calling
+  // `snsClient.send()`. The test here is to ensure this doesn't break.
+  const customSpan = apm.startSpan('get-signed-url')
+  const signedUrl = await getSignedUrl(
+    snsClient,
+    new ListTopicsCommand({}),
+    { expiresIn: 3600 })
+  log.info({ signedUrl }, 'getSignedUrl')
+  customSpan.end()
+
+  // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/PublishCommand/
+  command = new PublishCommand({
+    Message: 'message to be sent',
+    PhoneNumber: '+34555555555'
+  })
+  data = await snsClient.send(command)
+  assert(apm.currentSpan === null,
+    'SNS span (or its HTTP span) should not be currentSpan after awaiting the task')
+  log.info({ data }, 'publish with PhoneNumber')
+
+  command = new PublishCommand({
+    Message: 'message to be sent',
+    TopicArn: topicArn
+  })
+  data = await snsClient.send(command)
+  assert(apm.currentSpan === null,
+    'SNS span (or its HTTP span) should not be currentSpan after awaiting the task')
+  log.info({ data }, 'publish with TopicArn')
+
+  command = new PublishCommand({
+    Message: 'message to be sent',
+    TopicArn: topicArn + '-unexistent'
+  })
+  try {
+    data = await snsClient.send(command)
+    throw new Error('expected NotFoundException error')
+  } catch (err) {
+    log.info({ data }, 'publish with non existent TopicArn')
+    const statusCode = err && err.$metadata && err.$metadata.httpStatusCode
+    if (statusCode !== 404) {
+      throw err
+    }
+  }
+
+  command = new PublishCommand({
+    Message: 'message to be sent',
+    TopicArn: 'arn:aws:sns:us-west-2:111111111111:ignore-name'
+  })
+  try {
+    data = await snsClient.send(command)
+    throw new Error('expected NotFoundException error')
+  } catch (err) {
+    log.info({ data }, 'publish with TopicArn to ignore')
+    const statusCode = err && err.$metadata && err.$metadata.httpStatusCode
+    if (statusCode !== 404) {
+      throw err
+    }
+  }
+
+  // TODO: execute a publish with TargetArn in input, combinations of phone and arn?
+
+  command = new DeleteTopicCommand({ TopicArn: topicArn })
+  data = await snsClient.send(command)
+  assert(apm.currentSpan === null,
+    'SNS span (or its HTTP span) should not be currentSpan after awaiting the task')
+  log.info({ data }, 'deleteTopic')
+}
+
+// Return a timestamp of the form YYYYMMDDHHMMSS, which can be used in an S3
+// bucket name:
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+function getTimestamp () {
+  return (new Date()).toISOString().split('.')[0].replace(/[^0-9]/g, '')
+}
+
+// ---- mainline
+
+function main () {
+  // Config vars.
+  const region = process.env.TEST_REGION || 'us-east-2'
+  const endpoint = process.env.TEST_ENDPOINT || null
+  const topicName = process.env.TEST_BUCKET_NAME || TEST_TOPIC_NAME_PREFIX + getTimestamp()
+
+  // Guard against any topic name being used because we will be publishing
+  // messages in it, and potentially *deleting* the topic.
+  if (!topicName.startsWith(TEST_TOPIC_NAME_PREFIX)) {
+    throw new Error(`cannot use topic name "${topicName}", it must start with ${TEST_TOPIC_NAME_PREFIX}`)
+  }
+
+  const snsClient = new SNSClient({
+    region,
+    endpoint
+  })
+
+  // Ensure an APM transaction so spans can happen.
+  const tx = apm.startTransaction('manual')
+
+  useClientSNS(snsClient, topicName).then(
+    function () {
+      tx.end()
+      snsClient.destroy()
+      process.exitCode = 0
+    },
+    function (err) {
+      apm.logger.error(err, 'useClientSNS rejected')
+      tx.setOutcome('failure')
+      tx.end()
+      snsClient.destroy()
+      process.exitCode = 1
+    }
+  )
+}
+
+main()

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.mjs
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.mjs
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict'
+
+// A small subset of "./use-client-sns.js". Mainly this is to test that
+// instrumentation of @aws-sdk/client-sns in an ES module works.
+// See "./use-client-sns.js" for more details.
+//
+// Usage:
+//    node --experimental-loader=./loader.mjs --require=./start.js test/instrumentation/modules/@aws-sdk/fixtures/use-client-s3.mjs
+
+import apm from '../../../../../index.js' // 'elastic-apm-node'
+import {
+  SNSClient,
+  PublishCommand
+} from '@aws-sdk/client-sns'
+
+import assert from 'assert'
+
+// ---- support functions
+
+async function useClientSNS (snsClient) {
+  const command = new PublishCommand({ Message: 'message to be sent', PhoneNumber: '+34555555555' })
+  const data = await snsClient.send(command)
+  assert(apm.currentSpan === null,
+    'SNS span (or its HTTP span) should not be currentSpan after awaiting the task')
+  console.log('PublishCommand sent with id %s', data.MessageId)
+}
+
+// ---- mainline
+
+function main () {
+  const region = process.env.TEST_REGION || 'us-east-2'
+  const endpoint = process.env.TEST_ENDPOINT || null
+  const snsClient = new SNSClient({ region, endpoint })
+
+  const tx = apm.startTransaction('manual')
+  useClientSNS(snsClient).then(
+    function () {
+      tx.end()
+      snsClient.destroy()
+      process.exitCode = 0
+    },
+    function () {
+      tx.setOutcome('failure')
+      tx.end()
+      snsClient.destroy()
+      process.exitCode = 1
+    }
+  )
+}
+
+main()


### PR DESCRIPTION
This PR adds instrumentation of SNS client of AWS SDK. Also includes some changes in `smithy-client` so other clients (S3, SNS, SQS & DynamoDB) can filter which commands want to instrument or not.

Closes #2956

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
