### PR TITLE
fix: the loader.mjs needed for ESM support was not included in the published package

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,9 +43,12 @@ Notes:
 [float]
 ===== Bug fixes
 
+* Fix ESM support: the "loader.mjs" file was accidentally not included in
+  the published package in v3.48.0. ({pull}3534[#3534])
+
 * Fix instrumentation of `@aws-sdk/client-s3` from v3.378.0 and up. The new version requires `@smithy/smithy-client`
   v2.0.1 and the agent was instrumeting it within the semver range '>=1 <2'.
-  
+
 * Fix wrapping of `http.request()` for node v18.17.0. Before this change, a
   call with a non-Function callback -- `http.request(urlString, {}, 'this-is-not-a-cb-function')`
   -- would accidentally *not* fail because of the agent's instrumentation.
@@ -62,6 +65,10 @@ Notes:
 
 [[release-notes-3.48.0]]
 ==== 3.48.0 - 2023/07/07
+
+*Known issue*: You must upgrade to 3.49.0 or later for the ESM support
+described below to work, because the "loader.mjs" file was accidentally not
+published.
 
 [float]
 ===== Features

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "types",
     "start.js",
     "start-next.js",
+    "loader.mjs",
     "index.d.ts",
     "start.d.ts",
     "start-next.d.ts"


### PR DESCRIPTION
This was noted here: https://github.com/elastic/apm-agent-nodejs/issues/1952#issuecomment-1652228018