### PR TITLE
chore!: drop ELASTIC_APM_KUBERNETES_* envvars, bump min to node v14.5.0

### DIFF
--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -10,6 +10,11 @@
   Users of earlier Node.js versions can use elastic-apm-node v3.x, which
   supports back to Node.js v8.6.
 
+* Remove long deprecated support for the `ELASTIC_APM_`-prefixed environment
+  variables for the <<kubernetes-node-name,Kubernetes config options>>. For
+  example, one must use `KUBERNETES_POD_NAME` and not
+  `ELASTIC_APM_KUBERNETES_POD_NAME`.
+
 [float]
 ===== Features
 

--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -6,14 +6,14 @@
 [float]
 ===== Breaking changes
 
-* Set the new minimum supported Node.js to version 14.
+* Set the new minimum supported Node.js to version 14.5.0.
   Users of earlier Node.js versions can use elastic-apm-node v3.x, which
   supports back to Node.js v8.6.
 
 * Remove long deprecated support for the `ELASTIC_APM_`-prefixed environment
   variables for the <<kubernetes-node-name,Kubernetes config options>>. For
   example, one must use `KUBERNETES_POD_NAME` and not
-  `ELASTIC_APM_KUBERNETES_POD_NAME`.
+  `ELASTIC_APM_KUBERNETES_POD_NAME`. ({issues}2661[#2661])
 
 [float]
 ===== Features

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -1,0 +1,33 @@
+[[upgrade-to-v4]]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/nodejs/current/upgrade-to-v4.html[elastic.co]
+endif::[]
+
+=== Upgrade to v4.x
+
+The following is a guide on upgrading your APM Node.js agent
+(`elastic-apm-node`) from version 3.x to version 4.x.
+
+[[v4-nodejs]]
+==== Node.js versions
+
+Version 4.0.0 of the Node.js APM agent supports Node.js v14.5.0 and later.
+
+[[v4-config-options]]
+==== Config options
+
+Support for the following Kubernetes environment variables have been removed:
+`ELASTIC_APM_KUBERNETES_NAMESPACE`, `ELASTIC_APM_KUBERNETES_NODE_NAME`,
+`ELASTIC_APM_KUBERNETES_POD_NAME`, and `ELASTIC_APM_KUBERNETES_POD_UID`. The
+correct environment variables for these config vars are **without** the
+`ELASTIC_APM_` prefix -- for example
+<<kubernetes-pod-name,`KUBERNETES_POD_NAME`>> -- and has been documented that
+way since v2.11.0.
+
+[[v4-api-changes]]
+==== API changes
+
+XXX
+

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -22,6 +22,7 @@ The following upgrade guides are available:
 * <<upgrade-to-v1,Upgrade to v1.x>> - Follow this guide to upgrade from version 0.x to version 1.x of the Elastic APM Node.js agent
 * <<upgrade-to-v2,Upgrade to v2.x>> - Follow this guide to upgrade from version 1.x to version 2.x of the Elastic APM Node.js agent
 * <<upgrade-to-v3,Upgrade to v3.x>> - Follow this guide to upgrade from version 2.x to version 3.x of the Elastic APM Node.js agent
+* <<upgrade-to-v4,Upgrade to v4.x>> - Follow this guide to upgrade from version 3.x to version 4.x of the Elastic APM Node.js agent
 
 [float]
 [[end-of-life-dates]]
@@ -37,3 +38,5 @@ include::./upgrade-to-v1.asciidoc[Upgrade to v1.x]
 include::./upgrade-to-v2.asciidoc[Upgrade to v2.x]
 
 include::./upgrade-to-v3.asciidoc[Upgrade to v3.x]
+
+include::./upgrade-to-v4.asciidoc[Upgrade to v4.x]

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -169,16 +169,10 @@ const ENV_TABLE = {
   instrument: 'ELASTIC_APM_INSTRUMENT',
   instrumentIncomingHTTPRequests:
     'ELASTIC_APM_INSTRUMENT_INCOMING_HTTP_REQUESTS',
-  kubernetesNamespace: [
-    'ELASTIC_APM_KUBERNETES_NAMESPACE',
-    'KUBERNETES_NAMESPACE',
-  ],
-  kubernetesNodeName: [
-    'ELASTIC_APM_KUBERNETES_NODE_NAME',
-    'KUBERNETES_NODE_NAME',
-  ],
-  kubernetesPodName: ['ELASTIC_APM_KUBERNETES_POD_NAME', 'KUBERNETES_POD_NAME'],
-  kubernetesPodUID: ['ELASTIC_APM_KUBERNETES_POD_UID', 'KUBERNETES_POD_UID'],
+  kubernetesNamespace: ['KUBERNETES_NAMESPACE'],
+  kubernetesNodeName: ['KUBERNETES_NODE_NAME'],
+  kubernetesPodName: ['KUBERNETES_POD_NAME'],
+  kubernetesPodUID: ['KUBERNETES_POD_UID'],
   logLevel: 'ELASTIC_APM_LOG_LEVEL',
   logUncaughtExceptions: 'ELASTIC_APM_LOG_UNCAUGHT_EXCEPTIONS',
   longFieldMaxLength: 'ELASTIC_APM_LONG_FIELD_MAX_LENGTH',

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "git://github.com/elastic/apm-agent-nodejs.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.5.0"
   },
   "keywords": [
     "opbeat",


### PR DESCRIPTION
This starts an "Upgrade to 4.x" guide.

Bumping the min Node.js to 14.5.0 means we will be able to rely on
AsyncLocalStorage support.

Closes: https://github.com/elastic/apm-agent-nodejs/issues/2661
Refs: https://github.com/elastic/apm-agent-nodejs/issues/3529

---

I know I'm mixing multiple things here. When starting the "Upgrade to" guide I wanted to not forget about where we have the min supported Node.js mentioned. If we decide we want the base 14 version to be 14.0.0 later, then we can change these two references back. We should discuss this in https://github.com/elastic/apm-agent-nodejs/issues/3529
