### PR TITLE
chore: add warning on missing units for duration config options

### DIFF
--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -30,7 +30,8 @@
 [float]
 ===== Chores
 
-
+* Add a warning message when a duration config option is provided
+  without units. ({issues}2121[#2121])
 
 [[release-notes-3.x]]
 === Node.js Agent version 3.x

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -160,6 +160,8 @@ function normalizeBytes(opts, fields, defaults, logger) {
  * @param {Array<string>} allowedUnits - An array of the allowed unit strings. This
  *    array may include any number of `us`, `ms`, `s`, and `m`.
  * @param {Boolean} allowNegative - Whether a negative number is allowed.
+ * @param {string} key - the config option key
+ * @param {Logger} logger
  * @returns {number|null}
  */
 function secondsFromDuration(
@@ -167,6 +169,8 @@ function secondsFromDuration(
   defaultUnit,
   allowedUnits,
   allowNegative,
+  key,
+  logger,
 ) {
   let val;
   let unit;
@@ -184,7 +188,18 @@ function secondsFromDuration(
     if (isNaN(val) || !Number.isFinite(val)) {
       return null;
     }
-    unit = match[2] || defaultUnit;
+    // XXX: if we have the logger we can war here
+    // unit = match[2] || defaultUnit;
+    unit = match[2];
+    if (!unit) {
+      logger.warn(
+        'units missing in duration value "%s" for "%s" config option: using default units "%s"',
+        duration,
+        key,
+        defaultUnit,
+      );
+      unit = defaultUnit;
+    }
     if (!allowedUnits.includes(unit)) {
       return null;
     }
@@ -237,6 +252,8 @@ function normalizeDurationOptions(opts, fields, defaults, logger) {
         optSpec.defaultUnit,
         optSpec.allowedUnits,
         optSpec.allowNegative,
+        key,
+        logger,
       );
       if (val === null) {
         if (key in defaults) {
@@ -252,6 +269,8 @@ function normalizeDurationOptions(opts, fields, defaults, logger) {
             optSpec.defaultUnit,
             optSpec.allowedUnits,
             optSpec.allowNegative,
+            key,
+            logger,
           );
         } else {
           logger.warn(

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -188,8 +188,6 @@ function secondsFromDuration(
     if (isNaN(val) || !Number.isFinite(val)) {
       return null;
     }
-    // XXX: if we have the logger we can war here
-    // unit = match[2] || defaultUnit;
     unit = match[2];
     if (!unit) {
       logger.warn(

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -515,6 +515,8 @@ DURATION_OPTS.forEach(function (optSpec) {
       optSpec.defaultUnit,
       optSpec.allowedUnits,
       optSpec.allowNegative,
+      key,
+      new MockLogger(),
     );
   } else if (key === 'spanStackTraceMinDuration') {
     // Because of special handling in normalizeSpanStackTraceMinDuration()
@@ -590,6 +592,26 @@ DURATION_OPTS.forEach(function (optSpec) {
       'warning message includes the invalid key',
     );
 
+    agent.destroy();
+    t.end();
+  });
+
+  test(key + ' warn about units not beng set', function (t) {
+    var agent = new Agent();
+    var logger = new MockLogger();
+    var opts = { logger };
+    opts[key] = '1';
+    agent.start(Object.assign({}, agentOptsNoopTransport, opts));
+    const warning = logger.calls.find((log) => log.type === 'warn');
+    t.equal(warning.type, 'warn', 'got a log.warn');
+    t.ok(
+      warning.message.indexOf('units missing') !== -1,
+      'warning message tells about missing units',
+    );
+    t.ok(
+      warning.message.indexOf(key) !== -1,
+      'warning message contains the key',
+    );
     agent.destroy();
     t.end();
   });

--- a/test/config/normalizers.test.js
+++ b/test/config/normalizers.test.js
@@ -231,31 +231,36 @@ test('#normalizeDurationOptions()', function (t) {
   });
 
   const warnings = logger.calls;
-  t.ok(warnings.length === 4, 'we got warnings for bad duration options');
+  t.ok(warnings.length === 5, 'we got warnings for bad duration options');
   t.ok(
-    warnings[0].message.indexOf('ignoring this option') !== -1,
-    'ignores not allowed unit',
+    warnings[0].message.indexOf('units missing') !== -1,
+    'warns about missing unit',
   );
-  t.deepEqual(warnings[0].interpolation, ['20us', 'notAllowedUnit']);
+  t.deepEqual(warnings[0].interpolation, ['200', 'withoutUnit', 'ms']);
   t.ok(
     warnings[1].message.indexOf('ignoring this option') !== -1,
+    'ignores not allowed unit',
+  );
+  t.deepEqual(warnings[1].interpolation, ['20us', 'notAllowedUnit']);
+  t.ok(
+    warnings[2].message.indexOf('ignoring this option') !== -1,
     'ignores not allowed negative value',
   );
-  t.deepEqual(warnings[1].interpolation, ['-1s', 'notAllowedNegative']);
+  t.deepEqual(warnings[2].interpolation, ['-1s', 'notAllowedNegative']);
   t.ok(
-    warnings[2].message.indexOf('using default') !== -1,
+    warnings[3].message.indexOf('using default') !== -1,
     'uses default value',
   );
-  t.deepEqual(warnings[2].interpolation, [
+  t.deepEqual(warnings[3].interpolation, [
     'not-duration',
     'badWithDefault',
     '25s',
   ]);
   t.ok(
-    warnings[3].message.indexOf('ignoring this option') !== -1,
+    warnings[4].message.indexOf('ignoring this option') !== -1,
     'ignores bad value without default',
   );
-  t.deepEqual(warnings[3].interpolation, ['not-duration', 'badWithoutDefault']);
+  t.deepEqual(warnings[4].interpolation, ['not-duration', 'badWithoutDefault']);
   t.end();
 });
 


### PR DESCRIPTION
Add a warning when a duration config option does not have the units in its value.

Closes #2121 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
