### PR TITLE
chore: remove error message max length config option

### DIFF
--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -21,6 +21,11 @@
 
 * The config option `filterHttpHeaders` is now *removed*. ({pull}3539[#3539])
 
+* The `errorMessageMaxLength` configuration option is now *removed*. From now
+  the size of the fields `error.exception.message` and `error.log.message` is
+  configured with `longFieldMaxLength` option.
+
+
 [float]
 ===== Features
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -800,33 +800,6 @@ The default value `0` means that no source code will be collected for in-app spa
 
 The default value `0` means that no source code will be collected for span library frames.
 
-[[error-message-max-length]]
-==== `errorMessageMaxLength`
-
-* *Type:* String
-* *Default:* `"2kb"`
-* *Env:* `ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH`
-
-This option is **deprecated** -- use <<long-field-max-length,`longFieldMaxLength`>> instead.
-
-The maximum length allowed for error messages.
-It is expressed in bytes or includes a size suffix such as `2kb`.
-Size suffixes are case-insensitive and include `b`,
-`kb`,
-`mb`,
-and `gb`.
-Messages above this length will be truncated before being sent to the APM Server.
-Note that while the configuration option accepts a number of *bytes*, truncation
-is based on a number of unicode characters, not bytes.
-
-Set to `-1` do disable truncation.
-
-This applies to the following properties:
-
-- `error.exception.message`
-- `error.log.message`
-
-
 [[long-field-max-length]]
 ==== `longFieldMaxLength`
 
@@ -841,15 +814,12 @@ number of unicode characters before being sent to APM server:
 - `transaction.context.message.body`, `span.context.message.body`,
   `error.context.message.body`
 - `span.context.db.statement`
-- `error.exception.message`, `error.log.message` - If
-  <<error-message-max-length,`errorMessageMaxLength`>> is specified, then that
-  value takes precedence for these error message fields.
+- `error.exception.message`, `error.log.message`
 
 Note that tracing data is limited at the upstream APM server to
 {apm-guide-ref}/configuration-process.html#max_event_size[`max_event_size`],
 which defaults to 300kB. If you configure `longFieldMaxLength` too large, it
 could result in transactions, spans, or errors that are rejected by APM server.
-
 
 [[stack-trace-limit]]
 ==== `stackTraceLimit`

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,10 +256,6 @@ declare namespace apm {
     disableSend?: boolean;
     elasticsearchCaptureBodyUrls?: Array<string>;
     environment?: string;
-    /**
-     * @deprecated Use `longFieldMaxLength`
-     */
-    errorMessageMaxLength?: string;
     errorOnAbortedRequests?: boolean;
     exitSpanMinDuration?: string;
     frameworkName?: string;

--- a/lib/apm-client/apm-client.js
+++ b/lib/apm-client/apm-client.js
@@ -223,12 +223,6 @@ function getHttpClientConfig(conf, agent) {
     );
   }
 
-  if (conf.errorMessageMaxLength !== undefined) {
-    // As of v10 of the http client, truncation of error messages will default
-    // to `truncateLongFieldsAt` if `truncateErrorMessagesAt` is not specified.
-    clientConfig.truncateErrorMessagesAt = conf.errorMessageMaxLength;
-  }
-
   return clientConfig;
 }
 

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -154,7 +154,6 @@ const ENV_TABLE = {
     'ELASTIC_APM_IGNORE_MESSAGE_QUEUES',
   ],
   elasticsearchCaptureBodyUrls: 'ELASTIC_APM_ELASTICSEARCH_CAPTURE_BODY_URLS',
-  errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
   errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
   frameworkName: 'ELASTIC_APM_FRAMEWORK_NAME',
   frameworkVersion: 'ELASTIC_APM_FRAMEWORK_VERSION',
@@ -331,7 +330,7 @@ const DURATION_OPTS = [
   },
 ];
 
-const BYTES_OPTS = ['apiRequestSize', 'errorMessageMaxLength'];
+const BYTES_OPTS = ['apiRequestSize'];
 
 const MINUS_ONE_EQUAL_INFINITY = ['transactionMaxSpans'];
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -134,7 +134,6 @@ var optionFixtures = [
   ['disableSend', 'ELASTIC_APM_DISABLE_SEND', false],
   ['disableInstrumentations', 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS', []],
   ['environment', 'ELASTIC_APM_ENVIRONMENT', 'development'],
-  ['errorMessageMaxLength', 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH', undefined],
   ['errorOnAbortedRequests', 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS', false],
   ['frameworkName', 'ELASTIC_APM_FRAMEWORK_NAME'],
   ['frameworkVersion', 'ELASTIC_APM_FRAMEWORK_VERSION'],
@@ -209,10 +208,7 @@ optionFixtures.forEach(function (fixture) {
       type = 'customMetricsHistogramBoundaries';
     } else if (fixture[0] === 'traceContinuationStrategy') {
       type = 'traceContinuationStrategy';
-    } else if (
-      typeof fixture[2] === 'number' ||
-      fixture[0] === 'errorMessageMaxLength'
-    ) {
+    } else if (typeof fixture[2] === 'number') {
       type = 'number';
     } else if (Array.isArray(fixture[2])) {
       type = 'array';
@@ -485,7 +481,7 @@ MINUS_ONE_EQUAL_INFINITY.forEach(function (key) {
   });
 });
 
-var bytesValues = ['apiRequestSize', 'errorMessageMaxLength'];
+var bytesValues = ['apiRequestSize'];
 
 bytesValues.forEach(function (key) {
   test(key + ' should be converted to a number', function (t) {


### PR DESCRIPTION
Another PR for cleaning up deprecated configuration options. This time is `errorMessageMaxLength` option which was deprecated in favor of `longFieldMaxLength`.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Modify tests
- [x] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
