### PR TITLE
chore: add some logging for 3xx and 4xx responses polling for central config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,25 @@ Notes:
 === Node.js Agent version 3.x
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+* Add debug logging for 4xx responses from APM server when polling for
+  central config. This is based on https://github.com/elastic/apm-nodejs-http-client/pull/182
+  by @linjunpop.
+
+
 [[release-notes-3.49.0]]
 ==== 3.49.0 - 2023/08/03
 

--- a/lib/apm-client/http-apm-client/index.js
+++ b/lib/apm-client/http-apm-client/index.js
@@ -427,11 +427,19 @@ Client.prototype._pollConfig = function () {
 
     this._scheduleNextConfigPoll(getMaxAge(res));
 
-    if (
-      res.statusCode === 304 || // No new config since last time
-      res.statusCode === 403 || // Central config not enabled in APM Server
-      res.statusCode === 404 // Old APM Server that doesn't support central config
-    ) {
+    // Spec: https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#dealing-with-errors
+    if (res.statusCode === 304) {
+      this._log.trace('_pollConfig: no new central config since last poll');
+      res.resume();
+      return;
+    } else if (res.statusCode === 403) {
+      this._log.debug('_pollConfig: central config not enabled in APM Server');
+      res.resume();
+      return;
+    } else if (res.statusCode === 404) {
+      this._log.debug(
+        '_pollConfig: old APM server does not support central config',
+      );
       res.resume();
       return;
     }


### PR DESCRIPTION
Refs: https://github.com/elastic/apm-nodejs-http-client/pull/182

---

In https://github.com/elastic/apm-agent-nodejs/pull/3507 the APM http-client was moved in this repo. At the time there were some remaining PRs and issues. One of them was https://github.com/elastic/apm-nodejs-http-client/pull/182 by @linjunpop to add some logging for 304, 403, and 404 responses from APM server when polling for central config.  This was adapted to this PR.  Changes from the original PR:

- I've reduced the log levels from debug to trace -- because 'trace' is the more typical "show the inner workings" log level being used in the http-client -- and warn to debug -- because [this part of the spec](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#dealing-with-errors) says:

> If the server responds with 4xx, agents are not required to log the response, but may choose to log it at debug level.

- I've tweaked the log messages.
