### PR TITLE
chore: warn for missing units in config and for `errorMessagesMaxLength` usage

### DIFF
--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -36,7 +36,7 @@
 [float]
 ===== Chores
 
-* Add a warning message when a duration config option is provided
+* Add a warning message when a duration or size config option is provided
   without units. ({issues}2121[#2121])
 
 [[release-notes-3.x]]

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -85,7 +85,7 @@ unit, to avoid ambiguity the APM agent will now warn if the units are not
 provided.
 
 [[v4-warning-size-units]]
-=====
+===== "units missing in size value" 
 
 Byte size config options like `apiRequestSize` expect to have the size
 units specified in the value (e.g. `"10kb"`, `"1gb"`). If the unit is not

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -70,7 +70,7 @@ For log correlation with _structured_ logs, see <<log-correlation-ids>>.
 This section documents some new log output warnings from the APM agent, and how to avoid them.
 
 [[v4-warning-duration-units]]
-=====
+===== "units missing in duration value"
 
 
 [source,json]

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -81,6 +81,6 @@ the default value.
 [[v4-warning-size-units]]
 =====
 
-`apiRequestSize` and `errorMessageMaxLength` config options expect to
-have the size specified in the value (e.g. `10kb`, `1gb`). If the unit
-is not in the value tha agent will warn about it and fallback to `bytes`.
+Byte size config options like `apiRequestSize` expect to have the size
+units specified in the value (e.g. `10kb`, `1gb`). If the unit is not
+in the value tha agent will warn about it and fallback to `bytes`.

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -78,14 +78,14 @@ This section documents some new log output warnings from the APM agent, and how 
 {"log.level":"warn","@timestamp":"2023-08-04T16:54:03.116Z","log":{"logger":"elastic-apm-node"},"ecs":{"version":"1.6.0"},"message":"units missing in duration value \"5\" for \"metricsInterval\" config option: using default units \"s\""}
 ----
 
-Configuration options that define a duration, like `metricsInterval` or 
+Configuration options that define a duration, like `metricsInterval` or
 `exitSpanMinDuration`, expect to have their units specified in the value
 (e.g. `"10s"`, `"100ms"`). While current duration options have a default
 unit, to avoid ambiguity the APM agent will now warn if the units are not
 provided.
 
 [[v4-warning-size-units]]
-===== "units missing in size value" 
+===== "units missing in size value"
 
 Byte size config options like `apiRequestSize` expect to have the size
 units specified in the value (e.g. `"10kb"`, `"1gb"`). If the unit is not

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -88,5 +88,5 @@ provided.
 =====
 
 Byte size config options like `apiRequestSize` expect to have the size
-units specified in the value (e.g. `10kb`, `1gb`). If the unit is not
-in the value tha agent will warn about it and fallback to `bytes`.
+units specified in the value (e.g. `"10kb"`, `"1gb"`). If the unit is not
+in the value, the agent will warn about it and fallback to bytes (`b`).

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -67,7 +67,7 @@ For log correlation with _structured_ logs, see <<log-correlation-ids>>.
 [[v4-warnings]]
 ==== Log warnings
 
-There are some 
+This section documents some new log output warnings from the APM agent, and how to avoid them.
 
 [[v4-warning-duration-units]]
 =====

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -72,11 +72,17 @@ This section documents some new log output warnings from the APM agent, and how 
 [[v4-warning-duration-units]]
 =====
 
-Configuration options that define a duration like `apiRequestTime` or 
-`exitSpanMinDuration` expect to have their units specified in the value
-(e.g. `10s`, `100ms`). If the unit is not in the value tha agent will
-warn about it and fallback to its default unit which is specified in
-the default value.
+
+[source,json]
+----
+{"log.level":"warn","@timestamp":"2023-08-04T16:54:03.116Z","log":{"logger":"elastic-apm-node"},"ecs":{"version":"1.6.0"},"message":"units missing in duration value \"5\" for \"metricsInterval\" config option: using default units \"s\""}
+----
+
+Configuration options that define a duration, like `metricsInterval` or 
+`exitSpanMinDuration`, expect to have their units specified in the value
+(e.g. `"10s"`, `"100ms"`). While current duration options have a default
+unit, to avoid ambiguity the APM agent will now warn if the units are not
+provided.
 
 [[v4-warning-size-units]]
 =====

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -59,7 +59,28 @@ via:
 [source,js]
 ----
 const {stringify} = require('querystring');
-console.log( stringify(span.ids, ' ', '=')) );
+console.log(stringify(span.ids, ' ', '='));
 ----
 
 For log correlation with _structured_ logs, see <<log-correlation-ids>>.
+
+[[v4-warnings]]
+==== Log warnings
+
+There are some 
+
+[[v4-warning-duration-units]]
+=====
+
+Configuration options that define a duration like `apiRequestTime` or 
+`exitSpanMinDuration` expect to have their units specified in the value
+(e.g. `10s`, `100ms`). If the unit is not in the value tha agent will
+warn about it and fallback to its default unit which is specified in
+the default value.
+
+[[v4-warning-size-units]]
+=====
+
+`apiRequestSize` and `errorMessageMaxLength` config options expect to
+have the size specified in the value (e.g. `10kb`, `1gb`). If the unit
+is not in the value tha agent will warn about it and fallback to `bytes`.

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -84,3 +84,9 @@ the default value.
 Byte size config options like `apiRequestSize` expect to have the size
 units specified in the value (e.g. `10kb`, `1gb`). If the unit is not
 in the value tha agent will warn about it and fallback to `bytes`.
+
+[[v4-warning-error-message-max-length]]
+=====
+
+Agent will warn if the deprecated config option `errorMessageMaxLength`
+is set

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -90,9 +90,3 @@ provided.
 Byte size config options like `apiRequestSize` expect to have the size
 units specified in the value (e.g. `10kb`, `1gb`). If the unit is not
 in the value tha agent will warn about it and fallback to `bytes`.
-
-[[v4-warning-error-message-max-length]]
-=====
-
-Agent will warn if the deprecated config option `errorMessageMaxLength`
-is set

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -94,7 +94,7 @@ function bytes(input, key, logger) {
   const matches = input.match(/^(\d+)(b|kb|mb|gb)$/i);
   if (!matches) {
     logger.warn(
-      'units missing in value "%s" for "%s" config option. Use one of b|kb|mb|gb',
+      'units missing in size value "%s" for "%s" config option. Use one of b|kb|mb|gb',
       input,
       key,
     );

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -93,7 +93,6 @@ function normalizeInfinity(opts, fields, defaults, logger) {
 function bytes(input, key, logger) {
   const matches = input.match(/^(\d+)(b|kb|mb|gb)$/i);
   if (!matches) {
-    console.log('no match!!!!', input);
     logger.warn(
       'units missing in value "%s" for "%s" config option. Use one of b|kb|mb|gb',
       input,

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -134,7 +134,14 @@ function bytes(input, key, logger) {
  */
 function normalizeBytes(opts, fields, defaults, logger) {
   for (const key of fields) {
-    if (key in opts) opts[key] = bytes(String(opts[key]), key, logger);
+    if (key in opts) {
+      opts[key] = bytes(String(opts[key]), key, logger);
+      if (key === 'errorMessageMaxLength') {
+        logger.warn(
+          'config option "errorMessageMaxLength" is deprecated. Use "longFieldMaxLength"',
+        );
+      }
+    }
   }
 }
 

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -86,11 +86,21 @@ function normalizeInfinity(opts, fields, defaults, logger) {
  * Translates a string byte size, e.g. '10kb', into an integer number of bytes.
  *
  * @param {String} input
+ * @param {string} key - the config option key
+ * @param {import('../logging.js').Logger} logger
  * @returns {Number|undefined}
  */
-function bytes(input) {
+function bytes(input, key, logger) {
   const matches = input.match(/^(\d+)(b|kb|mb|gb)$/i);
-  if (!matches) return Number(input);
+  if (!matches) {
+    console.log('no match!!!!', input);
+    logger.warn(
+      'units missing in value "%s" for "%s" config option. Use one of b|kb|mb|gb',
+      input,
+      key,
+    );
+    return Number(input);
+  }
 
   const suffix = matches[2].toLowerCase();
   let value = Number(matches[1]);
@@ -125,7 +135,7 @@ function bytes(input) {
  */
 function normalizeBytes(opts, fields, defaults, logger) {
   for (const key of fields) {
-    if (key in opts) opts[key] = bytes(String(opts[key]));
+    if (key in opts) opts[key] = bytes(String(opts[key]), key, logger);
   }
 }
 

--- a/test/config/normalizers.test.js
+++ b/test/config/normalizers.test.js
@@ -167,7 +167,8 @@ test('#normalizeBytes()', function (t) {
     errorMessageMaxLength: 102400,
   });
 
-  const isMissingUnitsWarn = (s) => s.indexOf('units missing in value') !== -1;
+  const isMissingUnitsWarn = (s) =>
+    s.indexOf('units missing in size value') !== -1;
   const warnings = logger.calls;
   t.ok(warnings.length === 4, 'we got warnings');
   t.ok(isMissingUnitsWarn(warnings[0].message), 'warns about missing unit');

--- a/test/config/normalizers.test.js
+++ b/test/config/normalizers.test.js
@@ -138,6 +138,7 @@ test('#normalizeBytes()', function (t) {
     'numberBytes',
     'badWithDefault',
     'badWithoutDefault',
+    'errorMessageMaxLength',
   ];
   const defaults = { badWithDefault: '25kb' };
   const opts = {
@@ -149,6 +150,7 @@ test('#normalizeBytes()', function (t) {
     badWithDefault: 'not-bytes',
     badWithoutDefault: 'not-bytes',
     anotherProperty: 25,
+    errorMessageMaxLength: '100kb',
   };
 
   normalizeBytes(opts, fields, defaults, logger);
@@ -162,26 +164,22 @@ test('#normalizeBytes()', function (t) {
     badWithDefault: NaN,
     badWithoutDefault: NaN,
     anotherProperty: 25,
+    errorMessageMaxLength: 102400,
   });
 
-  const warnString = 'units missing in value';
+  const isMissingUnitsWarn = (s) => s.indexOf('units missing in value') !== -1;
   const warnings = logger.calls;
-  t.ok(warnings.length === 3, 'we got warnings for missing units');
-  t.ok(
-    warnings[0].message.indexOf(warnString) !== -1,
-    'warns about missing unit',
-  );
+  t.ok(warnings.length === 4, 'we got warnings');
+  t.ok(isMissingUnitsWarn(warnings[0].message), 'warns about missing unit');
   t.deepEqual(warnings[0].interpolation, ['12345678', 'numberBytes']);
-  t.ok(
-    warnings[1].message.indexOf(warnString) !== -1,
-    'warns about missing unit',
-  );
+  t.ok(isMissingUnitsWarn(warnings[1].message), 'warns about missing unit');
   t.deepEqual(warnings[1].interpolation, ['not-bytes', 'badWithDefault']);
-  t.ok(
-    warnings[2].message.indexOf(warnString) !== -1,
-    'warns about missing unit',
-  );
+  t.ok(isMissingUnitsWarn(warnings[2].message), 'warns about missing unit');
   t.deepEqual(warnings[2].interpolation, ['not-bytes', 'badWithoutDefault']);
+  t.ok(
+    warnings[3].message.indexOf('"errorMessageMaxLength" is deprecated') !== -1,
+    'warns about errorMessageMaxLength deprecation',
+  );
   t.end();
 });
 

--- a/test/config/normalizers.test.js
+++ b/test/config/normalizers.test.js
@@ -164,7 +164,24 @@ test('#normalizeBytes()', function (t) {
     anotherProperty: 25,
   });
 
-  t.ok(logger.calls.length === 0, 'we got no warnings for bad byte options');
+  const warnString = 'units missing in value';
+  const warnings = logger.calls;
+  t.ok(warnings.length === 3, 'we got warnings for missing units');
+  t.ok(
+    warnings[0].message.indexOf(warnString) !== -1,
+    'warns about missing unit',
+  );
+  t.deepEqual(warnings[0].interpolation, ['12345678', 'numberBytes']);
+  t.ok(
+    warnings[1].message.indexOf(warnString) !== -1,
+    'warns about missing unit',
+  );
+  t.deepEqual(warnings[1].interpolation, ['not-bytes', 'badWithDefault']);
+  t.ok(
+    warnings[2].message.indexOf(warnString) !== -1,
+    'warns about missing unit',
+  );
+  t.deepEqual(warnings[2].interpolation, ['not-bytes', 'badWithoutDefault']);
   t.end();
 });
 


### PR DESCRIPTION
Spit out a warning whenever a size/bytes config option is given without its units. The log shows the value provided and the name of the option.

This PR also adds a warning log if the deprecated `errorMessagesMaxLength` is used.

Closes #2121 
Closes #2314 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
