### PR TITLE
chore: return noop transaction if agent not started

### DIFF
--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -27,6 +27,9 @@
 * Remove instrumentation support for the old 'hapi' package -- the current
   '@hapi/hapi' package is still instrumented. ({issues}2691[#2691])
 
+* Change `agent.startTransaction()` api to return a noop transaction instead of
+  null. ({issues}2429[#2429])
+
 [float]
 ===== Features
 

--- a/docs/agent-api.asciidoc
+++ b/docs/agent-api.asciidoc
@@ -560,15 +560,18 @@ The `links` argument is an array of objects with a single "context" field
 that is a `Transaction`, `Span`, or W3C trace-context 'traceparent' string.
 For example: `apm.startTransaction('aName', { links: [{ context: anotherSpan }] })`.
 
-Start a new transaction.
-
-Use this function to create a custom transaction.
-Note that the agent will do this for you automatically whenever your application receives an incoming HTTP request.
-You only need to use this function to create custom transactions.
-
-There's a special `type` called `request` which is used by the agent for the transactions automatically created when an incoming HTTP request is detected.
-
+Start a new custom/manual transaction.
 See the <<transaction-api,Transaction API>> docs for details on how to use custom transactions.
+
+Note that the APM agent will automatically start a transaction for incoming
+HTTP requests. You only need to use this function to create custom transactions,
+for example for a periodic background routine. There's a special `type` called
+`request` which is used by the agent for the transactions automatically created
+when an incoming HTTP request is detected.
+
+If the APM agent has not yet been started, then a do-nothing "no-op" transaction
+object will be returned.
+
 
 [[apm-end-transaction]]
 ==== `apm.endTransaction([result][, endTime])`

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -67,6 +67,9 @@ For log correlation with _structured_ logs, see <<log-correlation-ids>>.
 [[v4-api-start-transaction]]
 ===== `agent.startTransaction()`
 
-The `agent.startTransaction()` method has been changed to return an invalid
-or noop transaction if the agent is not yet started.
+The `agent.startTransaction()` method has been changed to return a do-nothing
+no-op Transaction, if the agent is not yet started. The return type has changed to
+no longer include `| null`. The intent of these changes is to allow the user to use
+`.startTransaction()` without having to worry if the agent is yet started, nor to
+have to handle a possible `null` return value.
 

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -63,3 +63,10 @@ console.log( stringify(span.ids, ' ', '=')) );
 ----
 
 For log correlation with _structured_ logs, see <<log-correlation-ids>>.
+
+[[v4-api-start-transaction]]
+===== `agent.startTransaction()`
+
+The `agent.startTransaction()` method has been changed to return an invalid
+or noop transaction if the agent is not yet started.
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ declare namespace apm {
       subtype: string | null,
       action: string | null,
       options?: TransactionOptions
-    ): Transaction | null;
+    ): Transaction;
     setTransactionName (name: string): void;
     endTransaction (result?: string | number, endTime?: number): void;
     currentTransaction: Transaction | null;

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -21,6 +21,7 @@ const {
 var { Ids } = require('./ids');
 var NamedArray = require('./named-array');
 var Transaction = require('./transaction');
+var NoopTransaction = require('./noop-transaction');
 const {
   BasicRunContextManager,
   AsyncHooksRunContextManager,
@@ -741,6 +742,9 @@ Instrumentation.prototype.createTransaction = function (name, ...args) {
 };
 
 Instrumentation.prototype.startTransaction = function (name, ...args) {
+  if (!this._agent.isStarted()) {
+    return new NoopTransaction();
+  }
   const trans = new Transaction(this._agent, name, ...args);
   this.supersedeWithTransRunContext(trans);
   return trans;

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -21,7 +21,7 @@ const {
 var { Ids } = require('./ids');
 var NamedArray = require('./named-array');
 var Transaction = require('./transaction');
-var NoopTransaction = require('./noop-transaction');
+var { NoopTransaction } = require('./noop-transaction');
 const {
   BasicRunContextManager,
   AsyncHooksRunContextManager,

--- a/lib/instrumentation/noop-transaction.js
+++ b/lib/instrumentation/noop-transaction.js
@@ -19,7 +19,7 @@ const NOOP_TRACEPARENT = '00-00000000000000000000000000000-0000000000000000-00';
 function NoopTransaction() {
   // Public properties:
   // https://www.elastic.co/guide/en/apm/agent/nodejs/current/transaction-api.html
-  this.name = 'Noop Transaction';
+  this.name = 'unnamed';
   this.type = 'noop';
   this.subtype = undefined;
   this.action = undefined;

--- a/lib/instrumentation/noop-transaction.js
+++ b/lib/instrumentation/noop-transaction.js
@@ -8,70 +8,71 @@
 
 const constants = require('../constants');
 
-module.exports = NoopTransaction;
-
 const NOOP_TRANSACTION_ID = '0000000000000000';
 const NOOP_TRACEID = '00000000000000000000000000000000';
 const NOOP_TRACEPARENT = '00-00000000000000000000000000000-0000000000000000-00';
 
-// Usage:
-//    new NoopTransaction()
-function NoopTransaction() {
-  // Public properties:
-  // https://www.elastic.co/guide/en/apm/agent/nodejs/current/transaction-api.html
-  this.name = 'unnamed';
-  this.type = 'noop';
-  this.subtype = undefined;
-  this.action = undefined;
-  this.traceparent = NOOP_TRACEPARENT;
-  this.result = constants.RESULT_SUCCESS;
-  this.outcome = 'unknown';
-  this.ids = {
-    'trace.id': NOOP_TRACEID,
-    'transaction.id': NOOP_TRANSACTION_ID,
-  };
+/**
+ * A do-nothing Transaction object.
+ * https://www.elastic.co/guide/en/apm/agent/nodejs/current/transaction-api.html
+ */
+class NoopTransaction {
+  constructor() {
+    this.name = 'unnamed';
+    this.type = 'noop';
+    this.subtype = undefined;
+    this.action = undefined;
+    this.traceparent = NOOP_TRACEPARENT;
+    this.result = constants.RESULT_SUCCESS;
+    this.outcome = constants.OUTCOME_UNKNOWN;
+    this.ids = {
+      'trace.id': NOOP_TRACEID,
+      'transaction.id': NOOP_TRANSACTION_ID,
+    };
 
-  // Non official mentioned in index.d.ts
-  this.timestamp = Date.now();
-  this.id = NOOP_TRANSACTION_ID;
-  this.traceId = NOOP_TRACEID;
-  this.sampled = false;
-  this.ended = false;
+    // Unofficial properties mentioned in a comment in index.d.ts.
+    this.timestamp = Date.now();
+    this.id = NOOP_TRANSACTION_ID;
+    this.traceId = NOOP_TRACEID;
+    this.sampled = false;
+    this.ended = false;
+  }
+
+  // Public methods.
+  setType() {}
+  setLabel() {
+    return true;
+  }
+  addLabels() {
+    return true;
+  }
+  setOutcome() {}
+  startSpan() {
+    return null;
+  }
+  end() {}
+  ensureParentId() {
+    return NOOP_TRANSACTION_ID;
+  }
+  toString() {
+    return `Transaction(${this.id}, '${this.name}'${
+      this.ended ? ', ended' : ''
+    })`;
+  }
+
+  // Non-public methods mentioned in a comment in index.d.ts.
+  setUserContext() {}
+  setCustomContext() {}
+  setDefaultName() {}
+  setDefaultNameFromRequest() {}
+  toJSON() {
+    return {};
+  }
+  duration() {
+    return 0;
+  }
 }
 
-// Public methods:
-// https://www.elastic.co/guide/en/apm/agent/nodejs/current/transaction-api.html
-NoopTransaction.prototype.setType = returnVoid;
-NoopTransaction.prototype.setLabel = returnTrue;
-NoopTransaction.prototype.addLabels = returnTrue;
-NoopTransaction.prototype.setOutcome = returnVoid;
-NoopTransaction.prototype.startSpan = returnNull;
-NoopTransaction.prototype.end = returnVoid;
-NoopTransaction.prototype.ensureParentId = function () {
-  return NOOP_TRANSACTION_ID;
+module.exports = {
+  NoopTransaction,
 };
-NoopTransaction.prototype.toString = function () {
-  return `Transaction(${this.id}, '${this.name}'${
-    this.ended ? ', ended' : ''
-  })`;
-};
-
-// Non public methods mentioned in index.d.ts
-NoopTransaction.prototype.setUserContext = returnVoid;
-NoopTransaction.prototype.setCustomContext = returnVoid;
-NoopTransaction.prototype.setDefaultName = returnVoid;
-NoopTransaction.prototype.setDefaultNameFromRequest = returnVoid;
-NoopTransaction.prototype.toJSON = function () {
-  return {};
-};
-NoopTransaction.prototype.duration = function () {
-  return 0;
-};
-
-function returnVoid() {}
-function returnTrue() {
-  return true;
-}
-function returnNull() {
-  return null;
-}

--- a/lib/instrumentation/noop-transaction.js
+++ b/lib/instrumentation/noop-transaction.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+'use strict';
+
+const constants = require('../constants');
+
+module.exports = NoopTransaction;
+
+const NOOP_TRANSACTION_ID = '0000000000000000';
+const NOOP_TRACEID = '00000000000000000000000000000000';
+const NOOP_TRACEPARENT = '00-00000000000000000000000000000-0000000000000000-00';
+
+// Usage:
+//    new NoopTransaction()
+function NoopTransaction() {
+  // Public properties:
+  // https://www.elastic.co/guide/en/apm/agent/nodejs/current/transaction-api.html
+  this.name = 'Noop Transaction';
+  this.type = 'noop';
+  this.subtype = undefined;
+  this.action = undefined;
+  this.traceparent = NOOP_TRACEPARENT;
+  this.result = constants.RESULT_SUCCESS;
+  this.outcome = 'unknown';
+  this.ids = {
+    'trace.id': NOOP_TRACEID,
+    'transaction.id': NOOP_TRANSACTION_ID,
+  };
+
+  // Non official mentioned in index.d.ts
+  this.timestamp = Date.now();
+  this.id = NOOP_TRANSACTION_ID;
+  this.traceId = NOOP_TRACEID;
+  this.sampled = false;
+  this.ended = false;
+}
+
+// Public methods:
+// https://www.elastic.co/guide/en/apm/agent/nodejs/current/transaction-api.html
+NoopTransaction.prototype.setType = returnVoid;
+NoopTransaction.prototype.setLabel = returnTrue;
+NoopTransaction.prototype.addLabels = returnTrue;
+NoopTransaction.prototype.setOutcome = returnVoid;
+NoopTransaction.prototype.startSpan = returnNull;
+NoopTransaction.prototype.end = returnVoid;
+NoopTransaction.prototype.ensureParentId = function () {
+  return '00000000';
+};
+NoopTransaction.prototype.toString = function () {
+  return `Transaction(${this.id}, '${this.name}'${
+    this.ended ? ', ended' : ''
+  })`;
+};
+
+// Non public methods mentioned in index.d.ts
+NoopTransaction.prototype.setUserContext = returnVoid;
+NoopTransaction.prototype.setCustomContext = returnVoid;
+NoopTransaction.prototype.setDefaultName = returnVoid;
+NoopTransaction.prototype.setDefaultNameFromRequest = returnVoid;
+NoopTransaction.prototype.toJSON = function () {
+  return {};
+};
+NoopTransaction.prototype.duration = function () {
+  return 0;
+};
+
+function returnVoid() {}
+function returnTrue() {
+  return true;
+}
+function returnNull() {
+  return null;
+}

--- a/lib/instrumentation/noop-transaction.js
+++ b/lib/instrumentation/noop-transaction.js
@@ -48,7 +48,7 @@ NoopTransaction.prototype.setOutcome = returnVoid;
 NoopTransaction.prototype.startSpan = returnNull;
 NoopTransaction.prototype.end = returnVoid;
 NoopTransaction.prototype.ensureParentId = function () {
-  return '00000000';
+  return NOOP_TRANSACTION_ID;
 };
 NoopTransaction.prototype.toString = function () {
   return `Transaction(${this.id}, '${this.name}'${

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -28,7 +28,7 @@ const {
 const { findObjInArray } = require('./_utils');
 const { MockAPMServer } = require('./_mock_apm_server');
 const { NoopApmClient } = require('../lib/apm-client/noop-apm-client');
-const NoopTransaction = require('../lib/instrumentation/noop-transaction');
+const { NoopTransaction } = require('../lib/instrumentation/noop-transaction');
 var packageJson = require('../package.json');
 
 // Options to pass to `agent.start()` to turn off some default agent behavior
@@ -196,11 +196,13 @@ test('#setFramework()', function (t) {
 
 test('#startTransaction()', function (t) {
   t.test(
-    'agent not yet started: startTransaction() should return a noop transaction',
+    'agent not yet started: startTransaction() should return a NoopTransaction',
     function (t) {
       const agent = new Agent(); // do not start the agent
       const trans = agent.startTransaction('foo');
-      t.ok(trans instanceof NoopTransaction, 'agent retuns a noop transaction');
+      t.ok(trans instanceof NoopTransaction, 'agent retuns a NoopTransaction');
+      // A limited sanity check that the Transaction API works on it.
+      t.ok(trans.traceparent, 'traceparent: ' + trans.traceparent);
       agent.destroy();
       t.end();
     },

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -194,7 +194,7 @@ test('#setFramework()', function (t) {
   t.end();
 });
 
-test.only('#startTransaction()', function (t) {
+test('#startTransaction()', function (t) {
   t.test(
     'agent not yet started: startTransaction() should return a noop transaction',
     function (t) {

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -28,6 +28,7 @@ const {
 const { findObjInArray } = require('./_utils');
 const { MockAPMServer } = require('./_mock_apm_server');
 const { NoopApmClient } = require('../lib/apm-client/noop-apm-client');
+const NoopTransaction = require('../lib/instrumentation/noop-transaction');
 var packageJson = require('../package.json');
 
 // Options to pass to `agent.start()` to turn off some default agent behavior
@@ -193,12 +194,13 @@ test('#setFramework()', function (t) {
   t.end();
 });
 
-test('#startTransaction()', function (t) {
+test.only('#startTransaction()', function (t) {
   t.test(
-    'agent not yet started: startTransaction() should not crash',
+    'agent not yet started: startTransaction() should return a noop transaction',
     function (t) {
       const agent = new Agent(); // do not start the agent
-      agent.startTransaction('foo');
+      const trans = agent.startTransaction('foo');
+      t.ok(trans instanceof NoopTransaction, 'agent retuns a noop transaction');
       agent.destroy();
       t.end();
     },
@@ -207,6 +209,10 @@ test('#startTransaction()', function (t) {
   t.test('name, type, subtype and action', function (t) {
     const agent = new Agent().start(agentOptsNoopTransport);
     var trans = agent.startTransaction('foo', 'type', 'subtype', 'action');
+    t.ok(
+      !(trans instanceof NoopTransaction),
+      'agent retuns a real transaction',
+    );
     t.strictEqual(trans.name, 'foo');
     t.strictEqual(trans.type, 'type');
     t.strictEqual(trans.subtype, 'subtype');
@@ -218,6 +224,7 @@ test('#startTransaction()', function (t) {
   t.test('options.startTime', function (t) {
     const agent = new Agent().start(agentOptsNoopTransport);
     var startTime = Date.now() - 1000;
+    t.ok(agent.isStarted(), 'agent started');
     var trans = agent.startTransaction('foo', 'bar', { startTime });
     trans.end();
     var duration = trans.duration();


### PR DESCRIPTION
This PR adds a check in the `agent.startTransaction()` API which looks if the agent has been started. If so it lets the method run otherwise returns a noop transaction (same a approach as OTel does).

Closes #2429 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
