### PR TITLE
chore: set `useElasticTraceparentHeader`'s default value to `false`

### DIFF
--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -27,8 +27,6 @@
 * Remove instrumentation support for the old 'hapi' package -- the current
   '@hapi/hapi' package is still instrumented. ({issues}2691[#2691])
 
-* Change default value of `useElasticTraceparentHeader` config option to `false`.
-
 [float]
 ===== Features
 
@@ -40,6 +38,8 @@
 
 * Add a warning message when a duration config option is provided
   without units. ({issues}2121[#2121])
+
+* Change default value of `useElasticTraceparentHeader` config option to `false`.
 
 [[release-notes-3.x]]
 === Node.js Agent version 3.x

--- a/CHANGELOG4.asciidoc
+++ b/CHANGELOG4.asciidoc
@@ -27,6 +27,8 @@
 * Remove instrumentation support for the old 'hapi' package -- the current
   '@hapi/hapi' package is still instrumented. ({issues}2691[#2691])
 
+* Change default value of `useElasticTraceparentHeader` config option to `false`.
+
 [float]
 ===== Features
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1423,7 +1423,7 @@ The captured request body (if any) is stored on the `span.db.statement` field. C
 ==== `useElasticTraceparentHeader`
 
 * *Type:* Boolean
-* *Default:* `true`
+* *Default:* `false`
 * *Env:* `ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER`
 
 To enable {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing], the agent

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -34,6 +34,12 @@ Support for `filterHttpHeaders` config option has been removed. Redaction of
 HTTP headers and also request cookies is controlled by the existing config
 option <<sanitize-field-names, `sanitizeFieldNames`>>.
 
+===== `useElasticTraceparentHeader`
+
+The default value of `useElasticTraceparentHeader` config option has changed
+to `false` since the standard `traceparent` header is added in outgoing
+HTTP requests. If you want the agent to continue sending `elastic-apm-traceparent`
+HTTP header you can set to `true` via env var or start options.
 
 [[v4-api-changes]]
 ==== API changes

--- a/docs/upgrade-to-v4.asciidoc
+++ b/docs/upgrade-to-v4.asciidoc
@@ -15,6 +15,7 @@ The following is a guide on upgrading your APM Node.js agent
 
 Version 4.0.0 of the Node.js APM agent supports Node.js v14.5.0 and later.
 
+
 [[v4-config-options]]
 ==== Config options
 
@@ -36,12 +37,15 @@ option <<sanitize-field-names, `sanitizeFieldNames`>>.
 
 ===== `useElasticTraceparentHeader`
 
-The default value of the <<use-elastic-traceparent-header>> config option has changed
-to `false`. This means that the vendor-specific `elastic-apm-traceparent` header will no
-longer by added to outgoing HTTP requests. The `traceparent` header (from the 
-https://w3c.github.io/trace-context/[W3C trace-context standard]) is added by the
-APM agent. If you want the agent to continue sending `elastic-apm-traceparent`
-HTTP header you can set it to `true` via env var or start options.
+The default value of the <<use-elastic-traceparent-header>> config option has
+changed to `false`. This means that the vendor-specific
+`elastic-apm-traceparent` header will no longer be added to outgoing HTTP
+requests. The `traceparent` header (from the
+https://w3c.github.io/trace-context/[W3C trace-context standard]) is added by
+the APM agent. If you want the agent to continue sending
+`elastic-apm-traceparent` HTTP header you can set it to `true` via env var or
+start options.
+
 
 [[v4-api-changes]]
 ==== API changes

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -118,7 +118,7 @@ const DEFAULTS = {
   transactionIgnoreUrls: [],
   transactionMaxSpans: 500,
   transactionSampleRate: 1.0,
-  useElasticTraceparentHeader: true,
+  useElasticTraceparentHeader: false,
   usePathAsTransactionName: false,
   verifyServerCert: true,
 };

--- a/test/instrumentation/modules/http/outgoing.test.js
+++ b/test/instrumentation/modules/http/outgoing.test.js
@@ -57,7 +57,7 @@ test(
 
 test(
   'http: consider useElasticTraceparentHeader config option',
-  echoTest('http', { useElasticTraceparentHeader: false }, (port, cb) => {
+  echoTest('http', { useElasticTraceparentHeader: true }, (port, cb) => {
     var options = { port };
     return http.request(options, cb);
   }),
@@ -364,13 +364,13 @@ function echoTest(type, opts, handler) {
 
       var traceparent = req.getHeader('traceparent');
       t.ok(traceparent, 'should have traceparent header');
-      if (opts && opts.useElasticTraceparentHeader === false) {
-        t.strictEqual(req.getHeader('elastic-apm-traceparent'), undefined);
-      } else {
+      if (opts && opts.useElasticTraceparentHeader) {
         t.ok(
           req.getHeader('elastic-apm-traceparent'),
           'should have elastic-apm-traceparent header',
         );
+      } else {
+        t.strictEqual(req.getHeader('elastic-apm-traceparent'), undefined);
       }
 
       var expected = TraceParent.fromString(trans._context.toString());

--- a/test/instrumentation/modules/http2.test.js
+++ b/test/instrumentation/modules/http2.test.js
@@ -602,8 +602,6 @@ function assertPath(t, trans, secure, port, path, httpVersion) {
   if (trans.context.request.headers.traceparent) {
     expectedReqHeaders.traceparent = trans.context.request.headers.traceparent;
     expectedReqHeaders.tracestate = trans.context.request.headers.tracestate;
-    expectedReqHeaders['elastic-apm-traceparent'] =
-      trans.context.request.headers['elastic-apm-traceparent'];
   }
 
   // What is "expected" for transaction.context.request.socket.remote_address

--- a/test/opentelemetry-bridge/fixtures.test.js
+++ b/test/opentelemetry-bridge/fixtures.test.js
@@ -264,10 +264,6 @@ const cases = [
         'incoming http "traceparent" header',
       );
       t.ok(
-        trans.context.request.headers['elastic-apm-traceparent'],
-        'incoming http "elastic-apm-traceparent" header',
-      );
-      t.ok(
         (trans.context.request.headers.tracestate || '').indexOf('es=s:1') !==
           -1,
         'incoming http "tracestate" header has expected "es=" section',

--- a/test/tracecontext/tracecontext.test.js
+++ b/test/tracecontext/tracecontext.test.js
@@ -45,13 +45,13 @@ tape.test('propagateTraceContextHeaders tests', function (suite) {
     span.end();
     transaction.end();
 
-    t.equals(span._context.traceparent.toString(), newHeaders.traceparent);
-    t.equals(traceStateString, newHeaders.tracestate);
     t.equals(
       span._context.traceparent.toString(),
-      newHeaders['elastic-apm-traceparent'],
+      newHeaders.traceparent,
+      'traceparent',
     );
-    t.true(span._hasPropagatedTraceContext);
+    t.equals(traceStateString, newHeaders.tracestate, 'tracestate');
+    t.true(span._hasPropagatedTraceContext, '_hasPropagatedTraceContext');
     t.end();
   });
 


### PR DESCRIPTION
As part of the config changes we're doing for next major version `4.x` we're disabling the elastic traceparent header by default. This PR does that change and also updates its tests & docs accordingly.

Closes #3510

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Update tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
