### PR TITLE
3.49.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,16 +32,16 @@ Notes:
 === Node.js Agent version 3.x
 
 
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
+[[release-notes-3.49.1]]
+==== 3.49.1 - 2023/08/09
 
 [float]
 ===== Bug fixes
+
+* Upgrade import-in-the-middle dependency to v1.4.2 to fix a vulnerability
+  (https://github.com/DataDog/import-in-the-middle/security/advisories/GHSA-5r27-rw8r-7967[CVE-2023-38704]).
+  Note: This dependency is only used by elastic-apm-node when using the
+  <<esm,experimental ESM support>>. ({pull}3569[#3569])
 
 [float]
 ===== Chores

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.49.0",
+  "version": "3.49.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.49.0",
+      "version": "3.49.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.49.0",
+  "version": "3.49.1",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
A patch-level release to get https://github.com/elastic/apm-agent-nodejs/pull/3569 out.