### PR TITLE
chore: bump deps from main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8458,12 +8458,15 @@
       "dev": true
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotignore": {
@@ -8968,9 +8971,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
+      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.6",
@@ -8982,13 +8985,12 @@
         "eslint-import-resolver-node": "^0.3.7",
         "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.12.1",
+        "is-core-module": "^2.13.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.6",
         "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.3",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.2"
       },
@@ -11402,9 +11404,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -12504,29 +12506,29 @@
       "dev": true
     },
     "node_modules/lambda-local": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lambda-local/-/lambda-local-2.0.3.tgz",
-      "integrity": "sha512-Vs55gujwdjhPL2VpXEXAWWwxiOYdnVPDsMgwOr9BqC0O1EoSXs1S8TKBmD/ySEnPVRiQfFlABcQgcykF1mkE8Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lambda-local/-/lambda-local-2.1.2.tgz",
+      "integrity": "sha512-nGTJn2JxZWcLGpNwXFmXC7UEXL7QCLieQWDiXs46vIv9y/gSPm/uHygEMCaym+HIziniAw0XIm+1VTrXCvG1Zw==",
       "dev": true,
       "dependencies": {
-        "commander": "^9.4.0",
-        "dotenv": "^16.0.2",
-        "winston": "^3.8.2"
+        "commander": "^10.0.1",
+        "dotenv": "^16.3.1",
+        "winston": "^3.10.0"
       },
       "bin": {
         "lambda-local": "build/cli.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/lambda-local/node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/levn": {
@@ -14185,9 +14187,9 @@
       "dev": true
     },
     "node_modules/pg": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.2.tgz",
-      "integrity": "sha512-l4rmVeV8qTIrrPrIR3kZQqBgSN93331s9i6wiUiLOSk0Q7PmUxZD/m1rQI622l3NfqBby9Ar5PABfS/SulfieQ==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
       "dev": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
@@ -14583,9 +14585,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -17643,9 +17645,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
       "dev": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
@@ -24567,9 +24569,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true
     },
     "dotignore": {
@@ -25115,9 +25117,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
+      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.6",
@@ -25129,13 +25131,12 @@
         "eslint-import-resolver-node": "^0.3.7",
         "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.12.1",
+        "is-core-module": "^2.13.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.6",
         "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.3",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.2"
       },
@@ -26803,9 +26804,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -27626,20 +27627,20 @@
       "dev": true
     },
     "lambda-local": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lambda-local/-/lambda-local-2.0.3.tgz",
-      "integrity": "sha512-Vs55gujwdjhPL2VpXEXAWWwxiOYdnVPDsMgwOr9BqC0O1EoSXs1S8TKBmD/ySEnPVRiQfFlABcQgcykF1mkE8Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lambda-local/-/lambda-local-2.1.2.tgz",
+      "integrity": "sha512-nGTJn2JxZWcLGpNwXFmXC7UEXL7QCLieQWDiXs46vIv9y/gSPm/uHygEMCaym+HIziniAw0XIm+1VTrXCvG1Zw==",
       "dev": true,
       "requires": {
-        "commander": "^9.4.0",
-        "dotenv": "^16.0.2",
-        "winston": "^3.8.2"
+        "commander": "^10.0.1",
+        "dotenv": "^16.3.1",
+        "winston": "^3.10.0"
       },
       "dependencies": {
         "commander": {
-          "version": "9.4.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
           "dev": true
         }
       }
@@ -28958,9 +28959,9 @@
       "dev": true
     },
     "pg": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.2.tgz",
-      "integrity": "sha512-l4rmVeV8qTIrrPrIR3kZQqBgSN93331s9i6wiUiLOSk0Q7PmUxZD/m1rQI622l3NfqBby9Ar5PABfS/SulfieQ==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
       "dev": true,
       "requires": {
         "buffer-writer": "2.0.0",
@@ -29242,9 +29243,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -31665,9 +31666,9 @@
       }
     },
     "winston": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
       "dev": true,
       "requires": {
         "@colors/colors": "1.5.0",

--- a/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp/package-lock.json
+++ b/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp/package-lock.json
@@ -11,9 +11,9 @@
       }
     },
     "node_modules/azure-functions-core-tools": {
-      "version": "4.0.5174",
-      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.5174.tgz",
-      "integrity": "sha512-VW7NTYo4/mAhGSQbr748XPsVmlVOefiOQ4l3PXRW+y3/OJtjSA0XPwDMBlAx5iTTxv2VgphQgkesvMDB8vMsKw==",
+      "version": "4.0.5274",
+      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.5274.tgz",
+      "integrity": "sha512-chonhkn8ADVkFMs/5cDS01xHtInxMnBM0eMlnHJBepHDvzwwQ1iFVhtbbDPjjEuUed9DoOOCinUorDXbb5c7GA==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/azure-functions-core-tools/node_modules/agent-base": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "dependencies": {
         "debug": "4"
@@ -382,9 +382,9 @@
   },
   "dependencies": {
     "azure-functions-core-tools": {
-      "version": "4.0.5174",
-      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.5174.tgz",
-      "integrity": "sha512-VW7NTYo4/mAhGSQbr748XPsVmlVOefiOQ4l3PXRW+y3/OJtjSA0XPwDMBlAx5iTTxv2VgphQgkesvMDB8vMsKw==",
+      "version": "4.0.5274",
+      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.0.5274.tgz",
+      "integrity": "sha512-chonhkn8ADVkFMs/5cDS01xHtInxMnBM0eMlnHJBepHDvzwwQ1iFVhtbbDPjjEuUed9DoOOCinUorDXbb5c7GA==",
       "dev": true,
       "requires": {
         "chalk": "3.0.0",
@@ -418,9 +418,9 @@
           }
         },
         "agent-base": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-          "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "dev": true,
           "requires": {
             "debug": "4"


### PR DESCRIPTION
This PR keeps dependencies aligned with `main` branch so it would be easier to merge `dev/4.x` for the next major release.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
