### PR TITLE
chore: add default ports to `context.service.target.name` for exit HTTP spans 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,21 @@ Notes:
 [[release-notes-3.x]]
 === Node.js Agent version 3.x
 
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+* Add default ports into `context.service.target.name` for HTTP spans conforming to the
+  spec update done in https://github.com/elastic/apm/pull/700 ({pull}3590[#3590])
+
 
 [[release-notes-3.49.1]]
 ==== 3.49.1 - 2023/08/09

--- a/lib/instrumentation/span.js
+++ b/lib/instrumentation/span.js
@@ -196,7 +196,15 @@ Span.prototype._inferServiceTargetAndDestinationService = function () {
         }
       } else if (this._http && this._http.url) {
         try {
-          this._serviceTarget.name = new URL(this._http.url).host;
+          const defaultPorts = { 'https:': '443', 'http:': '80' };
+          const url = new URL(this._http.url);
+          if (!url.port && defaultPorts[url.protocol]) {
+            this._serviceTarget.name = `${url.host}:${
+              defaultPorts[url.protocol]
+            }`;
+          } else {
+            this._serviceTarget.name = url.host;
+          }
         } catch (invalidUrlErr) {
           this._agent.logger.debug(
             'cannot set "service.target.name": %s (ignoring)',

--- a/test/fixtures/json-specs/service_resource_inference.json
+++ b/test/fixtures/json-specs/service_resource_inference.json
@@ -196,15 +196,15 @@
         "http": {
           "url": {
             "host": "my-cluster.com",
-            "port": -1
+            "port": "80"
           }
         }
       }
     },
-    "expected_resource": "my-cluster.com",
+    "expected_resource": "my-cluster.com:80",
     "expected_service_target": {
       "type": "http",
-      "name": "my-cluster.com"
+      "name": "my-cluster.com:80"
     },
     "failure_message": "Negative `context.http.url.port` should be omitted from output"
   },
@@ -216,15 +216,16 @@
       "context": {
         "http": {
           "url": {
-            "host": "my-cluster.com"
+            "host": "my-cluster.com",
+            "port": "80"
           }
         }
       }
     },
-    "expected_resource": "my-cluster.com",
+    "expected_resource": "my-cluster.com:80",
     "expected_service_target": {
       "type": "http",
-      "name": "my-cluster.com"
+      "name": "my-cluster.com:80"
     },
     "failure_message": "If `context.http.url.port` does not exist, output should be `${context.http.url.host}`"
   },

--- a/test/service-resource-inference.test.js
+++ b/test/service-resource-inference.test.js
@@ -51,8 +51,11 @@ testData.forEach((testDatum) => {
         // service_resource_inference.json oddly provides context.http.url as
         // an object with "host" and "port" fields, rather than as a URL string
         // as accepted by the intake API. So we need to construct it.
+        // UPDATE: there is a PR fixing it https://github.com/elastic/apm-agent-nodejs/pull/3589
+        // making this test fail so for a short period we need to accept both cases
+        // before removing this tweak.
         const httpContext = Object.assign({}, testDatum.span.context.http);
-        if (httpContext.url) {
+        if (httpContext.url && typeof httpContext.url !== 'string') {
           const u = new URL('', 'http://example.com');
           if (httpContext.url.host) {
             u.hostname = httpContext.url.host;


### PR DESCRIPTION
This PR is conform  with the agreements of the discussion in https://github.com/elastic/apm/pull/700 which in summary says that default ports should be explicit in `serviceTarget.name` property of the span.

Updatecli workflows are failing because of that and JSON specs cannot be updated #3589


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
