### PR TITLE
fix: update return type of startTransaction

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,12 +61,12 @@ declare namespace apm {
     startTransaction(
       name?: string | null,
       options?: TransactionOptions
-    ): Transaction | null;
+    ): Transaction;
     startTransaction(
       name: string | null,
       type: string | null,
       options?: TransactionOptions
-    ): Transaction | null;
+    ): Transaction;
     setTransactionName (name: string): void;
     endTransaction (result?: string | number, endTime?: number): void;
     currentTransaction: Transaction | null;


### PR DESCRIPTION
In #3554 we missed to update the return type of `startTransaction` method, it should not return null anymore. This PR fixes it.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [x] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
