### PR TITLE
chore: improve release tagging to support pre-releases

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -97,11 +97,7 @@ create-arn-file: validate-release-notes-url
 	@RELEASE_NOTES_URL=$(RELEASE_NOTES_URL) ./scripts/create-arn-table.sh
 
 github-release: validate-ref-name
-	@gh release list
-	@gh release create $(GITHUB_REF_NAME) \
-		--latest \
-		--title '$(GITHUB_REF_NAME)' \
-		--notes-file $(AWS_FOLDER)/$(SUFFIX_ARN_FILE)
+	echo ../dev-utils/github-release.sh "$(GITHUB_REF_NAME)" "$(AWS_FOLDER)/$(SUFFIX_ARN_FILE)"
 
 validate-version:
 ifndef AGENT_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,9 @@ jobs:
       - name: npm publish
         run: |-
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
-          npm publish --tag=latest --otp=${{ env.TOTP_CODE }}
+          # Publishing without a '--tag=...' will do the right thing: "latest"
+          # if this is a non-pre-release, no tag if this is a pre-release.
+          npm publish --otp=${{ env.TOTP_CODE }}
 
       - if: always()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,6 @@ A release involves the following published artifacts:
 If this is a new major release, then:
 
 - [Create an issue](https://github.com/elastic/website-requests/issues/new) to request an update of the [EOL table](https://www.elastic.co/support/eol).
-- Update the "Active release branches" section of the main README.
+- Update the "Active release branches" section of the main "README.md".
 - Update the "release.yml" for the new "N.x" *maintenance* branch as follows:
     - The `npm publish ...` call must include a `--tag=latest-<major>` option.
-    - The `gh release create ...` call must include a `--latest=false` option.

--- a/dev-utils/github-release.sh
+++ b/dev-utils/github-release.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Create a GitHub release. If the given tag name is the *latest* version, and
+# is not a pre-release, then the GH release will be marked as the latest.
+# (This is typically only run from the release.yml CI workflow.)
+#
+# Usage:
+#   ./dev-utils/github-release.sh TAG_NAME RELEASE_NOTES_FILE
+# Example:
+#   ./dev-utils/github-release.sh v3.49.1 ../build/aws/arn-file.md
+#
+# - For auth, this expects the 'GH_TOKEN' envvar to have been set.
+# - The 'TAG_NAME' is typically from the 'GITHUB_REF_NAME' variable
+#   (https://docs.github.com/en/actions/learn-github-actions/variables)
+#   from a GitHub Actions workflow run.
+# - The 'RELEASE_NOTES_FILE' is a path to an already built file to use as
+#   the release notes (using GitHub-flavored Markdown).
+
+set -euo pipefail
+
+readonly TAG_NAME="$1"
+readonly RELEASE_NOTES_FILE="$2"
+
+echo "INFO: List current GitHub releases"
+gh release list
+
+# The latest (by semver version ordering) git version tag, excluding pre-releases.
+readonly LATEST_GIT_TAG=$(git tag --list --sort=version:refname "v*" | grep -v - | tail -n1)
+if [[ "$TAG_NAME" == "$LATEST_GIT_TAG" ]]; then
+  IS_LATEST=true
+else
+  IS_LATEST=false
+fi
+
+echo "INFO: Create '$TAG_NAME' GitHub release (latest=$IS_LATEST)."
+gh release create "$TAG_NAME" \
+  --title "$TAG_NAME" \
+  --notes-file "$RELEASE_NOTES_FILE" \
+  --latest=$IS_LATEST


### PR DESCRIPTION
This updates the 'npm publish' and 'github release' steps of the
release process to do the right thing for pre-releases. If a release
for a pre-release tag (one with hyphen) is started, this will now
properly avoid tagging the npm package and github release as
latest.

---

This should be backported to 3.x. It will make the github-release step smarter, so that we don't need to explicitly added `--latest=false` to the `gh release create ...` call; it will do the right thing automatically.