### PR TITLE
feat: add observability for lambdas that call other lambdas

### DIFF
--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -207,7 +207,10 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
   return function wrapHttpRequest(orig) {
     return function wrappedHttpRequest(input, options, cb) {
       const parentRunContext = ins.currRunContext();
-      var span = ins.createSpan(null, 'external', 'http', { exitSpan: true });
+      var span =
+        input?.headers?.['x-amz-invocation-type'] === 'RequestResponse'
+          ? null
+          : ins.createSpan(null, 'external', 'http', { exitSpan: true });
       var id = span && span.transaction.id;
       agent.logger.debug('intercepted call to %s.%s %o', moduleName, method, {
         id,

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -706,6 +706,14 @@ function elasticApmAwsLambda(agent) {
       let traceparent;
       let tracestate;
       if (
+        triggerType === TRIGGER_GENERIC &&
+        event.traceparent &&
+        event.tracestate
+      ) {
+        traceparent = event.traceparent;
+        tracestate = event.tracestate;
+      }
+      if (
         (triggerType === TRIGGER_API_GATEWAY || triggerType === TRIGGER_ELB) &&
         event.headers
       ) {


### PR DESCRIPTION
This Pull Request enables the visualization of Lambda-to-Lambda invocations in the Service Map of Elastic Search and provides detailed insights into the "spans" and "transactions" used by the internal Lambda function. The way we use to identify Lambda-to-Lambda invocations is by checking for the presence of the `traceparent` and `tracestate` in the invocation payload.

I welcome any insights or recommendations to make it even more robust and user-friendly.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
