### PR TITLE
fix: capture route from base on express app.use

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ See the <<upgrade-to-v4>> guide.
 
 [float]
 ===== Bug fixes
+* The problem of route name not being captured in Express.Use direct use in middleware has been resolved.
 
 [float]
 ===== Chores

--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -48,6 +48,8 @@ function getPathFromRequest(req, useBase, usePathAsTransactionName) {
     return path ? join([path, route]) : route;
   } else if (path && (path !== '/' || useBase)) {
     return path;
+  } else if (req.baseUrl && req.baseUrl !== '/') {
+    return req.baseUrl;
   }
 
   if (usePathAsTransactionName) {

--- a/test/instrumentation/express-utils.test.js
+++ b/test/instrumentation/express-utils.test.js
@@ -26,13 +26,26 @@ test('#getPathFromRequest', function (t) {
     t.equals(path, '/foo/bar');
     t.end();
   });
+  t.test('should return path for express.use base urls as path ', function (t) {
+    const req = createRequest(
+      'https://test.com/foo/bar?query=value#hash',
+      'example.com',
+      {
+        baseUrl: '/foo/bar',
+      },
+    );
+    const path = getPathFromRequest(req, false, false);
+    t.equals(path, '/foo/bar');
+    t.end();
+  });
 });
 
-function createRequest(url, host = 'example.com') {
+function createRequest(url, host = 'example.com', additionalRequestItems) {
   return {
     url,
     headers: {
       host,
     },
+    ...additionalRequestItems,
   };
 }


### PR DESCRIPTION
Closes: #3630

The error mentioned in the issue has been corrected.

### Checklist

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
