### PR TITLE
tests: use a known test phone for SNS v3 tests

### DIFF
--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -36,7 +36,7 @@
 
 const TEST_IGNORE_TOPIC = 'topic-to-ignore';
 const TEST_IGNORE_TARGET = 'target-to-ignore';
-const TEST_IGNORE_PHONE = '6666666';
+const TEST_IGNORE_PHONE = '0101';
 
 const apm = require('../../../../..').start({
   serviceName: 'use-client-sns',
@@ -110,7 +110,7 @@ async function useClientSNS(snsClient, topicName) {
   // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/PublishCommand/
   command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: '1-555-555-5555',
+    PhoneNumber: '+1-555-555-0100',
   });
   data = await snsClient.send(command);
   assert(
@@ -177,7 +177,7 @@ async function useClientSNS(snsClient, topicName) {
 
   command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: `+34${TEST_IGNORE_PHONE}`,
+    PhoneNumber: `+1-555-555-${TEST_IGNORE_PHONE}`,
   });
   data = await snsClient.send(command);
   assert(
@@ -190,7 +190,7 @@ async function useClientSNS(snsClient, topicName) {
     Message: 'message to be sent',
     TopicArn: topicArn,
     TargetArn: topicArn,
-    PhoneNumber: '1-555-555-5555',
+    PhoneNumber: '+1-555-555-0100',
   });
   data = await snsClient.send(command);
   assert(

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -110,7 +110,7 @@ async function useClientSNS(snsClient, topicName) {
   // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/PublishCommand/
   command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: '+1-555-555-0100',
+    PhoneNumber: '+15555550100',
   });
   data = await snsClient.send(command);
   assert(
@@ -177,7 +177,7 @@ async function useClientSNS(snsClient, topicName) {
 
   command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: `+1-555-555-${TEST_IGNORE_PHONE}`,
+    PhoneNumber: `+1555555${TEST_IGNORE_PHONE}`,
   });
   data = await snsClient.send(command);
   assert(
@@ -190,7 +190,7 @@ async function useClientSNS(snsClient, topicName) {
     Message: 'message to be sent',
     TopicArn: topicArn,
     TargetArn: topicArn,
-    PhoneNumber: '+1-555-555-0100',
+    PhoneNumber: '+15555550100',
   });
   data = await snsClient.send(command);
   assert(

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.js
@@ -110,7 +110,7 @@ async function useClientSNS(snsClient, topicName) {
   // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sns/command/PublishCommand/
   command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: '+34555555555',
+    PhoneNumber: '1-555-555-5555',
   });
   data = await snsClient.send(command);
   assert(
@@ -190,7 +190,7 @@ async function useClientSNS(snsClient, topicName) {
     Message: 'message to be sent',
     TopicArn: topicArn,
     TargetArn: topicArn,
-    PhoneNumber: `+345555555`,
+    PhoneNumber: '1-555-555-5555',
   });
   data = await snsClient.send(command);
   assert(

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.mjs
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.mjs
@@ -23,7 +23,7 @@ import assert from 'assert';
 async function useClientSNS(snsClient) {
   const command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: '+1-555-555-0100',
+    PhoneNumber: '+15555550100',
   });
   const data = await snsClient.send(command);
   assert(

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.mjs
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-sns.mjs
@@ -23,7 +23,7 @@ import assert from 'assert';
 async function useClientSNS(snsClient) {
   const command = new PublishCommand({
     Message: 'message to be sent',
-    PhoneNumber: '+34555555555',
+    PhoneNumber: '+1-555-555-0100',
   });
   const data = await snsClient.send(command);
   assert(

--- a/test/instrumentation/modules/aws-sdk/sns.test.js
+++ b/test/instrumentation/modules/aws-sdk/sns.test.js
@@ -103,10 +103,10 @@ tape.test('AWS SNS: Unit Test Functions', function (test) {
         params: {
           Message:
             'this is my test, there are many like it but this one is mine',
-          PhoneNumber: '+1-555-555-0100',
+          PhoneNumber: '+15555550100',
         },
       }),
-      '+1-555-555-0100',
+      '+15555550100',
     );
 
     t.end();
@@ -170,7 +170,7 @@ tape.test('AWS SNS: Unit Test Functions', function (test) {
         params: {
           Message: 'work test',
           Subject: 'Admin',
-          PhoneNumber: '+1-555-555-0100',
+          PhoneNumber: '+15555550100',
         },
       }),
       '<PHONE_NUMBER>',
@@ -189,7 +189,7 @@ tape.test('AWS SNS: Unit Test Functions', function (test) {
         params: {
           Message: 'work test',
           Subject: 'Admin',
-          PhoneNumber: '+1-555-555-0100',
+          PhoneNumber: '+15555550100',
         },
       }),
       'SNS PUBLISH to <PHONE_NUMBER>',

--- a/test/instrumentation/modules/aws-sdk/sns.test.js
+++ b/test/instrumentation/modules/aws-sdk/sns.test.js
@@ -103,10 +103,10 @@ tape.test('AWS SNS: Unit Test Functions', function (test) {
         params: {
           Message:
             'this is my test, there are many like it but this one is mine',
-          PhoneNumber: '1-555-555-5555',
+          PhoneNumber: '+1-555-555-0100',
         },
       }),
-      '1-555-555-5555',
+      '+1-555-555-0100',
     );
 
     t.end();
@@ -170,7 +170,7 @@ tape.test('AWS SNS: Unit Test Functions', function (test) {
         params: {
           Message: 'work test',
           Subject: 'Admin',
-          PhoneNumber: '15037299028',
+          PhoneNumber: '+1-555-555-0100',
         },
       }),
       '<PHONE_NUMBER>',
@@ -189,7 +189,7 @@ tape.test('AWS SNS: Unit Test Functions', function (test) {
         params: {
           Message: 'work test',
           Subject: 'Admin',
-          PhoneNumber: '15555555555',
+          PhoneNumber: '+1-555-555-0100',
         },
       }),
       'SNS PUBLISH to <PHONE_NUMBER>',


### PR DESCRIPTION
Reuse phone number defined on `aws-sdk` tests in `@aws-sdk/clilent-sns`.  

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] Modify tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
