### PR TITLE
fix: @aws-sdk/client-sns tav failure: NotFound error type

### DIFF
--- a/test/instrumentation/modules/@aws-sdk/client-sns.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sns.test.js
@@ -223,9 +223,11 @@ const testFixtures = [
         'error is a child of the failing span from publish to a non existant topic',
       );
       t.equal(errors[0].transaction_id, tx.id, 'error.transaction_id');
-      t.equal(
-        errors[0].exception.type,
-        'NotFoundException',
+      t.ok(
+        // In @aws-sdk/client-sns@3.181.0 the exception name/type changed.
+        // https://github.com/aws/aws-sdk-js-v3/commit/384cbd7cbdbc0635d2dbff53b54d769ca80dabbb
+        ['NotFoundException', 'NotFound'].indexOf(errors[0].exception.type) !==
+          -1,
         'error.exception.type',
       );
 


### PR DESCRIPTION
In @aws-sdk/client-sns@3.181.0 the exception name/type changed.
https://github.com/aws/aws-sdk-js-v3/commit/384cbd7cbdbc0635d2dbff53b54d769ca80dabbb

---

The TAV tests were failing on older client-sns versions with:

```
node_tests_1  | not ok 19 error.exception.type
node_tests_1  |   ---
node_tests_1  |     operator: equal
node_tests_1  |     expected: 'NotFoundException'
node_tests_1  |     actual:   'NotFound'
node_tests_1  |     at: Object.checkApmServer (/app/test/instrumentation/modules/@aws-sdk/client-sns.test.js:226:9)
node_tests_1  |     stack: |-
node_tests_1  |       Error: error.exception.type
node_tests_1  |           at Test.assert [as _assert] (/app/node_modules/tape/lib/test.js:309:48)
node_tests_1  |           at Test.strictEqual (/app/node_modules/tape/lib/test.js:473:7)
node_tests_1  |           at Object.checkApmServer (/app/test/instrumentation/modules/@aws-sdk/client-sns.test.js:226:9)
node_tests_1  |           at done (/app/test/_utils.js:365:26)
node_tests_1  |           at ChildProcess.exithandler (child_process.js:374:7)
node_tests_1  |           at ChildProcess.emit (events.js:400:28)
node_tests_1  |           at maybeClose (internal/child_process.js:1088:16)
node_tests_1  |           at Process.ChildProcess._handle.onexit (internal/child_process.js:296:5)
node_tests_1  |   ...
```