### PR TITLE
test: add a lame delay in payloadLogFile test to avoid flaky failures

### DIFF
--- a/dev-utils/docker-compose.yml
+++ b/dev-utils/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   nodejs-agent:
-    image: node:12
+    image: node:20
     entrypoint: /bin/bash
     volumes:
       - ..:/agent


### PR DESCRIPTION
This test has been flaky in CI with node v20 and v21. I don't know
why the node version could matter here.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3313#issuecomment-1734291517
