### PR TITLE
test: skip some timing-sensitive tests on Windows CI to avoid flaky tests

### DIFF
--- a/test/instrumentation/timer.test.js
+++ b/test/instrumentation/timer.test.js
@@ -9,6 +9,7 @@
 var test = require('tape');
 
 var Timer = require('../../lib/instrumentation/timer');
+const { TIMING_SENSITIVE_TEST_OPTS } = require('../testconsts');
 
 test('started', function (t) {
   var timer = new Timer();
@@ -47,7 +48,7 @@ test('elapsed', function (t) {
   });
 });
 
-test('custom start time', function (t) {
+test('custom start time', TIMING_SENSITIVE_TEST_OPTS, function (t) {
   var startTime = Date.now() - 1000;
   var timer = new Timer(null, startTime);
   t.strictEqual(timer.start, startTime * 1000);

--- a/test/metrics/index.test.js
+++ b/test/metrics/index.test.js
@@ -12,6 +12,7 @@ const semver = require('semver');
 const test = require('tape');
 
 const Metrics = require('../../lib/metrics');
+const { TIMING_SENSITIVE_TEST_OPTS } = require('../testconsts');
 
 const delayMs = 500;
 const delayDeviationMs = (delayMs / 100) * 10;
@@ -41,7 +42,7 @@ function isRoughlyAbsolute(received, expected, range) {
   return received >= lower && received < upper;
 }
 
-test('reports expected metrics', function (t) {
+test('reports expected metrics', TIMING_SENSITIVE_TEST_OPTS, function (t) {
   let count = 0;
   let last;
 

--- a/test/testconsts.js
+++ b/test/testconsts.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const os = require('os');
+
 // Supported Node.js version range for import-in-the-middle usage.
 // - v12.20.0 add "named exports for CJS via static analysis"
 //   https://nodejs.org/en/blog/release/v12.20.0
@@ -18,7 +20,17 @@
 const NODE_VER_RANGE_IITM = '^12.20.0 || ^14.13.1 || ^16.0.0 || ^18.1.0 <20';
 const NODE_VER_RANGE_IITM_GE14 = '^14.13.1 || ^16.0.0 || ^18.1.0 <20'; // NODE_VER_RANGE_IITM minus node v12
 
+// This can be passed as tape test options for tests that are timing sensitive,
+// to *skip* those tests on Windows CI.
+const TIMING_SENSITIVE_TEST_OPTS = {
+  skip:
+    os.platform() === 'win32' && process.env.CI === 'true'
+      ? '(skip timing-sensitive test on Windows CI)'
+      : false,
+};
+
 module.exports = {
   NODE_VER_RANGE_IITM,
   NODE_VER_RANGE_IITM_GE14,
+  TIMING_SENSITIVE_TEST_OPTS,
 };


### PR DESCRIPTION
We should try to avoid timing-sensitive tests where possible, but
where that isn't possible and if experience shows that Windows CI
builds flake out frequently, then let's just skip them. Windows
isn't important enough.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3313

---

Review note: One of the changes here is mostly whitespace. Look at the diff with `?w=1`.
