### PR TITLE
chore!: drop next@11 support

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,25 @@ Notes:
 See the <<upgrade-to-v4>> guide.
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+* Drop support for next@11. Next.js instrumentation support is currently in
+  technical preview, so it is not considered a semver-major change to drop
+  support for this old version of next. ({pull}3664[#3664])
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+
 [[release-notes-4.1.0]]
 ==== 4.1.0 - 2023/10/09
 
@@ -70,6 +89,8 @@ See the <<upgrade-to-v4>> guide.
 
 [[release-notes-4.0.0]]
 ==== 4.0.0 - 2023/09/07
+
+See the <<upgrade-to-v4>> guide.
 
 [float]
 ===== Breaking changes

--- a/docs/nextjs.asciidoc
+++ b/docs/nextjs.asciidoc
@@ -22,8 +22,9 @@ monitor the client-side parts of a Next.js application, see the
 {apm-rum-ref}/intro.html[Elastic RUM agent].
 
 NOTE: preview:[] This Next.js instrumentation is a _technical preview_ while we
-solicit feedback from Next.js users. If you are a Next.js user, please help us
-provide a better Next.js observability experience with your feedback on our
+solicit feedback from Next.js users. Currently `next` versions `>=12.0.0
+<13.3.0` are supported. If you are a Next.js user, please help us provide a
+better Next.js observability experience with your feedback on our
 https://discuss.elastic.co/tags/c/apm/nodejs[Discuss forum].
 
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -68,7 +68,7 @@ These are the frameworks that we officially support:
 | <<fastify,Fastify>>   | >=1.0.0 | See also https://www.fastify.io/docs/latest/Reference/LTS/[Fastify's own LTS documentation]
 | <<hapi,@hapi/hapi>>   | >=17.9.0 <22.0.0 |
 | <<koa,Koa>> via koa-router or @koa/router | >=5.2.0 <13.0.0 | Koa doesn't have a built in router, so we can't support Koa directly since we rely on router information for full support. We currently support the most popular Koa router called https://github.com/koajs/koa-router[koa-router].
-| <<nextjs,Next.js>>    | >=11.1.0 <13.3.0 | (Technical Preview) This instruments Next.js routing to name transactions for incoming HTTP transactions; and reports errors in user pages. It supports the Next.js production server (`next start`) and development server (`next dev`). See the <<nextjs,Getting Started document>>.
+| <<nextjs,Next.js>>    | >=12.0.0 <13.3.0 | (Technical Preview) This instruments Next.js routing to name transactions for incoming HTTP transactions; and reports errors in user pages. It supports the Next.js production server (`next start`) and development server (`next dev`). See the <<nextjs,Getting Started document>>.
 | <<restify,Restify>>   | >=5.2.0 <12.0.0 |
 |=======================================================================
 

--- a/lib/instrumentation/modules/next.js
+++ b/lib/instrumentation/modules/next.js
@@ -15,7 +15,7 @@ module.exports = function (mod, agent, { version, enabled }) {
     return mod;
   }
   if (
-    !semver.satisfies(version, '>=11.1.0 <13.3.0', { includePrerelease: true })
+    !semver.satisfies(version, '>=12.0.0 <13.3.0', { includePrerelease: true })
   ) {
     agent.logger.debug('next version %s not supported, skipping', version);
     return mod;

--- a/lib/instrumentation/modules/next/dist/server/api-utils/node.js
+++ b/lib/instrumentation/modules/next/dist/server/api-utils/node.js
@@ -19,7 +19,7 @@ module.exports = function (mod, agent, { version, enabled }) {
     return mod;
   }
   if (
-    !semver.satisfies(version, '>=11.1.0 <14.0.0', { includePrerelease: true })
+    !semver.satisfies(version, '>=12.0.0 <13.3.0', { includePrerelease: true })
   ) {
     agent.logger.debug(
       'next/dist/server/api-utils/node.js version %s not supported, skipping',

--- a/lib/instrumentation/modules/next/dist/server/dev/next-dev-server.js
+++ b/lib/instrumentation/modules/next/dist/server/dev/next-dev-server.js
@@ -22,7 +22,7 @@ module.exports = function (mod, agent, { version, enabled }) {
     return mod;
   }
   if (
-    !semver.satisfies(version, '>=11.1.0 <14.0.0', { includePrerelease: true })
+    !semver.satisfies(version, '>=12.0.0 <13.3.0', { includePrerelease: true })
   ) {
     agent.logger.debug('next version %s not supported, skipping', version);
     return mod;
@@ -38,10 +38,6 @@ module.exports = function (mod, agent, { version, enabled }) {
     'findPageComponents',
     wrapFindPageComponents,
   );
-  if (semver.satisfies(version, '11.x')) {
-    // See comment for `wrapEnsureApiPage` in "../next-server.js".
-    shimmer.wrap(DevServer.prototype, 'ensureApiPage', wrapEnsureApiPage);
-  }
   // Instrumenting the DevServer also uses the wrapping of
   // 'NextNodeServer.renderErrorToResponse' in "next-server.js".
 
@@ -161,22 +157,6 @@ module.exports = function (mod, agent, { version, enabled }) {
         };
       }
       return origRouteFn.apply(this, arguments);
-    };
-  }
-
-  // Only used with next@11.
-  function wrapEnsureApiPage(orig) {
-    return function wrappedEnsureApiPage(pathname) {
-      if (this.constructor !== DevServer) {
-        return orig.apply(this, arguments);
-      }
-      const trans = ins.currTransaction();
-      if (trans && trans.req) {
-        log.trace({ pathname }, 'set transaction name from ensureApiPage');
-        trans.setDefaultName(`${trans.req.method} ${pathname}`);
-        trans[kSetTransNameFn] = noopFn;
-      }
-      return orig.apply(this, arguments);
     };
   }
 

--- a/lib/instrumentation/modules/next/dist/server/next-server.js
+++ b/lib/instrumentation/modules/next/dist/server/next-server.js
@@ -23,7 +23,7 @@ module.exports = function (mod, agent, { version, enabled }) {
     return mod;
   }
   if (
-    !semver.satisfies(version, '>=11.1.0 <14.0.0', { includePrerelease: true })
+    !semver.satisfies(version, '>=12.0.0 <13.3.0', { includePrerelease: true })
   ) {
     agent.logger.debug('next version %s not supported, skipping', version);
     return mod;
@@ -34,15 +34,9 @@ module.exports = function (mod, agent, { version, enabled }) {
 
   const NextNodeServer = mod.default;
   shimmer.wrap(NextNodeServer.prototype, 'generateRoutes', wrapGenerateRoutes);
-  // Capturing the resolve page name for *API* routes: We are instrumenting a
+  // Capturing the resolved page name for *API* routes: We are instrumenting a
   // function called inside `NextNodeServer.handleApiRequest()`.
-  // `this.ensureApiPage(page)` existed up to next@13.2.0. `this.runApi(...)`
-  // was added in next@12.
-  if (semver.satisfies(version, '11.x')) {
-    shimmer.wrap(NextNodeServer.prototype, 'ensureApiPage', wrapEnsureApiPage);
-  } else {
-    shimmer.wrap(NextNodeServer.prototype, 'runApi', wrapRunApi);
-  }
+  shimmer.wrap(NextNodeServer.prototype, 'runApi', wrapRunApi);
   shimmer.wrap(
     NextNodeServer.prototype,
     'findPageComponents',
@@ -167,22 +161,6 @@ module.exports = function (mod, agent, { version, enabled }) {
         };
       }
       return origRouteFn.apply(this, arguments);
-    };
-  }
-
-  // Only used with next@11.
-  function wrapEnsureApiPage(orig) {
-    return function wrappedEnsureApiPage(pathname) {
-      if (this.constructor !== NextNodeServer) {
-        return orig.apply(this, arguments);
-      }
-      const trans = ins.currTransaction();
-      if (trans && trans.req) {
-        log.trace({ pathname }, 'set transaction name from ensureApiPage');
-        trans.setDefaultName(`${trans.req.method} ${pathname}`);
-        trans[kSetTransNameFn] = noopFn;
-      }
-      return orig.apply(this, arguments);
     };
   }
 

--- a/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
+++ b/test/instrumentation/modules/next/a-nextjs-app/.tav.yml
@@ -1,28 +1,13 @@
 # Test Next.js versions.
 #
-# - We instrument Next.js ">=11.1.0 <14.0.0". I don't see much value in testing
-#   every patch-level release. Instead we will test the latest patch release
-#   for each minor. (It would be nice if tav supported this natively.)
-# - Next.js 11 supports back to node v12.22.0 and v14.5.0. However, when this
-#   instrumentation was added, Node v12 was already EOL, so there is less value
-#   in testing it.
-# - Next.js 11 crashes with Node >=17 unless this workaround is used;
-#      NODE_OPTIONS=--openssl-legacy-provider ...
-#   See https://github.com/vercel/next.js/issues/30078 for details. There isn't
-#   much value in testing this old Next.js version with newer Node versions.
+# - We instrument `>=11.1.0 <13.3.0`.
+# - We don't test next@11 because spurious errors.
+# - We don't test every patch-level release, because that's too much.
 # - For the latest version, we guard on the *minor* version, because 13.2 and
 #   13.3 releases have both broken our instrumentation.
-next-11:
-  name: next
-  versions: '11.1.0 || 11.1.4'
-  node: '>=14.5.0 <17.0.0'
-  commands: node ../next.test.js
-  peerDependencies:
-    - "react@^17.0.2"
-    - "react-dom@^17.0.2"
 next-12:
   name: next
-  versions: '12.0.10 || 12.1.6 || 12.2.6 || 12.3.1 || >12.3.1 <13'
+  versions: '12.0.10 || 12.1.6 || 12.2.6 || 12.3.4 || >12.3.4 <13'
   node: '>=14.5.0'
   commands: node ../next.test.js
   peerDependencies:
@@ -30,7 +15,7 @@ next-12:
     - "react-dom@^18.2.0"
 next:
   name: next
-  versions: '>=13.0.0 <13.3.0'
+  versions: '13.0.7 || 13.1.6 || 13.2.4 || >13.2.4 <13.3.0'
   node: '>=14.6.0'
   commands: node ../next.test.js
   peerDependencies:


### PR DESCRIPTION
next@11 does not get new releases, and only works on node 14 and 16,
which are EOL.  It is failing in our CI TAV tests and it is not worth
the time digging into older versions.

---

Currently `test-tav (next 14)` and `test-tav (next 16)`, i.e. the TAV tests of Next.js with Node v14 and v16, are failing with `next@11`. For example, from https://github.com/elastic/apm-agent-nodejs/actions/runs/6488426576/job/17620863144

```
...
node_tests_1  | -- installing ["react@^18.2.0","react-dom@^18.2.0","next@12.0.10"]
node_tests_1  | -- running test "node ../next.test.js" with next
node_tests_1  | -- required packages ["react@^17.0.2","react-dom@^17.0.2","next@11.1.4"]
node_tests_1  | -- installing ["react@^17.0.2","react-dom@^17.0.2","next@11.1.4"]
node_tests_1  | -- running test "node ../next.test.js" with next
node_tests_1  | -- detected failing command, flushing stdout...
node_tests_1  | TAP version 13
...
node_tests_1  | # -- dev server tests --
...
node_tests_1  | not ok 147 waitForServerReady request
node_tests_1  |   ---
node_tests_1  |     operator: equal
node_tests_1  |     expected: |-
node_tests_1  |       'GET /api/an-api-endpoint'
node_tests_1  |     actual: |-
node_tests_1  |       'GET unknown route'
node_tests_1  |     at: checkExpectedApmEvents (/app/test/instrumentation/modules/next/next.test.js:721:5)
node_tests_1  |     stack: |-
node_tests_1  |       Error: waitForServerReady request
node_tests_1  |           at Test.assert [as _assert] (/app/node_modules/tape/lib/test.js:479:48)
node_tests_1  |           at Test.strictEqual (/app/node_modules/tape/lib/test.js:643:7)
node_tests_1  |           at checkExpectedApmEvents (/app/test/instrumentation/modules/next/next.test.js:721:5)
...
```

I don't know what changed or when exactly, but I propose that it isn't worth digging into this because:

- Our Next.js support is still experimental/preview.
- The last next@11 release was `'11.1.4': '2022-01-27T02:04:33.982Z',`.  (FWIW, the last next@12 release was `  '12.3.4': '2022-11-21T23:40:47.122Z',`.)
- Unfortunately we don't support the latest 13.x minor versions. The current release is 13.5.4 and we only support to 13.2.x. If any time is to be spent on Next.js, it should be on supporting the latest and/or looking at better using and guiding users towards Next.js' built-in OpenTelemetry support.

Instead, let's drop next@11 support, so our builds can go green.

---

This change also reduces the number of next@12 and 13 versions tested, because the `next` TAV tests have become too long:

```
% ./dev-utils/ci-tav-slow-jobs.sh | tail
793 13m13s test-tav (@elastic/elasticsearch 14)
807 13m27s test-tav (elasticsearch 14)
814 13m34s test-tav (redis 14)
1002 16m42s test-tav (express 14)
1070 17m50s test-tav (graphql 14)
1110 18m30s test-tav (mysql2 14)
1127 18m47s test-tav (next 18)
1193 19m53s test-tav (next 14)
1238 20m38s test-tav (next 20)
1310 21m50s test-tav (next 16)
```


# checklist

- [x] wait for 4.1.0 release to go out
- [x] add a changelog entry for this
