### PR TITLE
chore: test with Node v21

### DIFF
--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -1,5 +1,5 @@
 {
-  "versions": [ 20, 18, 16, 14 ],
+  "versions": [ 21, 20, 18, 16, 14 ],
   "// modules": [
     "List of instrumented modules with the min Node version supported.",
     "minVersion for each module should be kept in sync with .tav.yml"

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ "21" ]
+        node: [ "22" ]
     steps:
       - uses: actions/checkout@v3
       - run: .ci/scripts/test.sh -b "nightly" "${{ matrix.node }}"
@@ -58,7 +58,6 @@ jobs:
           - "21"
           - "20"
           - "18"
-          - "16"
     steps:
       - uses: actions/checkout@v3
       - run: .ci/scripts/test.sh -b "rc" "${{ matrix.node }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
+          - '21'
           - '20'
           - '20.0'
           - '18'


### PR DESCRIPTION
Node.js v21 was first released on 2023-10-17. v22 nightlies should
start coming as well.
