### PR TITLE
chore: skip `cassandra-driver` tests if node <16.9

### DIFF
--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -16,7 +16,7 @@
     { "name": "@opentelemetry/sdk-metrics", "minVersion": 14 },
     { "name": "apollo-server-express", "minVersion": 8 },
     { "name": "aws-sdk", "minVersion": 8 },
-    { "name": "cassandra-driver", "minVersion": 8 },
+    { "name": "cassandra-driver", "minVersion": 16 },
     { "name": "elasticsearch", "minVersion": 8 },
     { "name": "express", "minVersion": 8 },
     { "name": "express-queue", "minVersion": 8 },

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,9 +65,6 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Chores
 
-* Skip `cassandra-driver` for non officialy supported nodejs versions (<16.9).
-  See <https://github.com/datastax/nodejs-driver/pull/415#discussion_r1331010721>
-  ({issues}3694[#3694])
 
 [[release-notes-4.1.0]]
 ==== 4.1.0 - 2023/10/09

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,6 +65,9 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Chores
 
+* Skip `cassandra-driver` for non officialy supported nodejs versions (<16.9).
+  See <https://github.com/datastax/nodejs-driver/pull/415#discussion_r1331010721>
+  ({issues}3694[#3694])
 
 [[release-notes-4.1.0]]
 ==== 4.1.0 - 2023/10/09

--- a/test/instrumentation/modules/cassandra-driver/cassandra-driver.test.js
+++ b/test/instrumentation/modules/cassandra-driver/cassandra-driver.test.js
@@ -41,9 +41,14 @@ const testFixtures = [
     },
     versionRanges: {
       // cassandra-driver@4.7.0 introduced a change that requires nodejs v16.9
-      // and up but previous versions support from v8 so we want to test
-      // these previous driver versions with all node versions in TAV
-      'cassandra-driver': '>=3.0.0 <4.7.0',
+      // and up but previous versions support from v8. In the fix process Cassandra
+      // team decided to drop versions from 8 to 16.
+      // Issue: https://datastax-oss.atlassian.net/browse/NODEJS-665
+      // Pull: https://github.com/datastax/nodejs-driver/pull/415#discussion_r1331010721
+      //
+      // We cannot expect new versions of the driver to work with nodejs versions <16.9
+      // therefore we want test only if node >=16.9
+      node: '>=16.9',
     },
     verbose: true,
     checkApmServer: (t, apmServer) => {
@@ -422,22 +427,6 @@ const testFixtures = [
     },
   },
 ];
-
-// We need to do exactly the same test for `cassandra-driver` v4.7.0 and up
-// the only difference is we require NodeJS version to be >16.
-// This is necessary because of an issue in the driver that led to
-// a change in the node compatibility from >=8 to >=16
-//
-// The issue: https://datastax-oss.atlassian.net/browse/NODEJS-665
-testFixtures.push(
-  Object.assign({}, testFixtures[0], {
-    name: 'cassandra-driver simple usage for versions >=4.7.0',
-    versionRanges: {
-      node: '>=16.9',
-      'cassandra-driver': '>=4.7.0',
-    },
-  }),
-);
 
 test('cassandra-driver fixtures', (suite) => {
   runTestFixtures(suite, testFixtures);

--- a/test/instrumentation/modules/cassandra-driver/cassandra-driver.test.js
+++ b/test/instrumentation/modules/cassandra-driver/cassandra-driver.test.js
@@ -28,7 +28,7 @@ const TEST_USE_PROMISES = semver.satisfies(CASSANDRA_VERSION, '>=3.2');
 
 const testFixtures = [
   {
-    name: 'cassandra-driver simple usage for versions <4.7.0',
+    name: 'cassandra-driver simple usage',
     script: 'fixtures/use-cassandra-driver.js',
     cwd: __dirname,
     timeout: 20000, // sanity guard on the test hanging
@@ -40,14 +40,10 @@ const testFixtures = [
       TEST_USE_PROMISES: String(TEST_USE_PROMISES),
     },
     versionRanges: {
-      // cassandra-driver@4.7.0 introduced a change that requires nodejs v16.9
-      // and up but previous versions support from v8. In the fix process Cassandra
-      // team decided to drop versions from 8 to 16.
-      // Issue: https://datastax-oss.atlassian.net/browse/NODEJS-665
-      // Pull: https://github.com/datastax/nodejs-driver/pull/415#discussion_r1331010721
-      //
-      // We cannot expect new versions of the driver to work with nodejs versions <16.9
-      // therefore we want test only if node >=16.9
+      // - cassandra-driver >=4.7.0 only supports node >=16, but
+      // - cassandra-driver 4.7.0 and 4.7.1 had a hiccup where only node >=16.9.0 worked.
+      // Because of these complications and because Node v14 is EOL, we are skipping testing
+      // with earlier node versions.
       node: '>=16.9',
     },
     verbose: true,


### PR DESCRIPTION
This PR simplifies the version ranges for testing `cassandra-driver`. Tests are going to be skipped if node version is <16.9

Refs:  #3629 
Closes: #3629 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] Update tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
