### PR TITLE
fix: set outcome for mongodb spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -61,7 +61,7 @@ See the <<upgrade-to-v4>> guide.
 * Fix `mongodb` instrumentation to avoid loosing context when multiple cursors
   are running concurrently. ({issues}3161[#3161])
 
-* Set `mongodb` span's outcome acordingly to the result of the command being traced.
+* Set `mongodb` span's outcome according to the result of the command being traced.
   ({pull}3695[#3695])
 
 [float]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -61,6 +61,8 @@ See the <<upgrade-to-v4>> guide.
 * Fix `mongodb` instrumentation to avoid loosing context when multiple cursors
   are running concurrently. ({issues}3161[#3161])
 
+* Set `mongodb` span's outcome acordingly to the result of the command being traced.
+  ({pull}3695[#3695])
 
 [float]
 ===== Chores

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -33,8 +33,8 @@ module.exports = (mongodb, agent, { version, enabled }) => {
   if (mongodb.instrument) {
     const listener = mongodb.instrument();
     listener.on('started', onStart);
-    listener.on('succeeded', onEnd);
-    listener.on('failed', onEnd);
+    listener.on('succeeded', onSuccess);
+    listener.on('failed', onFailure);
   } else if (mongodb.MongoClient) {
     // mongodb 4.0+ removed the instrument() method in favor of
     // listeners on the instantiated client objects. There are two mechanisms
@@ -52,8 +52,8 @@ module.exports = (mongodb, agent, { version, enabled }) => {
         }
         super(...args);
         this.on('commandStarted', onStart);
-        this.on('commandSucceeded', onEnd);
-        this.on('commandFailed', onEnd);
+        this.on('commandSucceeded', onSuccess);
+        this.on('commandFailed', onFailure);
         this[kListenersAdded] = true;
       }
     }
@@ -103,8 +103,8 @@ module.exports = (mongodb, agent, { version, enabled }) => {
             } else {
               if (!client[kListenersAdded]) {
                 client.on('commandStarted', onStart);
-                client.on('commandSucceeded', onEnd);
-                client.on('commandFailed', onEnd);
+                client.on('commandSucceeded', onSuccess);
+                client.on('commandFailed', onFailure);
                 client[kListenersAdded] = true;
               }
               callback(err, client);
@@ -116,8 +116,8 @@ module.exports = (mongodb, agent, { version, enabled }) => {
         p.then((client) => {
           if (!client[kListenersAdded]) {
             client.on('commandStarted', onStart);
-            client.on('commandSucceeded', onEnd);
-            client.on('commandFailed', onEnd);
+            client.on('commandSucceeded', onSuccess);
+            client.on('commandFailed', onFailure);
             client[kListenersAdded] = true;
           }
         });
@@ -128,17 +128,15 @@ module.exports = (mongodb, agent, { version, enabled }) => {
 
   function onStart(event) {
     // `event` is a `CommandStartedEvent`
-    // https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst#api
-    // E.g. with mongodb@3.6.3:
+    // https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst#command-started-message
+    // E.g. with mongodb@6.2.0:
     //   CommandStartedEvent {
-    //     address: '127.0.0.1:27017',
-    //     connectionId: 1,
+    //     connectionId: '127.0.0.1:27017',
     //     requestId: 1,
     //     databaseName: 'test',
     //     commandName: 'insert',
     //     command:
     //     { ... } }
-
     const name = [
       event.databaseName,
       collectionFor(event),
@@ -175,13 +173,49 @@ module.exports = (mongodb, agent, { version, enabled }) => {
     }
   }
 
-  function onEnd(event) {
+  function onSuccess(event) {
+    // `event` is a `CommandSucceededEvent`
+    // https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst#command-succeeded-message
+    // E.g. with mongodb@6.2.0:
+    //   CommandSucceededEvent {
+    //     connectionId: '127.0.0.1:27017',
+    //     requestId: 1,
+    //     duration: 1,
+    //     reply: { ... }
+    //   }
     if (!activeSpans.has(event.requestId)) return;
-    const { failure, reply } = event;
-    const hasFailed = failure || (reply && reply.writeErrors);
+
     const span = activeSpans.get(event.requestId);
     activeSpans.delete(event.requestId);
-    span.setOutcome(hasFailed ? OUTCOME_FAILURE : OUTCOME_SUCCESS);
+
+    // From mongodb@3.6.0 and up some commands like `deleteOne` may contain
+    // error data inside the `reply` property. It makes sense to capture it.
+    const writeErrors = event && event.reply && event.reply.writeErrors;
+
+    if (writeErrors && writeErrors.length) {
+      // TODO: this gets linked to the parent transaction. How to link it to the span?
+      agent.captureError(writeErrors[0].errmsg, { skipOutcome: true });
+    }
+    span.setOutcome(OUTCOME_SUCCESS);
+    span.end(span._timer.start / 1000 + event.duration);
+  }
+
+  function onFailure(event) {
+    // `event` is a `CommandFailedEvent`
+    // https://github.com/mongodb/specifications/blob/master/source/command-logging-and-monitoring/command-logging-and-monitoring.rst#command-failed-message
+    // E.g. with mongodb@6.2.0:
+    // CommandFailedEvent {
+    //   connectionId: '127.0.0.1:27017',
+    //   requestId: 6,
+    //   commandName: "find",
+    //   duration: 1,
+    //   "failure": { ... }
+    // }
+    if (!activeSpans.has(event.requestId)) return;
+
+    const span = activeSpans.get(event.requestId);
+    activeSpans.delete(event.requestId);
+    span.setOutcome(OUTCOME_FAILURE);
     span.end(span._timer.start / 1000 + event.duration);
   }
 

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -8,6 +8,7 @@
 
 const semver = require('semver');
 
+const { OUTCOME_SUCCESS, OUTCOME_FAILURE } = require('../../constants');
 const { getDBDestination } = require('../context');
 const shimmer = require('../shimmer');
 const kListenersAdded = Symbol('kListenersAdded');
@@ -176,8 +177,11 @@ module.exports = (mongodb, agent, { version, enabled }) => {
 
   function onEnd(event) {
     if (!activeSpans.has(event.requestId)) return;
+    const { name, reply } = event;
+    const hasFailed = name === 'commandFailed' || (reply && reply.writeErrors);
     const span = activeSpans.get(event.requestId);
     activeSpans.delete(event.requestId);
+    span.setOutcome(hasFailed ? OUTCOME_FAILURE : OUTCOME_SUCCESS);
     span.end(span._timer.start / 1000 + event.duration);
   }
 

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -177,8 +177,8 @@ module.exports = (mongodb, agent, { version, enabled }) => {
 
   function onEnd(event) {
     if (!activeSpans.has(event.requestId)) return;
-    const { name, reply } = event;
-    const hasFailed = name === 'commandFailed' || (reply && reply.writeErrors);
+    const { failure, reply } = event;
+    const hasFailed = failure || (reply && reply.writeErrors);
     const span = activeSpans.get(event.requestId);
     activeSpans.delete(event.requestId);
     span.setOutcome(hasFailed ? OUTCOME_FAILURE : OUTCOME_SUCCESS);

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -190,11 +190,13 @@ module.exports = (mongodb, agent, { version, enabled }) => {
 
     // From mongodb@3.6.0 and up some commands like `deleteOne` may contain
     // error data inside the `reply` property. It makes sense to capture it.
-    const writeErrors = event && event.reply && event.reply.writeErrors;
+    const writeErrors = event?.reply?.writeErrors;
 
     if (writeErrors && writeErrors.length) {
-      // TODO: this gets linked to the parent transaction. How to link it to the span?
-      agent.captureError(writeErrors[0].errmsg, { skipOutcome: true });
+      agent.captureError(writeErrors[0].errmsg, {
+        skipOutcome: true,
+        parent: span,
+      });
     }
     span.setOutcome(OUTCOME_SUCCESS);
     span.end(span._timer.start / 1000 + event.duration);

--- a/test/instrumentation/modules/mongodb/fixtures/use-mongodb.js
+++ b/test/instrumentation/modules/mongodb/fixtures/use-mongodb.js
@@ -94,6 +94,13 @@ async function useMongodb(mongodbClient, options) {
   const queries = [{ a: 1 }, { b: 2 }, { c: 3 }];
   await Promise.all(queries.map((q) => collection.findOne(q)));
 
+  // Force an error to check the span outcome
+  try {
+    await collection.findOne({ a: 1 }, { hint: 'foo' });
+  } catch (err) {
+    log.info({ err }, 'error in .findOne() with bogus "hint"');
+  }
+
   if (useCallbacks) {
     data = await new Promise((resolve, reject) => {
       collection.findOne({ a: 4 }, function (err, res) {
@@ -148,6 +155,13 @@ async function useMongodb(mongodbClient, options) {
     'Mongodb span (or its HTTP span) should not be currentSpan after awaiting the task',
   );
   log.info({ data }, 'deleteOne with promises');
+
+  // Force an error to check the span outcome
+  try {
+    await collection.deleteOne({ a: 1 }, { hint: 'foo' });
+  } catch (err) {
+    log.info({ err }, 'error in .deleteOne() with bogus "hint"');
+  }
 
   if (useCallbacks) {
     data = await new Promise((resolve, reject) => {

--- a/test/instrumentation/modules/mongodb/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb/mongodb.test.js
@@ -43,6 +43,9 @@ const TEST_DB = 'elasticapm';
 const TEST_COLLECTION = 'test';
 const TEST_USE_CALLBACKS = semver.satisfies(MONGODB_VERSION, '<5');
 
+// From mongodb@3.6.0 and up CommandSuccessEvents may contain errors
+const MONGODB_SUCESS_WITH_ERRORS = semver.satisfies(MONGODB_VERSION, '>=3.6.0');
+
 /** @type {import('../../../_utils').TestFixture[]} */
 const testFixtures = [
   {
@@ -66,6 +69,7 @@ const testFixtures = [
       // First the transaction.
       t.ok(events[0].transaction, 'got the transaction');
       const tx = events.shift().transaction;
+      const errors = events.filter((e) => e.error).map((e) => e.error);
 
       // Compare some common fields across all spans.
       // ignore http/external spans
@@ -97,6 +101,8 @@ const testFixtures = [
         'all spans have sample_rate=1',
       );
 
+      // TODO: uncomment this when we attach correctly the error to the span
+      // const failingSpanId = spans[TEST_USE_CALLBACKS ? 12 : 8].id; // index of `.deleteOne` with bogus "hint"
       spans.forEach((s) => {
         // Remove variable and common fields to facilitate t.deepEqual below.
         delete s.id;
@@ -284,11 +290,25 @@ const testFixtures = [
         'deleteOne produced expected span',
       );
 
+      // Delete command errors are not faling
+      // - Promise API does not reject
+      // - callback API does not return an error param
+      // - CommandSucceededvent is fired (althoug it contains error data)
       t.deepEqual(
         spans.shift(),
-        { ...deleteOneSpan, outcome: 'failure' },
+        deleteOneSpan,
         'deleteOne with bogus "hint" produced expected span',
       );
+
+      if (MONGODB_SUCESS_WITH_ERRORS) {
+        t.equal(errors.length, 1, 'got 1 error');
+        // TODO: uncomment this when we attach correctly the error to the span
+        // t.equal(
+        //   errors[0].parent_id,
+        //   failingSpanId,
+        //   'error is a child of the failing span from deleteOne with bogus "hint"',
+        // );
+      }
 
       if (TEST_USE_CALLBACKS) {
         t.deepEqual(

--- a/test/instrumentation/modules/mongodb/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb/mongodb.test.js
@@ -194,6 +194,12 @@ const testFixtures = [
       t.deepEqual(spans.shift(), findOneSpan, 'findOne 2nd concurrent call');
       t.deepEqual(spans.shift(), findOneSpan, 'findOne 3rd concurrent call');
 
+      t.deepEqual(
+        spans.shift(),
+        { ...findOneSpan, outcome: 'failure' },
+        'findOne with bogus "hint" produced expected span',
+      );
+
       if (TEST_USE_CALLBACKS) {
         t.deepEqual(
           spans.shift(),
@@ -276,6 +282,12 @@ const testFixtures = [
         spans.shift(),
         deleteOneSpan,
         'deleteOne produced expected span',
+      );
+
+      t.deepEqual(
+        spans.shift(),
+        { ...deleteOneSpan, outcome: 'failure' },
+        'deleteOne with bogus "hint" produced expected span',
       );
 
       if (TEST_USE_CALLBACKS) {

--- a/test/instrumentation/modules/mongodb/mongodb.test.js
+++ b/test/instrumentation/modules/mongodb/mongodb.test.js
@@ -44,7 +44,10 @@ const TEST_COLLECTION = 'test';
 const TEST_USE_CALLBACKS = semver.satisfies(MONGODB_VERSION, '<5');
 
 // From mongodb@3.6.0 and up CommandSuccessEvents may contain errors
-const MONGODB_SUCESS_WITH_ERRORS = semver.satisfies(MONGODB_VERSION, '>=3.6.0');
+const MONGODB_SUCCESS_WITH_ERRORS = semver.satisfies(
+  MONGODB_VERSION,
+  '>=3.6.0',
+);
 
 /** @type {import('../../../_utils').TestFixture[]} */
 const testFixtures = [
@@ -101,8 +104,7 @@ const testFixtures = [
         'all spans have sample_rate=1',
       );
 
-      // TODO: uncomment this when we attach correctly the error to the span
-      // const failingSpanId = spans[TEST_USE_CALLBACKS ? 12 : 8].id; // index of `.deleteOne` with bogus "hint"
+      const failingSpanId = spans[TEST_USE_CALLBACKS ? 11 : 8].id; // index of `.deleteOne` with bogus "hint"
       spans.forEach((s) => {
         // Remove variable and common fields to facilitate t.deepEqual below.
         delete s.id;
@@ -300,14 +302,13 @@ const testFixtures = [
         'deleteOne with bogus "hint" produced expected span',
       );
 
-      if (MONGODB_SUCESS_WITH_ERRORS) {
+      if (MONGODB_SUCCESS_WITH_ERRORS) {
         t.equal(errors.length, 1, 'got 1 error');
-        // TODO: uncomment this when we attach correctly the error to the span
-        // t.equal(
-        //   errors[0].parent_id,
-        //   failingSpanId,
-        //   'error is a child of the failing span from deleteOne with bogus "hint"',
-        // );
+        t.equal(
+          errors[0].parent_id,
+          failingSpanId,
+          'error is a child of the failing span from deleteOne with bogus "hint"',
+        );
       }
 
       if (TEST_USE_CALLBACKS) {


### PR DESCRIPTION
This PR sets span outcome for `mongodb` commands. The tests realised (see related issue) reveals that a failed command triggers:
- a **CommandFailed** event with a property named `failure`
- a **CommandSucceeded** event with the a property named `reply`. The presence of a sub-property named `writeErrors` indicates the command failed.

Closes: #3182 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
