### PR TITLE
chore: change use docker v2 command

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -233,7 +233,7 @@ NODE_VERSION=${NODE_VERSION} \
 NODE_FULL_VERSION=${NODE_FULL_VERSION} \
 TAV_MODULE=${TAV_MODULE} \
 USER_ID="$(id -u):$(id -g)" \
-docker-compose \
+docker compose \
   --no-ansi \
   --log-level ERROR \
   -f .ci/docker/${DOCKER_COMPOSE_FILE} \
@@ -253,7 +253,7 @@ NODE_VERSION=${NODE_VERSION} \
 NODE_FULL_VERSION=${NODE_FULL_VERSION} \
 TAV_MODULE=${TAV_MODULE} \
 USER_ID="$(id -u):$(id -g)" \
-docker-compose \
+docker compose \
   --no-ansi \
   --log-level ERROR \
   -f .ci/docker/${DOCKER_COMPOSE_FILE} \
@@ -263,14 +263,14 @@ docker-compose \
   --abort-on-container-exit \
   node_tests
 
-if ! NODE_VERSION=${NODE_VERSION} docker-compose \
+if ! NODE_VERSION=${NODE_VERSION} docker compose \
     --no-ansi \
     --log-level ERROR \
     -f .ci/docker/${DOCKER_COMPOSE_FILE} \
     down -v --remove-orphans; then
   # Workaround for this commonly seen error:
   #   error while removing network: network docker_default id $id has active endpoints
-  echo "error: Unexpected error in 'docker-compose down ...'. Forcing removal of unused networks."
+  echo "error: Unexpected error in 'docker compose down ...'. Forcing removal of unused networks."
   docker network inspect docker_default || true
   docker network inspect -f '{{range .Containers}}{{ .Name }} {{end}}' docker_default || true
   docker network prune --force || true

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -234,8 +234,7 @@ NODE_FULL_VERSION=${NODE_FULL_VERSION} \
 TAV_MODULE=${TAV_MODULE} \
 USER_ID="$(id -u):$(id -g)" \
 docker compose \
-  --no-ansi \
-  --log-level ERROR \
+  --ansi never \
   -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   build >docker-compose.log 2>docker-compose.err
 
@@ -254,8 +253,7 @@ NODE_FULL_VERSION=${NODE_FULL_VERSION} \
 TAV_MODULE=${TAV_MODULE} \
 USER_ID="$(id -u):$(id -g)" \
 docker compose \
-  --no-ansi \
-  --log-level ERROR \
+  --ansi never \
   -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   up \
   --exit-code-from node_tests \
@@ -264,8 +262,7 @@ docker compose \
   node_tests
 
 if ! NODE_VERSION=${NODE_VERSION} docker compose \
-    --no-ansi \
-    --log-level ERROR \
+    --ansi never \
     -f .ci/docker/${DOCKER_COMPOSE_FILE} \
     down -v --remove-orphans; then
   # Workaround for this commonly seen error:

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -233,7 +233,8 @@ NODE_VERSION=${NODE_VERSION} \
 NODE_FULL_VERSION=${NODE_FULL_VERSION} \
 TAV_MODULE=${TAV_MODULE} \
 USER_ID="$(id -u):$(id -g)" \
-docker compose \
+docker --log-level error\
+  compose \
   --ansi never \
   -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   build >docker-compose.log 2>docker-compose.err
@@ -252,7 +253,8 @@ NODE_VERSION=${NODE_VERSION} \
 NODE_FULL_VERSION=${NODE_FULL_VERSION} \
 TAV_MODULE=${TAV_MODULE} \
 USER_ID="$(id -u):$(id -g)" \
-docker compose \
+docker --log-level error\
+  compose \
   --ansi never \
   -f .ci/docker/${DOCKER_COMPOSE_FILE} \
   up \
@@ -261,7 +263,8 @@ docker compose \
   --abort-on-container-exit \
   node_tests
 
-if ! NODE_VERSION=${NODE_VERSION} docker compose \
+if ! NODE_VERSION=${NODE_VERSION} docker --log-level error\
+    compose \
     --ansi never \
     -f .ci/docker/${DOCKER_COMPOSE_FILE} \
     down -v --remove-orphans; then

--- a/.ci/scripts/windows/prepare-test.sh
+++ b/.ci/scripts/windows/prepare-test.sh
@@ -5,7 +5,7 @@ NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 
 NODE_VERSION=${NODE_VERSION} \
 USER_ID="$(id -u):$(id -g)" \
-docker-compose \
+docker compose \
   --no-ansi \
   --log-level ERROR \
   -f .ci/docker/docker-compose-all.yml \

--- a/.ci/scripts/windows/prepare-test.sh
+++ b/.ci/scripts/windows/prepare-test.sh
@@ -5,7 +5,8 @@ NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 
 NODE_VERSION=${NODE_VERSION} \
 USER_ID="$(id -u):$(id -g)" \
-docker compose \
+docker --log-level error\
+  compose \
   --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   up \

--- a/.ci/scripts/windows/prepare-test.sh
+++ b/.ci/scripts/windows/prepare-test.sh
@@ -6,8 +6,7 @@ NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 NODE_VERSION=${NODE_VERSION} \
 USER_ID="$(id -u):$(id -g)" \
 docker compose \
-  --no-ansi \
-  --log-level ERROR \
+  --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   up \
   --build \

--- a/.ci/scripts/windows/stop-test.sh
+++ b/.ci/scripts/windows/stop-test.sh
@@ -3,13 +3,15 @@ set -exo pipefail
 
 NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 
-NODE_VERSION=${NODE_VERSION} docker compose \
+NODE_VERSION=${NODE_VERSION} docker --log-level error\
+  compose \
   --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   logs \
   --timestamps > docker-compose-logs.txt
 
-NODE_VERSION=${NODE_VERSION} docker compose \
+NODE_VERSION=${NODE_VERSION} docker --log-level error\
+  compose \
   --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   down -v

--- a/.ci/scripts/windows/stop-test.sh
+++ b/.ci/scripts/windows/stop-test.sh
@@ -4,13 +4,12 @@ set -exo pipefail
 NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 
 NODE_VERSION=${NODE_VERSION} docker compose \
-  --no-ansi \
+  --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   logs \
   --timestamps > docker-compose-logs.txt
 
 NODE_VERSION=${NODE_VERSION} docker compose \
-  --no-ansi \
-  --log-level ERROR \
+  --ansi never \
   -f .ci/docker/docker-compose-all.yml \
   down -v

--- a/.ci/scripts/windows/stop-test.sh
+++ b/.ci/scripts/windows/stop-test.sh
@@ -3,13 +3,13 @@ set -exo pipefail
 
 NODE_VERSION=${1:?Nodejs version missing NODE_VERSION is not set}
 
-NODE_VERSION=${NODE_VERSION} docker-compose \
+NODE_VERSION=${NODE_VERSION} docker compose \
   --no-ansi \
   -f .ci/docker/docker-compose-all.yml \
   logs \
   --timestamps > docker-compose-logs.txt
 
-NODE_VERSION=${NODE_VERSION} docker-compose \
+NODE_VERSION=${NODE_VERSION} docker compose \
   --no-ansi \
   --log-level ERROR \
   -f .ci/docker/docker-compose-all.yml \

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "bench:ci": "./test/benchmarks/scripts/run-benchmarks-ci.sh",
     "local:start": "./test/script/local-deps-start.sh",
     "local:stop": "./test/script/local-deps-stop.sh",
-    "docker:start": "docker-compose -f ./test/docker-compose.yml up -d",
-    "docker:stop": "docker-compose -f ./test/docker-compose.yml down",
+    "docker:start": "docker compose -f ./test/docker-compose.yml up -d",
+    "docker:stop": "docker compose -f ./test/docker-compose.yml down",
     "docker:clean": "./test/script/docker/cleanup.sh",
-    "docker:dev": "docker-compose -f ./dev-utils/docker-compose.yml run --workdir=/agent nodejs-agent",
+    "docker:dev": "docker compose -f ./dev-utils/docker-compose.yml run --workdir=/agent nodejs-agent",
     "package:snapshot": "rm -rf ./build/snapshot && mkdir -p ./build/snapshot && npm pack --pack-destination ./build/snapshot"
   },
   "directories": {


### PR DESCRIPTION
Move to docker v2 before v1 hits EOL. Basically it uses the new CLI options since the images we're using in CI (ubuntu-latest) already has [Docker V2](https://github.com/actions/runner-images/blob/cdbbd8a4455b608075cbf785bf0e969c13681890/images/linux/Ubuntu2204-Readme.md?plain=1#L71)
- `--log-level` option is now moved to docker command
- `--no-ansi` has been changed for `--ansi never` as suggested in the warning from Docker

Closes: #3306 


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
