### PR TITLE
chore: run edge tests periodically

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -8,6 +8,7 @@ name: edge
 on:
   workflow_dispatch:
   schedule:
+    # Every Monday & Thursday at 6:00 AM
     - cron: '0 6 * * 1,4'
 
 # limit the access of the generated GITHUB_TOKEN

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -7,14 +7,8 @@ name: edge
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**/**.md'
-      - '**/**.asciidoc'
-      - 'docs/**'
-      - 'examples/**'
+  schedule:
+    - cron: '0 6 * * 1,4'
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:


### PR DESCRIPTION
Change the trigger events for "edge" tests to make them run twice a week instead of in each commit to main.

Closes: #3338 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
