### PR TITLE
chore: unify configuration options definition

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -785,8 +785,10 @@ The default value `0` means that no source code will be collected for span libra
 [[error-message-max-length]]
 ==== `errorMessageMaxLength`
 
+[small]#Deprecated in: v3.21.0, use <<long-field-max-length,`longFieldMaxLength`>>#
+
 * *Type:* String
-* *Default:* `"2kb"`
+* *Default:* `longFieldMaxLength`'s value
 * *Env:* `ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH`
 
 This option is **deprecated** -- use <<long-field-max-length,`longFieldMaxLength`>> instead.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -16,7 +16,7 @@ const { agentActivationMethodFromStartStack } = require('./activation-method');
 const {
   CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS,
   CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
-} = require('./config/schema');
+} = require('./constants');
 const config = require('./config/config');
 const connect = require('./middleware/connect');
 const constants = require('./constants');

--- a/lib/apm-client/apm-client.js
+++ b/lib/apm-client/apm-client.js
@@ -8,10 +8,8 @@
 
 const fs = require('fs');
 const version = require('../../package').version;
-const {
-  CENTRAL_CONFIG_OPTS,
-  INTAKE_STRING_MAX_SIZE,
-} = require('../config/schema');
+const { INTAKE_STRING_MAX_SIZE } = require('../constants');
+const { CENTRAL_CONFIG_OPTS } = require('../config/schema');
 const { normalize } = require('../config/config');
 const { CloudMetadata } = require('../cloud-metadata');
 const { isLambdaExecutionEnvironment } = require('../lambda');

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -14,7 +14,8 @@ const { URL } = require('url');
 const truncate = require('unicode-byte-truncate');
 
 const AGENT_VERSION = require('../../package.json').version;
-const REDACTED = require('../constants').REDACTED;
+
+const { INTAKE_STRING_MAX_SIZE, REDACTED } = require('../constants');
 const logging = require('../logging');
 const { NoopApmClient } = require('../apm-client/noop-apm-client');
 const { isLambdaExecutionEnvironment } = require('../lambda');
@@ -23,7 +24,6 @@ const {
 } = require('../instrumentation/azure-functions');
 
 const {
-  INTAKE_STRING_MAX_SIZE,
   BOOL_OPTS,
   NUM_OPTS,
   DURATION_OPTS,
@@ -31,10 +31,11 @@ const {
   MINUS_ONE_EQUAL_INFINITY,
   ARRAY_OPTS,
   KEY_VALUE_OPTS,
-  ENV_TABLE,
-  DEFAULTS,
-  CROSS_AGENT_CONFIG_VAR_NAME,
   URL_OPTS,
+  CROSS_AGENT_CONFIG_VAR_NAME,
+  getDefaulOptions,
+  getEnvionmentOptions,
+  getFileOptions,
 } = require('./schema');
 
 const {
@@ -76,20 +77,23 @@ const NICE_REGEXPS_FIELDS = {
   ignoreMessageQueuesRegExp: true,
 };
 
-let confFile = loadConfigFile();
-let confFilePath = confFile.path;
-let confFileOpts = confFile.opts;
+const confDefaultOptions = getDefaulOptions();
+const confEnvOpts = getEnvionmentOptions();
+let confFilePath = path.resolve(
+  confEnvOpts.configFile || confDefaultOptions.configFile,
+);
+let confFileOpts = getFileOptions();
 
 // Configure a logger for the agent.
 //
 // This is separate from `createConfig` to allow the agent to have an early
 // logger before `agent.start()` is called.
-function configLogger(opts) {
+function configLogger(opts = {}) {
   const logLevel =
-    process.env[ENV_TABLE.logLevel] ||
-    (opts && opts.logLevel) ||
+    confEnvOpts.logLevel ||
+    opts.logLevel ||
     (confFileOpts && confFileOpts.logLevel) ||
-    DEFAULTS.logLevel;
+    confDefaultOptions.logLevel;
 
   // `ELASTIC_APM_LOGGER=false` is provided as a mechanism to *disable* a
   // custom logger for troubleshooting because a wrapped custom logger does
@@ -97,8 +101,7 @@ function configLogger(opts) {
   // https://www.elastic.co/guide/en/apm/agent/nodejs/current/troubleshooting.html#debug-mode
   let customLogger = null;
   if (process.env.ELASTIC_APM_LOGGER !== 'false') {
-    customLogger =
-      (opts && opts.logger) || (confFileOpts && confFileOpts.logger);
+    customLogger = opts.logger || (confFileOpts && confFileOpts.logger);
   }
 
   return logging.createLogger(logLevel, customLogger);
@@ -107,7 +110,7 @@ function configLogger(opts) {
 // Create an initial configuration from DEFAULTS. This is used as a stand-in
 // for Agent configuration until `agent.start(...)` is called.
 function initialConfig(logger) {
-  const cfg = Object.assign({}, DEFAULTS);
+  const cfg = Object.assign({}, confDefaultOptions);
 
   // Reproduce the generated properties for `Config`.
   cfg.disableMetricsRegExp = [];
@@ -143,19 +146,18 @@ class Config {
     this.ignoreMessageQueuesRegExp = [];
 
     const isLambda = isLambdaExecutionEnvironment();
-    const envOptions = readEnv();
+    const envOptions = getEnvionmentOptions();
 
     // If we didn't find a config file on process boot, but a path to one is
     // provided as a config option, let's instead try to load that
     if (confFileOpts === null && opts && opts.configFile) {
-      confFile = loadConfigFile(opts.configFile);
-      confFilePath = confFile.path;
-      confFileOpts = confFile.opts;
+      confFilePath = path.resolve(opts.configFile);
+      confFileOpts = getFileOptions(opts.configFile);
     }
 
     Object.assign(
       this,
-      DEFAULTS, // default options
+      confDefaultOptions, // default options
       confFileOpts, // options read from config file
       opts, // options passed in to agent.start()
       envOptions, // options read from environment variables
@@ -280,20 +282,6 @@ class Config {
     }
     return loggable;
   }
-}
-
-function readEnv() {
-  var opts = {};
-  for (const key of Object.keys(ENV_TABLE)) {
-    let env = ENV_TABLE[key];
-    if (!Array.isArray(env)) env = [env];
-    for (const envKey of env) {
-      if (envKey in process.env) {
-        opts[key] = process.env[envKey];
-      }
-    }
-  }
-  return opts;
 }
 
 function validateServiceName(s) {
@@ -439,28 +427,30 @@ function serviceVersionFromPackageJson() {
 }
 
 function normalize(opts, logger) {
-  normalizeKeyValuePairs(opts, KEY_VALUE_OPTS, DEFAULTS, logger);
-  normalizeNumbers(opts, NUM_OPTS, DEFAULTS, logger);
-  normalizeInfinity(opts, MINUS_ONE_EQUAL_INFINITY, DEFAULTS, logger);
-  normalizeBytes(opts, BYTES_OPTS, DEFAULTS, logger);
-  normalizeArrays(opts, ARRAY_OPTS, DEFAULTS, logger);
-  normalizeDurationOptions(opts, DURATION_OPTS, DEFAULTS, logger);
-  normalizeBools(opts, BOOL_OPTS, DEFAULTS, logger);
+  const defaults = confDefaultOptions;
+
+  normalizeKeyValuePairs(opts, KEY_VALUE_OPTS, defaults, logger);
+  normalizeNumbers(opts, NUM_OPTS, defaults, logger);
+  normalizeInfinity(opts, MINUS_ONE_EQUAL_INFINITY, defaults, logger);
+  normalizeBytes(opts, BYTES_OPTS, defaults, logger);
+  normalizeArrays(opts, ARRAY_OPTS, defaults, logger);
+  normalizeDurationOptions(opts, DURATION_OPTS, defaults, logger);
+  normalizeBools(opts, BOOL_OPTS, defaults, logger);
   normalizeIgnoreOptions(opts);
   normalizeElasticsearchCaptureBodyUrls(opts);
   normalizeDisableMetrics(opts);
   normalizeSanitizeFieldNames(opts);
-  normalizeContextManager(opts, [], DEFAULTS, logger);
-  normalizeCloudProvider(opts, [], DEFAULTS, logger);
-  normalizeTransactionSampleRate(opts, [], DEFAULTS, logger);
-  normalizeTraceContinuationStrategy(opts, [], DEFAULTS, logger);
-  normalizeCustomMetricsHistogramBoundaries(opts, [], DEFAULTS, logger);
-  normalizeUrls(opts, URL_OPTS, DEFAULTS, logger);
+  normalizeContextManager(opts, [], defaults, logger);
+  normalizeCloudProvider(opts, [], defaults, logger);
+  normalizeTransactionSampleRate(opts, [], defaults, logger);
+  normalizeTraceContinuationStrategy(opts, [], defaults, logger);
+  normalizeCustomMetricsHistogramBoundaries(opts, [], defaults, logger);
+  normalizeUrls(opts, URL_OPTS, defaults, logger);
 
   // This must be after `normalizeDurationOptions()` and `normalizeBools()`
   // because it synthesizes the deprecated `spanFramesMinDuration` and
   // `captureSpanStackTraces` options into `spanStackTraceMinDuration`.
-  normalizeSpanStackTraceMinDuration(opts, [], DEFAULTS, logger);
+  normalizeSpanStackTraceMinDuration(opts, [], defaults, logger);
 
   truncateOptions(opts);
 }
@@ -473,34 +463,6 @@ function truncateOptions(opts) {
     );
   if (opts.hostname)
     opts.hostname = truncate(String(opts.hostname), INTAKE_STRING_MAX_SIZE);
-}
-
-/**
- * Tries to load a configuration file for the given path or from the ENV vars, if both undefined
- * it uses the default config filename `elastic-apm-node.js`. If the config file is not present or
- * there is something wrong in the file it will return no options
- *
- * @param {String | undefined} filePath Path where to look for configuration
- * @returns {{path: String, opts: Object}} - The path used and options which will be null if load failed
- */
-function loadConfigFile(filePath) {
-  const confPath = path.resolve(
-    filePath || process.env.ELASTIC_APM_CONFIG_FILE || 'elastic-apm-node.js',
-  );
-
-  if (fs.existsSync(confPath)) {
-    try {
-      return { path: confPath, opts: require(confPath) };
-    } catch (err) {
-      console.error(
-        "Elastic APM initialization error: Can't read config file %s",
-        confPath,
-      );
-      console.error(err.stack);
-    }
-  }
-
-  return { path: confPath, opts: null };
 }
 
 /**

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -33,8 +33,8 @@ const {
   KEY_VALUE_OPTS,
   URL_OPTS,
   CROSS_AGENT_CONFIG_VAR_NAME,
-  getDefaulOptions,
-  getEnvionmentOptions,
+  getDefaultOptions,
+  getEnvironmentOptions,
   getFileOptions,
 } = require('./schema');
 
@@ -77,8 +77,8 @@ const NICE_REGEXPS_FIELDS = {
   ignoreMessageQueuesRegExp: true,
 };
 
-const confDefaultOptions = getDefaulOptions();
-const confEnvOpts = getEnvionmentOptions();
+const confDefaultOptions = getDefaultOptions();
+const confEnvOpts = getEnvironmentOptions();
 let confFilePath = path.resolve(
   confEnvOpts.configFile || confDefaultOptions.configFile,
 );
@@ -146,7 +146,7 @@ class Config {
     this.ignoreMessageQueuesRegExp = [];
 
     const isLambda = isLambdaExecutionEnvironment();
-    const envOptions = getEnvionmentOptions();
+    const envOptions = getEnvironmentOptions();
 
     // If we didn't find a config file on process boot, but a path to one is
     // provided as a config option, let's instead try to load that

--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -10,13 +10,12 @@ const { URL } = require('url');
 
 const { WildcardMatcher } = require('../wildcard-matcher');
 const {
-  DEFAULTS,
   TRACE_CONTINUATION_STRATEGY_CONTINUE,
   TRACE_CONTINUATION_STRATEGY_RESTART,
   TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL,
   CONTEXT_MANAGER_ASYNCHOOKS,
   CONTEXT_MANAGER_ASYNCLOCALSTORAGE,
-} = require('./schema');
+} = require('../constants');
 
 /**
  * Normalizes the key/value pairs properties of the config options object
@@ -580,9 +579,9 @@ function normalizeTraceContinuationStrategy(opts, fields, defaults, logger) {
     logger.warn(
       'Invalid "traceContinuationStrategy" config value %j, falling back to default %j',
       opts.traceContinuationStrategy,
-      DEFAULTS.traceContinuationStrategy,
+      defaults.traceContinuationStrategy,
     );
-    opts.traceContinuationStrategy = DEFAULTS.traceContinuationStrategy;
+    opts.traceContinuationStrategy = defaults.traceContinuationStrategy;
   }
 }
 

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -6,260 +6,679 @@
 
 'use strict';
 
-const INTAKE_STRING_MAX_SIZE = 1024;
-const CAPTURE_ERROR_LOG_STACK_TRACES_NEVER = 'never';
-const CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES = 'messages';
-const CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS = 'always';
-const CONTEXT_MANAGER_ASYNCHOOKS = 'asynchooks';
-const CONTEXT_MANAGER_ASYNCLOCALSTORAGE = 'asynclocalstorage';
-const TRACE_CONTINUATION_STRATEGY_CONTINUE = 'continue';
-const TRACE_CONTINUATION_STRATEGY_RESTART = 'restart';
-const TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL = 'restart_external';
+const fs = require('fs');
+const path = require('path');
 
-const DEFAULTS = {
-  abortedErrorThreshold: '25s',
-  active: true,
-  addPatch: undefined,
-  apiRequestSize: '768kb',
-  apiRequestTime: '10s',
-  breakdownMetrics: true,
-  captureBody: 'off',
-  captureErrorLogStackTraces: CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
-  captureExceptions: true,
-  captureHeaders: true,
-  centralConfig: true,
-  cloudProvider: 'auto',
-  containerId: undefined,
-  // 'contextManager' is explicitly *not* included in DEFAULTS because
-  // normalizeContextManager() needs to know if a value was provided by the
-  // user.
-  contextPropagationOnly: false,
-  // Exponential powers-of-2 bucket boundaries, rounded to 6 significant figures.
-  //    2**N for N in [-8, -7.5, -7, ..., 16, 16.5, 17]
-  // https://github.com/elastic/apm/blob/main/specs/agents/metrics-otel.md#histogram-aggregation
-  customMetricsHistogramBoundaries: [
-    0.00390625, 0.00552427, 0.0078125, 0.0110485, 0.015625, 0.0220971, 0.03125,
-    0.0441942, 0.0625, 0.0883883, 0.125, 0.176777, 0.25, 0.353553, 0.5,
-    0.707107, 1, 1.41421, 2, 2.82843, 4, 5.65685, 8, 11.3137, 16, 22.6274, 32,
-    45.2548, 64, 90.5097, 128, 181.019, 256, 362.039, 512, 724.077, 1024,
-    1448.15, 2048, 2896.31, 4096, 5792.62, 8192, 11585.2, 16384, 23170.5, 32768,
-    46341, 65536, 92681.9, 131072,
-  ],
-  disableInstrumentations: [],
-  disableMetrics: [],
-  disableSend: false,
-  elasticsearchCaptureBodyUrls: [
-    '*/_search',
-    '*/_search/template',
-    '*/_msearch',
-    '*/_msearch/template',
-    '*/_async_search',
-    '*/_count',
-    '*/_sql',
-    '*/_eql/search',
-  ],
-  environment: process.env.NODE_ENV || 'development',
-  errorOnAbortedRequests: false,
-  exitSpanMinDuration: '0ms',
-  globalLabels: undefined,
-  ignoreMessageQueues: [],
-  instrument: true,
-  instrumentIncomingHTTPRequests: true,
-  kubernetesNamespace: undefined,
-  kubernetesNodeName: undefined,
-  kubernetesPodName: undefined,
-  kubernetesPodUID: undefined,
-  logLevel: 'info',
-  longFieldMaxLength: 10000,
-  // Rough equivalent of the Java Agent's max_queue_size:
-  // https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-max-queue-size
-  maxQueueSize: 1024,
-  metricsInterval: '30s',
-  metricsLimit: 1000,
-  opentelemetryBridgeEnabled: false,
-  sanitizeFieldNames: [
+/**
+ * @typedef {Object} OptionDefinition
+ * @property {string} name the name of the configuration option
+ * @property {any} defaultValue the default value of the property or undefined
+ * @property {keyof TypeNormalizers} type the type of the configuration option
+ * @property {string} [envVar] the name of the environment varaiable associated with the option
+ * @property {string} [envDeprecatedVar] the name of the deprecated environment varaiable associated with the option
+ * @property {string} [crossAgentName] name of cross agent property
+ */
+
+// TODO: options with `crossAgentName` property
+// check for more cross agent config option names in
+// https://docs.google.com/spreadsheets/d/1JJjZotapacA3FkHc2sv_0wiChILi3uKnkwLTjtBmxwU/edit#gid=0
+
+/**
+ * @type Array<OptionDefinition>
+ */
+const CONFIG_SCHEMA = [
+  {
+    name: 'configFile',
+    type: 'string',
+    defaultValue: 'elastic-apm-node.js',
+    envVar: 'ELASTIC_APM_CONFIG_FILE',
+  },
+  {
+    name: 'abortedErrorThreshold',
+    type: 'durationSeconds',
+    defaultValue: '25s',
+    envVar: 'ELASTIC_APM_ABORTED_ERROR_THRESHOLD',
+  },
+  {
+    name: 'active',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_ACTIVE',
+  },
+  {
+    name: 'addPatch',
+    type: 'stringKeyValuePairs',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_ADD_PATCH',
+  },
+  {
+    name: 'apiRequestSize',
+    type: 'byte',
+    defaultValue: '768kb',
+    envVar: 'ELASTIC_APM_API_REQUEST_SIZE',
+  },
+  {
+    name: 'apiRequestTime',
+    type: 'durationSeconds',
+    defaultValue: '10s',
+    envVar: 'ELASTIC_APM_API_REQUEST_TIME',
+  },
+  {
+    name: 'breakdownMetrics',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_BREAKDOWN_METRICS',
+  },
+  {
+    name: 'captureBody',
+    type: 'select(off,all,errors,transactions)',
+    defaultValue: 'off',
+    envVar: 'ELASTIC_APM_CAPTURE_BODY',
+    centralConfigName: 'capture_body',
+    crossAgentName: 'capture_body',
+  },
+  {
+    name: 'captureErrorLogStackTraces',
+    type: 'select(messages,always)',
+    defaultValue: 'messages',
+    envVar: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
+  },
+  {
+    name: 'captureExceptions',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
+  },
+  {
+    name: 'captureHeaders',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_CAPTURE_HEADERS',
+  },
+  {
+    name: 'centralConfig',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_CENTRAL_CONFIG',
+  },
+  {
+    name: 'cloudProvider',
+    type: 'select(auto,gcp,azure,aws,none)',
+    defaultValue: 'auto',
+    envVar: 'ELASTIC_APM_CLOUD_PROVIDER',
+  },
+  {
+    name: 'containerId',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_CONTAINER_ID',
+  },
+  {
+    name: 'contextPropagationOnly',
+    type: 'boolean',
+    defaultValue: false,
+    envVar: 'ELASTIC_APM_CONTEXT_PROPAGATION_ONLY',
+  },
+  {
+    name: 'customMetricsHistogramBoundaries',
+    type: 'sortedNumberArray',
+    // Exponential powers-of-2 bucket boundaries, rounded to 6 significant figures.
+    //    2**N for N in [-8, -7.5, -7, ..., 16, 16.5, 17]
+    // https://github.com/elastic/apm/blob/main/specs/agents/metrics-otel.md#histogram-aggregation
+    defaultValue: [
+      0.00390625, 0.00552427, 0.0078125, 0.0110485, 0.015625, 0.0220971,
+      0.03125, 0.0441942, 0.0625, 0.0883883, 0.125, 0.176777, 0.25, 0.353553,
+      0.5, 0.707107, 1, 1.41421, 2, 2.82843, 4, 5.65685, 8, 11.3137, 16,
+      22.6274, 32, 45.2548, 64, 90.5097, 128, 181.019, 256, 362.039, 512,
+      724.077, 1024, 1448.15, 2048, 2896.31, 4096, 5792.62, 8192, 11585.2,
+      16384, 23170.5, 32768, 46341, 65536, 92681.9, 131072,
+    ],
+    envVar: 'ELASTIC_APM_CUSTOM_METRICS_HISTOGRAM_BOUNDARIES',
+  },
+  {
+    name: 'disableInstrumentations',
+    type: 'stringArray',
+    defaultValue: [],
+    envVar: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
+  },
+  {
+    name: 'disableMetrics',
+    type: 'stringArray',
+    defaultValue: [],
+    envVar: 'ELASTIC_APM_DISABLE_METRICS',
+  },
+  {
+    name: 'disableMetricsRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['disableMetrics'],
+  },
+  {
+    name: 'disableSend',
+    type: 'boolean',
+    defaultValue: false,
+    envVar: 'ELASTIC_APM_DISABLE_SEND',
+  },
+  {
+    name: 'elasticsearchCaptureBodyUrls',
+    type: 'stringArray',
+    defaultValue: [
+      '*/_search',
+      '*/_search/template',
+      '*/_msearch',
+      '*/_msearch/template',
+      '*/_async_search',
+      '*/_count',
+      '*/_sql',
+      '*/_eql/search',
+    ],
+    envVar: 'ELASTIC_APM_ELASTICSEARCH_CAPTURE_BODY_URLS',
+  },
+  {
+    name: 'elasticsearchCaptureBodyUrlsRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['elasticsearchCaptureBodyUrls'],
+  },
+  {
+    name: 'environment',
+    type: 'string',
+    defaultValue: 'development',
+    envVar: 'ELASTIC_APM_ENVIRONMENT',
+  },
+  {
+    name: 'errorOnAbortedRequests',
+    type: 'boolean',
+    defaultValue: false,
+    envVar: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
+  },
+  {
+    name: 'exitSpanMinDuration',
+    type: 'durationMiliseconds',
+    defaultValue: '0ms',
+    envVar: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
+    centralConfigName: 'exit_span_min_duration',
+    crossAgentName: 'exit_span_min_duration',
+  },
+  {
+    name: 'globalLabels',
+    type: 'stringKeyValuePairs',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_GLOBAL_LABELS',
+  },
+  {
+    name: 'ignoreMessageQueues',
+    type: 'stringArray',
+    defaultValue: [],
+    envVar: 'ELASTIC_APM_IGNORE_MESSAGE_QUEUES',
+    centralConfigName: 'ignore_message_queues',
+    crossAgentName: 'ignore_message_queues',
+  },
+  {
+    name: 'ignoreMessageQueuesRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['ignoreMessageQueues'],
+  },
+  {
+    name: 'instrument',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_INSTRUMENT',
+  },
+  {
+    name: 'instrumentIncomingHTTPRequests',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_INSTRUMENT_INCOMING_HTTP_REQUESTS',
+  },
+  {
+    name: 'kubernetesNamespace',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'KUBERNETES_NAMESPACE',
+  },
+  {
+    name: 'kubernetesNodeName',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'KUBERNETES_NODE_NAME',
+  },
+  {
+    name: 'kubernetesPodName',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'KUBERNETES_POD_NAME',
+  },
+  {
+    name: 'kubernetesPodUID',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'KUBERNETES_POD_UID',
+  },
+  {
+    name: 'logLevel',
+    type: 'select(debug,info,warning,error,critical,off,trace)',
+    defaultValue: 'info',
+    envVar: 'ELASTIC_APM_LOG_LEVEL',
+    centralConfigName: 'log_level',
+    crossAgentName: 'log_level',
+  },
+  {
+    name: 'longFieldMaxLength',
+    type: 'number',
+    defaultValue: 10000,
+    envVar: 'ELASTIC_APM_LONG_FIELD_MAX_LENGTH',
+  },
+  {
+    name: 'maxQueueSize',
+    type: 'number',
+    // Rough equivalent of the Java Agent's max_queue_size:
+    // https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-max-queue-size
+    defaultValue: 1024,
+    envVar: 'ELASTIC_APM_MAX_QUEUE_SIZE',
+  },
+  {
+    name: 'metricsInterval',
+    type: 'durationSeconds',
+    defaultValue: '30s',
+    envVar: 'ELASTIC_APM_METRICS_INTERVAL',
+  },
+  {
+    name: 'metricsLimit',
+    type: 'number',
+    defaultValue: 1000,
+    envVar: 'ELASTIC_APM_METRICS_LIMIT',
+  },
+  {
+    name: 'opentelemetryBridgeEnabled',
+    type: 'boolean',
+    defaultValue: false,
+    envVar: 'ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED',
+  },
+  {
+    name: 'sanitizeFieldNames',
+    type: 'stringArray',
     // These patterns are specified in the shared APM specs:
     // https://github.com/elastic/apm/blob/main/specs/agents/sanitization.md
-    'password',
-    'passwd',
-    'pwd',
-    'secret',
-    '*key',
-    '*token*',
-    '*session*',
-    '*credit*',
-    '*card*',
-    '*auth*',
-    'set-cookie',
-    '*principal*',
-    // These are default patterns only in the Node.js APM agent, historically
-    // from when the "is-secret" dependency was used.
-    'pw',
-    'pass',
-    'connect.sid',
-  ],
-  serviceNodeName: undefined,
-  serverTimeout: '30s',
-  serverUrl: 'http://127.0.0.1:8200',
-  sourceLinesErrorAppFrames: 5,
-  sourceLinesErrorLibraryFrames: 5,
-  sourceLinesSpanAppFrames: 0,
-  sourceLinesSpanLibraryFrames: 0,
-  spanCompressionEnabled: true,
-  spanCompressionExactMatchMaxDuration: '50ms',
-  spanCompressionSameKindMaxDuration: '0ms',
-  // 'spanStackTraceMinDuration' is explicitly *not* included in DEFAULTS
-  // because normalizeSpanStackTraceMinDuration() needs to know if a value
-  // was provided by the user.
-  stackTraceLimit: 50,
-  traceContinuationStrategy: TRACE_CONTINUATION_STRATEGY_CONTINUE,
-  transactionIgnoreUrls: [],
-  transactionMaxSpans: 500,
-  transactionSampleRate: 1.0,
-  useElasticTraceparentHeader: false,
-  usePathAsTransactionName: false,
-  verifyServerCert: true,
-};
-
-const ENV_TABLE = {
-  abortedErrorThreshold: 'ELASTIC_APM_ABORTED_ERROR_THRESHOLD',
-  active: 'ELASTIC_APM_ACTIVE',
-  addPatch: 'ELASTIC_APM_ADD_PATCH',
-  apiKey: 'ELASTIC_APM_API_KEY',
-  apiRequestSize: 'ELASTIC_APM_API_REQUEST_SIZE',
-  apiRequestTime: 'ELASTIC_APM_API_REQUEST_TIME',
-  breakdownMetrics: 'ELASTIC_APM_BREAKDOWN_METRICS',
-  captureBody: 'ELASTIC_APM_CAPTURE_BODY',
-  captureErrorLogStackTraces: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
-  captureExceptions: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
-  captureHeaders: 'ELASTIC_APM_CAPTURE_HEADERS',
-  captureSpanStackTraces: 'ELASTIC_APM_CAPTURE_SPAN_STACK_TRACES',
-  centralConfig: 'ELASTIC_APM_CENTRAL_CONFIG',
-  cloudProvider: 'ELASTIC_APM_CLOUD_PROVIDER',
-  containerId: 'ELASTIC_APM_CONTAINER_ID',
-  contextManager: 'ELASTIC_APM_CONTEXT_MANAGER',
-  contextPropagationOnly: 'ELASTIC_APM_CONTEXT_PROPAGATION_ONLY',
-  customMetricsHistogramBoundaries:
-    'ELASTIC_APM_CUSTOM_METRICS_HISTOGRAM_BOUNDARIES',
-  disableInstrumentations: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
-  disableMetrics: 'ELASTIC_APM_DISABLE_METRICS',
-  disableSend: 'ELASTIC_APM_DISABLE_SEND',
-  environment: 'ELASTIC_APM_ENVIRONMENT',
-  exitSpanMinDuration: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
-  ignoreMessageQueues: 'ELASTIC_APM_IGNORE_MESSAGE_QUEUES',
-  elasticsearchCaptureBodyUrls: 'ELASTIC_APM_ELASTICSEARCH_CAPTURE_BODY_URLS',
-  errorMessageMaxLength: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
-  errorOnAbortedRequests: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
-  frameworkName: 'ELASTIC_APM_FRAMEWORK_NAME',
-  frameworkVersion: 'ELASTIC_APM_FRAMEWORK_VERSION',
-  globalLabels: 'ELASTIC_APM_GLOBAL_LABELS',
-  hostname: 'ELASTIC_APM_HOSTNAME',
-  instrument: 'ELASTIC_APM_INSTRUMENT',
-  instrumentIncomingHTTPRequests:
-    'ELASTIC_APM_INSTRUMENT_INCOMING_HTTP_REQUESTS',
-  kubernetesNamespace: 'KUBERNETES_NAMESPACE',
-  kubernetesNodeName: 'KUBERNETES_NODE_NAME',
-  kubernetesPodName: 'KUBERNETES_POD_NAME',
-  kubernetesPodUID: 'KUBERNETES_POD_UID',
-  logLevel: 'ELASTIC_APM_LOG_LEVEL',
-  longFieldMaxLength: 'ELASTIC_APM_LONG_FIELD_MAX_LENGTH',
-  maxQueueSize: 'ELASTIC_APM_MAX_QUEUE_SIZE',
-  metricsInterval: 'ELASTIC_APM_METRICS_INTERVAL',
-  metricsLimit: 'ELASTIC_APM_METRICS_LIMIT',
-  opentelemetryBridgeEnabled: 'ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED',
-  payloadLogFile: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
-  sanitizeFieldNames: 'ELASTIC_APM_SANITIZE_FIELD_NAMES',
-  serverCaCertFile: 'ELASTIC_APM_SERVER_CA_CERT_FILE',
-  secretToken: 'ELASTIC_APM_SECRET_TOKEN',
-  serverTimeout: 'ELASTIC_APM_SERVER_TIMEOUT',
-  serverUrl: 'ELASTIC_APM_SERVER_URL',
-  serviceName: 'ELASTIC_APM_SERVICE_NAME',
-  serviceNodeName: 'ELASTIC_APM_SERVICE_NODE_NAME',
-  serviceVersion: 'ELASTIC_APM_SERVICE_VERSION',
-  sourceLinesErrorAppFrames: 'ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES',
-  sourceLinesErrorLibraryFrames:
-    'ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES',
-  sourceLinesSpanAppFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
-  sourceLinesSpanLibraryFrames: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
-  spanCompressionEnabled: 'ELASTIC_APM_SPAN_COMPRESSION_ENABLED',
-  spanCompressionExactMatchMaxDuration:
-    'ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION',
-  spanCompressionSameKindMaxDuration:
-    'ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION',
-  spanStackTraceMinDuration: 'ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION',
-  spanFramesMinDuration: 'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION',
-  stackTraceLimit: 'ELASTIC_APM_STACK_TRACE_LIMIT',
-  traceContinuationStrategy: 'ELASTIC_APM_TRACE_CONTINUATION_STRATEGY',
-  transactionIgnoreUrls: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
-  transactionMaxSpans: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
-  transactionSampleRate: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
-  useElasticTraceparentHeader: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
-  usePathAsTransactionName: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
-  verifyServerCert: 'ELASTIC_APM_VERIFY_SERVER_CERT',
-};
-
-const CENTRAL_CONFIG_OPTS = {
-  log_level: 'logLevel',
-  transaction_sample_rate: 'transactionSampleRate',
-  transaction_max_spans: 'transactionMaxSpans',
-  capture_body: 'captureBody',
-  transaction_ignore_urls: 'transactionIgnoreUrls',
-  sanitize_field_names: 'sanitizeFieldNames',
-  ignore_message_queues: 'ignoreMessageQueues',
-  span_stack_trace_min_duration: 'spanStackTraceMinDuration',
-  trace_continuation_strategy: 'traceContinuationStrategy',
-  exit_span_min_duration: 'exitSpanMinDuration',
-};
-
-const CROSS_AGENT_CONFIG_VAR_NAME = {
-  apiKey: 'api_key',
-  serviceName: 'service_name',
-  serviceVersion: 'service_version',
-  secretToken: 'secret_token',
-  serverUrl: 'server_url',
-  logLevel: 'log_level',
-  transactionSampleRate: 'transaction_sample_rate',
-  transactionMaxSpans: 'transaction_max_spans',
-  captureBody: 'capture_body',
-  transactionIgnoreUrls: 'transaction_ignore_urls',
-  sanitizeFieldNames: 'sanitize_field_names',
-  ignoreMessageQueues: 'ignore_message_queues',
-  spanStackTraceMinDuration: 'span_stack_trace_min_duration',
-  traceContinuationStrategy: 'trace_continuation_strategy',
-  exitSpanMinDuration: 'exit_span_min_duration',
-  // TODO: check for more in https://docs.google.com/spreadsheets/d/1JJjZotapacA3FkHc2sv_0wiChILi3uKnkwLTjtBmxwU/edit#gid=0
-};
-
-const BOOL_OPTS = [
-  'active',
-  'breakdownMetrics',
-  'captureExceptions',
-  'captureHeaders',
-  'captureSpanStackTraces',
-  'centralConfig',
-  'contextPropagationOnly',
-  'disableSend',
-  'errorOnAbortedRequests',
-  'instrument',
-  'instrumentIncomingHTTPRequests',
-  'opentelemetryBridgeEnabled',
-  'spanCompressionEnabled',
-  'usePathAsTransactionName',
-  'verifyServerCert',
+    defaultValue: [
+      'password',
+      'passwd',
+      'pwd',
+      'secret',
+      '*key',
+      '*token*',
+      '*session*',
+      '*credit*',
+      '*card*',
+      '*auth*',
+      'set-cookie',
+      '*principal*',
+      // These are default patterns only in the Node.js APM agent, historically
+      // from when the "is-secret" dependency was used.
+      'pw',
+      'pass',
+      'connect.sid',
+    ],
+    envVar: 'ELASTIC_APM_SANITIZE_FIELD_NAMES',
+    centralConfigName: 'sanitize_field_names',
+    crossAgentName: 'sanitize_field_names',
+  },
+  {
+    name: 'sanitizeFieldNamesRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['sanitizeFieldNames'],
+  },
+  {
+    name: 'serviceNodeName',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SERVICE_NODE_NAME',
+  },
+  {
+    name: 'serverTimeout',
+    type: 'durationSeconds',
+    defaultValue: '30s',
+    envVar: 'ELASTIC_APM_SERVER_TIMEOUT',
+  },
+  {
+    name: 'serverUrl',
+    type: 'url',
+    defaultValue: 'http://127.0.0.1:8200',
+    envVar: 'ELASTIC_APM_SERVER_URL',
+    crossAgentName: 'server_url',
+  },
+  {
+    name: 'sourceLinesErrorAppFrames',
+    type: 'number',
+    defaultValue: 5,
+    envVar: 'ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES',
+  },
+  {
+    name: 'sourceLinesErrorLibraryFrames',
+    type: 'number',
+    defaultValue: 5,
+    envVar: 'ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES',
+  },
+  {
+    name: 'sourceLinesSpanAppFrames',
+    type: 'number',
+    defaultValue: 0,
+    envVar: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
+  },
+  {
+    name: 'sourceLinesSpanLibraryFrames',
+    type: 'number',
+    defaultValue: 0,
+    envVar: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
+  },
+  {
+    name: 'spanCompressionEnabled',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_SPAN_COMPRESSION_ENABLED',
+  },
+  {
+    name: 'spanCompressionExactMatchMaxDuration',
+    type: 'durationCompression',
+    defaultValue: '50ms',
+    envVar: 'ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION',
+  },
+  {
+    name: 'spanCompressionSameKindMaxDuration',
+    type: 'durationCompression',
+    defaultValue: '0ms',
+    envVar: 'ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION',
+  },
+  {
+    name: 'stackTraceLimit',
+    type: 'number',
+    defaultValue: 50,
+    envVar: 'ELASTIC_APM_STACK_TRACE_LIMIT',
+  },
+  {
+    name: 'traceContinuationStrategy',
+    type: 'select(continue,restart,external)',
+    defaultValue: 'continue',
+    envVar: 'ELASTIC_APM_TRACE_CONTINUATION_STRATEGY',
+    centralConfigName: 'trace_continuation_strategy',
+    crossAgentName: 'trace_continuation_strategy',
+  },
+  {
+    name: 'transactionIgnoreUrls',
+    type: 'stringArray',
+    defaultValue: [],
+    envVar: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
+    centralConfigName: 'transaction_ignore_urls',
+    crossAgentName: 'transaction_ignore_urls',
+  },
+  {
+    name: 'transactionIgnoreUrlRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['transactionIgnoreUrls'],
+  },
+  {
+    name: 'transactionMaxSpans',
+    type: 'numberInfinity',
+    defaultValue: 500,
+    envVar: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
+    centralConfigName: 'transaction_max_spans',
+    crossAgentName: 'transaction_max_spans',
+  },
+  {
+    name: 'transactionSampleRate',
+    type: 'sampleRate',
+    defaultValue: 1,
+    envVar: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
+    centralConfigName: 'transaction_sample_rate',
+    crossAgentName: 'transaction_sample_rate',
+  },
+  {
+    name: 'useElasticTraceparentHeader',
+    type: 'boolean',
+    defaultValue: false,
+    envVar: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
+  },
+  {
+    name: 'usePathAsTransactionName',
+    type: 'boolean',
+    defaultValue: false,
+    envVar: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
+  },
+  {
+    name: 'verifyServerCert',
+    type: 'boolean',
+    defaultValue: true,
+    envVar: 'ELASTIC_APM_VERIFY_SERVER_CERT',
+  },
+  {
+    name: 'errorMessageMaxLength',
+    type: 'byte',
+    // XXX: this is the default from docs but we test for `undefined`
+    // defaultValue: '2kb',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
+    deprecated: 'Deprecated in: v3.21.0, use longFieldMaxLength',
+  },
+  {
+    name: 'spanStackTraceMinDuration',
+    type: 'durationMilisecondsNegative',
+    // 'spanStackTraceMinDuration' is explicitly *not* defined in DEFAULTS
+    // because normalizeSpanStackTraceMinDuration() needs to know if a value
+    // was provided by the user.
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION',
+    centralConfigName: 'span_stack_trace_min_duration',
+    crossAgentName: 'span_stack_trace_min_duration',
+  },
+  {
+    name: 'apiKey',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_API_KEY',
+    crossAgentName: 'api_key',
+  },
+  {
+    name: 'captureSpanStackTraces',
+    type: 'boolean',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_CAPTURE_SPAN_STACK_TRACES',
+    deprecated: 'Deprecated in: v3.30.0, use spanStackTraceMinDuration',
+  },
+  {
+    name: 'contextManager',
+    type: 'select(asynclocalstorage,asynchooks)',
+    // 'contextManager' is explicitly *not* defined in DEFAULTS because
+    // normalizeContextManager() needs to know if a value was provided by the
+    // user.
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_CONTEXT_MANAGER',
+  },
+  {
+    name: 'frameworkName',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_FRAMEWORK_NAME',
+  },
+  {
+    name: 'frameworkVersion',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_FRAMEWORK_VERSION',
+  },
+  {
+    name: 'hostname',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_HOSTNAME',
+  },
+  {
+    name: 'payloadLogFile',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
+  },
+  {
+    name: 'serverCaCertFile',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SERVER_CA_CERT_FILE',
+  },
+  {
+    name: 'secretToken',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SECRET_TOKEN',
+    crossAgentName: 'secret_token',
+  },
+  {
+    name: 'serviceName',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SERVICE_NAME',
+    crossAgentName: 'service_name',
+  },
+  {
+    name: 'serviceVersion',
+    type: 'string',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SERVICE_VERSION',
+    crossAgentName: 'service_version',
+  },
+  {
+    name: 'spanFramesMinDuration',
+    type: 'durationSecondsNegative',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION',
+    deprecated: 'Deprecated in: v3.30.0, use spanStackTraceMinDuration',
+  },
+  { name: 'ignoreUrls', type: 'stringArray', defaultValue: undefined },
+  {
+    name: 'ignoreUrlRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['ignoreUrls'],
+  },
+  {
+    name: 'ignoreUrlStr',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['ignoreUrls'],
+  },
+  {
+    name: 'ignoreUserAgents',
+    type: 'stringArray',
+    defaultValue: undefined,
+  },
+  {
+    name: 'ignoreUserAgentRegExp',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['ignoreUserAgents'],
+  },
+  {
+    name: 'ignoreUserAgentStr',
+    type: 'wildcardArray',
+    defaultValue: [],
+    deps: ['ignoreUserAgents'],
+  },
 ];
 
-const NUM_OPTS = [
-  'longFieldMaxLength',
-  'maxQueueSize',
-  'metricsLimit',
-  'sourceLinesErrorAppFrames',
-  'sourceLinesErrorLibraryFrames',
-  'sourceLinesSpanAppFrames',
-  'sourceLinesSpanLibraryFrames',
-  'stackTraceLimit',
-  'transactionMaxSpans',
-  'transactionSampleRate',
-];
+/**
+ * Retuns an object with th default values for all config options
+ * @returns {Record<string,any>}
+ */
+function getDefaulOptions() {
+  return CONFIG_SCHEMA.reduce((acc, def) => {
+    if (typeof def.defaultValue !== 'undefined') {
+      acc[def.name] = def.defaultValue;
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ * Retuns an object with the values of config options defined set
+ * in the environment
+ * @returns {Record<string,any>}
+ */
+function getEnvionmentOptions() {
+  return CONFIG_SCHEMA.filter((def) => def.envVar).reduce((acc, def) => {
+    const val = process.env[def.envVar];
+    if (val) {
+      acc[def.name] = val;
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ * Tries to load a configuration file for the given path or from the ENV vars, if both undefined
+ * it uses the default config filename `elastic-apm-node.js`. If the config file is not present or
+ * there is something wrong in the file it will return no options
+ * @param {string} [confPath] the path to the file
+ * @returns {Record<string,any> | null}
+ */
+function getFileOptions(confPath) {
+  const configFileDef = CONFIG_SCHEMA.find((def) => def.name === 'configFile');
+  const defaultValue = configFileDef.defaultValue;
+  const envValue = process.env[configFileDef.envVar];
+  const filePath = path.resolve(confPath || envValue || defaultValue);
+
+  if (fs.existsSync(filePath)) {
+    try {
+      return require(filePath);
+    } catch (err) {
+      console.error(
+        "Elastic APM initialization error: Can't read config file %s",
+        filePath,
+      );
+      console.error(err.stack);
+    }
+  }
+
+  return null;
+}
+
+// Fail fast if CONFIG_SCHEMA has issues
+// - duplicated options
+// - dependencies not defined or defined after the dependant option
+// - type with no normalizer
+const depSet = new Set();
+CONFIG_SCHEMA.forEach((def) => {
+  if (depSet.has(def.name)) {
+    throw Error(`config option ${def.name} duplicated.`);
+  }
+  if (def.deps && def.deps.some((d) => !depSet.has(d))) {
+    throw Error(
+      `config option ${def.name} dependencies (${def.deps}) need to be defined before.`,
+    );
+  }
+  depSet.add(def.name);
+});
+
+// TODO: these constants below to be removed in the future (normalization)
+function getConfigName(def) {
+  return def.name;
+}
+function optsOfTypes(types) {
+  if (!Array.isArray(types)) {
+    types = [types];
+  }
+  return CONFIG_SCHEMA.filter((def) => types.indexOf(def.type) !== -1);
+}
+
+const BOOL_OPTS = optsOfTypes('boolean').map(getConfigName);
+const NUM_OPTS = optsOfTypes(['number', 'numberInfinity']).map(getConfigName);
+const BYTES_OPTS = optsOfTypes('byte').map(getConfigName);
+const URL_OPTS = optsOfTypes('url').map(getConfigName);
+const ARRAY_OPTS = optsOfTypes('stringArray').map(getConfigName);
+const KEY_VALUE_OPTS = optsOfTypes('stringKeyValuePairs').map(getConfigName);
+const MINUS_ONE_EQUAL_INFINITY = optsOfTypes(['numberInfinity']).map(
+  getConfigName,
+);
 
 const DURATION_OPTS = [
   {
@@ -318,40 +737,24 @@ const DURATION_OPTS = [
     allowNegative: true,
   },
 ];
+const CROSS_AGENT_CONFIG_VAR_NAME = CONFIG_SCHEMA.filter(
+  (def) => def.crossAgentName,
+).reduce((acc, def) => {
+  acc[def.name] = def.crossAgentName;
+  return acc;
+}, {});
 
-const BYTES_OPTS = ['apiRequestSize', 'errorMessageMaxLength'];
+const ENV_TABLE = CONFIG_SCHEMA.filter((def) => def.envVar).reduce(
+  (acc, def) => {
+    acc[def.name] = def.envVar;
+    return acc;
+  },
+  {},
+);
 
-const MINUS_ONE_EQUAL_INFINITY = ['transactionMaxSpans'];
-
-const ARRAY_OPTS = [
-  'disableInstrumentations',
-  'disableMetrics',
-  'elasticsearchCaptureBodyUrls',
-  'sanitizeFieldNames',
-  'transactionIgnoreUrls',
-  'ignoreMessageQueues',
-];
-
-const KEY_VALUE_OPTS = ['addPatch', 'globalLabels'];
-
-const URL_OPTS = ['serverUrl'];
-
-// Exports.
+// Exports
 module.exports = {
-  // Constant values
-  INTAKE_STRING_MAX_SIZE,
-  CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
-  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
-  CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS,
-  CONTEXT_MANAGER_ASYNCHOOKS,
-  CONTEXT_MANAGER_ASYNCLOCALSTORAGE,
-  TRACE_CONTINUATION_STRATEGY_CONTINUE,
-  TRACE_CONTINUATION_STRATEGY_RESTART,
-  TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL,
-
-  // Options
-  CROSS_AGENT_CONFIG_VAR_NAME,
-  CENTRAL_CONFIG_OPTS,
+  // TYPE_NORMALIZERS,
   BOOL_OPTS,
   NUM_OPTS,
   DURATION_OPTS,
@@ -360,8 +763,11 @@ module.exports = {
   ARRAY_OPTS,
   KEY_VALUE_OPTS,
   URL_OPTS,
-
-  // The following are exported for tests.
-  DEFAULTS,
+  CROSS_AGENT_CONFIG_VAR_NAME,
   ENV_TABLE,
+  getDefaulOptions,
+  getEnvionmentOptions,
+  getFileOptions,
+  // setStartValues,
+  // normalize,
 };

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -29,12 +29,6 @@ const path = require('path');
  */
 const CONFIG_SCHEMA = [
   {
-    name: 'configFile',
-    type: 'string',
-    defaultValue: 'elastic-apm-node.js',
-    envVar: 'ELASTIC_APM_CONFIG_FILE',
-  },
-  {
     name: 'abortedErrorThreshold',
     type: 'durationSeconds',
     defaultValue: '25s',
@@ -585,14 +579,33 @@ const CONFIG_SCHEMA = [
     defaultValue: [],
     deps: ['ignoreUserAgents'],
   },
-  // Hidden options or for testing purposes
-  // TODO: should they need a flag?
-
-  // HttpApmClient transport which can be a function
+  // Special options that
+  // - may afect the whole config
+  // - change the behavior of thelogger
+  // - are for testing or internal use
+  {
+    name: 'configFile',
+    type: 'string',
+    defaultValue: 'elastic-apm-node.js',
+    envVar: 'ELASTIC_APM_CONFIG_FILE',
+  },
+  {
+    name: 'logger',
+    type: 'logger',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_LOGGER',
+  },
   {
     name: 'transport',
     type: 'function',
     defaultValue: undefined,
+    internal: true,
+  },
+  {
+    name: 'loggingPreambleData',
+    type: 'object',
+    defaultValue: undefined,
+    internal: true,
   },
 ];
 

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -585,6 +585,15 @@ const CONFIG_SCHEMA = [
     defaultValue: [],
     deps: ['ignoreUserAgents'],
   },
+  // Hidden options or for testing purposes
+  // TODO: should they need a flag?
+
+  // HttpApmClient transport which can be a function
+  {
+    name: 'transport',
+    type: 'function',
+    defaultValue: undefined,
+  },
 ];
 
 /**

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -16,7 +16,8 @@ const path = require('path');
  * @property {keyof TypeNormalizers} type the type of the configuration option
  * @property {string} [envVar] the name of the environment varaiable associated with the option
  * @property {string} [envDeprecatedVar] the name of the deprecated environment varaiable associated with the option
- * @property {string} [crossAgentName] name of cross agent property
+ * @property {string} [centralConfigName] name of option in central configuration
+ * @property {string} [crossAgentName] name of the same option in other agents
  */
 
 // TODO: options with `crossAgentName` property
@@ -680,6 +681,13 @@ const MINUS_ONE_EQUAL_INFINITY = optsOfTypes(['numberInfinity']).map(
   getConfigName,
 );
 
+const CENTRAL_CONFIG_OPTS = CONFIG_SCHEMA.filter(
+  (def) => def.centralConfigName,
+).reduce((acc, def) => {
+  acc[def.centralConfigName] = def.name;
+  return acc;
+}, {});
+
 const DURATION_OPTS = [
   {
     name: 'abortedErrorThreshold',
@@ -754,7 +762,6 @@ const ENV_TABLE = CONFIG_SCHEMA.filter((def) => def.envVar).reduce(
 
 // Exports
 module.exports = {
-  // TYPE_NORMALIZERS,
   BOOL_OPTS,
   NUM_OPTS,
   DURATION_OPTS,
@@ -764,10 +771,9 @@ module.exports = {
   KEY_VALUE_OPTS,
   URL_OPTS,
   CROSS_AGENT_CONFIG_VAR_NAME,
+  CENTRAL_CONFIG_OPTS,
   ENV_TABLE,
   getDefaulOptions,
   getEnvionmentOptions,
   getFileOptions,
-  // setStartValues,
-  // normalize,
 };

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -13,7 +13,7 @@ const path = require('path');
  * @typedef {Object} OptionDefinition
  * @property {string} name the name of the configuration option
  * @property {any} defaultValue the default value of the property or undefined
- * @property {keyof TypeNormalizers} type the type of the configuration option
+ * @property {keyof TypeNormalizers} configType the type of the configuration option
  * @property {string} [envVar] the name of the environment varaiable associated with the option
  * @property {string} [envDeprecatedVar] the name of the deprecated environment varaiable associated with the option
  * @property {string} [centralConfigName] name of option in central configuration
@@ -30,43 +30,43 @@ const path = require('path');
 const CONFIG_SCHEMA = [
   {
     name: 'abortedErrorThreshold',
-    type: 'durationSeconds',
+    configType: 'durationSeconds',
     defaultValue: '25s',
     envVar: 'ELASTIC_APM_ABORTED_ERROR_THRESHOLD',
   },
   {
     name: 'active',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_ACTIVE',
   },
   {
     name: 'addPatch',
-    type: 'stringKeyValuePairs',
+    configType: 'stringKeyValuePairs',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_ADD_PATCH',
   },
   {
     name: 'apiRequestSize',
-    type: 'byte',
+    configType: 'byte',
     defaultValue: '768kb',
     envVar: 'ELASTIC_APM_API_REQUEST_SIZE',
   },
   {
     name: 'apiRequestTime',
-    type: 'durationSeconds',
+    configType: 'durationSeconds',
     defaultValue: '10s',
     envVar: 'ELASTIC_APM_API_REQUEST_TIME',
   },
   {
     name: 'breakdownMetrics',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_BREAKDOWN_METRICS',
   },
   {
     name: 'captureBody',
-    type: 'select(off,all,errors,transactions)',
+    configType: 'select(off,all,errors,transactions)',
     defaultValue: 'off',
     envVar: 'ELASTIC_APM_CAPTURE_BODY',
     centralConfigName: 'capture_body',
@@ -74,49 +74,49 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'captureErrorLogStackTraces',
-    type: 'select(messages,always)',
+    configType: 'select(messages,always)',
     defaultValue: 'messages',
     envVar: 'ELASTIC_APM_CAPTURE_ERROR_LOG_STACK_TRACES',
   },
   {
     name: 'captureExceptions',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_CAPTURE_EXCEPTIONS',
   },
   {
     name: 'captureHeaders',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_CAPTURE_HEADERS',
   },
   {
     name: 'centralConfig',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_CENTRAL_CONFIG',
   },
   {
     name: 'cloudProvider',
-    type: 'select(auto,gcp,azure,aws,none)',
+    configType: 'select(auto,gcp,azure,aws,none)',
     defaultValue: 'auto',
     envVar: 'ELASTIC_APM_CLOUD_PROVIDER',
   },
   {
     name: 'containerId',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_CONTAINER_ID',
   },
   {
     name: 'contextPropagationOnly',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: false,
     envVar: 'ELASTIC_APM_CONTEXT_PROPAGATION_ONLY',
   },
   {
     name: 'customMetricsHistogramBoundaries',
-    type: 'sortedNumberArray',
+    configType: 'sortedNumberArray',
     // Exponential powers-of-2 bucket boundaries, rounded to 6 significant figures.
     //    2**N for N in [-8, -7.5, -7, ..., 16, 16.5, 17]
     // https://github.com/elastic/apm/blob/main/specs/agents/metrics-otel.md#histogram-aggregation
@@ -132,31 +132,31 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'disableInstrumentations',
-    type: 'stringArray',
+    configType: 'stringArray',
     defaultValue: [],
     envVar: 'ELASTIC_APM_DISABLE_INSTRUMENTATIONS',
   },
   {
     name: 'disableMetrics',
-    type: 'stringArray',
+    configType: 'stringArray',
     defaultValue: [],
     envVar: 'ELASTIC_APM_DISABLE_METRICS',
   },
   {
     name: 'disableMetricsRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['disableMetrics'],
   },
   {
     name: 'disableSend',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: false,
     envVar: 'ELASTIC_APM_DISABLE_SEND',
   },
   {
     name: 'elasticsearchCaptureBodyUrls',
-    type: 'stringArray',
+    configType: 'stringArray',
     defaultValue: [
       '*/_search',
       '*/_search/template',
@@ -171,25 +171,25 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'elasticsearchCaptureBodyUrlsRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['elasticsearchCaptureBodyUrls'],
   },
   {
     name: 'environment',
-    type: 'string',
+    configType: 'string',
     defaultValue: 'development',
     envVar: 'ELASTIC_APM_ENVIRONMENT',
   },
   {
     name: 'errorOnAbortedRequests',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: false,
     envVar: 'ELASTIC_APM_ERROR_ON_ABORTED_REQUESTS',
   },
   {
     name: 'exitSpanMinDuration',
-    type: 'durationMiliseconds',
+    configType: 'durationMiliseconds',
     defaultValue: '0ms',
     envVar: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
     centralConfigName: 'exit_span_min_duration',
@@ -197,13 +197,13 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'globalLabels',
-    type: 'stringKeyValuePairs',
+    configType: 'stringKeyValuePairs',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_GLOBAL_LABELS',
   },
   {
     name: 'ignoreMessageQueues',
-    type: 'stringArray',
+    configType: 'stringArray',
     defaultValue: [],
     envVar: 'ELASTIC_APM_IGNORE_MESSAGE_QUEUES',
     centralConfigName: 'ignore_message_queues',
@@ -211,49 +211,49 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'ignoreMessageQueuesRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['ignoreMessageQueues'],
   },
   {
     name: 'instrument',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_INSTRUMENT',
   },
   {
     name: 'instrumentIncomingHTTPRequests',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_INSTRUMENT_INCOMING_HTTP_REQUESTS',
   },
   {
     name: 'kubernetesNamespace',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'KUBERNETES_NAMESPACE',
   },
   {
     name: 'kubernetesNodeName',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'KUBERNETES_NODE_NAME',
   },
   {
     name: 'kubernetesPodName',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'KUBERNETES_POD_NAME',
   },
   {
     name: 'kubernetesPodUID',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'KUBERNETES_POD_UID',
   },
   {
     name: 'logLevel',
-    type: 'select(debug,info,warning,error,critical,off,trace)',
+    configType: 'select(debug,info,warning,error,critical,off,trace)',
     defaultValue: 'info',
     envVar: 'ELASTIC_APM_LOG_LEVEL',
     centralConfigName: 'log_level',
@@ -261,13 +261,13 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'longFieldMaxLength',
-    type: 'number',
+    configType: 'number',
     defaultValue: 10000,
     envVar: 'ELASTIC_APM_LONG_FIELD_MAX_LENGTH',
   },
   {
     name: 'maxQueueSize',
-    type: 'number',
+    configType: 'number',
     // Rough equivalent of the Java Agent's max_queue_size:
     // https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-max-queue-size
     defaultValue: 1024,
@@ -275,25 +275,25 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'metricsInterval',
-    type: 'durationSeconds',
+    configType: 'durationSeconds',
     defaultValue: '30s',
     envVar: 'ELASTIC_APM_METRICS_INTERVAL',
   },
   {
     name: 'metricsLimit',
-    type: 'number',
+    configType: 'number',
     defaultValue: 1000,
     envVar: 'ELASTIC_APM_METRICS_LIMIT',
   },
   {
     name: 'opentelemetryBridgeEnabled',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: false,
     envVar: 'ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED',
   },
   {
     name: 'sanitizeFieldNames',
-    type: 'stringArray',
+    configType: 'stringArray',
     // These patterns are specified in the shared APM specs:
     // https://github.com/elastic/apm/blob/main/specs/agents/sanitization.md
     defaultValue: [
@@ -321,80 +321,80 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'sanitizeFieldNamesRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['sanitizeFieldNames'],
   },
   {
     name: 'serviceNodeName',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SERVICE_NODE_NAME',
   },
   {
     name: 'serverTimeout',
-    type: 'durationSeconds',
+    configType: 'durationSeconds',
     defaultValue: '30s',
     envVar: 'ELASTIC_APM_SERVER_TIMEOUT',
   },
   {
     name: 'serverUrl',
-    type: 'url',
+    configType: 'url',
     defaultValue: 'http://127.0.0.1:8200',
     envVar: 'ELASTIC_APM_SERVER_URL',
     crossAgentName: 'server_url',
   },
   {
     name: 'sourceLinesErrorAppFrames',
-    type: 'number',
+    configType: 'number',
     defaultValue: 5,
     envVar: 'ELASTIC_APM_SOURCE_LINES_ERROR_APP_FRAMES',
   },
   {
     name: 'sourceLinesErrorLibraryFrames',
-    type: 'number',
+    configType: 'number',
     defaultValue: 5,
     envVar: 'ELASTIC_APM_SOURCE_LINES_ERROR_LIBRARY_FRAMES',
   },
   {
     name: 'sourceLinesSpanAppFrames',
-    type: 'number',
+    configType: 'number',
     defaultValue: 0,
     envVar: 'ELASTIC_APM_SOURCE_LINES_SPAN_APP_FRAMES',
   },
   {
     name: 'sourceLinesSpanLibraryFrames',
-    type: 'number',
+    configType: 'number',
     defaultValue: 0,
     envVar: 'ELASTIC_APM_SOURCE_LINES_SPAN_LIBRARY_FRAMES',
   },
   {
     name: 'spanCompressionEnabled',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_SPAN_COMPRESSION_ENABLED',
   },
   {
     name: 'spanCompressionExactMatchMaxDuration',
-    type: 'durationCompression',
+    configType: 'durationCompression',
     defaultValue: '50ms',
     envVar: 'ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION',
   },
   {
     name: 'spanCompressionSameKindMaxDuration',
-    type: 'durationCompression',
+    configType: 'durationCompression',
     defaultValue: '0ms',
     envVar: 'ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION',
   },
   {
     name: 'stackTraceLimit',
-    type: 'number',
+    configType: 'number',
     defaultValue: 50,
     envVar: 'ELASTIC_APM_STACK_TRACE_LIMIT',
   },
   {
     name: 'traceContinuationStrategy',
-    type: 'select(continue,restart,external)',
+    configType: 'select(continue,restart,external)',
     defaultValue: 'continue',
     envVar: 'ELASTIC_APM_TRACE_CONTINUATION_STRATEGY',
     centralConfigName: 'trace_continuation_strategy',
@@ -402,7 +402,7 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'transactionIgnoreUrls',
-    type: 'stringArray',
+    configType: 'stringArray',
     defaultValue: [],
     envVar: 'ELASTIC_APM_TRANSACTION_IGNORE_URLS',
     centralConfigName: 'transaction_ignore_urls',
@@ -410,13 +410,13 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'transactionIgnoreUrlRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['transactionIgnoreUrls'],
   },
   {
     name: 'transactionMaxSpans',
-    type: 'numberInfinity',
+    configType: 'numberInfinity',
     defaultValue: 500,
     envVar: 'ELASTIC_APM_TRANSACTION_MAX_SPANS',
     centralConfigName: 'transaction_max_spans',
@@ -424,7 +424,7 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'transactionSampleRate',
-    type: 'sampleRate',
+    configType: 'sampleRate',
     defaultValue: 1,
     envVar: 'ELASTIC_APM_TRANSACTION_SAMPLE_RATE',
     centralConfigName: 'transaction_sample_rate',
@@ -432,25 +432,25 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'useElasticTraceparentHeader',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: false,
     envVar: 'ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER',
   },
   {
     name: 'usePathAsTransactionName',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: false,
     envVar: 'ELASTIC_APM_USE_PATH_AS_TRANSACTION_NAME',
   },
   {
     name: 'verifyServerCert',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: true,
     envVar: 'ELASTIC_APM_VERIFY_SERVER_CERT',
   },
   {
     name: 'errorMessageMaxLength',
-    type: 'byte',
+    configType: 'byte',
     // XXX: this is the default from docs but we test for `undefined`
     // defaultValue: '2kb',
     defaultValue: undefined,
@@ -459,7 +459,7 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'spanStackTraceMinDuration',
-    type: 'durationMilisecondsNegative',
+    configType: 'durationMilisecondsNegative',
     // 'spanStackTraceMinDuration' is explicitly *not* defined in DEFAULTS
     // because normalizeSpanStackTraceMinDuration() needs to know if a value
     // was provided by the user.
@@ -470,21 +470,21 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'apiKey',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_API_KEY',
     crossAgentName: 'api_key',
   },
   {
     name: 'captureSpanStackTraces',
-    type: 'boolean',
+    configType: 'boolean',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_CAPTURE_SPAN_STACK_TRACES',
     deprecated: 'Deprecated in: v3.30.0, use spanStackTraceMinDuration',
   },
   {
     name: 'contextManager',
-    type: 'select(asynclocalstorage,asynchooks)',
+    configType: 'select(asynclocalstorage,asynchooks)',
     // 'contextManager' is explicitly *not* defined in DEFAULTS because
     // normalizeContextManager() needs to know if a value was provided by the
     // user.
@@ -493,89 +493,89 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'frameworkName',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_FRAMEWORK_NAME',
   },
   {
     name: 'frameworkVersion',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_FRAMEWORK_VERSION',
   },
   {
     name: 'hostname',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_HOSTNAME',
   },
   {
     name: 'payloadLogFile',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_PAYLOAD_LOG_FILE',
   },
   {
     name: 'serverCaCertFile',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SERVER_CA_CERT_FILE',
   },
   {
     name: 'secretToken',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SECRET_TOKEN',
     crossAgentName: 'secret_token',
   },
   {
     name: 'serviceName',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SERVICE_NAME',
     crossAgentName: 'service_name',
   },
   {
     name: 'serviceVersion',
-    type: 'string',
+    configType: 'string',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SERVICE_VERSION',
     crossAgentName: 'service_version',
   },
   {
     name: 'spanFramesMinDuration',
-    type: 'durationSecondsNegative',
+    configType: 'durationSecondsNegative',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SPAN_FRAMES_MIN_DURATION',
     deprecated: 'Deprecated in: v3.30.0, use spanStackTraceMinDuration',
   },
-  { name: 'ignoreUrls', type: 'stringArray', defaultValue: undefined },
+  { name: 'ignoreUrls', configType: 'stringArray', defaultValue: undefined },
   {
     name: 'ignoreUrlRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['ignoreUrls'],
   },
   {
     name: 'ignoreUrlStr',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['ignoreUrls'],
   },
   {
     name: 'ignoreUserAgents',
-    type: 'stringArray',
+    configType: 'stringArray',
     defaultValue: undefined,
   },
   {
     name: 'ignoreUserAgentRegExp',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['ignoreUserAgents'],
   },
   {
     name: 'ignoreUserAgentStr',
-    type: 'wildcardArray',
+    configType: 'wildcardArray',
     defaultValue: [],
     deps: ['ignoreUserAgents'],
   },
@@ -585,25 +585,25 @@ const CONFIG_SCHEMA = [
   // - are for testing or internal use
   {
     name: 'configFile',
-    type: 'string',
+    configType: 'string',
     defaultValue: 'elastic-apm-node.js',
     envVar: 'ELASTIC_APM_CONFIG_FILE',
   },
   {
     name: 'logger',
-    type: 'logger',
+    configType: 'logger',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_LOGGER',
   },
   {
     name: 'transport',
-    type: 'function',
+    configType: 'function',
     defaultValue: undefined,
     internal: true,
   },
   {
     name: 'loggingPreambleData',
-    type: 'object',
+    configType: 'object',
     defaultValue: undefined,
     internal: true,
   },
@@ -690,7 +690,7 @@ function optsOfTypes(types) {
   if (!Array.isArray(types)) {
     types = [types];
   }
-  return CONFIG_SCHEMA.filter((def) => types.indexOf(def.type) !== -1);
+  return CONFIG_SCHEMA.filter((def) => types.indexOf(def.configType) !== -1);
 }
 
 const BOOL_OPTS = optsOfTypes('boolean').map(getConfigName);

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -189,7 +189,7 @@ const CONFIG_SCHEMA = [
   },
   {
     name: 'exitSpanMinDuration',
-    configType: 'durationMiliseconds',
+    configType: 'durationMilliseconds',
     defaultValue: '0ms',
     envVar: 'ELASTIC_APM_EXIT_SPAN_MIN_DURATION',
     centralConfigName: 'exit_span_min_duration',
@@ -451,15 +451,13 @@ const CONFIG_SCHEMA = [
   {
     name: 'errorMessageMaxLength',
     configType: 'byte',
-    // XXX: this is the default from docs but we test for `undefined`
-    // defaultValue: '2kb',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH',
     deprecated: 'Deprecated in: v3.21.0, use longFieldMaxLength',
   },
   {
     name: 'spanStackTraceMinDuration',
-    configType: 'durationMilisecondsNegative',
+    configType: 'durationMillisecondsNegative',
     // 'spanStackTraceMinDuration' is explicitly *not* defined in DEFAULTS
     // because normalizeSpanStackTraceMinDuration() needs to know if a value
     // was provided by the user.
@@ -601,19 +599,13 @@ const CONFIG_SCHEMA = [
     defaultValue: undefined,
     internal: true,
   },
-  {
-    name: 'loggingPreambleData',
-    configType: 'object',
-    defaultValue: undefined,
-    internal: true,
-  },
 ];
 
 /**
  * Retuns an object with th default values for all config options
  * @returns {Record<string,any>}
  */
-function getDefaulOptions() {
+function getDefaultOptions() {
   return CONFIG_SCHEMA.reduce((acc, def) => {
     if (typeof def.defaultValue !== 'undefined') {
       acc[def.name] = def.defaultValue;
@@ -627,7 +619,7 @@ function getDefaulOptions() {
  * in the environment
  * @returns {Record<string,any>}
  */
-function getEnvionmentOptions() {
+function getEnvironmentOptions() {
   return CONFIG_SCHEMA.filter((def) => def.envVar).reduce((acc, def) => {
     const val = process.env[def.envVar];
     if (val) {
@@ -795,7 +787,7 @@ module.exports = {
   CROSS_AGENT_CONFIG_VAR_NAME,
   CENTRAL_CONFIG_OPTS,
   ENV_TABLE,
-  getDefaulOptions,
-  getEnvionmentOptions,
+  getDefaultOptions,
+  getEnvironmentOptions,
   getFileOptions,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,4 +21,15 @@ module.exports = {
 
   // https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-messaging.md#receiving-trace-context
   MAX_MESSAGES_PROCESSED_FOR_TRACE_CONTEXT: 1000,
+
+  // Config constants
+  INTAKE_STRING_MAX_SIZE: 1024,
+  CAPTURE_ERROR_LOG_STACK_TRACES_NEVER: 'never',
+  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES: 'messages',
+  CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS: 'always',
+  CONTEXT_MANAGER_ASYNCHOOKS: 'asynchooks',
+  CONTEXT_MANAGER_ASYNCLOCALSTORAGE: 'asynclocalstorage',
+  TRACE_CONTINUATION_STRATEGY_CONTINUE: 'continue',
+  TRACE_CONTINUATION_STRATEGY_RESTART: 'restart',
+  TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL: 'restart_external',
 };

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -8,7 +8,7 @@
 
 const truncate = require('unicode-byte-truncate');
 
-const { INTAKE_STRING_MAX_SIZE } = require('../config/schema');
+const { INTAKE_STRING_MAX_SIZE } = require('../constants');
 const constants = require('../constants');
 const { SpanCompression } = require('./span-compression');
 const Timer = require('./timer');

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -16,7 +16,7 @@ const semver = require('semver');
 const {
   CONTEXT_MANAGER_ASYNCHOOKS,
   CONTEXT_MANAGER_ASYNCLOCALSTORAGE,
-} = require('../config/schema');
+} = require('../constants');
 var { Ids } = require('./ids');
 var Transaction = require('./transaction');
 var { NoopTransaction } = require('./noop-transaction');

--- a/lib/instrumentation/transaction.js
+++ b/lib/instrumentation/transaction.js
@@ -21,7 +21,7 @@ const {
   TRACE_CONTINUATION_STRATEGY_CONTINUE,
   TRACE_CONTINUATION_STRATEGY_RESTART,
   TRACE_CONTINUATION_STRATEGY_RESTART_EXTERNAL,
-} = require('../config/schema');
+} = require('../constants');
 var { TransactionIds } = require('./ids');
 const TraceState = require('../tracecontext/tracestate');
 

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -23,13 +23,15 @@ const {
   CAPTURE_ERROR_LOG_STACK_TRACES_ALWAYS,
   CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
   CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
-  DEFAULTS,
-} = require('../lib/config/schema');
+} = require('../lib/constants');
+const { getDefaulOptions } = require('../lib/config/schema');
 const { findObjInArray } = require('./_utils');
 const { MockAPMServer } = require('./_mock_apm_server');
 const { NoopApmClient } = require('../lib/apm-client/noop-apm-client');
 const { NoopTransaction } = require('../lib/instrumentation/noop-transaction');
 var packageJson = require('../package.json');
+
+const DEFAULTS = getDefaulOptions();
 
 // Options to pass to `agent.start()` to turn off some default agent behavior
 // that is unhelpful for these tests.

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -24,14 +24,14 @@ const {
   CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
   CAPTURE_ERROR_LOG_STACK_TRACES_NEVER,
 } = require('../lib/constants');
-const { getDefaulOptions } = require('../lib/config/schema');
+const { getDefaultOptions } = require('../lib/config/schema');
 const { findObjInArray } = require('./_utils');
 const { MockAPMServer } = require('./_mock_apm_server');
 const { NoopApmClient } = require('../lib/apm-client/noop-apm-client');
 const { NoopTransaction } = require('../lib/instrumentation/noop-transaction');
 var packageJson = require('../package.json');
 
-const DEFAULTS = getDefaulOptions();
+const DEFAULTS = getDefaultOptions();
 
 // Options to pass to `agent.start()` to turn off some default agent behavior
 // that is unhelpful for these tests.

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -26,13 +26,13 @@ const { findObjInArray } = require('./_utils');
 const { secondsFromDuration } = require('../lib/config/normalizers');
 const { CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES } = require('../lib/constants');
 const {
-  getDefaulOptions,
+  getDefaultOptions,
   ENV_TABLE,
   DURATION_OPTS,
 } = require('../lib/config/schema');
 const config = require('../lib/config/config');
 
-const DEFAULTS = getDefaulOptions();
+const DEFAULTS = getDefaultOptions();
 
 var apmVersion = require('../package').version;
 var apmName = require('../package').name;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -24,13 +24,15 @@ const { MockLogger } = require('./_mock_logger');
 const { NoopApmClient } = require('../lib/apm-client/noop-apm-client');
 const { findObjInArray } = require('./_utils');
 const { secondsFromDuration } = require('../lib/config/normalizers');
+const { CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES } = require('../lib/constants');
 const {
-  CAPTURE_ERROR_LOG_STACK_TRACES_MESSAGES,
-  DEFAULTS,
-  DURATION_OPTS,
+  getDefaulOptions,
   ENV_TABLE,
+  DURATION_OPTS,
 } = require('../lib/config/schema');
 const config = require('../lib/config/config');
+
+const DEFAULTS = getDefaulOptions();
 
 var apmVersion = require('../package').version;
 var apmName = require('../package').name;

--- a/test/config/normalizers.test.js
+++ b/test/config/normalizers.test.js
@@ -14,7 +14,7 @@ const {
   TRACE_CONTINUATION_STRATEGY_CONTINUE,
   TRACE_CONTINUATION_STRATEGY_RESTART,
   CONTEXT_MANAGER_ASYNCHOOKS,
-} = require('../../lib/config/schema');
+} = require('../../lib/constants');
 const {
   normalizeUrls,
   normalizeArrays,


### PR DESCRIPTION
PR to unify the way configuration options are defined and processed.

NOTE: this is a draft and so its description, do not review yet

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
