### PR TITLE
tests: disable aws-sdk TAV tests for aws-sdk@2.1491.0 and up

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -532,18 +532,24 @@ aws-sdk:
   #
   # - v2.1372.0 changed the SQS client protocol from "query" to "json", which
   #   isn't supported in localstack. It was reverted in v2.1373.0.
+  # - v2.1491.0 and up changed protocol to "json" again. We may watch on protocol
+  #   support in localstack. https://github.com/elastic/apm-agent-nodejs/issues/3719
   #
   # Maintenance note: This should be updated periodically using:
-  #   ./dev-utils/aws-sdk-tav-versions.sh
+  #   node ./dev-utils/update-tav-versions.js
   #
   # Test v2.858.0, every N=122 of 614 releases, and current latest.
-  versions: '2.858.0 || 2.980.0 || 2.1102.0 || 2.1224.0 || 2.1346.0 || 2.1469.0 || 2.1472.0 || >2.1472.0 <3'
+  versions: '2.858.0 || 2.984.0 || 2.1110.0 || 2.1236.0 || 2.1362.0 || 2.1489.0 || 2.1490.0'
   commands:
     - node test/instrumentation/modules/aws-sdk/aws4-retries.test.js
     - node test/instrumentation/modules/aws-sdk/s3.test.js
     - node test/instrumentation/modules/aws-sdk/sns.test.js
     - node test/instrumentation/modules/aws-sdk/sqs.test.js
     - node test/instrumentation/modules/aws-sdk/dynamodb.test.js
+  update-versions:
+    mode: max-5
+    include: '>=2.858.0 <2.1491.0'
+    exclude: '2.1372.0'
 
 # For all AWS-SDK clients want this version range:
 #   versions: '>=3.15.0 <4'


### PR DESCRIPTION
`aws-sdk@2.1491.0` module switched the protocol to "json" whch is not suported yet by `localstack`. Disabled the tests and re-enable when we have suport

Ref: #3719 
Closes: #3718 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
