### PR TITLE
chore: move preamble data function to config schema

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -77,9 +77,6 @@ const NICE_REGEXPS_FIELDS = {
 
 const confDefaultOptions = getDefaultOptions();
 const confEnvOpts = getEnvironmentOptions();
-let confFilePath = path.resolve(
-  confEnvOpts.configFile || confDefaultOptions.configFile,
-);
 let confFileOpts = getFileOptions();
 
 // Configure a logger for the agent.

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -33,6 +33,7 @@ const {
   getFileOptions,
   setStartOptions,
   getPreambleData,
+  readEnvOptions,
 } = require('./schema');
 
 const {
@@ -122,22 +123,18 @@ function createConfig(opts, logger) {
 
 class Config {
   constructor(opts, logger) {
+    // TODO: remove this call once config and logging-preamble tests are refactored
+    readEnvOptions();
+
     const isLambda = isLambdaExecutionEnvironment();
     const envOptions = getEnvironmentOptions();
-
-    // If we didn't find a config file on process boot, but a path to one is
-    // provided as a config option, let's instead try to load that
-    if (confFileOpts === null && opts && opts.configFile) {
-      confFilePath = path.resolve(opts.configFile);
-      confFileOpts = getFileOptions(opts.configFile);
-    }
 
     setStartOptions(opts);
 
     Object.assign(
       this,
       confDefaultOptions, // default options
-      confFileOpts, // options read from config file
+      getFileOptions(), // options read from config file
       opts, // options passed in to agent.start()
       envOptions, // options read from environment variables
     );
@@ -227,9 +224,7 @@ class Config {
       this.breakdownMetrics = false;
     }
 
-    // Resolve data for logging preamble now that the logger & all config is resolved
-    // https://github.com/elastic/apm/blob/main/specs/agents/logging.md#logging-preamble
-    this.loggingPreambleData = getPreambleData(this, confFilePath);
+    this.loggingPreambleData = getPreambleData(this);
   }
 
   // Return a reasonably loggable object for this Config instance.

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -6,14 +6,10 @@
 
 'use strict';
 
-const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const { URL } = require('url');
 
 const truncate = require('unicode-byte-truncate');
-
-const AGENT_VERSION = require('../../package.json').version;
 
 const { INTAKE_STRING_MAX_SIZE, REDACTED } = require('../constants');
 const logging = require('../logging');
@@ -32,10 +28,11 @@ const {
   ARRAY_OPTS,
   KEY_VALUE_OPTS,
   URL_OPTS,
-  CROSS_AGENT_CONFIG_VAR_NAME,
   getDefaultOptions,
   getEnvironmentOptions,
   getFileOptions,
+  setStartOptions,
+  getPreambleData,
 } = require('./schema');
 
 const {
@@ -112,16 +109,6 @@ function configLogger(opts = {}) {
 function initialConfig(logger) {
   const cfg = Object.assign({}, confDefaultOptions);
 
-  // Reproduce the generated properties for `Config`.
-  cfg.disableMetricsRegExp = [];
-  cfg.ignoreUrlStr = [];
-  cfg.ignoreUrlRegExp = [];
-  cfg.ignoreUserAgentStr = [];
-  cfg.ignoreUserAgentRegExp = [];
-  cfg.elasticsearchCaptureBodyUrlsRegExp = [];
-  cfg.transactionIgnoreUrlRegExp = [];
-  cfg.sanitizeFieldNamesRegExp = [];
-  cfg.ignoreMessageQueuesRegExp = [];
   normalize(cfg, logger);
 
   cfg.transport = new NoopApmClient();
@@ -135,16 +122,6 @@ function createConfig(opts, logger) {
 
 class Config {
   constructor(opts, logger) {
-    this.disableMetricsRegExp = [];
-    this.ignoreUrlStr = [];
-    this.ignoreUrlRegExp = [];
-    this.ignoreUserAgentStr = [];
-    this.ignoreUserAgentRegExp = [];
-    this.elasticsearchCaptureBodyUrlsRegExp = [];
-    this.transactionIgnoreUrlRegExp = [];
-    this.sanitizeFieldNamesRegExp = [];
-    this.ignoreMessageQueuesRegExp = [];
-
     const isLambda = isLambdaExecutionEnvironment();
     const envOptions = getEnvironmentOptions();
 
@@ -154,6 +131,8 @@ class Config {
       confFilePath = path.resolve(opts.configFile);
       confFileOpts = getFileOptions(opts.configFile);
     }
+
+    setStartOptions(opts);
 
     Object.assign(
       this,
@@ -250,16 +229,7 @@ class Config {
 
     // Resolve data for logging preamble now that the logger & all config is resolved
     // https://github.com/elastic/apm/blob/main/specs/agents/logging.md#logging-preamble
-    const sources = [
-      { name: 'environment', opts: envOptions },
-      { name: 'start', opts: opts || {} },
-      { name: 'file', opts: confFileOpts || {} },
-    ];
-    this.loggingPreambleData = getLoggingPreambleData(
-      this,
-      sources,
-      confFilePath,
-    );
+    this.loggingPreambleData = getPreambleData(this, confFilePath);
   }
 
   // Return a reasonably loggable object for this Config instance.
@@ -463,118 +433,6 @@ function truncateOptions(opts) {
     );
   if (opts.hostname)
     opts.hostname = truncate(String(opts.hostname), INTAKE_STRING_MAX_SIZE);
-}
-
-/**
- * Collects information about the agent, environment and configuration options that are
- * sets from a source (env vars, start options or config file). For each config option it
- * collects
- * - source: where te value came from (environment, start, file)
- * - sourceValue: the raw value provided im the source
- * - normalizedValue: the value normalized by the configuration which is used in the agent
- * - file: if source === 'file' this proprty is defined with the path of the config file
- *
- * @param {Object} config The configuration object with normalized options
- * @param {Array<{ name: string, opts: Object}>} sources The list of sources of options ordered by priority, highest priority first.
- * @param {String | undefined} configFilePath Path of the config file if loaded
- * @returns {Object} Object with agent, environment, and configuration data.
- */
-function getLoggingPreambleData(config, sources, configFilePath) {
-  const optsFromSources = sources.reduceRight(
-    (prev, s) => Object.assign(prev, s.opts),
-    {},
-  );
-  const result = {
-    agentVersion: AGENT_VERSION,
-    env: {
-      pid: process.pid,
-      proctitle: process.title,
-      // For darwin: https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history
-      os: `${os.platform()} ${os.release()}`,
-      arch: os.arch(),
-      host: os.hostname(),
-      timezone: getTimezoneUtc(),
-      runtime: `Node.js ${process.version}`,
-    },
-    config: {},
-  };
-
-  const mandatoryKeys = [
-    'serviceName',
-    'serviceVersion',
-    'serverUrl',
-    'logLevel',
-  ];
-  const configKeys = new Set(
-    mandatoryKeys.concat(Object.keys(optsFromSources)),
-  );
-
-  configKeys.forEach((key) => {
-    if (key in EXCLUDE_FIELDS) {
-      return;
-    }
-
-    const shouldRedact = key in REDACT_FIELDS;
-    const sourceObj = sources.find((s) => key in s.opts);
-    const sourceName = (sourceObj && sourceObj.name) || 'default';
-    const optionDetails = { source: sourceName };
-
-    if (shouldRedact) {
-      optionDetails.value =
-        key === 'serverUrl' ? sanitizeUrl(config[key]) : REDACTED;
-    } else if (optsFromSources[key] === config[key]) {
-      optionDetails.value = config[key];
-    } else {
-      optionDetails.value = config[key];
-      optionDetails.sourceValue = optsFromSources[key];
-    }
-
-    if (key in CROSS_AGENT_CONFIG_VAR_NAME) {
-      optionDetails.commonName = CROSS_AGENT_CONFIG_VAR_NAME[key];
-    }
-    if (sourceName === 'file') {
-      optionDetails.file = configFilePath;
-    }
-
-    result.config[key] = optionDetails;
-  });
-
-  return result;
-}
-
-/**
- * Takes an URL string and redacts user & password info if present in the basic
- * auth part
- *
- * @param {String} urlStr The URL to strip sensitive info
- * @returns {String || null} url with basic auth REDACTED
- */
-function sanitizeUrl(urlStr) {
-  if (!urlStr) {
-    return '';
-  }
-
-  const url = new URL(urlStr);
-  if (url.username) {
-    url.username = REDACTED;
-  }
-  if (url.password) {
-    url.password = REDACTED;
-  }
-
-  return decodeURIComponent(url.href);
-}
-
-/**
- * Returns the current Timezone in UTC notation fomat
- *
- * @returns {String} ex. UTC-0600
- */
-function getTimezoneUtc() {
-  const offsetHours = -(new Date().getTimezoneOffset() / 60);
-  const offsetSign = offsetHours >= 0 ? '+' : '-';
-  const offsetPad = Math.abs(offsetHours) < 10 ? '0' : '';
-  return `UTC${offsetSign}${offsetPad}${Math.abs(offsetHours * 100)}`;
 }
 
 // Exports.

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -742,8 +742,11 @@ function getPreambleData(config, configFilePath) {
       return;
     }
 
-    const details = { source: def.source || 'default' };
-    const value = config[def.name];
+    const details = {
+      source: def.source || 'default',
+      value: config[def.name],
+    };
+    const sourceVal = def[`${details.source}Value`];
 
     if (def.crossAgentName) {
       details.commonName = def.crossAgentName;
@@ -754,13 +757,9 @@ function getPreambleData(config, configFilePath) {
     }
 
     if (typeof def.redactFn === 'function') {
-      details.value = def.redactFn(value);
-    } else {
-      const sourceVal = def[`${details.source}Value`];
-      if (sourceVal !== value) {
-        details.sourceValue = sourceVal;
-      }
-      details.value = value;
+      details.value = def.redactFn(details.value);
+    } else if (sourceVal !== details.value) {
+      details.sourceValue = sourceVal;
     }
 
     result.config[def.name] = details;

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -691,14 +691,16 @@ function getFileOptions(confPath) {
  * @param {Record<string,any>} options
  */
 function setStartOptions(options) {
-  CONFIG_SCHEMA.forEach((def) => {
-    if (def.name in options) {
-      def.startValue = options[def.name];
-      if (!def.source || def.source === 'file') {
-        def.source = 'start';
+  if (options) {
+    CONFIG_SCHEMA.forEach((def) => {
+      if (def.name in options) {
+        def.startValue = options[def.name];
+        if (!def.source || def.source === 'file') {
+          def.source = 'start';
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 /**

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -19,7 +19,7 @@ const { REDACTED } = require('../constants');
  * @property {string} name the name of the configuration option
  * @property {keyof TypeNormalizers} configType the type of the configuration option
  * @property {any} defaultValue the default value of the property or undefined
- * @property {any} [envValue] defined if value is provided via environment var
+ * @property {any} [environmentValue] defined if value is provided via environment var
  * @property {any} [startValue] defined if value is provided via `Agent.start()` API
  * @property {any} [fileValue] defined if value is provided via config file
  * @property {'env' | 'start' | 'file'} [source] defined value comes from any source keeping its priorities (env, star, file, default)
@@ -352,7 +352,7 @@ const CONFIG_SCHEMA = [
     defaultValue: 'http://127.0.0.1:8200',
     envVar: 'ELASTIC_APM_SERVER_URL',
     crossAgentName: 'server_url',
-    serializer: sanitizeUrl,
+    redactFn: sanitizeUrl,
   },
   {
     name: 'sourceLinesErrorAppFrames',
@@ -482,7 +482,7 @@ const CONFIG_SCHEMA = [
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_API_KEY',
     crossAgentName: 'api_key',
-    serializer: () => REDACTED,
+    redactFn: () => REDACTED,
   },
   {
     name: 'captureSpanStackTraces',
@@ -536,7 +536,7 @@ const CONFIG_SCHEMA = [
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SECRET_TOKEN',
     crossAgentName: 'secret_token',
-    serializer: () => REDACTED,
+    redactFn: () => REDACTED,
   },
   {
     name: 'serviceName',
@@ -604,14 +604,12 @@ const CONFIG_SCHEMA = [
     configType: 'logger',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_LOGGER',
-    serializer: () => undefined,
   },
   {
     name: 'transport',
     configType: 'function',
     defaultValue: undefined,
     internal: true,
-    serializer: () => undefined,
   },
 ];
 
@@ -637,8 +635,8 @@ function getEnvironmentOptions() {
   return CONFIG_SCHEMA.filter((def) => def.envVar).reduce((acc, def) => {
     const val = process.env[def.envVar];
     if (val) {
-      def.envValue = val;
-      def.source = 'env';
+      def.environmentValue = val;
+      def.source = 'environment';
       acc[def.name] = val;
     }
     return acc;
@@ -661,9 +659,8 @@ function getFileOptions(confPath) {
   if (fs.existsSync(filePath)) {
     try {
       const options = require(filePath);
-      const keys = Object.keys(options);
       CONFIG_SCHEMA.forEach((def) => {
-        if (def.name in keys) {
+        if (def.name in options) {
           def.fileValue = options[def.name];
           if (!def.source) {
             def.source = 'file';
@@ -729,6 +726,7 @@ function getPreambleData(config, configFilePath) {
     config: {},
   };
 
+  const excludedKeys = new Set(['logger', 'transport']);
   const mandatoryKeys = new Set([
     'serviceName',
     'serviceVersion',
@@ -736,16 +734,16 @@ function getPreambleData(config, configFilePath) {
     'logLevel',
   ]);
 
-  const defaultSerializer = (v) => v;
-
   CONFIG_SCHEMA.forEach((def) => {
-    if (!def.source && !mandatoryKeys.has(def.name)) {
+    if (
+      excludedKeys.has(def.name) ||
+      (!def.source && !mandatoryKeys.has(def.name))
+    ) {
       return;
     }
 
     const details = { source: def.source || 'default' };
-    const serializer = def.serializer || defaultSerializer;
-    const serializedVal = serializer(config[def.name]);
+    const value = config[def.name];
 
     if (def.crossAgentName) {
       details.commonName = def.crossAgentName;
@@ -755,13 +753,14 @@ function getPreambleData(config, configFilePath) {
       details.file = configFilePath;
     }
 
-    if (typeof serializedVal !== 'undefined') {
-      details.value = serializedVal;
-
+    if (typeof def.redactFn === 'function') {
+      details.value = def.redactFn(value);
+    } else {
       const sourceVal = def[`${details.source}Value`];
-      if (sourceVal !== serializedVal) {
+      if (sourceVal !== value) {
         details.sourceValue = sourceVal;
       }
+      details.value = value;
     }
 
     result.config[def.name] = details;

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -22,11 +22,12 @@ const { REDACTED } = require('../constants');
  * @property {any} [environmentValue] defined if value is provided via environment var
  * @property {any} [startValue] defined if value is provided via `Agent.start()` API
  * @property {any} [fileValue] defined if value is provided via config file
- * @property {'env' | 'start' | 'file'} [source] defined value comes from any source keeping its priorities (env, star, file, default)
+ * @property {'environment' | 'start' | 'file'} [source] defined value comes from any source keeping its priorities (env, star, file, default)
  * @property {string} [envVar] the name of the environment varaiable associated with the option
  * @property {string} [envDeprecatedVar] the name of the deprecated environment varaiable associated with the option
  * @property {string} [centralConfigName] name of option in central configuration
  * @property {string} [crossAgentName] name of the same option in other agents
+ * @property {(v: any) => any} [redactFn] if passed the value will be redacted with it on serialization (preamble...)
  */
 
 // TODO: options with `crossAgentName` property
@@ -659,14 +660,17 @@ function getFileOptions(confPath) {
   if (fs.existsSync(filePath)) {
     try {
       const options = require(filePath);
-      CONFIG_SCHEMA.forEach((def) => {
-        if (def.name in options) {
-          def.fileValue = options[def.name];
-          if (!def.source) {
-            def.source = 'file';
+
+      if (options) {
+        CONFIG_SCHEMA.forEach((def) => {
+          if (def.name in options) {
+            def.fileValue = options[def.name];
+            if (!def.source) {
+              def.source = 'file';
+            }
           }
-        }
-      });
+        });
+      }
 
       return options;
     } catch (err) {

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -7,13 +7,22 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { URL } = require('url');
+
+const AGENT_VERSION = require('../../package.json').version;
+const { REDACTED } = require('../constants');
 
 /**
  * @typedef {Object} OptionDefinition
  * @property {string} name the name of the configuration option
- * @property {any} defaultValue the default value of the property or undefined
  * @property {keyof TypeNormalizers} configType the type of the configuration option
+ * @property {any} defaultValue the default value of the property or undefined
+ * @property {any} [envValue] defined if value is provided via environment var
+ * @property {any} [startValue] defined if value is provided via `Agent.start()` API
+ * @property {any} [fileValue] defined if value is provided via config file
+ * @property {'env' | 'start' | 'file'} [source] defined value comes from any source keeping its priorities (env, star, file, default)
  * @property {string} [envVar] the name of the environment varaiable associated with the option
  * @property {string} [envDeprecatedVar] the name of the deprecated environment varaiable associated with the option
  * @property {string} [centralConfigName] name of option in central configuration
@@ -343,6 +352,7 @@ const CONFIG_SCHEMA = [
     defaultValue: 'http://127.0.0.1:8200',
     envVar: 'ELASTIC_APM_SERVER_URL',
     crossAgentName: 'server_url',
+    serializer: sanitizeUrl,
   },
   {
     name: 'sourceLinesErrorAppFrames',
@@ -472,6 +482,7 @@ const CONFIG_SCHEMA = [
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_API_KEY',
     crossAgentName: 'api_key',
+    serializer: () => REDACTED,
   },
   {
     name: 'captureSpanStackTraces',
@@ -525,6 +536,7 @@ const CONFIG_SCHEMA = [
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_SECRET_TOKEN',
     crossAgentName: 'secret_token',
+    serializer: () => REDACTED,
   },
   {
     name: 'serviceName',
@@ -592,12 +604,14 @@ const CONFIG_SCHEMA = [
     configType: 'logger',
     defaultValue: undefined,
     envVar: 'ELASTIC_APM_LOGGER',
+    serializer: () => undefined,
   },
   {
     name: 'transport',
     configType: 'function',
     defaultValue: undefined,
     internal: true,
+    serializer: () => undefined,
   },
 ];
 
@@ -623,6 +637,8 @@ function getEnvironmentOptions() {
   return CONFIG_SCHEMA.filter((def) => def.envVar).reduce((acc, def) => {
     const val = process.env[def.envVar];
     if (val) {
+      def.envValue = val;
+      def.source = 'env';
       acc[def.name] = val;
     }
     return acc;
@@ -644,7 +660,18 @@ function getFileOptions(confPath) {
 
   if (fs.existsSync(filePath)) {
     try {
-      return require(filePath);
+      const options = require(filePath);
+      const keys = Object.keys(options);
+      CONFIG_SCHEMA.forEach((def) => {
+        if (def.name in keys) {
+          def.fileValue = options[def.name];
+          if (!def.source) {
+            def.source = 'file';
+          }
+        }
+      });
+
+      return options;
     } catch (err) {
       console.error(
         "Elastic APM initialization error: Can't read config file %s",
@@ -655,6 +682,127 @@ function getFileOptions(confPath) {
   }
 
   return null;
+}
+
+/**
+ * Sets into the schema the value given at agent start
+ *
+ * @param {Record<string,any>} options
+ */
+function setStartOptions(options) {
+  CONFIG_SCHEMA.forEach((def) => {
+    if (def.name in options) {
+      def.startValue = options[def.name];
+      if (!def.source || def.source === 'file') {
+        def.source = 'start';
+      }
+    }
+  });
+}
+
+/**
+ * Collects information about the agent, environment and configuration options that are
+ * sets from a source (env vars, start options or config file). For each config option it
+ * collects
+ * - source: where te value came from (environment, start, file)
+ * - sourceValue: the raw value provided im the source
+ * - normalizedValue: the value normalized by the configuration which is used in the agent
+ * - file: if source === 'file' this proprty is defined with the path of the config file
+ *
+ * @param {Object} config The configuration object with normalized options
+ * @param {String | undefined} configFilePath Path of the config file if loaded
+ * @returns {Object} Object with agent, environment, and configuration data.
+ */
+function getPreambleData(config, configFilePath) {
+  const result = {
+    agentVersion: AGENT_VERSION,
+    env: {
+      pid: process.pid,
+      proctitle: process.title,
+      // For darwin: https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history
+      os: `${os.platform()} ${os.release()}`,
+      arch: os.arch(),
+      host: os.hostname(),
+      timezone: getTimezoneUtc(),
+      runtime: `Node.js ${process.version}`,
+    },
+    config: {},
+  };
+
+  const mandatoryKeys = new Set([
+    'serviceName',
+    'serviceVersion',
+    'serverUrl',
+    'logLevel',
+  ]);
+
+  const defaultSerializer = (v) => v;
+
+  CONFIG_SCHEMA.forEach((def) => {
+    if (!def.source && !mandatoryKeys.has(def.name)) {
+      return;
+    }
+
+    const details = { source: def.source || 'default' };
+    const serializer = def.serializer || defaultSerializer;
+    const serializedVal = serializer(config[def.name]);
+
+    if (def.crossAgentName) {
+      details.commonName = def.crossAgentName;
+    }
+
+    if (def.source === 'file') {
+      details.file = configFilePath;
+    }
+
+    if (typeof serializedVal !== 'undefined') {
+      details.value = serializedVal;
+
+      const sourceVal = def[`${details.source}Value`];
+      if (sourceVal !== serializedVal) {
+        details.sourceValue = sourceVal;
+      }
+    }
+
+    result.config[def.name] = details;
+  });
+
+  return result;
+}
+
+/**
+ * Returns the current Timezone in UTC notation fomat
+ *
+ * @returns {String} ex. UTC-0600
+ */
+function getTimezoneUtc() {
+  const offsetHours = -(new Date().getTimezoneOffset() / 60);
+  const offsetSign = offsetHours >= 0 ? '+' : '-';
+  const offsetPad = Math.abs(offsetHours) < 10 ? '0' : '';
+  return `UTC${offsetSign}${offsetPad}${Math.abs(offsetHours * 100)}`;
+}
+
+/**
+ * Takes an URL string and redacts user & password info if present in the basic
+ * auth part
+ *
+ * @param {String} urlStr The URL to strip sensitive info
+ * @returns {String || null} url with basic auth REDACTED
+ */
+function sanitizeUrl(urlStr) {
+  if (!urlStr) {
+    return '';
+  }
+
+  const url = new URL(urlStr);
+  if (url.username) {
+    url.username = REDACTED;
+  }
+  if (url.password) {
+    url.password = REDACTED;
+  }
+
+  return decodeURIComponent(url.href);
 }
 
 // Fail fast if CONFIG_SCHEMA has issues
@@ -790,4 +938,6 @@ module.exports = {
   getDefaultOptions,
   getEnvironmentOptions,
   getFileOptions,
+  setStartOptions,
+  getPreambleData,
 };

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -633,15 +633,47 @@ function getDefaultOptions() {
  * @returns {Record<string,any>}
  */
 function getEnvironmentOptions() {
-  return CONFIG_SCHEMA.filter((def) => def.envVar).reduce((acc, def) => {
-    const val = process.env[def.envVar];
-    if (val) {
-      def.environmentValue = val;
-      def.source = 'environment';
-      acc[def.name] = val;
+  return CONFIG_SCHEMA.reduce((acc, def) => {
+    if ('environmentValue' in def) {
+      acc[def.name] = def.environmentValue;
     }
     return acc;
   }, {});
+}
+
+/**
+ * Retuns an object with the values of config options defined set
+ * in the environment
+ * @returns {Record<string,any>}
+ */
+function getFileOptions() {
+  return CONFIG_SCHEMA.reduce((acc, def) => {
+    if ('fileValue' in def) {
+      acc[def.name] = def.fileValue;
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ * Support function to read environment after the module is loaded. This is needed to
+ * perform some tests that modify `process.env`
+ * - ./test/config.tes.js
+ * - ./test/logging-preamble.test.js
+ *
+ * TODO: remove this function when test are refactored using the good `runTestFixture` method
+ */
+function readEnvOptions() {
+  CONFIG_SCHEMA.forEach((def) => {
+    if (def.envVar && process.env[def.envVar]) {
+      def.environmentValue = process.env[def.envVar];
+      def.source = 'environment';
+    } else if (def.envVar) {
+      // TODO: this is necessary since config.test.js sets different vars during tests
+      delete def.environmentValue;
+      delete def.source;
+    }
+  });
 }
 
 /**
@@ -651,7 +683,7 @@ function getEnvironmentOptions() {
  * @param {string} [confPath] the path to the file
  * @returns {Record<string,any> | null}
  */
-function getFileOptions(confPath) {
+function readFileOptions(confPath) {
   const configFileDef = CONFIG_SCHEMA.find((def) => def.name === 'configFile');
   const defaultValue = configFileDef.defaultValue;
   const envValue = process.env[configFileDef.envVar];
@@ -659,20 +691,7 @@ function getFileOptions(confPath) {
 
   if (fs.existsSync(filePath)) {
     try {
-      const options = require(filePath);
-
-      if (options) {
-        CONFIG_SCHEMA.forEach((def) => {
-          if (def.name in options) {
-            def.fileValue = options[def.name];
-            if (!def.source) {
-              def.source = 'file';
-            }
-          }
-        });
-      }
-
-      return options;
+      return require(filePath);
     } catch (err) {
       console.error(
         "Elastic APM initialization error: Can't read config file %s",
@@ -691,16 +710,29 @@ function getFileOptions(confPath) {
  * @param {Record<string,any>} options
  */
 function setStartOptions(options) {
-  if (options) {
-    CONFIG_SCHEMA.forEach((def) => {
-      if (def.name in options) {
-        def.startValue = options[def.name];
-        if (!def.source || def.source === 'file') {
-          def.source = 'start';
-        }
-      }
-    });
+  if (!options) {
+    return;
   }
+
+  const fileOpts = options.configFile && readFileOptions(options.configFile);
+
+  CONFIG_SCHEMA.forEach((def) => {
+    const source = def.source || 'default';
+
+    if (def.name in options) {
+      def.startValue = options[def.name];
+      if (source !== 'environment') {
+        def.source = 'start';
+      }
+    } else if (fileOpts && def.name in fileOpts) {
+      // console.log('setting from file', def.name, fileOpts[def.name], source);
+      def.fileValue = fileOpts[def.name];
+      if (source === 'default') {
+        def.source = 'file';
+      }
+      console.log(def);
+    }
+  });
 }
 
 /**
@@ -713,10 +745,16 @@ function setStartOptions(options) {
  * - file: if source === 'file' this proprty is defined with the path of the config file
  *
  * @param {Object} config The configuration object with normalized options
- * @param {String | undefined} configFilePath Path of the config file if loaded
  * @returns {Object} Object with agent, environment, and configuration data.
  */
-function getPreambleData(config, configFilePath) {
+function getPreambleData(config) {
+  const configFileDef = CONFIG_SCHEMA.find((def) => def.name === 'configFile');
+  const configFilePath = path.resolve(
+    configFileDef.environmentValue ||
+      configFileDef.startValue ||
+      configFileDef.defaultValue,
+  );
+
   const result = {
     agentVersion: AGENT_VERSION,
     env: {
@@ -752,6 +790,7 @@ function getPreambleData(config, configFilePath) {
       source: def.source || 'default',
       value: config[def.name],
     };
+
     const sourceVal = def[`${details.source}Value`];
 
     if (def.crossAgentName) {
@@ -814,6 +853,8 @@ function sanitizeUrl(urlStr) {
 // - dependencies not defined or defined after the dependant option
 // - type with no normalizer
 const depSet = new Set();
+const fileOpts = readFileOptions();
+
 CONFIG_SCHEMA.forEach((def) => {
   if (depSet.has(def.name)) {
     throw Error(`config option ${def.name} duplicated.`);
@@ -824,6 +865,15 @@ CONFIG_SCHEMA.forEach((def) => {
     );
   }
   depSet.add(def.name);
+
+  // Initalize values comming from environment and config file
+  if (def.envVar && process.env[def.envVar]) {
+    def.environmentValue = process.env[def.envVar];
+    def.source = 'environment';
+  } else if (fileOpts && fileOpts[def.name]) {
+    def.fileValue = fileOpts[def.name];
+    def.source = 'file';
+  }
 });
 
 // TODO: these constants below to be removed in the future (normalization)
@@ -944,4 +994,5 @@ module.exports = {
   getFileOptions,
   setStartOptions,
   getPreambleData,
+  readEnvOptions,
 };


### PR DESCRIPTION
Follow up PR to refactor the configuration of the agent. this time we use the new schema to extract the data that is shown in the log preamble.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Refactor code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
