### PR TITLE
chore: try to group some dependabot PRs for dev-deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,25 @@ updates:
         update-types: ["version-update:semver-patch"]
       - dependency-name: "@types/*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      aws-sdk:
+        dependency-type: "development"
+        patterns:
+        - "aws-sdk"
+        - "@aws-sdk/*"
+      babel:
+        dependency-type: "development"
+        patterns:
+        - "@babel/*"
+      apollo:
+        dependency-type: "development"
+        patterns:
+        - "apollo-server-*"
+        - "@apollo/*"
+      eslint:
+        dependency-type: "development"
+        patterns:
+        - "eslint*"
 
   - package-ecosystem: "npm"
     directory: "/test/instrumentation/azure-functions/fixtures/AJsAzureFnApp"


### PR DESCRIPTION
Some of our devDeps can be logically grouped for updates. For example, there recently were two separate PRs to update apollo-server-* deps. Both PRs updated the other.

https://github.com/elastic/apm-agent-nodejs/pull/3738
https://github.com/elastic/apm-agent-nodejs/pull/3737