### PR TITLE
test: drop TAV=@opentelemetry/sdk-metrics tests; TAV test with latest otel/api release

### DIFF
--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -13,7 +13,6 @@
     { "name": "@elastic/elasticsearch", "minVersion": 10 },
     { "name": "@hapi/hapi", "minVersion": 8 },
     { "name": "@opentelemetry/api", "minVersion": 14 },
-    { "name": "@opentelemetry/sdk-metrics", "minVersion": 14 },
     { "name": "apollo-server-express", "minVersion": 8 },
     { "name": "aws-sdk", "minVersion": 8 },
     { "name": "cassandra-driver", "minVersion": 16 },

--- a/test/opentelemetry-bridge/.tav.yml
+++ b/test/opentelemetry-bridge/.tav.yml
@@ -1,5 +1,5 @@
 "@opentelemetry/api":
-  versions: '>=1.0.0 <1.7.0'
+  versions: '>=1.0.0 <1.8.0'
   node: '>=8.0.0'
   commands:
     - node OTelBridgeNonRecordingSpan.test.js

--- a/test/opentelemetry-metrics/fixtures/.tav.yml
+++ b/test/opentelemetry-metrics/fixtures/.tav.yml
@@ -1,11 +1,5 @@
 "@opentelemetry/api":
-  versions: '>=1.3.0 <1.7.0'
-  node: '>=14.0.0'
-  commands:
-    - node ../fixtures.test.js
-
-"@opentelemetry/sdk-metrics":
-  versions: '>=1.11.0 <2'
+  versions: '>=1.3.0 <1.8.0'
   node: '>=14.0.0'
   commands:
     - node ../fixtures.test.js

--- a/test/opentelemetry-metrics/fixtures/package.json
+++ b/test/opentelemetry-metrics/fixtures/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/exporter-prometheus": ">=0.41.2 <2",
     "@opentelemetry/sdk-metrics": "^1.18.1"
   }


### PR DESCRIPTION
The TAV=@opentelemetry/sdk-metrics tests were failing because
test/opentelemetry-metrics/fixtures/package.json would need
to update that dep and exporter-prometheus in lockstep to avoid
a crash with two different versions of sdk-metrics installed.
I don't know how to coordinate that in TAV without labouriously
writing out all the version combos. Let's not do that now.
