### PR TITLE
fix: error in @aws-sdk/client-sqs when SendMessageBatch entries have undefined attributes

### DIFF
--- a/.ci/docker/docker-compose-node-edge-test.yml
+++ b/.ci/docker/docker-compose-node-edge-test.yml
@@ -23,7 +23,7 @@ services:
       PGHOST: 'postgres'
       PGUSER: 'postgres'
       MEMCACHED_HOST: 'memcached'
-      LOCALSTACK_HOST: 'localstack'
+      LOCALSTACK_HOST: 'localstack:4566'
       NODE_VERSION: ${NODE_VERSION}
       NODE_FULL_VERSION: ${NODE_FULL_VERSION}
       NVM_NODEJS_ORG_MIRROR: ${NVM_NODEJS_ORG_MIRROR}

--- a/.ci/docker/docker-compose-node-test.yml
+++ b/.ci/docker/docker-compose-node-test.yml
@@ -20,7 +20,7 @@ services:
       PGHOST: 'postgres'
       PGUSER: 'postgres'
       MEMCACHED_HOST: 'memcached'
-      LOCALSTACK_HOST: 'localstack'
+      LOCALSTACK_HOST: 'localstack:4566'
       NODE_VERSION: ${NODE_VERSION}
       TAV: ${TAV_MODULE}
       ELASTIC_APM_CONTEXT_MANAGER: ${ELASTIC_APM_CONTEXT_MANAGER}

--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -119,7 +119,7 @@ services:
 
   localstack:
     # https://hub.docker.com/r/localstack/localstack/tags
-    image: localstack/localstack:2.1.0
+    image: localstack/localstack:3.0.0
     environment:
       - DATA_DIR=/var/lib/localstack
     ports:

--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -121,6 +121,14 @@ services:
     # https://hub.docker.com/r/localstack/localstack/tags
     image: localstack/localstack:3.0.0
     environment:
+      # Cannot use the default `localhost.localstack.cloud:4566` which, IIUC,
+      # relies on reaching out the external DNS for resolution.
+      # https://docs.localstack.cloud/getting-started/faq/#is-using-localhostlocalstackcloud4566-to-set-as-the-endpoint-for-aws-services-recommended
+      - LOCALSTACK_HOST=localstack:4566
+      # Cannot use the default 'SQS_ENDPOINT_STRATEGY=standard' which relies on
+      # `*.localhost.localstack.cloud` resolution.
+      # https://docs.localstack.cloud/user-guide/aws/sqs/#queue-urls
+      - SQS_ENDPOINT_STRATEGY=path
       - DATA_DIR=/var/lib/localstack
     ports:
       - "4566:4566"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           - nodeesdata:/usr/share/elasticsearch/data
 
       localstack:
-        image: localstack/localstack:2.1.0
+        image: localstack/localstack:3.0.0
         env:
           DATA_DIR: '/var/lib/localstack'
         ports:

--- a/.tav.yml
+++ b/.tav.yml
@@ -593,7 +593,7 @@ aws-sdk:
   # v3.446.0 and v3.447.0 (latest at 2023-11-09) switched the internal format from XML to JSON
   # and localstack does not support it yet. We stop testing at v3.445.0 intil JSON is supported
   # https://github.com/elastic/apm-agent-nodejs/issues/3716
-  versions: '3.15.0 || 3.67.0 || 3.179.0 || 3.261.0 || 3.342.0 || 3.436.0 || 3.445.0'
+  versions: '3.15.0 || 3.67.0 || 3.179.0 || 3.261.0 || 3.342.0 || 3.436.0 || ^3.445.0'
   commands:
     - node test/instrumentation/modules/@aws-sdk/client-sqs.test.js
   node: '>=14'

--- a/.tav.yml
+++ b/.tav.yml
@@ -532,14 +532,14 @@ aws-sdk:
   #
   # - v2.1372.0 changed the SQS client protocol from "query" to "json", which
   #   isn't supported in localstack. It was reverted in v2.1373.0.
-  # - v2.1491.0 and up changed protocol to "json" again. We may watch on protocol
-  #   support in localstack. https://github.com/elastic/apm-agent-nodejs/issues/3719
+  # - v2.1491.0 and up changed protocol to "json" again, eventually supported
+  #   in localstack v3.
   #
   # Maintenance note: This should be updated periodically using:
   #   node ./dev-utils/update-tav-versions.js
   #
   # Test v2.858.0, every N=122 of 614 releases, and current latest.
-  versions: '2.858.0 || 2.984.0 || 2.1110.0 || 2.1236.0 || 2.1362.0 || 2.1489.0 || 2.1490.0'
+  versions: '2.858.0 || 2.986.0 || 2.1114.0 || 2.1242.0 || 2.1370.0 || 2.1499.0 || ^2.1502.0'
   commands:
     - node test/instrumentation/modules/aws-sdk/aws4-retries.test.js
     - node test/instrumentation/modules/aws-sdk/s3.test.js
@@ -548,7 +548,7 @@ aws-sdk:
     - node test/instrumentation/modules/aws-sdk/dynamodb.test.js
   update-versions:
     mode: max-5
-    include: '>=2.858.0 <2.1491.0'
+    include: '>=2.858.0 <3'
     exclude: '2.1372.0'
 
 # For all AWS-SDK clients want this version range:
@@ -558,9 +558,9 @@ aws-sdk:
 # of versions to test.
 # Maintenance note: This should be updated periodically using:
 #   node ./dev-utils/update-tav-versions.js
-  
+
 '@aws-sdk/client-s3':
-  versions: '3.15.0 || 3.74.0 || 3.178.0 || 3.267.0 || 3.352.0 || 3.441.0 || ^3.445.0'
+  versions: '3.15.0 || 3.75.0 || 3.180.0 || 3.276.0 || 3.358.0 || 3.454.0 || ^3.456.0'
   commands:
     - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
   node: '>=14'
@@ -570,7 +570,7 @@ aws-sdk:
     include: '>=3.15.0 <4'
 
 '@aws-sdk/client-dynamodb':
-  versions: '3.15.0 || 3.72.0 || 3.180.0 || 3.261.0 || 3.344.0 || 3.435.0 || ^3.445.0'
+  versions: '3.15.0 || 3.74.0 || 3.183.0 || 3.266.0 || 3.348.0 || 3.445.0 || ^3.454.0'
   commands:
     - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
   node: '>=14'
@@ -580,7 +580,7 @@ aws-sdk:
     include: '>=3.15.0 <4'
 
 '@aws-sdk/client-sns':
-  versions: '3.15.0 || 3.72.0 || 3.180.0 || 3.263.0 || 3.344.0 || 3.438.0 || ^3.445.0'
+  versions: '3.15.0 || 3.74.0 || 3.183.0 || 3.266.1 || 3.348.0 || 3.451.0 || ^3.454.0'
   commands:
     - node test/instrumentation/modules/@aws-sdk/client-sns.test.js
   node: '>=14'
@@ -590,10 +590,7 @@ aws-sdk:
     include: '>=3.15.0 <4'
 
 '@aws-sdk/client-sqs':
-  # v3.446.0 and v3.447.0 (latest at 2023-11-09) switched the internal format from XML to JSON
-  # and localstack does not support it yet. We stop testing at v3.445.0 intil JSON is supported
-  # https://github.com/elastic/apm-agent-nodejs/issues/3716
-  versions: '3.15.0 || 3.67.0 || 3.179.0 || 3.261.0 || 3.342.0 || 3.436.0 || ^3.445.0'
+  versions: '3.15.0 || 3.72.0 || 3.181.0 || 3.266.0 || 3.347.1 || 3.446.0 || ^3.454.0'
   commands:
     - node test/instrumentation/modules/@aws-sdk/client-sqs.test.js
   node: '>=14'
@@ -601,7 +598,6 @@ aws-sdk:
   update-versions:
     mode: max-5
     include: '>=3.15.0 <4'
-    exclude: '3.446.0 || 3.447.0'
 
 # - undici@4.7.0 added its diagnostics_channel support.
 # - In undici@4.7.1 the `request.origin` property was added, which we need

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -64,6 +64,11 @@ See the <<upgrade-to-v4>> guide.
 * Set `mongodb` span's outcome according to the result of the command being traced.
   ({pull}3695[#3695])
 
+* Fix `@aws-sdk/client-sqs` instrumentation which was failing for `SendMessageBatch`
+  command when any of the entities does not contain `MessageAttributes`.
+  ({issues}3746[#3746])
+
+
 [float]
 ===== Chores
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,7 +68,6 @@ See the <<upgrade-to-v4>> guide.
   command when any of the entities does not contain `MessageAttributes`.
   ({issues}3746[#3746])
 
-
 [float]
 ===== Chores
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,7 +28,6 @@ Notes:
         ==== x.x.x - YYYY/MM/DD
 ////
 
-
 [[release-notes-4.x]]
 === Node.js Agent version 4.x
 

--- a/lib/instrumentation/modules/@aws-sdk/client-sqs.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sqs.js
@@ -61,7 +61,11 @@ function sqsMiddlewareFactory(client, agent) {
             commandName === 'SendMessageBatch' &&
             Array.isArray(input.Entries)
           ) {
-            toPropagate.push(...input.Entries.map((e) => e.MessageAttributes));
+            for (const e of input.Entries) {
+              if (e && e.MessageAttributes) {
+                toPropagate.push(e.MessageAttributes);
+              }
+            }
           }
 
           // Though our spec only mentions a 10-message-attribute limit for *SQS*, we'll

--- a/test/docker-compose.ci.yml
+++ b/test/docker-compose.ci.yml
@@ -11,7 +11,7 @@ services:
       MYSQL_HOST: 'mysql'
       CASSANDRA_HOST: 'cassandra'
       MEMCACHED_HOST: 'memcached'
-      LOCALSTACK_HOST: 'localstack'
+      LOCALSTACK_HOST: 'localstack:4566'
       PGHOST: 'postgres'
       PGUSER: 'postgres'
     depends_on:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -119,7 +119,7 @@ services:
 
   localstack:
     # https://hub.docker.com/r/localstack/localstack/tags
-    image: localstack/localstack:2.1.0
+    image: localstack/localstack:3.0.0
     environment:
       - "DATA_DIR=/var/lib/localstack"
     ports:

--- a/test/instrumentation/modules/@aws-sdk/client-dynamodb.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-dynamodb.test.js
@@ -24,8 +24,9 @@ const { runTestFixtures, sortApmEvents } = require('../../../_utils');
 const { NODE_VER_RANGE_IITM_GE14 } = require('../../../testconsts');
 const NODE_VER_RANGE_AWS_SDK = '>=14.0.0';
 const AWS_REGION = 'us-east-2';
-const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost';
-const endpoint = 'http://' + LOCALSTACK_HOST + ':4566';
+const localstackHost = process.env.LOCALSTACK_HOST || 'localhost:4566';
+const localstackHostname = localstackHost.split(':')[0];
+const endpoint = 'http://' + localstackHost;
 
 const testFixtures = [
   {
@@ -103,7 +104,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -132,7 +133,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -161,7 +162,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -190,7 +191,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -232,7 +233,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -275,7 +276,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -304,7 +305,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 'dynamodb', name: AWS_REGION } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {

--- a/test/instrumentation/modules/@aws-sdk/client-s3.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-s3.test.js
@@ -26,8 +26,9 @@ const { validateSpan } = require('../../../_validate_schema');
 const { runTestFixtures, sortApmEvents } = require('../../../_utils');
 const { NODE_VER_RANGE_IITM } = require('../../../testconsts');
 
-const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost';
-const endpoint = 'http://' + LOCALSTACK_HOST + ':4566';
+const localstackHost = process.env.LOCALSTACK_HOST || 'localhost:4566';
+const localstackHostname = localstackHost.split(':')[0];
+const endpoint = 'http://' + localstackHost;
 
 const testFixtures = [
   {
@@ -107,7 +108,7 @@ const testFixtures = [
           context: {
             service: { target: { type: 's3' } },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: { type: '', name: '', resource: 's3' },
@@ -131,7 +132,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -162,7 +163,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -193,7 +194,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -227,7 +228,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -261,7 +262,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -307,7 +308,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -342,7 +343,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -384,7 +385,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -418,7 +419,7 @@ const testFixtures = [
               target: { type: 's3', name: 'elasticapmtest-bucket-3' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {

--- a/test/instrumentation/modules/@aws-sdk/client-s3.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-s3.test.js
@@ -140,7 +140,7 @@ const testFixtures = [
                 resource: 'elasticapmtest-bucket-3',
               },
             },
-            http: { status_code: 200, response: { encoded_body_size: 61 } },
+            http: { status_code: 200, response: { encoded_body_size: 0 } },
           },
           otel: {
             attributes: { 'aws.s3.bucket': 'elasticapmtest-bucket-3' },
@@ -202,7 +202,7 @@ const testFixtures = [
                 resource: 'elasticapmtest-bucket-3',
               },
             },
-            http: { status_code: 200, response: { encoded_body_size: 58 } },
+            http: { status_code: 200, response: { encoded_body_size: 0 } },
           },
           otel: {
             attributes: {

--- a/test/instrumentation/modules/@aws-sdk/client-sns.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sns.test.js
@@ -22,8 +22,9 @@ const { validateSpan } = require('../../../_validate_schema');
 const { runTestFixtures, sortApmEvents } = require('../../../_utils');
 const { NODE_VER_RANGE_IITM_GE14 } = require('../../../testconsts');
 
-const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost';
-const endpoint = 'http://' + LOCALSTACK_HOST + ':4566';
+const localstackHost = process.env.LOCALSTACK_HOST || 'localhost:4566';
+const localstackHostname = localstackHost.split(':')[0];
+const endpoint = 'http://' + localstackHost;
 
 const testFixtures = [
   {
@@ -107,7 +108,7 @@ const testFixtures = [
             },
             destination: {
               service: { name: '', type: '', resource: 'sns/<PHONE_NUMBER>' },
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
             },
@@ -135,7 +136,7 @@ const testFixtures = [
                 type: '',
                 resource: 'sns/elasticapmtest-topic-3',
               },
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
             },
@@ -166,7 +167,7 @@ const testFixtures = [
                 type: '',
                 resource: 'sns/elasticapmtest-topic-3-unexistent',
               },
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
             },
@@ -198,7 +199,7 @@ const testFixtures = [
                 resource:
                   'sns/elasticapmtest-topic-3, elasticapmtest-topic-3, <PHONE_NUMBER>',
               },
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: {
                 region: 'us-east-2',

--- a/test/instrumentation/modules/@aws-sdk/client-sqs.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sqs.test.js
@@ -26,8 +26,9 @@ const { validateSpan } = require('../../../_validate_schema');
 const { runTestFixtures, sortApmEvents } = require('../../../_utils');
 const { NODE_VER_RANGE_IITM_GE14 } = require('../../../testconsts');
 
-const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost';
-const endpoint = 'http://' + LOCALSTACK_HOST + ':4566';
+const localstackHost = process.env.LOCALSTACK_HOST || 'localhost:4566';
+const localstackHostname = localstackHost.split(':')[0];
+const endpoint = 'http://' + localstackHost;
 
 const testFixtures = [
   {
@@ -113,7 +114,7 @@ const testFixtures = [
               target: { type: 'sqs', name: 'elasticapmtest-queue-1.fifo' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -141,7 +142,7 @@ const testFixtures = [
               target: { type: 'sqs', name: 'elasticapmtest-queue-1.fifo' },
             },
             destination: {
-              address: LOCALSTACK_HOST,
+              address: localstackHostname,
               port: 4566,
               cloud: { region: 'us-east-2' },
               service: {
@@ -190,7 +191,7 @@ const testFixtures = [
                   },
                 },
                 destination: {
-                  address: LOCALSTACK_HOST,
+                  address: localstackHostname,
                   port: 4566,
                   cloud: { region: 'us-east-2' },
                   service: {
@@ -221,7 +222,7 @@ const testFixtures = [
                   },
                 },
                 destination: {
-                  address: LOCALSTACK_HOST,
+                  address: localstackHostname,
                   port: 4566,
                   cloud: { region: 'us-east-2' },
                   service: {

--- a/test/instrumentation/modules/aws-sdk/aws4-retries.test.js
+++ b/test/instrumentation/modules/aws-sdk/aws4-retries.test.js
@@ -25,6 +25,7 @@ const apm = require('../../../..').start({
 
 const http = require('http');
 
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;
 const AWS = require('aws-sdk');
 const tape = require('tape');
 

--- a/test/instrumentation/modules/aws-sdk/dynamodb.test.js
+++ b/test/instrumentation/modules/aws-sdk/dynamodb.test.js
@@ -19,6 +19,7 @@ const agent = require('../../../..').start({
   logLevel: 'off',
 });
 const tape = require('tape');
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;
 const AWS = require('aws-sdk');
 const express = require('express');
 const bodyParser = require('body-parser');

--- a/test/instrumentation/modules/aws-sdk/fixtures/use-sqs.js
+++ b/test/instrumentation/modules/aws-sdk/fixtures/use-sqs.js
@@ -51,6 +51,7 @@ const apm = require('../../../../..').start({
 const assert = require('assert');
 const crypto = require('crypto');
 
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;
 const AWS = require('aws-sdk');
 
 const TEST_QUEUE_NAME_PREFIX = 'elasticapmtest-queue-';
@@ -145,7 +146,7 @@ async function useSQS(sqsClient, queueName) {
   for (const attemptNum of [0, 1, 2, 3, 4]) {
     data = await sqsClient.receiveMessage(params).promise();
     log.info({ attemptNum, data }, 'receiveMessage');
-    if (data.Messages) {
+    if (data.Messages && data.Messages.length > 0) {
       data.Messages.forEach((msg) => {
         messages.push(msg);
       });
@@ -232,12 +233,7 @@ async function main() {
     );
   }
 
-  const sqsClient = new AWS.SQS({
-    apiVersion: '2012-11-05',
-    endpoint,
-    region,
-    endpointDiscoveryEnabled: false,
-  });
+  const sqsClient = new AWS.SQS({ apiVersion: '2012-11-05', endpoint, region });
 
   // Ensure an APM transaction so spans can happen.
   const tx = apm.startTransaction('manual');

--- a/test/instrumentation/modules/aws-sdk/fixtures/use-sqs.js
+++ b/test/instrumentation/modules/aws-sdk/fixtures/use-sqs.js
@@ -232,7 +232,12 @@ async function main() {
     );
   }
 
-  const sqsClient = new AWS.SQS({ apiVersion: '2012-11-05', endpoint, region });
+  const sqsClient = new AWS.SQS({
+    apiVersion: '2012-11-05',
+    endpoint,
+    region,
+    endpointDiscoveryEnabled: false,
+  });
 
   // Ensure an APM transaction so spans can happen.
   const tx = apm.startTransaction('manual');

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -28,8 +28,9 @@ const tape = require('tape');
 const { MockAPMServer } = require('../../../_mock_apm_server');
 const { validateSpan } = require('../../../_validate_schema');
 
-const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost';
-const endpoint = 'http://' + LOCALSTACK_HOST + ':4566';
+const localstackHost = process.env.LOCALSTACK_HOST || 'localhost:4566';
+const localstackHostname = localstackHost.split(':')[0];
+const endpoint = 'http://' + localstackHost;
 
 // Execute 'node fixtures/use-s3js' and assert APM server gets the expected
 // spans.
@@ -133,7 +134,7 @@ tape.test('simple S3 usage scenario', function (t) {
             context: {
               service: { target: { type: 's3' } },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: { type: '', name: '', resource: 's3' },
@@ -157,7 +158,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -188,7 +189,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -219,7 +220,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -253,7 +254,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -287,7 +288,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -321,7 +322,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -355,7 +356,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -390,7 +391,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -432,7 +433,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -466,7 +467,7 @@ tape.test('simple S3 usage scenario', function (t) {
                 target: { type: 's3', name: 'elasticapmtest-bucket-1' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {

--- a/test/instrumentation/modules/aws-sdk/s3.test.js
+++ b/test/instrumentation/modules/aws-sdk/s3.test.js
@@ -166,7 +166,7 @@ tape.test('simple S3 usage scenario', function (t) {
                   resource: 's3/elasticapmtest-bucket-1',
                 },
               },
-              http: { status_code: 200, response: { encoded_body_size: 61 } },
+              http: { status_code: 200 },
             },
             otel: {
               attributes: { 'aws.s3.bucket': 'elasticapmtest-bucket-1' },
@@ -228,7 +228,7 @@ tape.test('simple S3 usage scenario', function (t) {
                   resource: 's3/elasticapmtest-bucket-1',
                 },
               },
-              http: { status_code: 200, response: { encoded_body_size: 58 } },
+              http: { status_code: 200 },
             },
             otel: {
               attributes: {

--- a/test/instrumentation/modules/aws-sdk/sns.test.js
+++ b/test/instrumentation/modules/aws-sdk/sns.test.js
@@ -25,6 +25,8 @@ const agent = require('../../../..').start({
 const tape = require('tape');
 const express = require('express');
 const bodyParser = require('body-parser');
+
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;
 const AWS = require('aws-sdk');
 
 const {

--- a/test/instrumentation/modules/aws-sdk/sqs.test.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.test.js
@@ -212,7 +212,7 @@ tape.test('SQS usage scenario', function (t) {
     t.comment(
       'executing test script with this env: ' + JSON.stringify(additionalEnv),
     );
-    console.time && console.time('exec use-s3');
+    console.time && console.time('exec use-sqs');
     execFile(
       process.execPath,
       ['fixtures/use-sqs.js'],
@@ -223,7 +223,7 @@ tape.test('SQS usage scenario', function (t) {
         env: Object.assign({}, process.env, additionalEnv),
       },
       function done(err, stdout, stderr) {
-        console.timeLog && console.timeLog('exec use-s3');
+        console.timeLog && console.timeLog('exec use-sqs');
         t.error(err, 'use-sqs.js did not error out');
         if (err) {
           t.comment('err: ' + util.inspect(err));
@@ -246,6 +246,7 @@ tape.test('SQS usage scenario', function (t) {
         });
 
         // First the transaction.
+        console.log(server.events);
         t.ok(events[0].transaction, 'got the transaction');
         const tx = events.shift().transaction;
 

--- a/test/instrumentation/modules/aws-sdk/sqs.test.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.test.js
@@ -246,7 +246,7 @@ tape.test('SQS usage scenario', function (t) {
         });
 
         // First the transaction.
-        console.log(server.events);
+        console.log(JSON.stringify(events, null, 2));
         t.ok(events[0].transaction, 'got the transaction');
         const tx = events.shift().transaction;
 

--- a/test/instrumentation/modules/aws-sdk/sqs.test.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.test.js
@@ -246,7 +246,6 @@ tape.test('SQS usage scenario', function (t) {
         });
 
         // First the transaction.
-        console.log(JSON.stringify(events, null, 2));
         t.ok(events[0].transaction, 'got the transaction');
         const tx = events.shift().transaction;
 

--- a/test/instrumentation/modules/aws-sdk/sqs.test.js
+++ b/test/instrumentation/modules/aws-sdk/sqs.test.js
@@ -29,9 +29,9 @@ const {
   shouldIgnoreRequest,
 } = require('../../../../lib/instrumentation/modules/aws-sdk/sqs');
 
-const LOCALSTACK_HOST = process.env.LOCALSTACK_HOST || 'localhost';
-const LOCALSTACK_PORT = 4566;
-const ENDPOINT = 'http://' + LOCALSTACK_HOST + ':' + LOCALSTACK_PORT;
+const localstackHost = process.env.LOCALSTACK_HOST || 'localhost:4566';
+const localstackHostname = localstackHost.split(':')[0];
+const endpoint = 'http://' + localstackHost;
 
 // ---- tests
 
@@ -206,7 +206,7 @@ tape.test('SQS usage scenario', function (t) {
       AWS_ACCESS_KEY_ID: 'fake',
       AWS_SECRET_ACCESS_KEY: 'fake',
       TEST_QUEUE_NAME: 'elasticapmtest-queue-1',
-      TEST_ENDPOINT: ENDPOINT,
+      TEST_ENDPOINT: endpoint,
       TEST_REGION: 'us-east-2',
     };
     t.comment(
@@ -309,7 +309,7 @@ tape.test('SQS usage scenario', function (t) {
                 target: { type: 'sqs', name: 'elasticapmtest-queue-1.fifo' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -338,7 +338,7 @@ tape.test('SQS usage scenario', function (t) {
                 target: { type: 'sqs', name: 'elasticapmtest-queue-1.fifo' },
               },
               destination: {
-                address: LOCALSTACK_HOST,
+                address: localstackHostname,
                 port: 4566,
                 cloud: { region: 'us-east-2' },
                 service: {
@@ -384,7 +384,7 @@ tape.test('SQS usage scenario', function (t) {
                     },
                   },
                   destination: {
-                    address: LOCALSTACK_HOST,
+                    address: localstackHostname,
                     port: 4566,
                     cloud: { region: 'us-east-2' },
                     service: {
@@ -415,7 +415,7 @@ tape.test('SQS usage scenario', function (t) {
                     },
                   },
                   destination: {
-                    address: LOCALSTACK_HOST,
+                    address: localstackHostname,
                     port: 4566,
                     cloud: { region: 'us-east-2' },
                     service: {


### PR DESCRIPTION
Kudos to @peterabbott to find the issue and give context to start with the fix.

This PR adds a check when instrumenting `SendMessageBatch` command. The `entries` may not have the property `MessageAttributes` or it could be undefined breaking the propagation of traceContext headers.

We also leverage this fix to bump the version of local stack to `v3.0.0`. This new version supports the JSON protocol so we can re-enable tests for `@aws-sdk/client-sqs@3.446.0` and up.

Fixes: #3746
Closes: https://github.com/elastic/apm-agent-nodejs/issues/3719

~NOTE: we will re-enable test for other modules (`aws-sdk`, ..) in a follow up PR.~

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
