### PR TITLE
chore: explicitly mark this package as being of type="commonjs"

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,26 @@ Notes:
 See the <<upgrade-to-v4>> guide.
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+* Explicitly mark this package as being of type="commonjs". The experimental
+  `node --experimental-default-type=module ...` option
+  https://nodejs.org/en/blog/release/v20.10.0#--experimental-default-type-flag-to-flip-module-defaults[added in Node.js v20.10.0]
+  means that a default to "commonjs" isn't guaranteed.
+
+
 [[release-notes-4.2.0]]
 ==== 4.2.0 - 2023/11/23
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "elastic-apm-node",
   "version": "4.2.0",
   "description": "The official Elastic APM agent for Node.js",
+  "type": "commonjs",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
The `node --experimental-default-type=module ...` option in Node
v20.10.0 means a default to "commonjs" isn't guaranteed.
