### PR TITLE
chore(undici): tune unidici version compatibility for testing

### DIFF
--- a/test/_is_undici_incompat.js
+++ b/test/_is_undici_incompat.js
@@ -30,12 +30,9 @@ function isUndiciIncompat() {
   const msg = `undici@${undiciVer} is incompatible with node@${nodeVer}`;
 
   if (
-    semver.satisfies(undiciVer, '>=5.22.0') &&
-    semver.satisfies(nodeVer, '<14.0.0')
+    semver.satisfies(undiciVer, '>=5.28.0') &&
+    semver.satisfies(nodeVer, '<14.18.0')
   ) {
-    return msg;
-  }
-  if (semver.satisfies(nodeVer, '<12.18.0')) {
     return msg;
   }
 


### PR DESCRIPTION
unidci `v5.28.0` is using `node:` prefix to import `assert` module. For more info check https://github.com/elastic/apm-agent-nodejs/pull/3754#issuecomment-1827462112


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] update tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
