### PR TITLE
feat: add 'apmClientHeaders' config option for custom headers in APM server comms

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,9 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Features
 
+* Add the <<apm-client-headers>> config option, to allow adding custom headers
+  to HTTP requests made to APM server by the APM agent. ({issues}3759[#3759])
+
 [float]
 ===== Bug fixes
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -942,6 +942,32 @@ option. That will likely result in healthy requests being aborted prematurely.
 The value should include a time suffix ('m' for minutes, 's' for seconds, or
 'ms' for milliseconds), but defaults to seconds if no suffix is given.
 
+[[apm-client-headers]]
+==== `apmClientHeaders`
+
+[small]#Added in: REPLACEME#
+
+* *Type:* Object
+* *Env:* `ELASTIC_APM_APM_CLIENT_HEADERS`
+
+Specify custom headers to be included in HTTP requests by the APM agent to
+APM Server. Generally this should not be required for normal usage.
+
+Examples:
+
+[source,bash]
+----
+ELASTIC_APM_APM_CLIENT_HEADERS="foo=bar,spam=eggs"
+----
+
+[source,js]
+----
+require('elastic-apm-node').start({
+  apmClientHeaders: { foo: 'bar', spam: 'eggs' },
+  // ...
+})
+----
+
 
 [[sanitize-field-names]]
 ==== `sanitizeFieldNames`

--- a/examples/trace-http-request.js
+++ b/examples/trace-http-request.js
@@ -45,10 +45,6 @@ function makeARequest(url, opts, cb) {
 // an HTTP server, we manually start a transaction. More details at:
 // https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-transactions.html
 const t0 = apm.startTransaction('t0');
-makeARequest(
-  'http://httpstat.us/200',
-  { headers: { accept: '*/*' } },
-  function () {
-    t0.end();
-  },
-);
+makeARequest('http://google.com/', { headers: { accept: '*/*' } }, function () {
+  t0.end();
+});

--- a/lib/apm-client/apm-client.js
+++ b/lib/apm-client/apm-client.js
@@ -166,6 +166,7 @@ function getHttpClientConfig(conf, agent) {
     serverCaCert: loadServerCaCertFile(conf.serverCaCertFile),
     rejectUnauthorized: conf.verifyServerCert,
     serverTimeout: conf.serverTimeout * 1000,
+    headers: maybePairsToObject(conf.apmClientHeaders),
 
     // APM Agent Configuration via Kibana:
     centralConfig: conf.centralConfig,

--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -590,6 +590,12 @@ const CONFIG_SCHEMA = [
     defaultValue: [],
     deps: ['ignoreUserAgents'],
   },
+  {
+    name: 'apmClientHeaders',
+    configType: 'stringKeyValuePairs',
+    defaultValue: undefined,
+    envVar: 'ELASTIC_APM_APM_CLIENT_HEADERS',
+  },
   // Special options that
   // - may afect the whole config
   // - change the behavior of thelogger


### PR DESCRIPTION
Closes: #3759

---

I haven't added any tests here. FWIW there are existing tests in the *http-apm-client tests* for the `headers` config option that we are using here:
https://github.com/elastic/apm-agent-nodejs/blob/f590ef67c5b016520b844ce3a87164a4b7bbbfbd/test/apm-client/http-apm-client/config.test.js#L171-L194

I don't think there is much value in a test case that a `apmClientHeaders` value given to `apm.start()` makes it to the HttpApmClient() instance. For example, there isn't an equivalent test for these related config vars being passed through:

```js
    rejectUnauthorized: conf.verifyServerCert,
    serverTimeout: conf.serverTimeout * 1000,
```
