### PR TITLE
chore(undici): fix opentelemetry tests using undici

### DIFF
--- a/test/opentelemetry-metrics/fixtures.test.js
+++ b/test/opentelemetry-metrics/fixtures.test.js
@@ -39,7 +39,13 @@ if (!semver.satisfies(process.version, '>=14')) {
   process.exit();
 }
 
-const undici = require('undici'); // import after we've excluded node <14
+const isUndiciIncompat = require('../_is_undici_incompat')();
+if (isUndiciIncompat) {
+  console.log(`# SKIP ${isUndiciIncompat}`);
+  process.exit();
+}
+
+const undici = require('undici'); // import after we've checked compatibility
 
 const fixturesDir = path.join(__dirname, 'fixtures');
 


### PR DESCRIPTION
Letftover from a previous PR https://github.com/elastic/apm-agent-nodejs/pull/3755

Opentelemetry tests are also using undici so we need also to apply the same checks and skip if necessary.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] Update tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
