### PR TITLE
chore: another batch of config tests being refactored

### DIFF
--- a/lib/config/normalizers.js
+++ b/lib/config/normalizers.js
@@ -34,7 +34,7 @@ function normalizeKeyValuePairs(opts, fields, defaults, logger) {
     if (key in opts) {
       if (typeof opts[key] === 'object' && !Array.isArray(opts[key])) {
         opts[key] = Object.entries(opts[key]);
-        return;
+        continue;
       }
 
       if (!Array.isArray(opts[key]) && typeof opts[key] === 'string') {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -273,32 +273,10 @@ DURATION_OPTS.forEach(function (optSpec) {
 var keyValuePairValues = ['addPatch', 'globalLabels'];
 
 keyValuePairValues.forEach(function (key) {
-  var string = 'foo=bar,baz=buz';
-  var object = { foo: 'bar', baz: 'buz' };
   var pairs = [
     ['foo', 'bar'],
     ['baz', 'buz'],
   ];
-
-  test(key + ' should support string form', function (t) {
-    var agent = new Agent();
-    var opts = {};
-    opts[key] = string;
-    agent.start(Object.assign({}, agentOptsNoopTransport, opts));
-    t.deepEqual(agent._conf[key], pairs);
-    agent.destroy();
-    t.end();
-  });
-
-  test(key + ' should support object form', function (t) {
-    var agent = new Agent();
-    var opts = {};
-    opts[key] = object;
-    agent.start(Object.assign({}, agentOptsNoopTransport, opts));
-    t.deepEqual(agent._conf[key], pairs);
-    agent.destroy();
-    t.end();
-  });
 
   test(key + ' should support pair form', function (t) {
     var agent = new Agent();

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -101,80 +101,6 @@ function assertEncodedError(t, error, result, trans, parent) {
 
 // ---- tests
 
-var falsyValues = [false, 'false'];
-var truthyValues = [true, 'true'];
-
-falsyValues.forEach(function (val) {
-  test(
-    'should be disabled by environment variable ELASTIC_APM_ACTIVE set to: ' +
-      util.inspect(val),
-    function (t) {
-      var agent = new Agent();
-      process.env.ELASTIC_APM_ACTIVE = val;
-      agent.start(
-        Object.assign({}, agentOptsNoopTransport, {
-          serviceName: 'foo',
-          secretToken: 'baz',
-        }),
-      );
-      t.strictEqual(agent._conf.active, false);
-      delete process.env.ELASTIC_APM_ACTIVE;
-      agent.destroy();
-      t.end();
-    },
-  );
-});
-
-truthyValues.forEach(function (val) {
-  test(
-    'should be enabled by environment variable ELASTIC_APM_ACTIVE set to: ' +
-      util.inspect(val),
-    function (t) {
-      var agent = new Agent();
-      process.env.ELASTIC_APM_ACTIVE = val;
-      agent.start(
-        Object.assign({}, agentOptsNoopTransport, {
-          serviceName: 'foo',
-          secretToken: 'baz',
-        }),
-      );
-      t.strictEqual(agent._conf.active, true);
-      delete process.env.ELASTIC_APM_ACTIVE;
-      agent.destroy();
-      t.end();
-    },
-  );
-});
-
-test('should log invalid booleans', function (t) {
-  var agent = new Agent();
-  var logger = new MockLogger();
-
-  agent.start(
-    Object.assign({}, agentOptsNoopTransport, {
-      serviceName: 'foo',
-      secretToken: 'baz',
-      active: 'nope',
-      logger,
-    }),
-  );
-
-  var warning = findObjInArray(logger.calls, 'type', 'warn');
-  t.strictEqual(
-    warning.message,
-    'unrecognized boolean value "nope" for "active"',
-  );
-
-  var debug = findObjInArray(logger.calls, 'type', 'debug');
-  t.strictEqual(
-    debug.message,
-    'Elastic APM agent disabled (`active` is false)',
-  );
-
-  agent.destroy();
-  t.end();
-});
-
 DURATION_OPTS.forEach(function (optSpec) {
   const key = optSpec.name;
 
@@ -385,26 +311,6 @@ keyValuePairValues.forEach(function (key) {
   });
 });
 
-var noPrefixValues = [
-  ['kubernetesNodeName', 'KUBERNETES_NODE_NAME'],
-  ['kubernetesNamespace', 'KUBERNETES_NAMESPACE'],
-  ['kubernetesPodName', 'KUBERNETES_POD_NAME'],
-  ['kubernetesPodUID', 'KUBERNETES_POD_UID'],
-];
-
-noPrefixValues.forEach(function (pair) {
-  const [key, envVar] = pair;
-  test(`maps ${envVar} to ${key}`, (t) => {
-    var agent = new Agent();
-    process.env[envVar] = 'test';
-    agent.start(agentOptsNoopTransport);
-    delete process.env[envVar];
-    t.strictEqual(agent._conf[key], 'test');
-    agent.destroy();
-    t.end();
-  });
-});
-
 test('should overwrite option property active by ELASTIC_APM_ACTIVE', function (t) {
   var agent = new Agent();
   var opts = { serviceName: 'foo', secretToken: 'baz', active: true };
@@ -412,18 +318,6 @@ test('should overwrite option property active by ELASTIC_APM_ACTIVE', function (
   agent.start(Object.assign({}, agentOptsNoopTransport, opts));
   t.strictEqual(agent._conf.active, false);
   delete process.env.ELASTIC_APM_ACTIVE;
-  agent.destroy();
-  t.end();
-});
-
-test('should default to empty request ignore arrays', function (t) {
-  var agent = new Agent();
-  agent.start(agentOptsNoopTransport);
-  t.strictEqual(agent._conf.ignoreUrlStr.length, 0);
-  t.strictEqual(agent._conf.ignoreUrlRegExp.length, 0);
-  t.strictEqual(agent._conf.ignoreUserAgentStr.length, 0);
-  t.strictEqual(agent._conf.ignoreUserAgentRegExp.length, 0);
-  t.strictEqual(agent._conf.transactionIgnoreUrlRegExp.length, 0);
   agent.destroy();
   t.end();
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -20,7 +20,6 @@ const Agent = require('../lib/agent');
 const { MockAPMServer } = require('./_mock_apm_server');
 const { MockLogger } = require('./_mock_logger');
 const { NoopApmClient } = require('../lib/apm-client/noop-apm-client');
-const { findObjInArray } = require('./_utils');
 const { secondsFromDuration } = require('../lib/config/normalizers');
 const {
   getDefaultOptions,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -175,34 +175,6 @@ test('should log invalid booleans', function (t) {
   t.end();
 });
 
-var MINUS_ONE_EQUAL_INFINITY = ['transactionMaxSpans'];
-
-MINUS_ONE_EQUAL_INFINITY.forEach(function (key) {
-  test(key + ' should be Infinity if set to -1', function (t) {
-    var agent = new Agent();
-    var opts = {};
-    opts[key] = -1;
-    agent.start(Object.assign({}, agentOptsNoopTransport, opts));
-    t.strictEqual(agent._conf[key], Infinity);
-    agent.destroy();
-    t.end();
-  });
-});
-
-var bytesValues = ['apiRequestSize', 'errorMessageMaxLength'];
-
-bytesValues.forEach(function (key) {
-  test(key + ' should be converted to a number', function (t) {
-    var agent = new Agent();
-    var opts = {};
-    opts[key] = '1mb';
-    agent.start(Object.assign({}, agentOptsNoopTransport, opts));
-    t.strictEqual(agent._conf[key], 1024 * 1024);
-    agent.destroy();
-    t.end();
-  });
-});
-
 DURATION_OPTS.forEach(function (optSpec) {
   const key = optSpec.name;
 

--- a/test/config/config.test.js
+++ b/test/config/config.test.js
@@ -316,12 +316,12 @@ const testFixtures = [
       t.equal(
         resolvedConfig.breakdownMetrics,
         false,
-        'boolean value is parsed',
+        '"false" value for breakdownMetrics is parsed',
       );
       t.equal(
         resolvedConfig.apiRequestSize,
         1024 * 1024,
-        'bytes value is parsed for apiRequestSize',
+        '"1mb" value is parsed for apiRequestSize',
       );
       t.equal(
         warnLogs[0].message,
@@ -366,7 +366,7 @@ const testFixtures = [
       KUBERNETES_POD_NAME: 'kube-pod-name',
       KUBERNETES_POD_UID: 'kube-pod-id',
     },
-    verbose: true,
+    verbose: false,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
       const useAgentLogs = getUseAgentLogs(stdout);
@@ -391,6 +391,39 @@ const testFixtures = [
         resolvedConfig.kubernetesPodUID,
         'kube-pod-id',
         'KUBERNETES_POD_UID maps to kubernetesPodUID',
+      );
+    },
+  },
+  {
+    name: 'use agent - should support ket/value pairs formats',
+    script: 'fixtures/use-agent.js',
+    cwd: __dirname,
+    noConvenienceConfig: true,
+    env: {
+      ELASTIC_APM_GLOBAL_LABELS: 'foo=bar,baz=buz', // string form
+      TEST_APM_START_OPTIONS: JSON.stringify({
+        addPatch: { foo: 'bar', baz: 'buz' },
+      }), // object form
+    },
+    verbose: true,
+    checkScriptResult: (t, err, stdout) => {
+      t.error(err, `use-agent.js script succeeded: err=${err}`);
+      const useAgentLogs = getUseAgentLogs(stdout);
+      const resolvedConfig = JSON.parse(useAgentLogs[2]);
+      const pairs = [
+        ['foo', 'bar'],
+        ['baz', 'buz'],
+      ];
+
+      t.deepEqual(
+        resolvedConfig.globalLabels,
+        pairs,
+        'globalLabels is parsed correctly from environment (string)',
+      );
+      t.deepEqual(
+        resolvedConfig.addPatch,
+        pairs,
+        'addPatch is parsed correctly from start options (object)',
       );
     },
   },

--- a/test/config/config.test.js
+++ b/test/config/config.test.js
@@ -44,7 +44,7 @@ function getUseAgentLogs(stdout) {
 }
 
 /**
- * Returns the warnings emitted by the logger
+ * Returns the logs emitted by the agent's logger filtered by level
  * @param {string} stdout
  * @param {string} level
  * @returns {Object[]}

--- a/test/config/config.test.js
+++ b/test/config/config.test.js
@@ -17,7 +17,7 @@ const defaultOptions = getDefaultOptions();
 
 // ---- support function
 /**
- * Changes the keys from ELASTIC_APM_* the the proper confgi name
+ * Changes the keys from ELASTIC_APM_* the the proper config name
  * @param {Record<string, string>} envVars
  * @returns {Record<string, string>}
  */
@@ -52,16 +52,10 @@ const testFixtures = [
     script: 'fixtures/use-agent.js',
     cwd: __dirname,
     noConvenienceConfig: true, // we want full control of the env
-    timeout: 20000, // sanity guard on the test hanging
-    maxBuffer: 10 * 1024 * 1024, // This is big, but I don't ever want this to be a failure reason.
-    verbose: true,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
 
-      const useAgentLogs = stdout
-        .split('\n')
-        .filter((l) => l.startsWith('use-agent log:'))
-        .map((l) => l.replace('use-agent log:', ''));
+      const useAgentLogs = getUseAgentLogs(stdout);
       const startConfig = JSON.parse(useAgentLogs[0]);
       const resolvedConfig = JSON.parse(useAgentLogs[1]);
       const defaultConfig = Object.assign({}, defaultOptions);
@@ -96,8 +90,6 @@ const testFixtures = [
     name: 'use agent - shoud be configurable by environment vars',
     script: 'fixtures/use-agent.js',
     cwd: __dirname,
-    timeout: 20000, // sanity guard on the test hanging
-    maxBuffer: 10 * 1024 * 1024, // This is big, but I don't ever want this to be a failure reason.
     noConvenienceConfig: true,
     env: {
       ELASTIC_APM_ABORTED_ERROR_THRESHOLD: '30',
@@ -176,8 +168,6 @@ const testFixtures = [
     name: 'use agent - shoud override start options by environment vars',
     script: 'fixtures/use-agent.js',
     cwd: __dirname,
-    timeout: 20000, // sanity guard on the test hanging
-    maxBuffer: 10 * 1024 * 1024, // This is big, but I don't ever want this to be a failure reason.
     noConvenienceConfig: true,
     env: (function () {
       const startOptsManual = {
@@ -214,7 +204,6 @@ const testFixtures = [
       envVars['TEST_APM_START_OPTIONS'] = JSON.stringify(startOpts);
       return envVars;
     })(),
-    verbose: false,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
 
@@ -248,7 +237,7 @@ const testFixtures = [
     },
   },
   {
-    name: 'use agent - shoud have prioroty of env, start, file',
+    name: 'use agent - should have priority of env, start, file',
     script: 'fixtures/use-agent.js',
     cwd: __dirname,
     timeout: 20000, // sanity guard on the test hanging

--- a/test/config/config.test.js
+++ b/test/config/config.test.js
@@ -299,7 +299,6 @@ const testFixtures = [
       ELASTIC_APM_ACTIVE: 'nope',
       ELASTIC_APM_LOG_LEVEL: 'debug', // we want debug logs to check
     },
-    verbose: true,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
       const reviver = (k, v) => (v === 'Infinity' ? Infinity : v);
@@ -344,15 +343,12 @@ const testFixtures = [
         'got a debug log about agent disabled',
       );
       // XXX: normalization turns this value to `undefined` because "bogus"
-      // is set at ENV level and overrides the other before normalization
-      // strategy probably should change to
-      // - normalize values of sources (invalid turn into undefined)
-      // - do the overrides then if defined
-      // t.equal(
-      //   resolvedConfig.active,
-      //   true,
-      //   'bogus boolean does not get into config',
-      // );
+      // is not a boolean. Do we want to keep it that way?
+      t.equal(
+        resolvedConfig.active,
+        undefined,
+        'bogus boolean does not get into config',
+      );
     },
   },
   {
@@ -366,7 +362,6 @@ const testFixtures = [
       KUBERNETES_POD_NAME: 'kube-pod-name',
       KUBERNETES_POD_UID: 'kube-pod-id',
     },
-    verbose: false,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
       const useAgentLogs = getUseAgentLogs(stdout);
@@ -405,7 +400,6 @@ const testFixtures = [
         addPatch: { foo: 'bar', baz: 'buz' },
       }), // object form
     },
-    verbose: true,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
       const useAgentLogs = getUseAgentLogs(stdout);

--- a/test/config/config.test.js
+++ b/test/config/config.test.js
@@ -262,7 +262,6 @@ const testFixtures = [
         configFile: 'fixtures/use-agent-config.js',
       }),
     },
-    verbose: false,
     checkScriptResult: (t, err, stdout) => {
       t.error(err, `use-agent.js script succeeded: err=${err}`);
 
@@ -298,7 +297,7 @@ const testFixtures = [
       ELASTIC_APM_API_REQUEST_SIZE: '1mb',
       ELASTIC_APM_ERROR_MESSAGE_MAX_LENGTH: '1mb',
       ELASTIC_APM_ACTIVE: 'nope',
-      ELASTIC_APM_LOG_LEVEL: 'debug',
+      ELASTIC_APM_LOG_LEVEL: 'debug', // we want debug logs to check
     },
     verbose: true,
     checkScriptResult: (t, err, stdout) => {
@@ -354,6 +353,45 @@ const testFixtures = [
       //   true,
       //   'bogus boolean does not get into config',
       // );
+    },
+  },
+  {
+    name: 'use agent - should work for nor ELASTIC_APM_* prefixed vars',
+    script: 'fixtures/use-agent.js',
+    cwd: __dirname,
+    noConvenienceConfig: true,
+    env: {
+      KUBERNETES_NODE_NAME: 'kube-node-name',
+      KUBERNETES_NAMESPACE: 'kube-namespace',
+      KUBERNETES_POD_NAME: 'kube-pod-name',
+      KUBERNETES_POD_UID: 'kube-pod-id',
+    },
+    verbose: true,
+    checkScriptResult: (t, err, stdout) => {
+      t.error(err, `use-agent.js script succeeded: err=${err}`);
+      const useAgentLogs = getUseAgentLogs(stdout);
+      const resolvedConfig = JSON.parse(useAgentLogs[2]);
+
+      t.equal(
+        resolvedConfig.kubernetesNodeName,
+        'kube-node-name',
+        'KUBERNETES_NODE_NAME maps to kubernetesNodeName',
+      );
+      t.equal(
+        resolvedConfig.kubernetesNamespace,
+        'kube-namespace',
+        'KUBERNETES_NAMESPACE maps to kubernetesNamespace',
+      );
+      t.equal(
+        resolvedConfig.kubernetesPodName,
+        'kube-pod-name',
+        'KUBERNETES_POD_NAME maps to kubernetesPodName',
+      );
+      t.equal(
+        resolvedConfig.kubernetesPodUID,
+        'kube-pod-id',
+        'KUBERNETES_POD_UID maps to kubernetesPodUID',
+      );
     },
   },
 ];

--- a/test/config/fixtures/use-agent.js
+++ b/test/config/fixtures/use-agent.js
@@ -31,11 +31,19 @@ const APM_ENV_OPTIONS = Object.keys(process.env).reduce((acc, key) => {
   return acc;
 }, {});
 
+// Make sure values like Infinity are passe back to test
+// TODO: check if necessary to add NaN and others
+function replacer(key, value) {
+  return value === Infinity ? 'Infinity' : value;
+}
+
 // Report options passed by env
-console.log(`${logPrefix}${JSON.stringify(APM_ENV_OPTIONS)}`);
+console.log(`${logPrefix}${JSON.stringify(APM_ENV_OPTIONS, replacer)}`);
 
 // Report options used to start
-console.log(`${logPrefix}${JSON.stringify(APM_START_OPTIONS)}`);
+console.log(`${logPrefix}${JSON.stringify(APM_START_OPTIONS, replacer)}`);
 
 // Just spit out the resolved configuration
-console.log(`${logPrefix}${JSON.stringify(apm._conf)}`);
+// NOTE: make use of Object.assign to get the whole config and not only the loggable version
+const configClone = Object.assign({}, apm._conf);
+console.log(`${logPrefix}${JSON.stringify(configClone, replacer)}`);


### PR DESCRIPTION
This PR refactors tests for:
- truthy/falsy values
- byte values
- -1 === Infinity values
- key/value pairs values

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] Refactor tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
