### PR TITLE
tests: refactor ignore config options tests (strings, regexp)

### DIFF
--- a/test/config.test.js
+++ b/test/config.test.js
@@ -13,7 +13,6 @@ var os = require('os');
 var path = require('path');
 var util = require('util');
 
-var isRegExp = require('core-util-is').isRegExp;
 var test = require('tape');
 
 const Agent = require('../lib/agent');

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -93,25 +93,6 @@ function assertEncodedError(t, error, result, trans, parent) {
 
 // ---- tests
 
-var keyValuePairValues = ['addPatch', 'globalLabels'];
-
-keyValuePairValues.forEach(function (key) {
-  var pairs = [
-    ['foo', 'bar'],
-    ['baz', 'buz'],
-  ];
-
-  test(key + ' should support pair form', function (t) {
-    var agent = new Agent();
-    var opts = {};
-    opts[key] = pairs;
-    agent.start(Object.assign({}, agentOptsNoopTransport, opts));
-    t.deepEqual(agent._conf[key], pairs);
-    agent.destroy();
-    t.end();
-  });
-});
-
 test('should overwrite option property active by ELASTIC_APM_ACTIVE', function (t) {
   var agent = new Agent();
   var opts = { serviceName: 'foo', secretToken: 'baz', active: true };
@@ -119,54 +100,6 @@ test('should overwrite option property active by ELASTIC_APM_ACTIVE', function (
   agent.start(Object.assign({}, agentOptsNoopTransport, opts));
   t.strictEqual(agent._conf.active, false);
   delete process.env.ELASTIC_APM_ACTIVE;
-  agent.destroy();
-  t.end();
-});
-
-test('should separate strings and regexes into their own ignore arrays', function (t) {
-  var agent = new Agent();
-  agent.start(
-    Object.assign({}, agentOptsNoopTransport, {
-      ignoreUrls: ['str1', /regex1/],
-      ignoreUserAgents: ['str2', /regex2/],
-    }),
-  );
-
-  t.deepEqual(agent._conf.ignoreUrlStr, ['str1']);
-  t.deepEqual(agent._conf.ignoreUserAgentStr, ['str2']);
-
-  t.strictEqual(agent._conf.ignoreUrlRegExp.length, 1);
-  t.ok(isRegExp(agent._conf.ignoreUrlRegExp[0]));
-  t.strictEqual(agent._conf.ignoreUrlRegExp[0].toString(), '/regex1/');
-
-  t.strictEqual(agent._conf.ignoreUserAgentRegExp.length, 1);
-  t.ok(isRegExp(agent._conf.ignoreUserAgentRegExp[0]));
-  t.strictEqual(agent._conf.ignoreUserAgentRegExp[0].toString(), '/regex2/');
-
-  agent.destroy();
-  t.end();
-});
-
-test('should prepare WildcardMatcher array config vars', function (t) {
-  var agent = new Agent();
-  agent.start(
-    Object.assign({}, agentOptsNoopTransport, {
-      transactionIgnoreUrls: ['foo', 'bar', '/wil*card'],
-      elasticsearchCaptureBodyUrls: ['*/_search', '*/_eql/search'],
-    }),
-  );
-
-  t.equal(
-    agent._conf.transactionIgnoreUrlRegExp.toString(),
-    '/^foo$/i,/^bar$/i,/^\\/wil.*card$/i',
-    'transactionIgnoreUrlRegExp',
-  );
-  t.equal(
-    agent._conf.elasticsearchCaptureBodyUrlsRegExp.toString(),
-    '/^.*\\/_search$/i,/^.*\\/_eql\\/search$/i',
-    'elasticsearchCaptureBodyUrlsRegExp',
-  );
-
   agent.destroy();
   t.end();
 });

--- a/test/config/_json-utils.js
+++ b/test/config/_json-utils.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+/**
+ * Replaces some special values to be printed in stdout or env vars and
+ * be revived by the test script or the fixture. These are
+ * - Infinity which serializes to `null` by default
+ * - RegExp serializes to `{}` by default
+ * @param {string} key
+ * @param {any} value
+ * @returns {any}
+ */
+function replacer(key, value) {
+  if (value === Infinity) {
+    return 'Infinity';
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (item instanceof RegExp || typeof item === 'string') {
+        return item.toString();
+      }
+      return item;
+    });
+  }
+
+  return value;
+}
+
+/**
+ * Revives values from the serialized JSON with `replacer`
+ * @param {string} key
+ * @param {any} value
+ * @returns {any}
+ */
+function reviver(key, value) {
+  if (value === 'Infinity') {
+    return Infinity;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (typeof item === 'string' && /^\/.+\/i?$/.test(item)) {
+        if (item.endsWith('i')) {
+          return new RegExp(item.slice(1, item.length - 2), 'i');
+        }
+        return new RegExp(item.slice(1, item.length - 1));
+      }
+      return item;
+    });
+  }
+  return value;
+}
+
+module.exports = {
+  replacer,
+  reviver,
+};

--- a/test/config/fixtures/use-agent.js
+++ b/test/config/fixtures/use-agent.js
@@ -8,6 +8,8 @@
 
 const { NoopApmClient } = require('../../../lib/apm-client/noop-apm-client');
 
+const { replacer, reviver } = require('../_json-utils');
+
 const APM_START_OPTIONS = {
   transport: () => new NoopApmClient(),
 };
@@ -16,7 +18,7 @@ const APM_START_OPTIONS = {
 if (process.env.TEST_APM_START_OPTIONS) {
   Object.assign(
     APM_START_OPTIONS,
-    JSON.parse(process.env.TEST_APM_START_OPTIONS),
+    JSON.parse(process.env.TEST_APM_START_OPTIONS, reviver),
   );
 }
 // this prefix will be used to get info from the test suite
@@ -30,12 +32,6 @@ const APM_ENV_OPTIONS = Object.keys(process.env).reduce((acc, key) => {
   }
   return acc;
 }, {});
-
-// Make sure values like Infinity are passe back to test
-// TODO: check if necessary to add NaN and others
-function replacer(key, value) {
-  return value === Infinity ? 'Infinity' : value;
-}
 
 // Report options passed by env
 console.log(`${logPrefix}${JSON.stringify(APM_ENV_OPTIONS, replacer)}`);


### PR DESCRIPTION
Another PR of the refactor config series. In this one:
- adds a missing test for key/value pair formats
- refactors the test for configurations which may hold regular expresions or wildcards

NOTE: a new file has been created to share replace & revive logic from JSON serialization and deserialization so test and fixture can transfer the right values of config and not loose them while stringifying them

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [x] Refactor tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
