### PR TITLE
release 4.3.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,10 +33,9 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-==== Unreleased
 
-[float]
-===== Breaking changes
+[[release-notes-4.3.0]]
+==== 4.3.0 - 2023/12/05
 
 [float]
 ===== Features
@@ -47,6 +46,9 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Bug fixes
 
+* Fix the dependency version range for `@elastic/ecs-pino-format`.
+  ({issues}3774[#3774])
+
 [float]
 ===== Chores
 
@@ -56,21 +58,6 @@ See the <<upgrade-to-v4>> guide.
 * Change the log level of `Sending error to Elastic APM: ...` from `info` to
   `debug`. There is no need to clutter the log output with this message.
   ({issues}3748[#3748])
-
-
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
-
-[float]
-===== Bug fixes
-
-[float]
-===== Chores
 
 * Explicitly mark this package as being of type="commonjs". The experimental
   `node --experimental-default-type=module ...` option

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -945,7 +945,7 @@ The value should include a time suffix ('m' for minutes, 's' for seconds, or
 [[apm-client-headers]]
 ==== `apmClientHeaders`
 
-[small]#Added in: REPLACEME#
+[small]#Added in: v4.3.0#
 
 * *Type:* Object
 * *Env:* `ELASTIC_APM_APM_CLIENT_HEADERS`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
# checklist

- [x] wait for https://github.com/elastic/apm-agent-nodejs/pull/3775 to get merged first

# highlights

* Fix the dependency version range for `@elastic/ecs-pino-format`. (#3774)
* Change the log level of `Sending error to Elastic APM: ...` from `info` to
  `debug`. There is no need to clutter the log output with this message. (#3748)
* Add the `apmClientHeaders` config option, to allow adding custom headers
  to HTTP requests made to APM server by the APM agent. (#3759)