### PR TITLE
fix: ESM hooking with Node.js v18.19.0

### DIFF
--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -1,6 +1,5 @@
 {
-  "// versions": "Skip >=18.19.0 until IITM double-import issue is resolved.",
-  "versions": [ "21", "20", "18.18.2", "16", "14" ],
+  "versions": [ "21", "20", "18", "16", "14" ],
   "// modules": [
     "List of instrumented modules with the minimum Node major version supported.",
     "minMajorVersion for each module should be kept in sync with .tav.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
           - '21.0'
           - '20'
           - '20.0'
-          - '18.18.2' # Skip >=18.19.0 until IITM double-import issue is resolved.
+          - '18'
           - '18.0'
           - '16'
           - '16.0'

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,23 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix <<esm>> with Node v18.19.0 (and later versions of Node v18.x).
+  ({issues}3784[#3784])
+
+[float]
+===== Chores
+
 
 [[release-notes-4.3.0]]
 ==== 4.3.0 - 2023/12/05

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "fast-safe-stringify": "^2.0.7",
         "fast-stream-to-buffer": "^1.0.0",
         "http-headers": "^3.0.2",
-        "import-in-the-middle": "1.5.0",
+        "import-in-the-middle": "^1.6.0",
         "json-bigint": "^1.0.0",
         "lru-cache": "^10.0.1",
         "measured-reporting": "^1.51.1",
@@ -11498,9 +11498,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.5.0.tgz",
-      "integrity": "sha512-H2hqR0jImhqe9+1k8pYewDKWJHnDeRsWZk5aSztv6MIWD5glmbEOqy1JZrMUC6SJiO1M4A+nVvUUYtWzP5wPYg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.6.0.tgz",
+      "integrity": "sha512-ENmVXh2AC5PV5xmtPK0QCV6nyde5Y8dXhMZFGDSYhlLcdBPJofge1bf6PnWzs7fnzyuesh/q/CPwO7/6HOTWqQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -27114,9 +27114,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.5.0.tgz",
-      "integrity": "sha512-H2hqR0jImhqe9+1k8pYewDKWJHnDeRsWZk5aSztv6MIWD5glmbEOqy1JZrMUC6SJiO1M4A+nVvUUYtWzP5wPYg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.6.0.tgz",
+      "integrity": "sha512-ENmVXh2AC5PV5xmtPK0QCV6nyde5Y8dXhMZFGDSYhlLcdBPJofge1bf6PnWzs7fnzyuesh/q/CPwO7/6HOTWqQ==",
       "requires": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "fast-safe-stringify": "^2.0.7",
     "fast-stream-to-buffer": "^1.0.0",
     "http-headers": "^3.0.2",
-    "import-in-the-middle": "1.5.0",
+    "import-in-the-middle": "^1.6.0",
     "json-bigint": "^1.0.0",
     "lru-cache": "^10.0.1",
     "measured-reporting": "^1.51.1",


### PR DESCRIPTION
import-in-the-middle@1.6.0 fixes an issue with double-importing
with node 18.19.0 (due to a backport of ESM loading being done
off main thread).

Fixes: #3784
