### PR TITLE
chore: rename apm-mutating-webhook to apm-k8s-attacher

### DIFF
--- a/lib/activation-method.js
+++ b/lib/activation-method.js
@@ -83,8 +83,8 @@ function agentActivationMethodFromStartStack(startStack, log) {
       // and created by "dev-utils/make-distribution.sh".
       return 'aws-lambda-layer';
     } else if (process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S') {
-      // This envvar will be set in versions of apm-mutating-webhook after v0.1.0.
-      // https://github.com/elastic/apm-mutating-webhook/blob/4faff6299dc689491d628c26503568b09f078cfa/charts/apm-attacher/values.yaml#L33-L38
+      // This envvar will be set in versions of apm-k8s-attacher after v0.1.0.
+      // https://github.com/elastic/apm-k8s-attacher/blob/4faff6299dc689491d628c26503568b09f078cfa/charts/apm-attacher/values.yaml#L33-L38
       return 'k8s-attach';
     } else if (
       process.env.NODE_OPTIONS &&


### PR DESCRIPTION
## What is the change being made?

* Rename `apm-mutating-webhook` to `apm-k8s-attacher`

## Why is the change being made?

* The repository `apm-mutating-webhook` has been renamed to `apm-k8s-attacher`.