### PR TITLE
fix fastify deprecated routerMethod、routerPath

### DIFF
--- a/lib/instrumentation/modules/fastify.js
+++ b/lib/instrumentation/modules/fastify.js
@@ -70,8 +70,8 @@ module.exports = function (
 
     agent.logger.debug('adding onRequest hook to fastify');
     _fastify.addHook('onRequest', (req, reply, next) => {
-      const method = req.routerMethod || req.raw.method; // Fallback for fastify >3 <3.3.0
-      const url = req.routerPath || reply.context.config.url; // Fallback for fastify >3 <3.3.0
+      const method = req.routeOptions.method || req.raw.method; // Fallback for fastify > 4
+      const url = req.routeOptions.url || reply.context.config.url; // Fallback for fastify > 4
       const name = method + ' ' + url;
       agent._instrumentation.setDefaultTransactionName(name);
       next();


### PR DESCRIPTION
FastifyDeprecation: You are accessing the deprecated "request.routerMethod" property. Use "request.routeOptions.method" instead. Property "req.routerMethod" will be removed in `fastify@5`.
FastifyDeprecation: You are accessing the deprecated "request.routerPath" property. Use "request.routeOptions.url" instead. Property "req.routerPath" will be removed in `fastify@5`.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
