### PR TITLE
chore: revert node v18.18.2 version lock for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
         env:
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
-          network.host: '_site_'
+          º.host: '_site_'
           transport.host: '127.0.0.1'
           http.host: '0.0.0.0'
           xpack.security.enabled: 'false'
@@ -130,7 +130,7 @@ jobs:
           - '21.0'
           - '20'
           - '20.0'
-          - '18.18.2' # Skip >=18.19.0 until IITM double-import issue is resolved.
+          - '18'
           - '18.0'
           - '16'
           - '16.0'

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,23 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Update import-in-the-middle to version v1.7.2 which includes a fix
+  for the double import issue with Node v18.19. ({issues}3784[#3784])
+
+[float]
+===== Chores
+
 
 [[release-notes-4.3.0]]
 ==== 4.3.0 - 2023/12/05


### PR DESCRIPTION
IITM v1.7.2 includes a fix for ES modules loading off thread. So we can revet our test workflow configuration to the original values.

Closes: #3784 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Update workflow
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
