### PR TITLE
Add link to APM attacher docs

### DIFF
--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -18,6 +18,8 @@ To get you off the ground, we've prepared guides for setting up the Agent with a
 // end::web-frameworks-list[]
 
 Alternatively, you can <<custom-stack>>.
+For Kubernetes, we support auto-attachment using the {apm-attacher-ref}/index.html[APM attacher].
+
 To see an overview of which components of your application we instrument automatically,
 use the <<supported-technologies>> page.
 


### PR DESCRIPTION
### Summary

This PR adds a link to the [APM attacher docs](https://www.elastic.co/guide/en/apm/attacher/current/apm-attacher.html). Copied from the [Java agent docs](https://github.com/elastic/apm-agent-java/blob/9da66286823e374bb7f9a4b877a48d0bad288790/docs/setup-attach-cli.asciidoc?plain=1#L12).