### PR TITLE
fix(fastify): avoid the FSTDEP017 and FSTDEP018 deprecation warnings

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,25 @@ Notes:
 See the <<upgrade-to-v4>> guide.
 
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Improve Fastify instrumentation to no longer cause the https://fastify.dev/docs/latest/Reference/Warnings/#FSTDEP017[`FSTDEP017`]
+  and https://fastify.dev/docs/latest/Reference/Warnings/#FSTDEP018[`FSTDEP018`]
+  deprecation warnings.
+
+[float]
+===== Chores
+
+
 [[release-notes-4.3.0]]
 ==== 4.3.0 - 2023/12/05
 

--- a/lib/instrumentation/modules/fastify.js
+++ b/lib/instrumentation/modules/fastify.js
@@ -11,6 +11,31 @@
 
 const semver = require('semver');
 
+// Return the fastify route or request method, without hitting a Fastify
+// deprecation warning.
+// https://fastify.dev/docs/latest/Reference/Warnings/#FSTDEP018
+function fastifyRouteMethod(req) {
+  if (req.routeOptions) {
+    // `.routeOptions` was added in fastify@4.10.0.
+    return req.routeOptions.method;
+  } else {
+    return req.routerMethod || req.raw.method; // Fallback for fastify >3 <3.3.0
+  }
+}
+
+// Return the fastify route or request URL, without hitting a Fastify
+// deprecation warning.
+// https://fastify.dev/docs/latest/Reference/Warnings/#FSTDEP017
+function fastifyRouteUrl(req, reply) {
+  if (req.routeOptions) {
+    // `.routeOptions` was added in fastify@4.10.0.
+    // Note that `.routeOptions.url` might be undefined for a 404 route.
+    return req.routeOptions.url;
+  } else {
+    return req.routerPath || reply.context.config.url; // Fallback for fastify >3 <3.3.0
+  }
+}
+
 module.exports = function (
   modExports,
   agent,
@@ -70,8 +95,8 @@ module.exports = function (
 
     agent.logger.debug('adding onRequest hook to fastify');
     _fastify.addHook('onRequest', (req, reply, next) => {
-      const method = req.routerMethod || req.raw.method; // Fallback for fastify >3 <3.3.0
-      const url = req.routerPath || reply.context.config.url; // Fallback for fastify >3 <3.3.0
+      const method = fastifyRouteMethod(req);
+      const url = fastifyRouteUrl(req, reply);
       const name = method + ' ' + url;
       agent._instrumentation.setDefaultTransactionName(name);
       next();


### PR DESCRIPTION
Obsoletes: #3789

* * *

This works on the same issue as #3789. It re-uses some lessons from the similar https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1763 that I did a few months back.