### PR TITLE
chore: support 'K8S_ATTACH' value for 'ELASTIC_APM_ACTIVATION_METHOD'

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,11 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Chores
 
+* Support `ELASTIC_APM_ACTIVATION_METHOD=K8S_ATTACH` (in addition to the
+  current `K8S` value) to indicate the agent is being started by
+  apm-k8s-attacher.  Newer releases of apm-k8s-attacher will be using this
+  value (to have a common value used between APM agents).
+
 
 [[release-notes-4.3.0]]
 ==== 4.3.0 - 2023/12/05

--- a/lib/activation-method.js
+++ b/lib/activation-method.js
@@ -82,8 +82,10 @@ function agentActivationMethodFromStartStack(startStack, log) {
       // This path is defined by https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
       // and created by "dev-utils/make-distribution.sh".
       return 'aws-lambda-layer';
-    } else if (process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S_ATTACH' ||
-        process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S') {
+    } else if (
+      process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S_ATTACH' ||
+      process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S'
+    ) {
       // apm-k8s-attacher v0.1.0 started setting value to K8S.
       // v0.4.0 will start using 'K8S_ATTACH'.
       return 'k8s-attach';

--- a/lib/activation-method.js
+++ b/lib/activation-method.js
@@ -34,7 +34,7 @@ const CONTAINS_R_ELASTIC_APM_NODE_START =
  *         import 'elastic-apm-node/start.js'
  *         import apm from 'elastic-apm-node'; apm.start()
  *    - "aws-lambda-layer": `NODE_OPTIONS` using Agent installed at /opt/nodejs/node_modules/elastic-apm-node
- *    - "k8s-attach": `NODE_OPTIONS` using Agent, and `ELASTIC_APM_ACTIVATION_METHOD=K8S` in env
+ *    - "k8s-attach": `NODE_OPTIONS` using Agent, and `ELASTIC_APM_ACTIVATION_METHOD=K8S_ATTACH` (or `K8S` for bwcompat to earlier apm-k8s-attacher versions) in env
  *    - "env-attach": Fallback for any other usage of NODE_OPTIONS='-r elastic-apm-node/start'
  *    - "preload": For usage of `node -r elastic-apm-node/start` without `NODE_OPTIONS`.
  */
@@ -82,9 +82,10 @@ function agentActivationMethodFromStartStack(startStack, log) {
       // This path is defined by https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
       // and created by "dev-utils/make-distribution.sh".
       return 'aws-lambda-layer';
-    } else if (process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S') {
-      // This envvar will be set in versions of apm-k8s-attacher after v0.1.0.
-      // https://github.com/elastic/apm-k8s-attacher/blob/4faff6299dc689491d628c26503568b09f078cfa/charts/apm-attacher/values.yaml#L33-L38
+    } else if (process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S_ATTACH' ||
+        process.env.ELASTIC_APM_ACTIVATION_METHOD === 'K8S') {
+      // apm-k8s-attacher v0.1.0 started setting value to K8S.
+      // v0.4.0 will start using 'K8S_ATTACH'.
       return 'k8s-attach';
     } else if (
       process.env.NODE_OPTIONS &&


### PR DESCRIPTION
This is a the new favoured value for the envvar to indicate the apm-k8s-attacher
is being used. This still supports the old 'K8S' value, so the current release of
apm-k8s-attacher still works to properly set `activation_method`.

This should be backported.

Refs: https://github.com/elastic/apm-k8s-attacher/issues/91
