### PR TITLE
fix(mongodb): fix #3834

### DIFF
--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -222,6 +222,10 @@ module.exports = (mongodb, agent, { version, enabled }) => {
   }
 
   function collectionFor(event) {
+    if (event.commandName === 'getMore') {
+      return event.command.collection;
+    }
+    
     const collection = event.command[event.commandName];
     return typeof collection === 'string' ? collection : '$cmd';
   }


### PR DESCRIPTION
command started event example:

```jsx
{
  event: CommandStartedEvent {
    name: 'commandStarted',
    address: '172.20.0.2:27017',
    connectionId: 12,
    serviceId: undefined,
    requestId: 686,
    databaseName: 'mydatabase',
    commandName: 'getMore',
    command: {
      getMore: new Long('1769182660590360229'),
      collection: 'Interaction',
      batchSize: 1000,
      lsid: [Object],
      '$clusterTime': [Object],
      '$db': 'mydatabase'
    }
  },
  commandName: 'getMore',
  collection: new Long('1769182660590360229')
}
```

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
