### PR TITLE
chore: clarify koa-router instrumentation range

### DIFF
--- a/lib/instrumentation/modules/koa-router.js
+++ b/lib/instrumentation/modules/koa-router.js
@@ -12,7 +12,7 @@ var shimmer = require('../shimmer');
 
 module.exports = function (Router, agent, { version, enabled }) {
   if (!enabled) return Router;
-  if (!semver.satisfies(version, '>=5.2.0 <=12')) {
+  if (!semver.satisfies(version, '>=5.2.0 <13')) {
     agent.logger.debug(
       'koa-router version %s not supported - aborting...',
       version,

--- a/lib/instrumentation/modules/mongodb.js
+++ b/lib/instrumentation/modules/mongodb.js
@@ -19,7 +19,7 @@ const HOSTNAME_PORT_RE = /^(.+):(\d+)$/;
 
 module.exports = (mongodb, agent, { version, enabled }) => {
   if (!enabled) return mongodb;
-  if (!semver.satisfies(version, '>=3.3 <7.0')) {
+  if (!semver.satisfies(version, '>=3.3 <7')) {
     agent.logger.debug(
       'mongodb version %s not instrumented (mongodb <3.3 is instrumented via mongodb-core)',
       version,


### PR DESCRIPTION
No functional change. However, I was confused for a little while that
'12.0.1' satisfies '>=5.2.0 <=12'. To me it isn't self-explanatory
that '<=12' is not the same as '<=12.0.0'.
