### PR TITLE
Fix incorrect hostname detection on Windows

### DIFF
--- a/lib/apm-client/http-apm-client/detect-hostname.js
+++ b/lib/apm-client/http-apm-client/detect-hostname.js
@@ -30,7 +30,15 @@ function detectHostname() {
       // https://learn.microsoft.com/en-us/dotnet/api/system.net.dns.gethostentry
       out = spawnSync(
         'powershell.exe',
-        ['[System.Net.Dns]::GetHostEntry($env:computerName).HostName'],
+        [
+          '-NoLogo',
+          '-NonInteractive',
+          '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-Command',
+          '[System.Net.Dns]::GetHostEntry($env:computerName).HostName',
+        ],
         { encoding: 'utf8', shell: true, timeout: 2000 },
       );
       if (!out.error) {


### PR DESCRIPTION
In some cases, the PowerShell command that is used to detect the hostname will contain extra output before the hostname, e.g. the Microsoft copyright banner or any output that is printed in the PowerShell profiles. This causes invalid hostnames to be sent to the APM server.

This change ensures that the PowerShell output is limited only to the hostname.