### PR TITLE
feat: add support for tedious v17

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -335,6 +335,9 @@ tedious:
   - versions: '16.0.0 || 16.1.0 || >16.1.0 <17' # first and last majors subset of '16.x'
     node: '>=16'
     commands: node test/instrumentation/modules/tedious.test.js
+  - versions: '>=17.0.0 <18' # first and last majors subset of '17.x' (as for now there is only v17.0.0)
+    node: '>=20'
+    commands: node test/instrumentation/modules/tedious.test.js
 
 cassandra-driver:
   # 3.1.0 is broken

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,8 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Features
 
+* Add support for `tedious` version v17. ({pull}[#])
+
 [float]
 ===== Bug fixes
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,7 +41,7 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Features
 
-* Add support for `tedious` version v17. ({pull}[#])
+* Add support for `tedious` version v17. ({pull}3901[#3901])
 
 [float]
 ===== Bug fixes

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -139,7 +139,7 @@ so those should be supported as well.
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <4.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/redis[redis] |>=2.0.0 <5.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <17.0.0 | (Excluding v4.0.0.) Will instrument all queries
+|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <18.0.0 | (Excluding v4.0.0.) Will instrument all queries
 |https://www.npmjs.com/package/undici[undici] | >=4.7.1 <6 | Will instrument undici HTTP requests, except HTTP CONNECT. Requires node v14.17.0 or later, or the user to have installed the https://www.npmjs.com/package/diagnostics_channel['diagnostics_channel' polyfill].
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages
 |=======================================================================

--- a/lib/apm-client/http-apm-client/detect-hostname.js
+++ b/lib/apm-client/http-apm-client/detect-hostname.js
@@ -30,7 +30,15 @@ function detectHostname() {
       // https://learn.microsoft.com/en-us/dotnet/api/system.net.dns.gethostentry
       out = spawnSync(
         'powershell.exe',
-        ['[System.Net.Dns]::GetHostEntry($env:computerName).HostName'],
+        [
+          '-NoLogo',
+          '-NonInteractive',
+          '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-Command',
+          '[System.Net.Dns]::GetHostEntry($env:computerName).HostName',
+        ],
         { encoding: 'utf8', shell: true, timeout: 2000 },
       );
       if (!out.error) {

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -14,7 +14,7 @@ var { getDBDestination } = require('../context');
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious;
-  if (version === '4.0.0' || !semver.satisfies(version, '>=1.9.0 <17')) {
+  if (version === '4.0.0' || !semver.satisfies(version, '>=1.9.0 <18')) {
     agent.logger.debug(
       'tedious version %s not supported - aborting...',
       version,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10363,9 +10363,9 @@
       }
     },
     "node_modules/fastify": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.1.tgz",
-      "integrity": "sha512-tznA/G55dsxzM5XChBfcvVSloG2ejeeotfPPJSFaWmHyCDVGMpvf3nRNbsCb/JTBF9RmQFBfuujWt3Nphjesng==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.2.tgz",
+      "integrity": "sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==",
       "dev": true,
       "funding": [
         {
@@ -26436,9 +26436,9 @@
       }
     },
     "fastify": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.1.tgz",
-      "integrity": "sha512-tznA/G55dsxzM5XChBfcvVSloG2ejeeotfPPJSFaWmHyCDVGMpvf3nRNbsCb/JTBF9RmQFBfuujWt3Nphjesng==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.2.tgz",
+      "integrity": "sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==",
       "dev": true,
       "requires": {
         "@fastify/ajv-compiler": "^3.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "rimraf": "^5.0.1",
         "tap-junit": "^5.0.1",
         "tape": "^5.0.0",
-        "tedious": "^16.1.0",
+        "tedious": "^17.0.0",
         "test-all-versions": "^6.1.0",
         "thunky": "^1.1.0",
         "tree-kill": "^1.2.2",
@@ -17147,9 +17147,9 @@
       }
     },
     "node_modules/tedious": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.7.0.tgz",
-      "integrity": "sha512-AwZeknjoPSg1z4sDkZYIpNUzqq3/GrPRWxoJEY0yL2RJbbIViD+AURnC+apbNpUza7sOUONagO1FQf74en8gxw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-17.0.0.tgz",
+      "integrity": "sha512-tXsl/kvDAFpnXU+ooEOQyrXdJFD0/OWvPq9i1bDhbOvoFGcrZURiXyUxbI8gJPsG6o2K5fs3HX6zRTSxuCUC5g==",
       "dev": true,
       "dependencies": {
         "@azure/identity": "^3.4.1",
@@ -17162,11 +17162,10 @@
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
         "node-abort-controller": "^3.1.1",
-        "punycode": "^2.3.0",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/tedious/node_modules/bl": {
@@ -31606,9 +31605,9 @@
       "dev": true
     },
     "tedious": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.7.0.tgz",
-      "integrity": "sha512-AwZeknjoPSg1z4sDkZYIpNUzqq3/GrPRWxoJEY0yL2RJbbIViD+AURnC+apbNpUza7sOUONagO1FQf74en8gxw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-17.0.0.tgz",
+      "integrity": "sha512-tXsl/kvDAFpnXU+ooEOQyrXdJFD0/OWvPq9i1bDhbOvoFGcrZURiXyUxbI8gJPsG6o2K5fs3HX6zRTSxuCUC5g==",
       "dev": true,
       "requires": {
         "@azure/identity": "^3.4.1",
@@ -31621,7 +31620,6 @@
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
         "node-abort-controller": "^3.1.1",
-        "punycode": "^2.3.0",
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "rimraf": "^5.0.1",
     "tap-junit": "^5.0.1",
     "tape": "^5.0.0",
-    "tedious": "^16.1.0",
+    "tedious": "^17.0.0",
     "test-all-versions": "^6.1.0",
     "thunky": "^1.1.0",
     "tree-kill": "^1.2.2",

--- a/test/instrumentation/modules/tedious.test.js
+++ b/test/instrumentation/modules/tedious.test.js
@@ -24,6 +24,7 @@ const tediousVer =
   require('../../../node_modules/tedious/package.json').version;
 const semver = require('semver');
 if (
+  (semver.gte(tediousVer, '17.0.0') && semver.lt(process.version, '18.0.0')) ||
   (semver.gte(tediousVer, '16.0.0') && semver.lt(process.version, '16.0.0')) ||
   (semver.gte(tediousVer, '15.0.0') && semver.lt(process.version, '14.0.0')) ||
   (semver.gte(tediousVer, '12.0.0') && semver.lt(process.version, '12.3.0')) ||


### PR DESCRIPTION
v17 release does not have major changes but just drops node versions support.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [x] Update documentation
- [x] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
