### PR TITLE
fix(next, redis, mongodb): ensure module sub-path RITM hooks are applied on Windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,7 +52,7 @@ See the <<upgrade-to-v4>> guide.
   ({pull}3897[#3897])
 
 * Fix a path normalization issue that broke (or partially broke) instrumentation
-  of some modules on Windows: Next.js, redis v4+, mongodb.
+  of some modules on Windows: Next.js, redis v4+, mongodb. ({pull}3905[#3905])
 
 [float]
 ===== Chores

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,9 @@ See the <<upgrade-to-v4>> guide.
   included changes that resulted in the APM agent's instrumentation breaking it.
   ({pull}3897[#3897])
 
+* Fix a path normalization issue that broke (or partially broke) instrumentation
+  of some modules on Windows: Next.js, redis v4+, mongodb.
+
 [float]
 ===== Chores
 

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -160,6 +160,10 @@ function modNameFromModPath(modPath) {
   }
 }
 
+function normPathSeps(s) {
+  return path.sep !== '/' ? s.split(path.sep).join('/') : s;
+}
+
 /**
  * Holds the registered set of "patchers" (functions that monkey patch imported
  * modules) for a module path (`modPath`).
@@ -558,6 +562,10 @@ Instrumentation.prototype._restartHooks = function () {
       if (self._lambdaHandlerInfo?.modName === modPath) {
         modPath = self._lambdaHandlerInfo.filePath;
         version = process.env.AWS_LAMBDA_FUNCTION_VERSION || '';
+      } else {
+        // RITM returns `modPath` using native path separators. However,
+        // _patcherReg is keyed with '/' separators, so we need to normalize.
+        modPath = normPathSeps(modPath);
       }
 
       if (!self._patcherReg.has(modPath)) {

--- a/test/instrumentation/modules/next/next.test.js
+++ b/test/instrumentation/modules/next/next.test.js
@@ -6,11 +6,6 @@
 
 'use strict';
 
-if (process.env.GITHUB_ACTIONS === 'true' && process.platform === 'win32') {
-  console.log('# SKIP: GH Actions do not support docker services on Windows');
-  process.exit(0);
-}
-
 // Test Next.js instrumentation.
 //
 // This test roughly does the following:


### PR DESCRIPTION
For some instrumentations we path module sub-paths (e.g. mongodb/lib/foo.js).
On Windows RITM returns modPath=mongodb\lib\foo.js. This change adds path
separator normalization so those values equate. Before this the module
patcher for that subpath was not applied.

* * *

This impacts instrumentation for Next.js, redis v4+, and part of the instrumentation for mongodb.
The reason this wasn't caught in testing is because:
- for other reasons testing Next.js on Windows is a limitation (process control things, see comments in the test file)
- redis and mongodb (among other) instrumentations are not tested on Windows because GH actions does not support "services" on Windows runners