### PR TITLE
chore: modernize issue/pull labeler action

### DIFF
--- a/.github/community-label.yml
+++ b/.github/community-label.yml
@@ -1,5 +1,0 @@
-# add 'community' label to all new issues and PRs created by the community
-community:
-  - '.*'
-triage:
-  - '.*'

--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -1,3 +1,0 @@
-# add 'agent-nodejs' label to all new issues
-agent-nodejs:
-  - '.*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,25 +4,20 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
+# 'issues: write' for https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue
 permissions:
   contents: read
-  # This permission is needed to add labels to issues/PRs per
-  # https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue
   issues: write
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - name: Add agent-nodejs label to this issue/PR
-      uses: AlexanderWert/issue-labeler@v2.3
+    - name: Add agent-nodejs label
+      uses: actions-ecosystem/action-add-labels@v1
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/labeler-config.yml
-        enable-versioned-regex: 0
+        labels: agent-nodejs
     - name: Check team membership for user
       uses: elastic/get-user-teams-membership@1.1.0
       id: checkUserMember
@@ -34,21 +29,10 @@ jobs:
           dependabot
           dependabot[bot]
         GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
-    - name: Show team membership
-      run: |
-        echo "::debug::isTeamMember: ${{ steps.checkUserMember.outputs.isTeamMember }}"
-        echo "::debug::isExcluded: ${{ steps.checkUserMember.outputs.isExcluded }}"
     - name: Add community and triage labels
       if: steps.checkUserMember.outputs.isTeamMember != 'true' && steps.checkUserMember.outputs.isExcluded != 'true'
-      uses: AlexanderWert/issue-labeler@v2.3
+      uses: actions-ecosystem/action-add-labels@v1
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/community-label.yml
-        enable-versioned-regex: 0
-    - name: Assign new internal pull requests to project
-      uses: elastic/assign-one-project-github-action@1.2.2
-      if: (steps.checkUserMember.outputs.isTeamMember == 'true' || steps.checkUserMember.outputs.isExcluded == 'true') && github.event.pull_request
-      with:
-        project: 'https://github.com/orgs/elastic/projects/454'
-        project_id: '5882982'
-        column_name: 'In Progress'
+        labels: |
+          community
+          triage

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions-ecosystem/action-add-labels@v1
       with:
         labels: agent-nodejs
+
     - name: Check team membership for user
       uses: elastic/get-user-teams-membership@1.1.0
       id: checkUserMember
@@ -29,6 +30,7 @@ jobs:
           dependabot
           dependabot[bot]
         GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+
     - name: Add community and triage labels
       if: steps.checkUserMember.outputs.isTeamMember != 'true' && steps.checkUserMember.outputs.isExcluded != 'true'
       uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
This is based on the more-recently updated labeler.yml in the apm-agent-dotnet repo.

- Switch away from Alex's old unmaintained issue-labeler action.
- Remove old debugging "Show team membership" step.
- Stop assigning the issue to project 454 (and old GH proj we no longer use)
- The hope is that these changes will also close #3884.
