### PR TITLE
feat: add support for tedious v18

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -335,7 +335,7 @@ tedious:
   - versions: '16.0.0 || 16.1.0 || >16.1.0 <17' # first and last majors subset of '16.x'
     node: '>=16'
     commands: node test/instrumentation/modules/tedious.test.js
-  - versions: '>=17.0.0 <18' # first and last majors subset of '17.x' (as for now there is only v17.0.0)
+  - versions: '>=17.0.0 <19' # first and last majors subset of '17.x' (as for now there is only v17.0.0)
     node: '18.x || >=20'
     commands: node test/instrumentation/modules/tedious.test.js
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,7 +42,7 @@ See the <<upgrade-to-v4>> guide.
 ===== Features
 
 * Update <<opentelemetry-bridge>> support to `@opentelemetry/api` version 1.8.0.
-* Add support for `tedious` version v17. ({pull}3901[#3901])
+* Add support for `tedious` versions 17 and 18. ({pull}3901[#3901])
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,7 +42,7 @@ See the <<upgrade-to-v4>> guide.
 ===== Features
 
 * Update <<opentelemetry-bridge>> support to `@opentelemetry/api` version 1.8.0.
-* Add support for `tedious` versions 17 and 18. ({pull}3901[#3901])
+* Add support for `tedious` versions 17 and 18. ({pull}3901[#3901], {pull}3911[#3911])
 
 [float]
 ===== Bug fixes

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -139,7 +139,7 @@ so those should be supported as well.
 |https://www.npmjs.com/package/mysql2[mysql2] |>=1.0.0 <4.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/pg[pg] |>=4.0.0 <9.0.0 |Will instrument all queries
 |https://www.npmjs.com/package/redis[redis] |>=2.0.0 <5.0.0 |Will instrument all queries
-|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <18.0.0 | (Excluding v4.0.0.) Will instrument all queries
+|https://www.npmjs.com/package/tedious[tedious] |>=1.9 <19.0.0 | (Excluding v4.0.0.) Will instrument all queries
 |https://www.npmjs.com/package/undici[undici] | >=4.7.1 <6 | Will instrument undici HTTP requests, except HTTP CONNECT. Requires node v14.17.0 or later, or the user to have installed the https://www.npmjs.com/package/diagnostics_channel['diagnostics_channel' polyfill].
 |https://www.npmjs.com/package/ws[ws] |>=1.0.0 <8.0.0 |Will instrument outgoing WebSocket messages
 |=======================================================================

--- a/lib/instrumentation/modules/tedious.js
+++ b/lib/instrumentation/modules/tedious.js
@@ -14,7 +14,7 @@ var { getDBDestination } = require('../context');
 
 module.exports = function (tedious, agent, { version, enabled }) {
   if (!enabled) return tedious;
-  if (version === '4.0.0' || !semver.satisfies(version, '>=1.9.0 <18')) {
+  if (version === '4.0.0' || !semver.satisfies(version, '>=1.9.0 <19')) {
     agent.logger.debug(
       'tedious version %s not supported - aborting...',
       version,

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "rimraf": "^5.0.1",
         "tap-junit": "^5.0.1",
         "tape": "^5.0.0",
-        "tedious": "^17.0.0",
+        "tedious": "^18.1.0",
         "test-all-versions": "^6.1.0",
         "thunky": "^1.1.0",
         "tree-kill": "^1.2.2",
@@ -5275,9 +5275,9 @@
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.5.3.tgz",
-      "integrity": "sha512-7dqNYwG8gCt4hfg5PKgM7xLEcgSBcx/UgC92OMnhMmvAnq11QzDFPrxUkNR/u5kn17WWLZ8beZ4A3Qrz4pZcmQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-Xla/d7ZMMR6+zRd6lTio0wRZECfcfFJP7GGe9A9L4tDOlD5CX4YcZ4YZle9w58bBYzssojVapI84RraKWDQZRg==",
       "dev": true
     },
     "node_modules/@koa/router": {
@@ -6640,6 +6640,16 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
+      "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -7569,6 +7579,87 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+    },
+    "node_modules/bl": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
+      "integrity": "sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bl/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/bl/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -9164,27 +9255,6 @@
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.10"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-aggregate-error": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.9.tgz",
-      "integrity": "sha512-fvnX40sb538wdU6r4s35cq4EY6Lr09Upj40BEVem4LEsuW8XgQep9yD5Q1U2KftokNp1rWODFJ2qwZSsAjFpbg==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "function-bind": "^1.1.1",
-        "functions-have-names": "^1.2.3",
-        "get-intrinsic": "^1.1.3",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12531,12 +12601,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/jsbi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==",
       "dev": true
     },
     "node_modules/jsbn": {
@@ -17108,69 +17172,23 @@
       }
     },
     "node_modules/tedious": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-17.0.0.tgz",
-      "integrity": "sha512-tXsl/kvDAFpnXU+ooEOQyrXdJFD0/OWvPq9i1bDhbOvoFGcrZURiXyUxbI8gJPsG6o2K5fs3HX6zRTSxuCUC5g==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-18.1.0.tgz",
+      "integrity": "sha512-3o9VZDPY9B5JBEsD0BuLXxvyRDFP11YVQS3JXr1JmV+0aISbpsn/Hj9LycyxAGBzdD1gU4Z2ME5RGq43QHdRNw==",
       "dev": true,
       "dependencies": {
         "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.6.1",
+        "@types/node": ">=18",
+        "bl": "^6.0.11",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.3"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tedious/node_modules/bl": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.3.tgz",
-      "integrity": "sha512-ZmReEQkPP4zOjCHVzGpXYLvf95/HnvwsNZ1sh2dhoy6OxqX9Sl3JF7UmoKXlXE40AjldnWlsSxvqDiDrgSCJDA==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/tedious/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/tedious/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/tedious/node_modules/iconv-lite": {
@@ -17185,46 +17203,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tedious/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/tedious/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/tedious/node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
     "node_modules/test-all-versions": {
@@ -22431,9 +22413,9 @@
       }
     },
     "@js-joda/core": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.5.3.tgz",
-      "integrity": "sha512-7dqNYwG8gCt4hfg5PKgM7xLEcgSBcx/UgC92OMnhMmvAnq11QzDFPrxUkNR/u5kn17WWLZ8beZ4A3Qrz4pZcmQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-Xla/d7ZMMR6+zRd6lTio0wRZECfcfFJP7GGe9A9L4tDOlD5CX4YcZ4YZle9w58bBYzssojVapI84RraKWDQZRg==",
       "dev": true
     },
     "@koa/router": {
@@ -23563,6 +23545,16 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "@types/readable-stream": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
+      "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -24276,6 +24268,55 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+    },
+    "bl": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
+      "integrity": "sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==",
+      "dev": true,
+      "requires": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+          "dev": true
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        }
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -25514,21 +25555,6 @@
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.10"
-      }
-    },
-    "es-aggregate-error": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.9.tgz",
-      "integrity": "sha512-fvnX40sb538wdU6r4s35cq4EY6Lr09Upj40BEVem4LEsuW8XgQep9yD5Q1U2KftokNp1rWODFJ2qwZSsAjFpbg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "function-bind": "^1.1.1",
-        "functions-have-names": "^1.2.3",
-        "get-intrinsic": "^1.1.3",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.0"
       }
     },
     "es-define-property": {
@@ -27974,12 +28000,6 @@
           "dev": true
         }
       }
-    },
-    "jsbi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==",
-      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -31531,51 +31551,22 @@
       "dev": true
     },
     "tedious": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-17.0.0.tgz",
-      "integrity": "sha512-tXsl/kvDAFpnXU+ooEOQyrXdJFD0/OWvPq9i1bDhbOvoFGcrZURiXyUxbI8gJPsG6o2K5fs3HX6zRTSxuCUC5g==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-18.1.0.tgz",
+      "integrity": "sha512-3o9VZDPY9B5JBEsD0BuLXxvyRDFP11YVQS3JXr1JmV+0aISbpsn/Hj9LycyxAGBzdD1gU4Z2ME5RGq43QHdRNw==",
       "dev": true,
       "requires": {
         "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.6.1",
+        "@types/node": ">=18",
+        "bl": "^6.0.11",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.3"
       },
       "dependencies": {
-        "bl": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.3.tgz",
-          "integrity": "sha512-ZmReEQkPP4zOjCHVzGpXYLvf95/HnvwsNZ1sh2dhoy6OxqX9Sl3JF7UmoKXlXE40AjldnWlsSxvqDiDrgSCJDA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^6.0.3",
-            "inherits": "^2.0.4",
-            "readable-stream": "^4.2.0"
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-          "dev": true
-        },
         "iconv-lite": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -31585,29 +31576,10 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
         "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "rimraf": "^5.0.1",
     "tap-junit": "^5.0.1",
     "tape": "^5.0.0",
-    "tedious": "^17.0.0",
+    "tedious": "^18.1.0",
     "test-all-versions": "^6.1.0",
     "thunky": "^1.1.0",
     "tree-kill": "^1.2.2",


### PR DESCRIPTION
Tedious v18 was released recently (soon after v17 was released):

```
...
  '16.6.0': '2023-10-21T13:29:58.966Z',
  '16.6.1': '2023-11-19T21:21:36.654Z',
  '16.7.0': '2024-01-31T21:53:12.246Z',
  '16.7.1': '2024-02-09T15:03:06.383Z',
  '17.0.0': '2024-02-11T17:27:44.577Z',
  '18.0.0': '2024-02-28T21:21:55.511Z',
  '18.1.0': '2024-03-02T10:47:28.209Z'
```