### PR TITLE
ci: fix 'test-nightly' job in 'edge' CI workflow

### DIFF
--- a/.ci/docker/docker-compose-all.yml
+++ b/.ci/docker/docker-compose-all.yml
@@ -84,3 +84,5 @@ volumes:
     driver: local
   nodekafkadata:
     driver: local
+  nodezookeeperdata:
+    driver: local

--- a/.ci/docker/docker-compose-edge.yml
+++ b/.ci/docker/docker-compose-edge.yml
@@ -41,6 +41,10 @@ services:
     extends:
       file: docker-compose.yml
       service: kafka
+  zookeeper:
+    extends:
+      file: docker-compose.yml
+      service: zookeeper
   node_tests:
     extends:
       file: docker-compose-node-edge-test.yml
@@ -83,4 +87,6 @@ volumes:
   nodecassandradata:
     driver: local
   nodekafkadata:
+    driver: local
+  nodezookeeperdata:
     driver: local

--- a/.ci/docker/docker-compose-kafka.yml
+++ b/.ci/docker/docker-compose-kafka.yml
@@ -16,10 +16,8 @@ services:
       file: docker-compose-node-test.yml
       service: node_tests
     depends_on:
-      - kafka
-      # TODO: uncomment this if health_check is necessary
-      # kafka:
-      #   condition: service_healthy
+      kafka:
+        condition: service_healthy
 
 volumes:
   nodekafkadata:

--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -168,14 +168,12 @@ services:
       - KAFKA_CFG_DELETE_TOPIC_ENABLE=true
     depends_on:
       - zookeeper
-    # TODO: maybe not necessary  but figure out how to do this
     healthcheck:
-      # use netcat to check tcp connection available
-      # test: nc -z localhost 9093 || exit -1
-      # start_period: 15s
-      # interval: 5s
-      # timeout: 10s
-      # retries: 5
+      # Kafka healthcheck ideas from https://github.com/wurstmeister/kafka-docker/issues/167
+      test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
 volumes:
   nodepgdata:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -162,10 +162,9 @@ services:
     depends_on:
       - zookeeper
     healthcheck:
-      # use netcat to check tcp connection available
-      test: nc -z localhost 9093 || exit -1
-      start_period: 15s
-      interval: 5s
+      # Kafka healthcheck ideas from https://github.com/wurstmeister/kafka-docker/issues/167
+      test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1
+      interval: 30s
       timeout: 10s
       retries: 5
 


### PR DESCRIPTION
This adds the require zookeeper volume refs.

Closes: https://github.com/elastic/apm-agent-nodejs/issues/3922
