### PR TITLE
test: add healthcheck for zookeeper test service so 'npm test' works outside of CI

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -149,6 +149,13 @@ services:
       - nodezookeeperdata:/bitnami
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
+    healthcheck:
+      # Using 'srvr' instead of the more common 'ruok' because this bitnami
+      # image does not have 'ruok' on the '4lw.commands.whitelist' in zoo.cfg.
+      test: ["CMD-SHELL", "echo srvr | nc -w 2 localhost 2181"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   kafka:
     # https://hub.docker.com/r/bitnami/kafka/tags

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -141,6 +141,13 @@ services:
       - nodezookeeperdata:/var/lib/zookeeper/data
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
+    healthcheck:
+      # Using 'srvr' instead of the more common 'ruok' because this bitnami
+      # image does not have 'ruok' on the '4lw.commands.whitelist' in zoo.cfg.
+      test: ["CMD-SHELL", "echo srvr | nc -w 2 localhost 2181"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   kafka:
     # https://hub.docker.com/r/bitnami/kafka/tags


### PR DESCRIPTION
Running 'npm test' outside of CI will start all test services in docker
*then wait for them to all be healthy*. Without a healthcheck for zk
the 'wait_for_healthy' in test/script/run_tests.sh would never pass.
