### PR TITLE
chore: add contributors to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "distributed-tracing"
   ],
   "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
+  "contributors": [
+    "Elastic Observability <https://www.elastic.co/observability>"
+  ],
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/elastic/apm-agent-nodejs/issues"


### PR DESCRIPTION
there was a internal conversation about changing the `author` field. This is my proposal to add info about the observability team within the `package.json` file

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
