### PR TITLE
github-action: provenance generation (initial attempt) 

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -37,10 +37,12 @@ env:
 
 # Create Docker image
 build-docker: validate-version
+	@echo "Obsoleted, use GitHub actions"
 	docker build -t $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(AGENT_VERSION) \
   --build-arg AGENT_DIR=$(DIST_DIR) ..
 
 push-docker: build-docker
+	@echo "Obsoleted, use GitHub actions"
 	../dev-utils/push-docker.sh $(DOCKER_REGISTRY) $(DOCKER_IMAGE_NAME) $(AGENT_VERSION)
 
 # List all the AWS regions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - v*.*.*
     branches:
       - main
-      - feature/sbom
+      - feature/provenance
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,12 @@ jobs:
 
       - name: Publish AWS lambda (only for tag release)
         if: startsWith(github.ref, 'refs/tags')
-        run: make -C .ci publish-in-all-aws-regions create-arn-file
+        run: echo 'make -C .ci publish-in-all-aws-regions create-arn-file'
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: create github release (only for tag release)
-        run: make -C .ci github-release
+        run: echo 'make -C .ci github-release'
         if: startsWith(github.ref, 'refs/tags')
         env:
           GH_TOKEN: ${{ github.token }}
@@ -115,7 +115,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         run: |-
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
-          npm publish --otp=${{ env.TOTP_CODE }}
+          echo 'npm publish' # --otp=${{ env.TOTP_CODE }}
 
       - if: always()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
           echo 'npm publish' # --otp=${{ env.TOTP_CODE }}
 
-      - if: always()
+      - if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,20 @@ on:
   push:
     tags:
       - v*.*.*
+    branches:
+      - main
+      - feature/sbom
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,7 +39,43 @@ jobs:
 
       - run: make -C .ci dist
 
-      - run: make -C .ci push-docker
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/build/aws/*.zip"
+
+      - id: setup-docker
+        name: Set up docker variables
+        run: |-
+          if [ "${{ startsWith(github.ref, 'refs/tags') }}" == "false" ] ; then
+            # for testing purposes
+            echo "tag=test" >> "${GITHUB_OUTPUT}"
+            echo "latest=test-latest" >> "${GITHUB_OUTPUT}"
+          else
+            # version without v prefix (e.g. 1.2.3)
+            echo "tag=${GITHUB_REF_NAME/v/}" >> "${GITHUB_OUTPUT}"
+            echo "latest=latest" >> "${GITHUB_OUTPUT}"
+          fi
+
+      # Use docker/build-push-action@v5.3.0 in conjunction with github-early-access/generate-build-provenance@main
+      - name: Build and Push Docker Image
+        id: push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.setup-docker.outputs.tag }}
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.setup-docker.outputs.latest }}
+          build-args: |
+            AGENT_DIR=/build/dist/nodejs
+
+      - name: Attest image
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: "${{ env.DOCKER_IMAGE_NAME }}:${{ steps.setup-docker.outputs.tag }}"
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false
 
       - name: Read AWS vault secrets
         uses: hashicorp/vault-action@v3.0.0
@@ -46,12 +88,15 @@ jobs:
             secret/observability-team/ci/service-account/apm-aws-lambda access_key_id | AWS_ACCESS_KEY_ID ;
             secret/observability-team/ci/service-account/apm-aws-lambda secret_access_key | AWS_SECRET_ACCESS_KEY
 
-      - name: Publish AWS lambda
+      - name: Publish AWS lambda (only for tag release)
+        if: startsWith(github.ref, 'refs/tags')
         run: make -C .ci publish-in-all-aws-regions create-arn-file
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - run: make -C .ci github-release
+      - name: create github release (only for tag release)
+        run: make -C .ci github-release
+        if: startsWith(github.ref, 'refs/tags')
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -66,7 +111,8 @@ jobs:
             secret/jenkins-ci/npmjs/elasticmachine token | NPMJS_TOKEN ;
             totp/code/npmjs-elasticmachine code | TOTP_CODE
 
-      - name: npm publish
+      - name: npm publish (only for tag release)
+        if: startsWith(github.ref, 'refs/tags')
         run: |-
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
           npm publish --otp=${{ env.TOTP_CODE }}


### PR DESCRIPTION
## What does this pull request do?

Run the release steps partially for `main` - to validate things work smooth before the release. It skips the below steps:
  - npm publish
  - github release creation 
  
In addition, I am figuring out how to use the GitHub provenance in this project.


## Related issues

Closes #ISSUE

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
