### PR TITLE
test: fix 'npm test' on Apple silicon Macs

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -32,6 +32,7 @@ services:
 
   mssql:
     image: mcr.microsoft.com/mssql/server
+    platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Very(!)Secure

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -32,6 +32,7 @@ services:
 
   mssql:
     image: mcr.microsoft.com/mssql/server
+    platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Very(!)Secure


### PR DESCRIPTION
Specifying the mssql image platform is necessary on *arm* Macs
because the mssql Docker image only provides binaries for the
amd64 architecture. My understanding is that Rosetta emulation
on recent macOS supports running the amd binary just fine.
