### PR TITLE
fix(undici): cope with undici@6.11.0 bug that removed req.addHeader

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,9 @@ See the <<upgrade-to-v4>> guide.
 * Fix path resolution for requests that contain invalid characters in its
   host header. ({pull}3923[#3923])
 * Fix span names for `getMore` command of mongodb. ({pull}3919[#3919])
+* Fix undici instrumentation to cope with a bug in undici@6.11.0 where
+  `request.addHeader()` was accidentally removed. (It was re-added in
+  undici@6.11.1.)
 
 [float]
 ===== Chores

--- a/lib/instrumentation/modules/undici.js
+++ b/lib/instrumentation/modules/undici.js
@@ -133,7 +133,12 @@ function instrumentUndici(agent) {
       propSpan.propagateTraceContextHeaders(
         request,
         function (req, name, value) {
-          req.addHeader(name, value);
+          if (typeof request.addHeader === 'function') {
+            req.addHeader(name, value);
+          } else if (Array.isArray(request.headers)) {
+            // undici@6.11.0 accidentally, briefly removed `request.addHeader()`.
+            req.headers.push(name, value);
+          }
         },
       );
     }


### PR DESCRIPTION
undici TAV tests started failing recently: https://github.com/elastic/apm-agent-nodejs/actions/runs/8606452765

The issue is a bug in undici@6.11.0 that removed an API used by our instrumentation.
That bug was discussed here: https://github.com/nodejs/undici/issues/3043
And it was fixed in undici@6.11.1 shortly after.