### PR TITLE
release 4.5.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,8 +33,8 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-[[release-notes-4.5.1]]
-==== 4.5.1 - 2024/04/11
+[[release-notes-4.5.2]]
+==== 4.5.2 - 2024/04/12
 
 [float]
 ===== Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
v4.5.1 (https://github.com/elastic/apm-agent-nodejs/pull/3966) was abortive because the release process failed and tags are protected (https://github.com/elastic/apm-agent-nodejs/pull/3969#issuecomment-2050685857).