### PR TITLE
docs: update 4.x branch for v4.5.2 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,8 +33,8 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-[[release-notes-4.5.1]]
-==== 4.5.1 - 2024/04/11
+[[release-notes-4.5.2]]
+==== 4.5.2 - 2024/04/12
 
 [float]
 ===== Bug fixes

--- a/dev-utils/make-distribution.sh
+++ b/dev-utils/make-distribution.sh
@@ -41,11 +41,13 @@ mkdir -p nodejs/node_modules/elastic-apm-node
     tar --strip-components=1 -xf elastic-apm-node-*.tgz;
     rm elastic-apm-node-*.tgz;
     cp $TOP/package-lock.json ./;
+    cp $TOP/.npmrc ./;
     # Then install the "package-lock.json"-dictated dependencies (excluding
     # devDependencies).  Use '--ignore-scripts' to have confidence no code but
     # ours and npm's is running.
     npm ci --omit=dev --ignore-scripts;
-    rm package-lock.json)
+    rm package-lock.json;
+    rm .npmrc)
 
 # Generate a NOTICE file including the licenses of all included deps.
 NOTICE=nodejs/node_modules/elastic-apm-node/NOTICE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
- fix(release): ensure our npm options are used during make-distribution (#3969)
- release 4.5.2 (#3970)
