### PR TITLE
ci: use docker/metadata-action to gather tags/labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,prefix=test-,enable={{is_default_branch}}
             type=ref,event=tag,prefix=,suffix=
 
       - name: Build and Push Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,13 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=auto
           tags: |
-            type=raw,value=latest,prefix=test-,enable={{is_default_branch}}
+            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
             type=semver,pattern={{version}}
+            # "edge" Docker tag on git push to default branch
+            type=edge
 
       - name: Build and Push Docker Image
         id: docker-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: |
             type=raw,value=latest,prefix=test-,enable={{is_default_branch}}
-            type=ref,event=tag,prefix=,suffix=
+            type=semver,pattern={{version}}
 
       - name: Build and Push Docker Image
         id: docker-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,28 +44,23 @@ jobs:
         with:
           subject-path: "${{ github.workspace }}/build/aws/elastic-apm-node-lambda-layer-*.zip"
 
-      - id: docker-vars
-        name: Set up docker variables
-        run: |-
-          if [ "${{ startsWith(github.ref, 'refs/tags') }}" == "false" ] ; then
-            # for testing purposes
-            echo "tag=test" >> "${GITHUB_OUTPUT}"
-            echo "latest=test-latest" >> "${GITHUB_OUTPUT}"
-          else
-            # version without v prefix (e.g. 1.2.3)
-            echo "tag=${GITHUB_REF_NAME/v/}" >> "${GITHUB_OUTPUT}"
-            echo "latest=latest" >> "${GITHUB_OUTPUT}"
-          fi
+      - name: Extract metadata (tags, labels)
+        id: docker-meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag,prefix=,suffix=
 
       - name: Build and Push Docker Image
         id: docker-push
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
         with:
           context: .
           push: true
-          tags: |
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.tag }}
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.latest }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
           build-args: |
             AGENT_DIR=/build/dist/nodejs
 


### PR DESCRIPTION
### What

Use https://github.com/docker/metadata-action/tree/8e5442c4ef9f78752691e2d8f8d19755c6f78e81/?tab=readme-ov-file#semver to get the tag version and [open-container](https://github.com/opencontainers/image-spec/blob/main/annotations.md) labels.

Use sha commit for the GitHub action related to docker.

### Test

See https://github.com/elastic/apm-agent-nodejs/actions/runs/8878357355, didn't run with `push`


```
Run docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
  with:
    context: .
    push: false
    tags: docker.elastic.co/observability/apm-agent-nodejs:test-latest
    labels: org.opencontainers.image.created=[2](https://github.com/elastic/apm-agent-nodejs/actions/runs/8878357355/job/24373834641#step:9:2)024-04-29T12:16:2[3](https://github.com/elastic/apm-agent-nodejs/actions/runs/8878357355/job/24373834641#step:9:3).000Z
  org.opencontainers.image.description=Elastic APM Node.js Agent
  org.opencontainers.image.licenses=BSD-2-Clause
  org.opencontainers.image.revision=f9f28681ae69736728d1[5](https://github.com/elastic/apm-agent-nodejs/actions/runs/8878357355/job/24373834641#step:9:5)aaa93880fffba5f2e6d
  org.opencontainers.image.source=https://github.com/elastic/apm-agent-nodejs
  org.opencontainers.image.title=apm-agent-nodejs
  org.opencontainers.image.url=https://github.com/elastic/apm-agent-nodejs
  org.opencontainers.image.version=test-latest
    build-args: AGENT_DIR=/build/dist/nodejs
```

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
