### PR TITLE
test: test with Node.js v22

### DIFF
--- a/.ci/tav.json
+++ b/.ci/tav.json
@@ -1,5 +1,5 @@
 {
-  "versions": [ "21", "20", "18", "16", "14" ],
+  "versions": [ "22", "20", "18", "16", "14" ],
   "// modules": [
     "List of instrumented modules with the minimum Node major version supported.",
     "minMajorVersion for each module should be kept in sync with .tav.yml"

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ "22" ]
+        node: [ "23" ]
     steps:
       - uses: actions/checkout@v4
       - run: .ci/scripts/test.sh -b "nightly" "${{ matrix.node }}"
@@ -50,7 +50,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "21"
+          - "23"
+          - "22"
           - "20"
           - "18"
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
           - "2181:2181"
         volumes:
           - nodezookeeperdata:/var/lib/zookeeper/data
-        
+
       kafka:
         image: bitnami/kafka:3.3.2
         ports:
@@ -154,8 +154,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '21'
-          - '21.0'
+          - '22'
+          - '22.0'
           - '20'
           - '20.0'
           - '18'


### PR DESCRIPTION
Now that v22 is out add it and drop v21 testing.
https://github.com/nodejs/release#release-schedule
