### PR TITLE
ci: build and push Docker image based on Chainguard base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           if [ "${{ contains(matrix.dockerfile, 'wolfi') }}" == "true" ] ; then
             # version without v prefix (e.g. 1.2.3)
             TAG="${TAG}-wolfi"
-            LATEST="latest-wolfi"
+            LATEST="${LATEST}-wolfi"
           fi
           echo "tag=${TAG}"       >> "${GITHUB_OUTPUT}"
           echo "latest=${LATEST}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,16 @@ on:
       - main
 
 permissions:
-  attestations: write
-  contents: write
-  id-token: write
-  pull-requests: read
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,14 +27,6 @@ jobs:
         with:
           node-version: 'v16.20.2'
 
-      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
-        with:
-          registry: docker.elastic.co
-          secret: secret/observability-team/ci/docker-registry/prod
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-
       - run: make -C .ci env
 
       - run: make -C .ci dist
@@ -43,38 +35,6 @@ jobs:
         uses: github-early-access/generate-build-provenance@main
         with:
           subject-path: "${{ github.workspace }}/build/aws/elastic-apm-node-lambda-layer-*.zip"
-
-      - id: docker-vars
-        name: Set up docker variables
-        run: |-
-          if [ "${{ startsWith(github.ref, 'refs/tags') }}" == "false" ] ; then
-            # for testing purposes
-            echo "tag=test" >> "${GITHUB_OUTPUT}"
-            echo "latest=test-latest" >> "${GITHUB_OUTPUT}"
-          else
-            # version without v prefix (e.g. 1.2.3)
-            echo "tag=${GITHUB_REF_NAME/v/}" >> "${GITHUB_OUTPUT}"
-            echo "latest=latest" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Build and Push Docker Image
-        id: docker-push
-        uses: docker/build-push-action@v5.3.0
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.tag }}
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.latest }}
-          build-args: |
-            AGENT_DIR=/build/dist/nodejs
-
-      - name: Attest Docker image
-        uses: github-early-access/generate-build-provenance@main
-        with:
-          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
-          subject-digest: ${{ steps.docker-push.outputs.digest }}
-          push-to-registry: true
 
       - name: Read AWS vault secrets
         uses: hashicorp/vault-action@v3.0.0
@@ -116,8 +76,79 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
           npm publish --otp=${{ env.TOTP_CODE }} --provenance
 
-      - if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
-        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+  publish-docker:
+    needs:
+      - release
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: [ 'Dockerfile', 'Dockerfile.wolfi' ]
+    env:
+      DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+        with:
+          registry: docker.elastic.co
+          secret: secret/observability-team/ci/docker-registry/prod
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - id: docker-vars
+        name: Set up docker variables
+        run: |-
+          TAG=test
+          LATEST=test-latest
+          if [ "${{ startsWith(github.ref, 'refs/tags') }}" == "true" ] ; then
+            # version without v prefix (e.g. 1.2.3)
+            TAG="${GITHUB_REF_NAME/v/}"
+            LATEST=latest
+          fi
+          if [ "${{ contains(matrix.dockerfile, 'wolfi') }}" == "true" ] ; then
+            # version without v prefix (e.g. 1.2.3)
+            TAG="${TAG}-wolfi"
+            LATEST="latest-wolfi"
+          fi
+          echo "tag=${TAG}"       >> "${GITHUB_OUTPUT}"
+          echo "latest=${LATEST}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and Push Docker Image
+        id: docker-push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.tag }}
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.latest }}
+          build-args: |
+            AGENT_DIR=/build/dist/nodejs
+
+      - name: Attest Docker image
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true
+
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
+    needs:
+      - publish-docker
+      - release
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,16 @@ on:
       - main
 
 permissions:
-  contents: read
+  attestations: write
+  contents: write
+  id-token: write
+  pull-requests: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      pull-requests: read
+    env:
+      DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,6 +27,14 @@ jobs:
         with:
           node-version: 'v16.20.2'
 
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+        with:
+          registry: docker.elastic.co
+          secret: secret/observability-team/ci/docker-registry/prod
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - run: make -C .ci env
 
       - run: make -C .ci dist
@@ -35,6 +43,71 @@ jobs:
         uses: github-early-access/generate-build-provenance@main
         with:
           subject-path: "${{ github.workspace }}/build/aws/elastic-apm-node-lambda-layer-*.zip"
+
+      - name: Extract metadata (tags, labels)
+        id: docker-meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
+            type=semver,pattern={{version}}
+            # "edge" Docker tag on git push to default branch
+            type=edge
+
+      - name: Build and Push Docker Image
+        id: docker-push
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
+        with:
+          context: .
+          file: 'Dockerfile'
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+          build-args: |
+            AGENT_DIR=/build/dist/nodejs
+
+      - name: Attest Docker image
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Extract metadata (tags, labels) (wolfi)
+        id: docker-meta-wolfi
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          flavor: |
+            latest=auto
+            suffix=-wolfi
+          tags: |
+            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
+            type=semver,pattern={{version}}
+            # "edge" Docker tag on git push to default branch
+            type=edge
+
+      - name: Build and Push Docker Image (wolfi)
+        id: docker-push-wolfi
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
+        with:
+          context: .
+          file: 'Dockerfile.wolfi'
+          push: true
+          tags: ${{ steps.docker-meta-wolfi.outputs.tags }}
+          labels: ${{ steps.docker-meta-wolfi.outputs.labels }}
+          build-args: |
+            AGENT_DIR=/build/dist/nodejs
+
+      - name: Attest Docker image (wolfi)
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
+          subject-digest: ${{ steps.docker-push-wolfi.outputs.digest }}
+          push-to-registry: true
 
       - name: Read AWS vault secrets
         uses: hashicorp/vault-action@v3.0.0
@@ -76,85 +149,8 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
           npm publish --otp=${{ env.TOTP_CODE }} --provenance
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: build-distribution
-          path: ./build/dist
-          retention-days: 1
-
-  publish-docker:
-    needs:
-      - release
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        dockerfile: [ 'Dockerfile', 'Dockerfile.wolfi' ]
-    env:
-      DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
-    steps:
-      - uses: actions/checkout@v4
-      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
-        with:
-          registry: docker.elastic.co
-          secret: secret/observability-team/ci/docker-registry/prod
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-distribution
-          path: ./build/dist
-
-      - name: Extract metadata (tags, labels)
-        id: docker-meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
-        with:
-          images: ${{ env.DOCKER_IMAGE_NAME }}
-          flavor: |
-            latest=auto
-            suffix=${{ contains(matrix.dockerfile, 'wolfi') && '-wolfi' || '' }}
-          tags: |
-            # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
-            type=semver,pattern={{version}}
-            # "edge" Docker tag on git push to default branch
-            type=edge
-
-      - name: Build and Push Docker Image
-        id: docker-push
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.docker-meta.outputs.tags }}
-          labels: ${{ steps.docker-meta.outputs.labels }}
-          build-args: |
-            AGENT_DIR=/build/dist/nodejs
-
-      - name: Attest Docker image
-        uses: github-early-access/generate-build-provenance@main
-        with:
-          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
-          subject-digest: ${{ steps.docker-push.outputs.digest }}
-          push-to-registry: true
-
-  notify:
-    runs-on: ubuntu-latest
-    if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
-    needs:
-      - publish-docker
-      - release
-    steps:
-      - id: check
-        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
-        with:
-          needs: ${{ toJSON(needs) }}
-      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+      - if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
+        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,12 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ env.NPMJS_TOKEN }}" > .npmrc
           npm publish --otp=${{ env.TOTP_CODE }} --provenance
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-distribution
+          path: ./build/dist
+          retention-days: 1
+
   publish-docker:
     needs:
       - release
@@ -99,7 +105,10 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-distribution
+          path: ./build/dist
       - id: docker-vars
         name: Set up docker variables
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: true
           tags: |
             ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker-vars.outputs.tag }}

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/wolfi/chainguard-base@sha256:9f940409f96296ef56140bcc4665c204dd499af4c32c96cc00e792558097c3f1
+ARG AGENT_DIR
+COPY ${AGENT_DIR} /opt/nodejs


### PR DESCRIPTION
## What does this pull request do?

Release two flavours of Docker images:
- the one we always do
- the one based on [Wolfi](https://www.chainguard.dev/unchained/introducing-wolfi-the-first-linux-un-distro) from [Chainguard](https://edu.chainguard.dev/chainguard/chainguard-images/overview/) 

Please note that we are going to preserve the current `Dockerfile`, so that users will still be able to build their own custom images based on `Alpine`: this is needed because `docker.elastic.co/wolfi/chainguard-base` is not a public base image, so docker build would fail for unauthenticated users.

## Implementation details

I refactored the release workflow to have three different jobs that run sequentially:
- release job, as usual
- docker build - so it can use the matrix format for `Dockerfile` and `Dockerfile.wolfi`
- notification - so if any of the above jobs failed then a message will be sent.

Then, I created the `Dockerfile.wolfi` - the naming convention we agreed upon.

## Tests

I created a feature branch `test-wolfi`:
- https://github.com/elastic/apm-agent-nodejs/tree/test-wolfi

```diff
diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
index 2bdb4ed1..7462b7b8 100644
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*.*.*
     branches:
-      - main
+      - test-wolfi
 
 permissions:
   contents: read
@@ -119,6 +119,8 @@ jobs:
             latest=auto
             suffix=${{ contains(matrix.dockerfile, 'wolfi') && '-wolfi' || '' }}
           tags: |
+            # test
+            type=raw,value=latest,prefix=test-,enable=${{ github.ref == format('refs/heads/{0}', 'test-wolfi') }}
             # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
             type=semver,pattern={{version}}
             # "edge" Docker tag on git push to default branch

```

Then I was able to test the release workflow without pushing any changes in production but generating docker images with the prefix `test-` and suffix if `-wolfi`.

See https://github.com/elastic/apm-agent-nodejs/actions/runs/9082550246

### Docker images

#### The ones we usually release

See this [line](https://github.com/elastic/apm-agent-nodejs/actions/runs/9061346754/job/24892945439#step:5:50)

<img width="1225" alt="image" src="https://github.com/elastic/apm-agent-nodejs/assets/2871786/20a924b3-c8ab-4c7d-a240-1844c36f45fc">


#### Wolfi docker images

See this [line](https://github.com/elastic/apm-agent-nodejs/actions/runs/9061346754/job/24892945811#step:5:50)

<img width="1268" alt="image" src="https://github.com/elastic/apm-agent-nodejs/assets/2871786/25dac1d8-f893-4e2e-b2c3-7b8118dcb02c">

`docker pull docker.elastic.co/observability/apm-agent-nodejs:test-latest-wolfi`

### Issues

Similar to https://github.com/elastic/apm-agent-python/pull/2036
Requires https://github.com/elastic/apm-agent-nodejs/pull/3998

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
