### PR TITLE
release 4.5.4

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,13 +33,8 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-==== Unreleased
-
-[float]
-===== Breaking changes
-
-[float]
-===== Features
+[[release-notes-4.5.4]]
+==== 4.5.4 - 2024/05/13
 
 [float]
 ===== Bug fixes
@@ -68,10 +63,6 @@ See the <<upgrade-to-v4>> guide.
 
   In other words, `http.request.cookies` are no longer separated out.
   ({issues}4006[#4006])
-
-
-[float]
-===== Chores
 
 
 [[release-notes-4.5.3]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.5.3",
+      "version": "4.5.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
This is a release to get a fix for https://github.com/elastic/apm-agent-nodejs/issues/4006 out.