### PR TITLE
docs: fix markup in changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,27 +42,29 @@ See the <<upgrade-to-v4>> guide.
 - Change how the "cookie" HTTP request header is represented in APM transaction
   data to avoid a rare, but possible, intake bug where the transaction could be
   rejected due to a mapping conflict.
-
-  Before this change a `Cookie: foo=bar; sessionid=42` HTTP request header
-  would be represented in the transaction document in Elasticsearch with these
-  document fields (the example assumes <<sanitize-field-names>> matches
-  "sessionid", as it does by default):
-
-  ```
-  http.request.headers.cookie: "[REDACTED]"
-  ...
-  http.request.cookies.foo: "bar"
-  http.request.cookies.sessionid: "[REDACTED]"
-  ```
-
-  After this change it is represented as:
-
-  ```
-  http.request.headers.cookie: "foo=bar; sessionid=REDACTED"
-  ```
-
-  In other words, `http.request.cookies` are no longer separated out.
-  ({issues}4006[#4006])
++
+Before this change a `Cookie: foo=bar; sessionid=42` HTTP request header
+would be represented in the transaction document in Elasticsearch with these
+document fields (the example assumes <<sanitize-field-names>> matches
+"sessionid", as it does by default):
++
+[source]
+----
+http.request.headers.cookie: "[REDACTED]"
+...
+http.request.cookies.foo: "bar"
+http.request.cookies.sessionid: "[REDACTED]"
+----
++
+After this change it is represented as:
++
+[source]
+----
+http.request.headers.cookie: "foo=bar; sessionid=REDACTED"
+----
++
+In other words, `http.request.cookies` are no longer separated out.
+({issues}4006[#4006])
 
 
 [[release-notes-4.5.3]]


### PR DESCRIPTION
This is asciidoc, not markdown.
