### PR TITLE
fix: patch @smithy/smithy-client@3 for release @aws-sdk/client-* releases

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,25 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix instrumentation for recent `@aws-sdk/client-*` releases that use
+  `@smithy/smithy-client` v3. (For example `@aws-sdk/client-s3@3.575.0` released
+  2024-05-13 updated to smithy-client v3.) The APM agent had been limiting
+  patching of `@smithy/smithy-client` to `>=1 <3`.
+
+[float]
+===== Chores
+
 [[release-notes-4.5.4]]
 ==== 4.5.4 - 2024/05/13
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,8 +46,8 @@ See the <<upgrade-to-v4>> guide.
 
 * Fix instrumentation for recent `@aws-sdk/client-*` releases that use
   `@smithy/smithy-client` v3. (For example `@aws-sdk/client-s3@3.575.0` released
-  2024-05-13 updated to smithy-client v3.) The APM agent had been limiting
-  patching of `@smithy/smithy-client` to `>=1 <3`.
+  2024-05-13 updated to smithy-client v3.) Before this change the APM agent had
+  been limiting patching of `@smithy/smithy-client` to `>=1 <3`.
 
 [float]
 ===== Chores

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ See the <<upgrade-to-v4>> guide.
   `@smithy/smithy-client` v3. (For example `@aws-sdk/client-s3@3.575.0` released
   2024-05-13 updated to smithy-client v3.) Before this change the APM agent had
   been limiting patching of `@smithy/smithy-client` to `>=1 <3`.
+
 * Mark the published AWS Lambda layers as supporting the "nodejs20.x" Lambda
   Runtime (`--compatible-runtimes`). The "nodejs20.x" runtime was released by
   AWS on 2023-11-15. ({issues}4033[#4033])

--- a/lib/instrumentation/modules/@smithy/smithy-client.js
+++ b/lib/instrumentation/modules/@smithy/smithy-client.js
@@ -107,10 +107,10 @@ module.exports = function (mod, agent, { name, version, enabled }) {
   if (!enabled) return mod;
 
   // As of `@aws-sdk/*@3.363.0` the underlying smithy-client is under the
-  // `@smithy/` npm org and is 1.x.
+  // `@smithy/` npm org.
   if (
     name === '@smithy/smithy-client' &&
-    !semver.satisfies(version, '>=1 <3')
+    !semver.satisfies(version, '>=1 <4')
   ) {
     agent.logger.debug(
       'cannot instrument @aws-sdk/client-*: @smithy/smithy-client version %s not supported',


### PR DESCRIPTION
Recently @aws-sdk/client-* releases started using v3 of smithy/smithy-client.
This updates our instr to allow patching v3.
