### PR TITLE
ci: use updatecli with GitHub secrets

### DIFF
--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -5,22 +5,20 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
   apm:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.apm_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
 sources:

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
+      commitusingapi: true
   apm:
     kind: github
     spec:

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -5,23 +5,21 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
   apm-data:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.apm_data_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
 sources:

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
+      commitusingapi: true
 
   apm-data:
     kind: github

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          command: "apply --config .ci/updatecli/updatecli.d --values .ci/updatecli/values.yml"
+          command: "--experimental apply --config .ci/updatecli/updatecli.d --values .ci/updatecli/values.yml"
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
 

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -13,17 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: .ci/updatecli/updatecli.d
-          values: .ci/updatecli/values.yml
+          command: "apply --config .ci/updatecli/updatecli.d --values .ci/updatecli/values.yml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
       - if: failure()
-        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        uses: elastic/oblt-actions/slack/send@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-node"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-node"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"


### PR DESCRIPTION
## What does this PR do?

Use oblt-actions with GitHub secrets.

No need to use Vault secrets path


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
