### PR TITLE
feat: support OTel span.addLink, span.addLinks; add similar APIs to the APM agent API

### DIFF
--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -242,3 +242,33 @@ If false-y values (e.g. `null`) are given for both `type` and `name`, then `serv
 If this method is not called, the service target values are inferred from other span fields (https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans-service-target.md#field-values[spec]).
 
 `service.target.*` fields are ignored for APM Server before v8.3.
+
+[[span-addlink]]
+==== `span.addLink(link)`
+
+[small]#Added in: REPLACEME#
+
+* `link` +{type-link}+
+
+A span can refer to zero or more other transactions or spans (separate
+from its parent). Span links will be shown in the Kibana APM app trace view. The
+`link` argument is an object with a single "context" field that is a
+`Transaction`, `Span`, OpenTelemetry `SpanContext` object, or W3C trace-context
+'traceparent' string.
+For example: `span.addLink({ context: anotherSpan })`.
+
+[[span-addlinks]]
+==== `span.addLinks([links])`
+
+[small]#Added in: REPLACEME#
+
+* `links` +{type-array}+ Span links.
+
+Add span links to this span.
+
+A span can refer to zero or more other transactions or spans (separate
+from its parent). Span links will be shown in the Kibana APM app trace view. The
+`link` argument is an object with a single "context" field that is a
+`Transaction`, `Span`, OpenTelemetry `SpanContext` object, or W3C trace-context
+'traceparent' string.
+For example: `span.addLinks([{ context: anotherSpan }])`.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -84,7 +84,7 @@ Metrics API and Metrics SDK to allow
 [options="header"]
 |=======================================================================
 | Framework | Version
-| <<opentelemetry-bridge,@opentelemetry/api>> | >=1.0.0 <1.9.0
+| <<opentelemetry-bridge,@opentelemetry/api>> | >=1.0.0 <1.10.0
 | https://www.npmjs.com/package/@opentelemetry/sdk-metrics[@opentelemetry/sdk-metrics] | >=1.11.0 <2
 |=======================================================================
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -308,3 +308,33 @@ Non-HTTP transactions will begin with an outcome of `unknown`.
 * `outcome` +{type-string}+
 
 The `setOutcome` method allows an end user to override the Node.js agent's default setting of a transaction's `outcome` property.  The `setOutcome` method accepts a string of either `success`, `failure`, or `unknown`, and will force the agent to report this value for a specific span.
+
+[[transaction-addlink]]
+==== `transaction.addLink(link)`
+
+[small]#Added in: REPLACEME#
+
+* `link` +{type-link}+
+
+A transaction can refer to zero or more other transactions or spans (separate
+from its parent). Span links will be shown in the Kibana APM app trace view. The
+`link` argument is an object with a single "context" field that is a
+`Transaction`, `Span`, OpenTelemetry `SpanContext` object, or W3C trace-context
+'traceparent' string.
+For example: `transaction.addLink({ context: anotherSpan })`.
+
+[[transaction-addlinks]]
+==== `transaction.addLinks([links])`
+
+[small]#Added in: REPLACEME#
+
+* `links` +{type-array}+ Span links.
+
+Add span links to this transaction.
+
+A transaction can refer to zero or more other transactions or spans (separate
+from its parent). Span links will be shown in the Kibana APM app trace view. The
+`link` argument is an object with a single "context" field that is a
+`Transaction`, `Span`, OpenTelemetry `SpanContext` object, or W3C trace-context
+'traceparent' string.
+For example: `transaction.addLinks([{ context: anotherSpan }])`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,8 @@ declare namespace apm {
     setLabel (name: string, value: LabelValue, stringify?: boolean): boolean;
     addLabels (labels: Labels, stringify?: boolean): boolean;
     setOutcome(outcome: Outcome): void;
+    addLink (link: Link): void;
+    addLinks (links: Link[]): void;
 
     startSpan(
       name?: string | null,
@@ -201,6 +203,8 @@ declare namespace apm {
     addLabels (labels: Labels, stringify?: boolean): boolean;
     setOutcome(outcome: Outcome): void;
     setServiceTarget(type?: string | null, name?: string | null): void;
+    addLink (link: Link): void;
+    addLinks (links: Link[]): void;
     end (endTime?: number): void;
   }
 
@@ -349,8 +353,8 @@ declare namespace apm {
   // equivalent APIs in "opentelemetry-js-api/src/trace/link.ts". Currently
   // span link attributes are not supported.
   export interface Link {
-    /** A W3C trace-context 'traceparent' string, Transaction, or Span. */
-    context: Transaction | Span | string; // This is a SpanContext in OTel.
+    /** A W3C trace-context 'traceparent' string, Transaction, Span, or OTel SpanContext. */
+    context: Transaction | Span | {traceId: string, spanId: string} | string;
   }
 
   export interface TransactionOptions {

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -281,7 +281,7 @@ GenericSpan.prototype._serializeOTel = function (payload) {
 // span link as it will be serialized and sent to APM server. If the linkArg is
 // invalid, this will return null.
 //
-// @param {Array} linkArg - An object with a `context` property that is
+// @param {Object} linkArg - An object with a `context` property that is
 //    a Transaction, Span, or TraceParent instance; an OTel SpanContext object;
 //    or a W3C trace-context 'traceparent' string.
 function linkFromLinkArg(linkArg) {

--- a/lib/instrumentation/generic-span.js
+++ b/lib/instrumentation/generic-span.js
@@ -170,25 +170,28 @@ GenericSpan.prototype.addLabels = function (labels, stringify) {
   return true;
 };
 
-// This method is private because the APM agents spec says that (for OTel
-// compat), adding links after span creation should not be allowed.
-// https://github.com/elastic/apm/blob/main/specs/agents/span-links.md
-//
-// To support adding span links for SQS ReceiveMessage and equivalent, the
-// message data isn't known until the *response*, after the span has been
-// created.
+// Add span links.
 //
 // @param {Array} links - An array of objects with a `context` property that is
-//    a Transaction, Span, or TraceParent instance, or a W3C trace-context
-//    'traceparent' string.
-GenericSpan.prototype._addLinks = function (links) {
+//    a Transaction, Span, or TraceParent instance; an OTel SpanContext object;
+//    or a W3C trace-context 'traceparent' string.
+GenericSpan.prototype.addLinks = function (links) {
   if (links) {
     for (let i = 0; i < links.length; i++) {
-      const link = linkFromLinkArg(links[i]);
-      if (link) {
-        this._links.push(link);
-      }
+      this.addLink(links[i]);
     }
+  }
+};
+
+// Add a span link.
+//
+// @param {Link} link - An object with a `context` property that is
+//    a Transaction, Span, or TraceParent instance; an OTel SpanContext object;
+//    or a W3C trace-context 'traceparent' string.
+GenericSpan.prototype.addLink = function (linkArg) {
+  const link = linkFromLinkArg(linkArg);
+  if (link) {
+    this._links.push(link);
   }
 };
 
@@ -278,9 +281,9 @@ GenericSpan.prototype._serializeOTel = function (payload) {
 // span link as it will be serialized and sent to APM server. If the linkArg is
 // invalid, this will return null.
 //
-// @param {Object} linkArg - An object with a `context` property that is a
-//    Transaction, Span, or TraceParent instance, or a W3C trace-context
-//    'traceparent' string.
+// @param {Array} linkArg - An object with a `context` property that is
+//    a Transaction, Span, or TraceParent instance; an OTel SpanContext object;
+//    or a W3C trace-context 'traceparent' string.
 function linkFromLinkArg(linkArg) {
   if (!linkArg || !linkArg.context) {
     return null;
@@ -290,7 +293,13 @@ function linkFromLinkArg(linkArg) {
   let traceId;
   let spanId;
 
-  if (ctx._context instanceof TraceContext) {
+  if (ctx.traceId && ctx.spanId) {
+    // Duck-typing for an OTel SpanContext. APM intake v2 only supports the
+    // trace id and span id fields for span links, so we only need care about
+    // those attributes.
+    traceId = ctx.traceId;
+    spanId = ctx.spanId;
+  } else if (ctx._context instanceof TraceContext) {
     // Transaction or Span
     traceId = ctx._context.traceparent.traceId;
     spanId = ctx._context.traceparent.id;

--- a/lib/instrumentation/modules/@aws-sdk/client-sqs.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sqs.js
@@ -160,7 +160,7 @@ function sqsMiddlewareFactory(client, agent) {
             // Links
             const links = getSpanLinksFromResponseData(result && result.output);
             if (links) {
-              span._addLinks(links);
+              span.addLinks(links);
             }
 
             // Metrics

--- a/lib/instrumentation/modules/aws-sdk/sqs.js
+++ b/lib/instrumentation/modules/aws-sdk/sqs.js
@@ -320,7 +320,7 @@ function instrumentationSqs(
     if (receiveMsgData) {
       const links = getSpanLinksFromResponseData(receiveMsgData);
       if (links) {
-        span._addLinks(links);
+        span.addLinks(links);
       }
     }
 

--- a/lib/instrumentation/modules/kafkajs.js
+++ b/lib/instrumentation/modules/kafkajs.js
@@ -238,7 +238,7 @@ module.exports = function (mod, agent, { version, enabled }) {
             }
           }
         }
-        trans._addLinks(links);
+        trans.addLinks(links);
       }
 
       let result, err;

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -383,7 +383,7 @@ function setSqsData(agent, trans, event, context, faasId, isColdStart) {
   trans.setCloudContext(cloudContext);
 
   const links = spanLinksFromSqsRecords(event.Records);
-  trans._addLinks(links);
+  trans.addLinks(links);
 }
 
 function setSnsData(agent, trans, event, context, faasId, isColdStart) {
@@ -424,7 +424,7 @@ function setSnsData(agent, trans, event, context, faasId, isColdStart) {
   trans.setCloudContext(cloudContext);
 
   const links = spanLinksFromSnsRecords(event.Records);
-  trans._addLinks(links);
+  trans.addLinks(links);
 }
 
 function setS3SingleData(trans, event, context, faasId, isColdStart) {

--- a/lib/opentelemetry-bridge/OTelBridgeNonRecordingSpan.js
+++ b/lib/opentelemetry-bridge/OTelBridgeNonRecordingSpan.js
@@ -127,6 +127,14 @@ class OTelBridgeNonRecordingSpan {
     return this;
   }
 
+  addLink(_link) {
+    return this;
+  }
+
+  addLinks(_links) {
+    return this;
+  }
+
   end(_endTime) {}
 
   // isRecording always returns false for NonRecordingSpan.

--- a/lib/opentelemetry-bridge/OTelSpan.js
+++ b/lib/opentelemetry-bridge/OTelSpan.js
@@ -169,10 +169,12 @@ class OTelSpan {
 
   addLink(link) {
     this._span.addLink(link);
+    return this;
   }
 
   addLinks(links) {
     this._span.addLinks(links);
+    return this;
   }
 
   end(otelEndTime) {

--- a/lib/opentelemetry-bridge/OTelSpan.js
+++ b/lib/opentelemetry-bridge/OTelSpan.js
@@ -167,6 +167,14 @@ class OTelSpan {
     return this;
   }
 
+  addLink(link) {
+    this._span.addLink(link);
+  }
+
+  addLinks(links) {
+    this._span.addLinks(links);
+  }
+
   end(otelEndTime) {
     oblog.apicall('%s.end(endTime=%s)', this, otelEndTime);
     const endTime =

--- a/package-lock.json
+++ b/package-lock.json
@@ -10335,39 +10335,6 @@
       "integrity": "sha512-dlGKiwLzRBKkEf5J5ho0uAD/Jdv8GQVUbriB3tAX3ehRUXE4gTV3lRd5inEg9li1aLzb0EGj8y2K4/8g1TN06g==",
       "dev": true
     },
-    "node_modules/fastify/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/fastify/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/fastify/node_modules/fast-json-stringify": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.8.0.tgz",
@@ -10396,26 +10363,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/fastify/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/fastify/node_modules/pino": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.0.0.tgz",
@@ -10438,46 +10385,11 @@
         "pino": "bin.js"
       }
     },
-    "node_modules/fastify/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
     "node_modules/fastify/node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "dev": true
-    },
-    "node_modules/fastify/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/fastify/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -26307,22 +26219,6 @@
         "toad-cache": "^3.3.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-          "dev": true
-        },
         "fast-json-stringify": {
           "version": "5.8.0",
           "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.8.0.tgz",
@@ -26348,12 +26244,6 @@
             "safe-regex2": "^2.0.0"
           }
         },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-          "dev": true
-        },
         "pino": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/pino/-/pino-9.0.0.tgz",
@@ -26373,39 +26263,10 @@
             "thread-stream": "^2.6.0"
           }
         },
-        "pino-abstract-transport": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^4.0.0",
-            "split2": "^4.0.0"
-          }
-        },
         "process-warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
           "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
-        "split2": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
           "dev": true
         }
       }

--- a/test/instrumentation/span.test.js
+++ b/test/instrumentation/span.test.js
@@ -263,6 +263,38 @@ test('#addLabels', function (t) {
   t.end();
 });
 
+test('#addLink, #addLinks', function (t) {
+  var trans = new Transaction(agent);
+  var span = new Span(trans);
+
+  const theTraceId = '00000000000000000000000000000001';
+  span.addLink({
+    context: { traceId: theTraceId, spanId: '0000000000000002' },
+  });
+  t.deepEqual(span._links, [
+    {
+      trace_id: theTraceId,
+      span_id: '0000000000000002',
+    },
+  ]);
+
+  span.addLinks([
+    {
+      context: { traceId: theTraceId, spanId: '0000000000000003' },
+    },
+    {
+      context: { traceId: theTraceId, spanId: '0000000000000004' },
+    },
+  ]);
+  t.deepEqual(span._links, [
+    { trace_id: theTraceId, span_id: '0000000000000002' },
+    { trace_id: theTraceId, span_id: '0000000000000003' },
+    { trace_id: theTraceId, span_id: '0000000000000004' },
+  ]);
+
+  t.end();
+});
+
 test('span.sync', function (t) {
   var trans = agent.startTransaction();
 
@@ -528,6 +560,10 @@ test('Span API on ended span', function (t) {
   t.pass('span.addLabels(...) does not blow up');
   span.setOutcome('failure');
   t.pass('span.setOutcome(...) does not blow up');
+  span.addLink({ context: { traceId: '001', spanId: '002' } });
+  t.pass('span.addLink(...) does not blow up');
+  span.addLinks([{ context: { traceId: '001', spanId: '002' } }]);
+  t.pass('span.addLinks(...) does not blow up');
   span.end(42);
   t.pass('span.end(...) does not blow up');
 

--- a/test/instrumentation/transaction.test.js
+++ b/test/instrumentation/transaction.test.js
@@ -226,6 +226,37 @@ test('#addLabels', function (t) {
   t.end();
 });
 
+test('#addLink, #addLinks', function (t) {
+  var trans = new Transaction(agent);
+
+  const theTraceId = '00000000000000000000000000000001';
+  trans.addLink({
+    context: { traceId: theTraceId, spanId: '0000000000000002' },
+  });
+  t.deepEqual(trans._links, [
+    {
+      trace_id: theTraceId,
+      span_id: '0000000000000002',
+    },
+  ]);
+
+  trans.addLinks([
+    {
+      context: { traceId: theTraceId, spanId: '0000000000000003' },
+    },
+    {
+      context: { traceId: theTraceId, spanId: '0000000000000004' },
+    },
+  ]);
+  t.deepEqual(trans._links, [
+    { trace_id: theTraceId, span_id: '0000000000000002' },
+    { trace_id: theTraceId, span_id: '0000000000000003' },
+    { trace_id: theTraceId, span_id: '0000000000000004' },
+  ]);
+
+  t.end();
+});
+
 test('#startSpan()', function (t) {
   t.test('basic', function (t) {
     var trans = new Transaction(agent);

--- a/test/opentelemetry-bridge/.tav.yml
+++ b/test/opentelemetry-bridge/.tav.yml
@@ -1,5 +1,5 @@
 "@opentelemetry/api":
-  versions: '>=1.0.0 <1.9.0'
+  versions: '>=1.0.0 <1.10.0'
   node: '>=8.0.0'
   commands:
     - node OTelBridgeNonRecordingSpan.test.js

--- a/test/opentelemetry-bridge/OTelBridgeNonRecordingSpan.test.js
+++ b/test/opentelemetry-bridge/OTelBridgeNonRecordingSpan.test.js
@@ -78,6 +78,13 @@ tape.test('OTelBridgeNonRecordingSpan', (suite) => {
       'setStatus',
     );
     t.equal(nrsOTelSpan.updateName('anotherName'), nrsOTelSpan, 'updateName');
+    const linkContext = {
+      traceId: '8b46594050c89c3d87248476ed8e0c57',
+      spanId: 'ffe4cfa94865ee2a',
+      traceFlags: otel.TraceFlags.SAMPLED,
+    };
+    t.equal(nrsOTelSpan.addLink(linkContext), nrsOTelSpan, 'addLink');
+    t.equal(nrsOTelSpan.addLinks([linkContext]), nrsOTelSpan, 'addLinks');
     t.equal(nrsOTelSpan.end(), undefined, 'end');
     t.equal(nrsOTelSpan.isRecording(), false, 'isRecording');
     t.equal(

--- a/test/opentelemetry-bridge/fixtures.test.js
+++ b/test/opentelemetry-bridge/fixtures.test.js
@@ -376,6 +376,7 @@ const cases = [
         'sSetStatusChildERROR.outcome',
       );
 
+      // Span#updateName
       t.strictEqual(
         findObjInArray(
           events,
@@ -384,6 +385,23 @@ const cases = [
         ).transaction.name,
         'three',
         'sUpdateName',
+      );
+
+      // Span#addLink, Span#addLinks
+      t.deepEqual(
+        findObjInArray(events, 'transaction.name', 'sAddLinks').transaction
+          .links,
+        [
+          {
+            trace_id: '8b46594050c89c3d87248476ed8e0c57',
+            span_id: 'ffe4cfa94865ee2a',
+          },
+          {
+            trace_id: '8b46594050c89c3d87248476ed8e0c57',
+            span_id: 'ffe4cfa94865ee2a',
+          },
+        ],
+        'sAddLinks links',
       );
 
       // Span#end

--- a/test/opentelemetry-bridge/fixtures/interface-span.js
+++ b/test/opentelemetry-bridge/fixtures/interface-span.js
@@ -176,8 +176,10 @@ const linkContext = {
   spanId: 'ffe4cfa94865ee2a',
   traceFlags: otel.TraceFlags.SAMPLED,
 };
-sAddLinks.addLink({ context: linkContext });
-sAddLinks.addLinks([{ context: linkContext }]);
+rv = sAddLinks.addLink({ context: linkContext });
+assert.strictEqual(rv, sAddLinks, 'addLink return value is the span');
+rv = sAddLinks.addLinks([{ context: linkContext }]);
+assert.strictEqual(rv, sAddLinks, 'addLinks return value is the span');
 sAddLinks.end();
 
 // Span#end

--- a/test/opentelemetry-bridge/fixtures/interface-span.js
+++ b/test/opentelemetry-bridge/fixtures/interface-span.js
@@ -169,6 +169,17 @@ sUpdateName.updateName('three');
 sUpdateName.end();
 sUpdateName.updateName('four'); // updateName after end should *not* take
 
+// Span#addLink, Span#addLinks
+const sAddLinks = tracer.startSpan('sAddLinks');
+const linkContext = {
+  traceId: '8b46594050c89c3d87248476ed8e0c57',
+  spanId: 'ffe4cfa94865ee2a',
+  traceFlags: otel.TraceFlags.SAMPLED,
+};
+sAddLinks.addLink({ context: linkContext });
+sAddLinks.addLinks([{ context: linkContext }]);
+sAddLinks.end();
+
 // Span#end
 // Specify approximately "now" in each of the supported TimeInput formats.
 // OTel HrTime is `[<seconds since epoch>, <nanoseconds>]`.

--- a/test/opentelemetry-metrics/fixtures/.tav.yml
+++ b/test/opentelemetry-metrics/fixtures/.tav.yml
@@ -1,5 +1,5 @@
 "@opentelemetry/api":
-  versions: '>=1.3.0 <1.9.0'
+  versions: '>=1.3.0 <1.10.0'
   node: '>=14.0.0'
   commands:
     - node ../fixtures.test.js

--- a/test/opentelemetry-metrics/fixtures/package-lock.json
+++ b/test/opentelemetry-metrics/fixtures/package-lock.json
@@ -22,27 +22,27 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.51.1.tgz",
-      "integrity": "sha512-c8TrTlLm9JJRIHW6MtFv6ESoZRgXBXD/YrTRYylWiyYBOVbYHo1c5Qaw/j/thXDhkmYOYAn4LAhJZpLl5gBFEQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.52.0.tgz",
+      "integrity": "sha512-DJoCAtm6J1/rAP9oAjd5q5iq9/IKeiPLCHWOw+2QhPkgHHFvwKeOHnUp3xTC7RvpiuV2GQAV8Hih0CRHjehHJQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -52,40 +52,40 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
-      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.1.tgz",
-      "integrity": "sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.0.tgz",
+      "integrity": "sha512-IF+Sv4VHgBr/BPMKabl+GouJIhEqAOexCHgXVTISdz3q9P9H/uA8ScCF+22gitQ69aFtESbdYOV+Fen5+avQng==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
       "engines": {
         "node": ">=14"
       }
@@ -103,46 +103,46 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/exporter-prometheus": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.51.1.tgz",
-      "integrity": "sha512-c8TrTlLm9JJRIHW6MtFv6ESoZRgXBXD/YrTRYylWiyYBOVbYHo1c5Qaw/j/thXDhkmYOYAn4LAhJZpLl5gBFEQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.52.0.tgz",
+      "integrity": "sha512-DJoCAtm6J1/rAP9oAjd5q5iq9/IKeiPLCHWOw+2QhPkgHHFvwKeOHnUp3xTC7RvpiuV2GQAV8Hih0CRHjehHJQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
-      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.1.tgz",
-      "integrity": "sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.0.tgz",
+      "integrity": "sha512-IF+Sv4VHgBr/BPMKabl+GouJIhEqAOexCHgXVTISdz3q9P9H/uA8ScCF+22gitQ69aFtESbdYOV+Fen5+avQng==",
       "requires": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "lodash.merge": "^4.6.2"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
-      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -192,6 +192,11 @@ apm.logger.fatal('')
     trans.startSpan('foo', 'type', 'subtype', { exitSpan: true })
     trans.startSpan('foo', { links: [{ context: '00-12345678901234567890123456789012-1234567890123456-01' }] })
 
+    trans.addLink({ context: '00-12345678901234567890123456789012-1234567890123456-01' })
+    trans.addLink({ context: { traceId: '12345678901234567890123456789012', spanId: '1234567890123456' }})
+    trans.addLinks([{ context: '00-12345678901234567890123456789012-1234567890123456-01' }])
+    trans.addLinks([{ context: { traceId: '12345678901234567890123456789012', spanId: '1234567890123456' }}])
+
     function ensureParentId (id: string) {}
     ensureParentId(trans.ensureParentId())
 
@@ -224,6 +229,11 @@ apm.logger.fatal('')
       span.setServiceTarget('myServiceTargetType', 'myServiceTargetName')
       span.setServiceTarget(null, null)
       span.setServiceTarget()
+
+      span.addLink({ context: '00-12345678901234567890123456789012-1234567890123456-01' })
+      span.addLink({ context: { traceId: '12345678901234567890123456789012', spanId: '1234567890123456' }})
+      span.addLinks([{ context: '00-12345678901234567890123456789012-1234567890123456-01' }])
+      span.addLinks([{ context: { traceId: '12345678901234567890123456789012', spanId: '1234567890123456' }}])
 
       span.end()
       span.end(42)


### PR DESCRIPTION
This also updates a few places for the new otel/api v1.9.0.

Refs: #4071 (the dependabot update doesn't get everything)
Refs: #4070
Refs: #4069
Refs: #4077 (a separate issue for this other new feature in otel/api@1.9.0)
Refs: https://github.com/elastic/apm/pull/870

---

`@opentelemetry/api@1.9.0` added support for `span.addLink()` and `span.addLinks()`.
This updates our OTel bridge tracing support to work with those APIs.

This also adds public `addLink()` and `addLinks()` equivalent methods on our Transaction and Span APIs.
Note that the span links support still has limitations: only trace_id and span_id are sent/stored (no span link attributes, no 'tracestate' in the span context).

I created a separate issue for the other feature added to otel/api@1.9.0.