### PR TITLE
release 4.7.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,18 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+[[release-notes-4.7.0]]
+==== 4.7.0 - 2024/06/13
+
+[float]
+===== Features
+
+* Update <<opentelemetry-bridge>> support to `@opentelemetry/api` version 1.9.0.
+  ({issues}4078[#4078])
++
+Support for the new `addLink` and `addLinks` methods on Span have been added.
+However, support for the new synchronous gauge have not yet been added.
+
 
 [[release-notes-4.6.0]]
 ==== 4.6.0 - 2024/06/05

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -246,7 +246,7 @@ If this method is not called, the service target values are inferred from other 
 [[span-addlink]]
 ==== `span.addLink(link)`
 
-[small]#Added in: REPLACEME#
+[small]#Added in: v4.7.0#
 
 * `link` +{type-link}+
 
@@ -260,7 +260,7 @@ For example: `span.addLink({ context: anotherSpan })`.
 [[span-addlinks]]
 ==== `span.addLinks([links])`
 
-[small]#Added in: REPLACEME#
+[small]#Added in: v4.7.0#
 
 * `links` +{type-array}+ Span links.
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -312,7 +312,7 @@ The `setOutcome` method allows an end user to override the Node.js agent's defau
 [[transaction-addlink]]
 ==== `transaction.addLink(link)`
 
-[small]#Added in: REPLACEME#
+[small]#Added in: v4.7.0#
 
 * `link` +{type-link}+
 
@@ -326,7 +326,7 @@ For example: `transaction.addLink({ context: anotherSpan })`.
 [[transaction-addlinks]]
 ==== `transaction.addLinks([links])`
 
-[small]#Added in: REPLACEME#
+[small]#Added in: v4.7.0#
 
 * `links` +{type-array}+ Span links.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
A release to get otel/api@1.9.0 support for the OTel Bridge. Without a release a user of `@opentelemetry/api@1.9.0` would get no-op implementations with our bridge's supplied providers implementing the older 1.8.0 version.