### PR TITLE
test: fix 'localhost' ipv4 vs. ipv6 test failures in GH actions TAV tests

### DIFF
--- a/test/instrumentation/modules/hapi/hapi.test.js
+++ b/test/instrumentation/modules/hapi/hapi.test.js
@@ -47,7 +47,7 @@ test('extract URL from request', function (t) {
     t.strictEqual(request.url.pathname, '/captureError');
     t.strictEqual(request.url.search, '?foo=bar');
     t.strictEqual(request.url.raw, '/captureError?foo=bar');
-    t.strictEqual(request.url.hostname, 'localhost');
+    t.strictEqual(request.url.hostname, '127.0.0.1');
     t.strictEqual(request.url.port, String(server.info.port));
     server.stop(noop);
     t.end();
@@ -57,7 +57,7 @@ test('extract URL from request', function (t) {
 
   var server = startServer(function (err, port) {
     t.error(err, 'no error from startServer');
-    http.get('http://localhost:' + port + '/captureError?foo=bar');
+    http.get('http://127.0.0.1:' + port + '/captureError?foo=bar');
   });
 });
 
@@ -71,7 +71,7 @@ test('route naming', function (t) {
 
   var server = startServer(function (err, port) {
     t.error(err);
-    http.get('http://localhost:' + port + '/hello', function (res) {
+    http.get('http://127.0.0.1:' + port + '/hello', function (res) {
       t.strictEqual(res.statusCode, 200);
       res.on('data', function (chunk) {
         t.strictEqual(chunk.toString(), 'hello world');
@@ -103,7 +103,7 @@ test('captureBody', function (t) {
     const cReq = http.request(
       {
         method: 'POST',
-        hostname: 'localhost',
+        hostname: '127.0.0.1',
         port,
         path: '/postSomeData',
         headers: {
@@ -383,7 +383,7 @@ test('request error logging with Error', function (t) {
   runServer(server, function (err) {
     t.error(err, 'start error');
 
-    http.get('http://localhost:' + server.info.port + '/error', function (res) {
+    http.get('http://127.0.0.1:' + server.info.port + '/error', function (res) {
       t.strictEqual(res.statusCode, 200);
 
       res.resume().on('end', function () {
@@ -439,7 +439,7 @@ test('request error logging with Error does not affect event tags', function (t)
       t.deepEqual(event.tags, ['elastic-apm', 'error']);
     });
 
-    http.get('http://localhost:' + server.info.port + '/error', function (res) {
+    http.get('http://127.0.0.1:' + server.info.port + '/error', function (res) {
       t.strictEqual(res.statusCode, 200);
 
       res.resume().on('end', function () {
@@ -484,7 +484,7 @@ test('request error logging with String', function (t) {
   runServer(server, function (err) {
     t.error(err, 'start error');
 
-    http.get('http://localhost:' + server.info.port + '/error', function (res) {
+    http.get('http://127.0.0.1:' + server.info.port + '/error', function (res) {
       t.strictEqual(res.statusCode, 200);
 
       res.resume().on('end', function () {
@@ -531,7 +531,7 @@ test('request error logging with Object', function (t) {
   runServer(server, function (err) {
     t.error(err, 'start error');
 
-    http.get('http://localhost:' + server.info.port + '/error', function (res) {
+    http.get('http://127.0.0.1:' + server.info.port + '/error', function (res) {
       t.strictEqual(res.statusCode, 200);
 
       res.resume().on('end', function () {
@@ -556,7 +556,7 @@ test('error handling', function (t) {
 
   var server = startServer(function (err, port) {
     t.error(err);
-    http.get('http://localhost:' + port + '/error', function (res) {
+    http.get('http://127.0.0.1:' + port + '/error', function (res) {
       t.strictEqual(res.statusCode, 500);
       res.on('data', function (chunk) {
         var data = JSON.parse(chunk.toString());
@@ -574,16 +574,14 @@ test('error handling', function (t) {
 });
 
 function makeServer(opts) {
-  // Specify 'localhost' to avoid Hapi default of '0.0.0.0' which ties to
-  // IPv4. We want a later HTTP client request using 'localhost' to work.
   var server;
   if (semver.satisfies(pkg.version, '<17')) {
     server = new Hapi.Server();
     opts = opts || {};
-    opts.host = opts.host || 'localhost';
+    opts.host = opts.host || '127.0.0.1';
     server.connection(opts);
   } else {
-    server = new Hapi.Server({ host: 'localhost' });
+    server = new Hapi.Server({ host: '127.0.0.1' });
   }
   return server;
 }

--- a/test/instrumentation/modules/next/a-nextjs-app/pages/a-throw-in-page-handler.js
+++ b/test/instrumentation/modules/next/a-nextjs-app/pages/a-throw-in-page-handler.js
@@ -16,7 +16,7 @@ export async function getServerSideProps() {
 function AThrowInPageHandler({ currTime }) {
   // If this is called from a browser-side click of a <Link>, e.g. as on the
   // index.js page, then this function is executed client-side. If called
-  // via separately visiting http://localhost:3000/a-throw-in-page-handler
+  // via separately visiting http://127.0.0.1:3000/a-throw-in-page-handler
   // or via `curl -i ...`, then this is executed server-side. Only in the
   // latter case will the Node.js APM agent capture an error, of course.
   throw new Error('throw in page handler');

--- a/test/instrumentation/modules/next/next.test.js
+++ b/test/instrumentation/modules/next/next.test.js
@@ -557,7 +557,7 @@ function waitForServerReady(t, cb) {
 
   const pollForServerReady = () => {
     const req = http.get(
-      'http://localhost:3000/api/an-api-endpoint',
+      'http://127.0.0.1:3000/api/an-api-endpoint',
       {
         agent: false,
         timeout: 500,
@@ -611,7 +611,7 @@ async function makeTestRequest(t, testReq, buildId) {
     if (typeof reqOpts === 'function') {
       reqOpts = reqOpts(buildId);
     }
-    const url = `http://localhost:3000${reqOpts.path}`;
+    const url = `http://127.0.0.1:3000${reqOpts.path}`;
     t.comment(
       `makeTestRequest: ${testReq.testName} (${reqOpts.method} ${url})`,
     );
@@ -862,9 +862,9 @@ tape.test('-- prod server tests --', (suite) => {
     // the actual server because the `npm` process is gone.
     nextServerProc = spawn(
       path.normalize('./node_modules/.bin/next'),
-      // Be explicit about "localhost" here, otherwise with node v18 we can
+      // Be explicit about "127.0.0.1" here, otherwise with node v18 we can
       // get the server listening on IPv6 and the client connecting on IPv4.
-      ['start', '-H', 'localhost'],
+      ['start', '-H', '127.0.0.1'],
       {
         shell: os.platform() === 'win32',
         cwd: testAppDir,
@@ -962,7 +962,7 @@ tape.test('-- dev server tests --', (suite) => {
     // See the warning notes for `spawn()` above. The same apply here.
     nextServerProc = spawn(
       path.normalize('./node_modules/.bin/next'),
-      ['dev', '-H', 'localhost'],
+      ['dev', '-H', '127.0.0.1'],
       {
         shell: os.platform() === 'win32',
         cwd: testAppDir,

--- a/test/opentelemetry-metrics/fixtures.test.js
+++ b/test/opentelemetry-metrics/fixtures.test.js
@@ -147,7 +147,7 @@ async function checkEventsHaveTestMetrics(t, events, extraMetricNames = []) {
 
 async function checkHasPrometheusMetrics(t) {
   const { statusCode, body } = await undici.request(
-    'http://localhost:9464/metrics',
+    'http://127.0.0.1:9464/metrics',
   );
   t.equal(statusCode, 200, 'prometheus exporter is still working');
   const text = await body.text();

--- a/test/opentelemetry-metrics/fixtures/use-just-otel-sdk.js
+++ b/test/opentelemetry-metrics/fixtures/use-just-otel-sdk.js
@@ -8,7 +8,7 @@
 
 // Run without the APM agent this script will export metrics via a Prometheus
 // endpoint:
-//      curl -i http://localhost:9464/metrics
+//      curl -i http://127.0.0.1:9464/metrics
 //
 // With the APM agent running we also expect periodic metricsets sent to APM
 // server, because the agent will add its MetricReader to the created
@@ -21,7 +21,7 @@ const {
 } = require('@opentelemetry/sdk-metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 
-const exporter = new PrometheusExporter({ host: 'localhost' });
+const exporter = new PrometheusExporter({ host: '127.0.0.1' });
 const meterProvider = new MeterProvider({
   views: [
     new View({

--- a/test/opentelemetry-metrics/fixtures/use-otel-api-with-registered-meter-provider.js
+++ b/test/opentelemetry-metrics/fixtures/use-otel-api-with-registered-meter-provider.js
@@ -8,7 +8,7 @@
 
 // Run without the APM agent this script will export metrics via a Prometheus
 // endpoint:
-//      curl -i http://localhost:9464/metrics
+//      curl -i http://127.0.0.1:9464/metrics
 //
 // With the APM agent running we also expect periodic metricsets sent to APM
 // server, because the agent will add its MetricReader to the created
@@ -22,7 +22,7 @@ const otel = require('@opentelemetry/api');
 const { MeterProvider } = require('@opentelemetry/sdk-metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 
-const exporter = new PrometheusExporter({ host: 'localhost' });
+const exporter = new PrometheusExporter({ host: '127.0.0.1' });
 const meterProvider = new MeterProvider();
 meterProvider.addMetricReader(exporter);
 otel.metrics.setGlobalMeterProvider(meterProvider);


### PR DESCRIPTION
A number of TAV tests started failing in GH Actions recently, starting on Jun 12, 2024 (see x's at https://github.com/elastic/apm-agent-nodejs/commits/main/).

For example https://github.com/elastic/apm-agent-nodejs/actions/runs/9503644674

![Screenshot 2024-06-13 at 12 38 33 PM](https://github.com/elastic/apm-agent-nodejs/assets/46866/12e4b778-d0f3-4cb2-a3aa-bd52509fb17d)


The failures were *all* of this basic form:

```
 node_tests-1  | -- running test "node test/instrumentation/modules/hapi/hapi.test.js" with @hapi/hapi (env: {})
node_tests-1  | node:events:497
node_tests-1  |       throw er; // Unhandled 'error' event
node_tests-1  |       ^
node_tests-1  | 
node_tests-1  | Error: connect ECONNREFUSED 127.0.0.1:33547
node_tests-1  |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1606:16)
node_tests-1  | Emitted 'error' event on ClientRequest instance at:
node_tests-1  |     at Socket.socketErrorListener (node:_http_client:500:9)
node_tests-1  |     at Socket.emit (node:events:519:28)
node_tests-1  |     at emitErrorNT (node:internal/streams/destroy:169:8)
node_tests-1  |     at emitErrorCloseNT (node:internal/streams/destroy:128:3)
node_tests-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
node_tests-1  |   errno: -111,
node_tests-1  |   code: 'ECONNREFUSED',
node_tests-1  |   syscall: 'connect',
node_tests-1  |   address: '127.0.0.1',
node_tests-1  |   port: 33547
node_tests-1  | }
```

- running some test (on node 18, 20, or 22)
- start some HTTP server
- error `Error: connect ECONNREFUSED 127.0.0.1:${someport}`

The tests were *not* failing locally for me on my dev macOS.
My guess is that this is about ambiguity over whether `localhost` is IPv4 (127.0.0.1) or IPv6 (::1).