### PR TITLE
chore: improve update-4x-branch.sh script instructions for the docs-update PR

### DIFF
--- a/dev-utils/update-4x-branch.sh
+++ b/dev-utils/update-4x-branch.sh
@@ -65,8 +65,9 @@ git log --pretty=format:"%h" $LASTTAG...$TARGTAG \
         git cherry-pick $sha
     done
 
+RELEASE_PR=$(git log --pretty=format:"%s" -1 $TARGTAG | sed -E 's/^.* \(\#([0-9]+)\)$/\1/')
 echo
 echo "# You can create a PR now with:"
 echo "    cd $WRKDIR/apm-agent-nodejs"
-echo "    gh pr create --fill -w -B 4.x -t 'docs: update 4.x branch for $TARGTAG release'"
+echo "    gh pr create -w -B 4.x -t 'docs: update 4.x branch for $TARGTAG release' --body 'Refs: #$RELEASE_PR (release PR)'"
 


### PR DESCRIPTION
I noticed that the 'gh pr ...' command did not create a PR filled with
the intended title. That was due to the '--fill' option that we don't want.
This also adds a better body, so that the release PR will always get a
link-back from the docs update PR.
