### PR TITLE
Add missing setFaas to noop-transaction

### DIFF
--- a/lib/instrumentation/noop-transaction.js
+++ b/lib/instrumentation/noop-transaction.js
@@ -60,6 +60,7 @@ class NoopTransaction {
 
   // Non-public methods mentioned in a comment in index.d.ts.
   setUserContext() {}
+  setFaas() {}
   setCustomContext() {}
   setDefaultName() {}
   setDefaultNameFromRequest() {}


### PR DESCRIPTION
In the context of an AWS Lambda function wrapped with apm.lambda, if the APM agent hasn’t started yet, it will raise error `TypeError: trans.setFaas is not a function`
<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
