### PR TITLE
Use keyless authentication in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
-      # TODO: use keyless
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,6 +114,10 @@ jobs:
           subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
           subject-digest: ${{ steps.docker-push-wolfi.outputs.digest }}
           push-to-registry: true
+
+      - uses: elastic/oblt-actions/aws/auth@v1.10.0
+        with:
+          aws-account-id: "267093732750"
 
       - name: Publish AWS lambda (only for tag release)
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Use keyless authentication (OIDC) instead of credentials to authenticate with elastic-observability-prod in the release workflow