### PR TITLE
fix: allow file config to override true default values

### DIFF
--- a/lib/config/schema.js
+++ b/lib/config/schema.js
@@ -876,7 +876,7 @@ CONFIG_SCHEMA.forEach((def) => {
   if (def.envVar && process.env[def.envVar]) {
     def.environmentValue = process.env[def.envVar];
     def.source = 'environment';
-  } else if (fileOpts && fileOpts[def.name]) {
+  } else if (fileOpts && typeof fileOpts[def.name] !== 'undefined') {
     def.fileValue = fileOpts[def.name];
     def.source = 'file';
   }

--- a/test/start/file/elastic-apm-node.js
+++ b/test/start/file/elastic-apm-node.js
@@ -7,5 +7,6 @@
 'use strict'
 
 module.exports = {
-  serviceName: 'from-file'
+  serviceName: 'from-file',
+  active: false
 }

--- a/test/start/file/test.test.js
+++ b/test/start/file/test.test.js
@@ -19,5 +19,6 @@ const tape = require('tape');
 
 tape('from-file serviceName test', function (t) {
   t.equals(agent._conf.serviceName, 'from-file');
+  t.equals(agent._conf.active, false);
   t.end();
 });

--- a/test/start/file/test.test.js
+++ b/test/start/file/test.test.js
@@ -20,5 +20,6 @@ const tape = require('tape');
 tape('from-file serviceName test', function (t) {
   t.equals(agent._conf.serviceName, 'from-file');
   t.equals(agent._conf.active, false);
+  t.equals(agent._conf.captureBody, 'off'); // Existing default
   t.end();
 });


### PR DESCRIPTION
This allows a "false" boolean value to override a "true" default value when loading the options via the elastic-apm-node.js config file

Fixes: #4112
Closes: #4112

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
