### PR TITLE
release 4.7.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,18 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+
+[[release-notes-4.7.1]]
+==== 4.7.1 - 2024/07/24
+
+[float]
+===== Bug fixes
+
+- Update import-in-the-middle internally-used library to v1.9.1. This can
+  fix usage with ESM code (see <<esm>>) in some cases, e.g. usage with
+  https://github.com/elastic/apm-agent-nodejs/issues/4143[Nuxt 3].
+
+
 [[release-notes-4.7.0]]
 ==== 4.7.0 - 2024/06/13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
The import-in-the-middle update is worth a bug fix release.
It fixes a crash when using vue with ESM code.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/4143