### PR TITLE
ci: lock on older mssql/server Docker image to avoid healthcheck breakage

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -31,7 +31,9 @@ services:
       retries: 30
 
   mssql:
-    image: mcr.microsoft.com/mssql/server
+    # Cumulative update 14 (CU14), released 2024-07-23, breaks the healthcheck.
+    # See https://github.com/elastic/apm-agent-nodejs/issues/4147
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,7 +31,9 @@ services:
       retries: 30
 
   mssql:
-    image: mcr.microsoft.com/mssql/server
+    # Cumulative update 14 (CU14), released 2024-07-23, breaks the healthcheck.
+    # See https://github.com/elastic/apm-agent-nodejs/issues/4147
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y


### PR DESCRIPTION
The latest mcr.microsoft.com/mssql/server release (CU14) moves the sqlcmd
install location, breaking our healthcheck. Just updating the path hits
a different error. As a workaround, lets pin to the working mssql/server
docker image for CI.
Note that this docker compose file is used for TAV tests.
I'm not sure if hte mssql/server image used by GH Actions' mssql
'service' will be affected at some point as well.

Closes: https://github.com/elastic/apm-agent-nodejs/issues/4147
