### PR TITLE
test: modernize our mssql/server Docker image usage

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -31,21 +31,21 @@ services:
       retries: 30
 
   mssql:
-    # Cumulative update 14 (CU14), released 2024-07-23, breaks the healthcheck.
-    # See https://github.com/elastic/apm-agent-nodejs/issues/4147
-    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
+    # Tags listed at https://hub.docker.com/r/microsoft/mssql-server
+    # Docs: https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker
+    image: mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04
     platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
-      - SA_PASSWORD=Very(!)Secure
+      - MSSQL_SA_PASSWORD=Very(!)Secure
       - MSSQL_PID=Developer
     ports:
       - "1433:1433"
     volumes:
       - nodemssqldata:/var/opt/mssql
     healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "mssql", "-U", "sa", "-P", "Very(!)Secure", "-Q", "select 1"]
-      interval: 30s
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "mssql", "-U", "sa", "-P", "Very(!)Secure", "-Q", "select 1"]
+      interval: 10s
       timeout: 10s
       retries: 5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         image: mcr.microsoft.com/mssql/server
         env:
           ACCEPT_EULA: 'Y'
-          SA_PASSWORD: 'Very(!)Secure'
+          MSSQL_SA_PASSWORD: 'Very(!)Secure'
           MSSQL_PID: 'Developer'
         ports:
           - 1433:1433

--- a/examples/trace-tedious.js
+++ b/examples/trace-tedious.js
@@ -20,7 +20,7 @@ const apm = require('../').start({
 const tedious = require('tedious');
 
 const host = process.env.MSSQL_HOST || 'localhost';
-const passwd = process.env.SA_PASSWORD || 'Very(!)Secure';
+const passwd = process.env.MSSQL_SA_PASSWORD || 'Very(!)Secure';
 const connOpts = {
   server: host,
   authentication: {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,21 +31,21 @@ services:
       retries: 30
 
   mssql:
-    # Cumulative update 14 (CU14), released 2024-07-23, breaks the healthcheck.
-    # See https://github.com/elastic/apm-agent-nodejs/issues/4147
-    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
+    # Tags listed at https://hub.docker.com/r/microsoft/mssql-server
+    # Docs: https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker
+    image: mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04
     platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
-      - SA_PASSWORD=Very(!)Secure
+      - MSSQL_SA_PASSWORD=Very(!)Secure
       - MSSQL_PID=Developer
     ports:
       - "1433:1433"
     volumes:
       - nodemssqldata:/var/opt/mssql
     healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "mssql", "-U", "sa", "-P", "Very(!)Secure", "-Q", "select 1"]
-      interval: 30s
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "mssql", "-U", "sa", "-P", "Very(!)Secure", "-Q", "select 1"]
+      interval: 10s
       timeout: 10s
       retries: 5
 

--- a/test/instrumentation/modules/tedious.test.js
+++ b/test/instrumentation/modules/tedious.test.js
@@ -51,7 +51,7 @@ if (semver.gte(version, '4.0.0')) {
       type: 'default',
       options: {
         userName: 'SA',
-        password: process.env.SA_PASSWORD || 'Very(!)Secure',
+        password: process.env.MSSQL_SA_PASSWORD || 'Very(!)Secure',
       },
     },
     options: {
@@ -65,7 +65,7 @@ if (semver.gte(version, '4.0.0')) {
   connOpts = {
     server: hostname,
     userName: 'SA',
-    password: process.env.SA_PASSWORD || 'Very(!)Secure',
+    password: process.env.MSSQL_SA_PASSWORD || 'Very(!)Secure',
   };
 }
 


### PR DESCRIPTION
- move to the latest CU (cumulative update) of SQLServer 2022
  (which involves updating the healthcheck for internal changes)
- use MSSQL_SA_PASSWORD rather than the long since deprecated SA_PASSWORD

Refs: https://github.com/elastic/apm-agent-nodejs/issues/4147

---

A working healthcheck for the latest mssql/server image was provided by:
https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2248045546