### PR TITLE
fix(@aws-sdk/client-sns): do not crash if there is no current transaction

### DIFF
--- a/lib/instrumentation/modules/@aws-sdk/client-sns.js
+++ b/lib/instrumentation/modules/@aws-sdk/client-sns.js
@@ -36,28 +36,30 @@ function snsMiddlewareFactory(client, agent) {
         const targetId =
           input && (input.TopicArn || input.TargetArn || input.PhoneNumber);
 
-        // Though our spec only mentions a 10-message-attribute limit for *SQS*, we'll
-        // do the same limit here, because
-        // https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
-        // mentions the 10-message-attribute limit for SQS subscriptions.
-        input.MessageAttributes = input.MessageAttributes || {};
-        const attributesCount = Object.keys(input.MessageAttributes).length;
+        if (parentSpan) {
+          // Though our spec only mentions a 10-message-attribute limit for *SQS*, we'll
+          // do the same limit here, because
+          // https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
+          // mentions the 10-message-attribute limit for SQS subscriptions.
+          input.MessageAttributes = input.MessageAttributes || {};
+          const attributesCount = Object.keys(input.MessageAttributes).length;
 
-        if (attributesCount + 2 > MAX_SNS_MESSAGE_ATTRIBUTES) {
-          log.warn(
-            'cannot propagate trace-context with SNS message to %s, too many MessageAttributes',
-            targetId,
-          );
-        } else {
-          parentSpan.propagateTraceContextHeaders(
-            input.MessageAttributes,
-            function (msgAttrs, name, value) {
-              if (name.startsWith('elastic-')) {
-                return;
-              }
-              msgAttrs[name] = { DataType: 'String', StringValue: value };
-            },
-          );
+          if (attributesCount + 2 > MAX_SNS_MESSAGE_ATTRIBUTES) {
+            log.warn(
+              'cannot propagate trace-context with SNS message to %s, too many MessageAttributes',
+              targetId,
+            );
+          } else {
+            parentSpan.propagateTraceContextHeaders(
+              input.MessageAttributes,
+              function (msgAttrs, name, value) {
+                if (name.startsWith('elastic-')) {
+                  return;
+                }
+                msgAttrs[name] = { DataType: 'String', StringValue: value };
+              },
+            );
+          }
         }
 
         // Ensure there is a span from the wrapped `client.send()`.

--- a/test/instrumentation/modules/@aws-sdk/client-sns.test.js
+++ b/test/instrumentation/modules/@aws-sdk/client-sns.test.js
@@ -235,6 +235,24 @@ const testFixtures = [
       t.equal(spans.length, 0, 'all spans accounted for');
     },
   },
+
+  {
+    name: 'use-client-sns.js without a created transaction to ensure does not crash',
+    script: 'fixtures/use-client-sns.js',
+    cwd: __dirname,
+    env: {
+      AWS_ACCESS_KEY_ID: 'fake',
+      AWS_SECRET_ACCESS_KEY: 'fake',
+      TEST_ENDPOINT: endpoint,
+      TEST_REGION: 'us-east-2',
+      TEST_NO_TRANSACTION: 'true',
+    },
+    versionRanges: {
+      node: '>=14',
+    },
+    verbose: true,
+  },
+
   {
     name: '@aws-sdk/client-sns ESM',
     script: 'fixtures/use-client-sns.mjs',


### PR DESCRIPTION
Before this change, instrumentation of `@aws-sdk/client-sns` would *crash*
if there wasn't a current transaction.

Fixes: #4138
