### PR TITLE
release 4.7.2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,13 +33,14 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-==== Unreleased
 
-[float]
-===== Breaking changes
+[[release-notes-4.7.2]]
+==== 4.7.2 - 2024/08/01
 
 [float]
 ===== Features
+
+* Support hooking built-in Node.js modules loaded via https://nodejs.org/api/all.html#all_process_processgetbuiltinmoduleid[`process.getBuiltinModule`], added in v22.3.0. ({pull}4160[#4160])
 
 [float]
 ===== Bug fixes
@@ -49,10 +50,9 @@ See the <<upgrade-to-v4>> guide.
 
 * Fix for config resolution process. Before this change falsy config options coming
   from the `elastic-apm-node.js` file were ignored. ({pull}4119[#4119])
-* Support hooking built-in Node.js modules loaded via https://nodejs.org/api/all.html#all_process_processgetbuiltinmoduleid[`process.getBuiltinModule`], added in v22.3.0. ({pull}4160[#4160])
 
-[float]
-===== Chores
+* Fix publishing of AWS Lambda layer to all AWS regions. This was broken in
+  the 4.7.1 release. ({issues}4171[#4171])
 
 
 [[release-notes-4.7.1]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
Highlights:
- wrapping of core Node.js modules loaded via  (#4160)
- fix publishing of the AWS Lambda Layer to all AWS regions (#4171)


Checklist:
- [x] merge https://github.com/elastic/apm-agent-nodejs/pull/4172 first