### PR TITLE
test: fix two issues running tests locally

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -28,7 +28,7 @@ npm run lint                  # or 'make check' if you are a Makefile kind of pe
 
 npm test                      # run test services and tests in Docker
 
-docker-compose -f test/docker-compose.yml config --services  # list test services
+docker compose -f test/docker-compose.yml config --services  # list test services
 npm run docker:start          # start all test services
 npm run docker:start redis    # start one or more test services
 npm run docker:stop           # stop all test services

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   postgres:
     user: postgres
@@ -51,6 +49,8 @@ services:
 
   mysql:
     image: mysql:5.7
+    # No ARM64 image layer. See https://stackoverflow.com/a/65592942
+    platform: linux/x86_64
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     ports:

--- a/test/script/docker/run_tests.sh
+++ b/test/script/docker/run_tests.sh
@@ -18,7 +18,7 @@ else
   CMD='npm test'
 fi
 
-NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml run \
+NODE_VERSION=${1} docker compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml run \
   -e NODE_VERSION=${NODE_VERSION} \
   -e TAV=${TAV_MODULES} \
   -e CI=true \
@@ -33,4 +33,4 @@ NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-co
       npm --version
       ${CMD}"
 
-NODE_VERSION=${1} docker-compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml down -v
+NODE_VERSION=${1} docker compose --no-ansi --log-level ERROR -f ./test/docker-compose.yml -f ./test/docker-compose.ci.yml down -v

--- a/test/script/run_tests.sh
+++ b/test/script/run_tests.sh
@@ -90,7 +90,7 @@ then
 else
   # No arguments was given. Let's just assume that the user wants to
   # spin up all dependencies inside Docker and run the tests locally
-  services=$(docker-compose  -f ./test/docker-compose.yml  config --services)
+  services=$(docker compose  -f ./test/docker-compose.yml  config --services)
 fi
 
 service_arr=( $services )
@@ -106,11 +106,11 @@ then
 elif [[ $healthy -lt $expected_healthy || $containers -lt $expected_containers ]]
 then
   finish () {
-    docker-compose -f ./test/docker-compose.yml down
+    docker compose -f ./test/docker-compose.yml down
   }
   trap finish EXIT
 
-  docker-compose -f ./test/docker-compose.yml up -d $services
+  docker compose -f ./test/docker-compose.yml up -d $services
   wait_for_healthy
 fi
 


### PR DESCRIPTION
Two issues with testing locally on my dev laptop:

1. `docker-compose` (i.e. Docker Compose v1) is dead and, in some versions, now gone. Time for `docker compose ...` (i.e. v2): https://docs.docker.com/compose/migrate/

```
% npm test

> elastic-apm-node@4.7.3 test
> ./test/script/run_tests.sh

./test/script/run_tests.sh: line 93: docker-compose: command not found
```

2. The mysql image has no layer for ARM, i.e. that natively runs on Apple Silicon.

```
% npm test

> elastic-apm-node@4.7.3 test
> ./test/script/run_tests.sh

[+] Running 0/1
 ⠼ mysql Pulling                                                                                                                                                                                                                                                                                 1.4s
no matching manifest for linux/arm64/v8 in the manifest list entries
```
