### PR TITLE
test(express): drop express@5 from TAV tests

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -188,10 +188,7 @@ graphql:
 express:
   versions:
     mode: latest-minors
-    # include requires an upper bound. v5 is still in beta
-    # (5.0.0-beta.1": "2022-02-15T01:11:25.229Z) but we use 6 to make sure any
-    # future release is included if we udpate
-    include: '>=4 <6' # latest minors subset of '>=4 <6'
+    include: '>=4 <5'
   commands:
     - node test/instrumentation/modules/express/basic.test.js
     - node test/instrumentation/modules/express/capture-exceptions-off.test.js


### PR DESCRIPTION
We don't yet support instrumenting express@5. 5.0.0 was recently released.
Our TAV config was including express@5 in tests.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/4238
