### PR TITLE
test: attempted fix of flaky 'span slower than configured spanStackTraceMinDuration' test

### DIFF
--- a/test/spanStackTraceMinDuration.test.js
+++ b/test/spanStackTraceMinDuration.test.js
@@ -63,7 +63,7 @@ tape.test(
         t.ok(data.stacktrace, 'stacktrace set');
         t.end();
       });
-    }, 101);
+    }, 200);
   },
 );
 


### PR DESCRIPTION
This test case has been occasionally fail in CI recently.
This bumps the timing to make a small timing issue less likely to
cause the test to fail.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/3313#issuecomment-2382538762
