### PR TITLE
release 4.8.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,10 +33,8 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-4.8.0]]
+==== 4.8.0 - 2024/10/08
 
 [float]
 ===== Features
@@ -53,9 +51,7 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Bug fixes
 
-[float]
-===== Chores
-
+- Update `cookie` to version `v0.7.2` to fix security issue [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x)
 
 [[release-notes-4.7.3]]
 ==== 4.7.3 - 2024/08/09

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.7.3",
+  "version": "4.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.7.3",
+      "version": "4.8.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.7.3",
+  "version": "4.8.0",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
This should fix the sec issue [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x)

ref: https://github.com/elastic/apm-dev/issues/1083