### PR TITLE
fix release workflow; release 3.52.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: read
 
 jobs:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,8 +37,8 @@ for the latest (4.x) releases. The 3.x branch will be maintained until
 2024-03-07 (6 months after the 4.0.0 release).
 
 
-[[release-notes-3.52.1]]
-==== 3.52.1 - 2024/11/05
+[[release-notes-3.52.2]]
+==== 3.52.2 - 2024/11/05
 
 [float]
 ===== Chores

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.52.1",
+  "version": "3.52.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "3.52.1",
+      "version": "3.52.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "3.52.1",
+  "version": "3.52.2",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Previous release workflow failed on missing id-token permission.

Refs: https://github.com/elastic/apm-agent-nodejs/pull/4304
