### PR TITLE
fix: ensure 3.x releases publish to npm with 'latest-3' dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: npm publish
         run: |-
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          npm publish --provenance
+          npm publish --tag="latest-3" --provenance
 
       - if: always()
         uses: elastic/oblt-actions/slack/notify-result@v1


### PR DESCRIPTION
Fixes: https://github.com/elastic/apm-agent-nodejs/issues/4307
