### PR TITLE
ci(updatecli): add policies autodiscovery, bump updatecli version and specs/jsons policies

### DIFF
--- a/.ci/updatecli/values.d/scm.yml
+++ b/.ci/updatecli/values.d/scm.yml
@@ -3,5 +3,8 @@ scm:
   owner: elastic
   repository: apm-agent-nodejs
   branch: main
-
-signedcommit: true
+  commitusingapi: true
+  # begin update-compose policy values
+  user: obltmachine
+  email: obltmachine@users.noreply.github.com
+  # end update-compose policy values

--- a/.ci/updatecli/values.d/update-compose.yml
+++ b/.ci/updatecli/values.d/update-compose.yml
@@ -1,0 +1,3 @@
+spec:
+  files:
+    - "updatecli-compose.yaml"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -38,12 +38,18 @@ jobs:
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose diff
+          # TODO: update to the latest version so the policies can work as expected.
+          #       latest changes in the policies require to use the dependson feature.
+          version: "v0.88.0"
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose apply
+          # TODO: update to the latest version so the policies can work as expected.
+          #       latest changes in the policies require to use the dependson feature.
+          version: "v0.88.0"
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -2,13 +2,19 @@
 # https://www.updatecli.io/docs/core/compose/
 policies:
   - name: Handle apm-data server specs
-    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-data-spec:0.2.0@sha256:7069c0773d44a74c4c8103b4d9957b468f66081ee9d677238072fe11c4d2197c
+    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-data-spec:0.6.0@sha256:c0bbdec23541bed38df1342c95aeb601530a113db1ff11715c1c7616ed5e9e8b
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/apm-data-spec.yml
 
   - name: Handle apm json specs
-    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-json-specs:0.2.0@sha256:969a6d21eabd6ebea66cb29b35294a273d6dbc0f7da78589c416aedf08728e78
+    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-json-specs:0.6.0@sha256:e5a74c159ceed02fd20515ea76fa25ff81e3ccf977e74e636f9973db86aa52a5
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/apm-json-specs.yml
+
+  - name: Update Updatecli policies
+    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.6.0@sha256:6bd6999620674b2fbb1d374f7a1a5e9740d042667f0592900b44259f3e1ae98f
+    values:
+      - .ci/updatecli/values.d/scm.yml
+      - .ci/updatecli/values.d/update-compose.yml

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -14,7 +14,7 @@ policies:
       - .ci/updatecli/values.d/apm-json-specs.yml
 
   - name: Update Updatecli policies
-    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.6.0@sha256:6bd6999620674b2fbb1d374f7a1a5e9740d042667f0592900b44259f3e1ae98f
+    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.8.0@sha256:99e9e61b501575c2c176c39f2275998d198b590a3f6b1fe829f7315f8d457e7f
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/update-compose.yml


### PR DESCRIPTION
### What

* Use the latest updatecli version for now
* Update policies for the specs/jsons
* Enable updatecli policies autodiscovery (but use the previous latest one, so I can test this PR)

### Why

Otherwise, https://github.com/elastic/apm-agent-go/pull/1671 won't work

🐔 🥚  since https://github.com/updatecli/updatecli/releases/tag/v0.86.0

> Sources were always executed before conditions and then targets.
With this change, sources, conditions, and targets can now depend on any other resource type to allow an advanced update scenario.

And there are errors like

```
target: target#agent-json-specs
-----------------------

**Dry Run enabled**

The shell 🐚 command "/bin/sh /tmp/updatecli/bin/68b2939c124c411192667268d8f6edefbaa79f085494796eb8122c21afdb37bf.sh" exited on error (exit code 2) with the following output:
----
----

command stderr output was:
----
tar (child): /home/runner/work/apm-agent-go/apm-agent-go/json-specs.tgz: Cannot open: No such file or directory
```

### Test

See https://github.com/elastic/apm-agent-nodejs/actions/runs/12117832379