### PR TITLE
chore: update CHANGELOG

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,23 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+* add support for `undici` v7. ({pull}4336[#4336])
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+
 [[release-notes-4.8.1]]
 ==== 4.8.1 - 2024/11/04
 


### PR DESCRIPTION
Add a new entry to the changelog file mentioning the support for `undici` v7. `supported-techonologies` file was already updated in https://github.com/elastic/apm-agent-nodejs/pull/4336

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Add CHANGELOG.asciidoc entry
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
