### PR TITLE
release 4.9.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,20 +37,14 @@ See the <<upgrade-to-v4>> guide.
 ==== 4.9.0 - 2024/12/09
 
 [float]
-===== Breaking changes
-
-[float]
 ===== Features
 
-* add support for `undici` v7. ({pull}4336[#4336])
+* Add support for `undici` v7. ({pull}4336[#4336])
 
 [float]
 ===== Bug fixes
 
-* fix to support a internal refactor in `mysql2` v3.11.5. ({pull}4334[#4334])
-
-[float]
-===== Chores
+* Fix to support a internal refactor in `mysql2` v3.11.5. ({pull}4334[#4334])
 
 
 [[release-notes-4.8.1]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@ See the <<upgrade-to-v4>> guide.
 [float]
 ===== Bug fixes
 
+* fix to support a internal refactor in `mysql2` v3.11.5. ({pull}4334[#4334])
+
 [float]
 ===== Chores
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-[[release-notes-x.y.z]]
+[[release-notes-4.9.0]]
 ==== 4.9.0 - 2024/12/09
 
 [float]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,7 +33,8 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-==== Unreleased
+[[release-notes-x.y.z]]
+==== 4.9.0 - 2024/12/09
 
 [float]
 ===== Breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.8.1",
+      "version": "4.9.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
Release with:

- add support for `undici` v7. #4336
- fix to support a internal refactor in `mysql2` v3.11.5. #4334
- fix for truncate errors in http-client #4359