### PR TITLE
fix: get 'npm ci' working again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13680,10 +13680,21 @@
       "dev": true
     },
     "node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
-      "dev": true
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/promise": {
       "version": "7.3.1",
@@ -27024,9 +27035,9 @@
       "dev": true
     },
     "process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
       "dev": true
     },
     "promise": {


### PR DESCRIPTION
This is a workaround for `npm ci` failing with:
    Invalid: lock file's process-warning@4.0.0 does not satisfy process-warning@4.0.1

Closes: #4396

---

Until this is merged we cannot do dev for this repo.