### PR TITLE
fix: instrumentation of `@aws-sdk/client-*` v3.723.0 and later now works

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -467,14 +467,20 @@ aws-sdk:
     - node test/instrumentation/modules/aws-sdk/dynamodb.test.js
 
 '@aws-sdk/client-s3':
-  versions:
-    # - 3.377.0 was a bad release (https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1828#issuecomment-1834276719)
-    mode: max-7
-    include: '>=3.15.0 <4'
-    exclude: '3.377.0'
-  commands:
-    - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
-  node: '>=14'
+  - versions:
+      # - 3.377.0 was a bad release (https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1828#issuecomment-1834276719)
+      mode: max-5
+      include: '>=3.15.0 <3.723.0'
+      exclude: '3.377.0'
+    node: '>=14'
+    commands:
+      - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
+  - versions:
+      mode: max-5
+      include: '>=3.723.0 <4'
+    node: '>=18'
+    commands:
+      - node test/instrumentation/modules/@aws-sdk/client-s3.test.js
 
 '@aws-sdk/client-dynamodb':
   versions:
@@ -485,20 +491,32 @@ aws-sdk:
   node: '>=14'
 
 '@aws-sdk/client-sns':
-  versions:
-    mode: max-7
-    include: '>=3.15.0 <4'
-  commands:
-    - node test/instrumentation/modules/@aws-sdk/client-sns.test.js
-  node: '>=14'
+  - versions:
+      mode: max-7
+      include: '>=3.15.0 <3.723.0'
+    node: '>=14'
+    commands:
+      - node test/instrumentation/modules/@aws-sdk/client-sns.test.js
+  - versions:
+      mode: max-5
+      include: '>=3.723.0 <4'
+    node: '>=18'
+    commands:
+      - node test/instrumentation/modules/@aws-sdk/client-sns.test.js
 
 '@aws-sdk/client-sqs':
-  versions:
-    mode: max-7
-    include: '>=3.15.0 <4'
-  commands:
-    - node test/instrumentation/modules/@aws-sdk/client-sqs.test.js
-  node: '>=14'
+  - versions:
+      mode: max-7
+      include: '>=3.15.0 <3.723.0'
+    node: '>=14'
+    commands:
+      - node test/instrumentation/modules/@aws-sdk/client-sqs.test.js
+  - versions:
+      mode: max-5
+      include: '>=3.723.0 <4'
+    node: '>=18'
+    commands:
+      - node test/instrumentation/modules/@aws-sdk/client-sqs.test.js
 
 # - undici@4.7.0 added its diagnostics_channel support.
 # - In undici@4.7.1 the `request.origin` property was added, which we need

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,24 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+* Fix instrumentation of `@aws-sdk/client-s3`, `@aws-sdk/client-sqs`, and
+  `@aws-sdk/client-sns` for versions 3.723.0 and later. (Internally the AWS SDK
+  clients updated to `@smithy/smithy-client@4`.)
+
+[float]
+===== Chores
+
 [[release-notes-4.10.0]]
 ==== 4.10.0 - 2024/12/24
 

--- a/lib/instrumentation/modules/@smithy/smithy-client.js
+++ b/lib/instrumentation/modules/@smithy/smithy-client.js
@@ -110,7 +110,7 @@ module.exports = function (mod, agent, { name, version, enabled }) {
   // `@smithy/` npm org.
   if (
     name === '@smithy/smithy-client' &&
-    !semver.satisfies(version, '>=1 <4')
+    !semver.satisfies(version, '>=1 <5')
   ) {
     agent.logger.debug(
       'cannot instrument @aws-sdk/client-*: @smithy/smithy-client version %s not supported',


### PR DESCRIPTION
v3.723.0 and later of some aws-sdk-js v3 clients updated to use `@smithy/smithy-client@4`
which is part of what is instrumented.

---

TAV tests for client-s3, client-sns, and client-sqs started failing with the 3.723.0 version released earlier today.
E.g.: https://github.com/elastic/apm-agent-nodejs/actions/runs/12641762762/job/35224835256

```
$ npm info @aws-sdk/client-s3 time
...
  '3.716.0': '2024-12-19T20:06:49.540Z',
  '3.717.0': '2024-12-20T19:58:02.159Z',
  '3.721.0': '2025-01-02T20:07:43.217Z',
  '3.722.0': '2025-01-03T19:56:43.048Z',
  '3.723.0': '2025-01-06T20:58:42.380Z'
```

The interesting part of the diff of those versions:

```diff
-        "@smithy/core": "^2.5.5",
-        "@smithy/smithy-client": "^3.5.1",
+        "@smithy/core": "^3.0.0",
+        "@smithy/smithy-client": "^4.0.0",

       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
```