### PR TITLE
chore(labeler): don't label PRs from our renovate bot as a community PR

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -33,7 +33,10 @@ jobs:
         github-token: ${{ steps.get_token.outputs.token }}
 
     - name: Add community and triage labels
-      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-observability-automation[bot]'
+      if: contains(steps.is_elastic_member.outputs.result, 'false') &&
+        github.actor != 'dependabot[bot]' &&
+        github.actor != 'elastic-renovate-prod[bot]' &&
+        github.actor != 'elastic-observability-automation[bot]'
       uses: actions/github-script@v7
       with:
         script: |


### PR DESCRIPTION
E.g. note how https://github.com/elastic/apm-agent-nodejs/pull/4402 was so labeled and should not have been.
