### PR TITLE
chore(ci): change from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   add_to_project:
     if: github.event.issue && github.event.issue.milestone
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get token
         id: get_token

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -27,7 +27,7 @@ jobs:
   # made, these will stop and there will be no value in testing v17 nightlies.
   #
   test-nightly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
   # The node.js project *sometimes* produces "rc" builds leading up to a new
   # release. They get uploaded to: https://nodejs.org/download/rc/
   test-rc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Get token
       id: get_token

--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   microbenchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Run microbenchmark

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-nodejs
     steps:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ !(github.event.action == 'opened' && github.event.pull_request.draft) ||
       github.event.pull_request.user.login != 'dependabot[bot]' ||
       github.event.pull_request.user.login != 'elastic-renovate-prod[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Prepare Slack message
         id: prepare

--- a/.github/workflows/tav-command.yml
+++ b/.github/workflows/tav-command.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   command-validation:
     if: startsWith(github.event.review.body, '/test tav')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       pull-requests: write
@@ -132,7 +132,7 @@ jobs:
 
   test-tav:
     needs: command-validation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     strategy:
       max-parallel: 15

--- a/.github/workflows/tav.yml
+++ b/.github/workflows/tav.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   prepare-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       permutations: ${{ steps.transform.outputs.permutations }}
@@ -59,7 +59,7 @@ jobs:
 
   test-tav:
     needs: prepare-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     strategy:
       max-parallel: 15

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "No build required"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -164,7 +164,7 @@ jobs:
           - '16.0'
           - '14'
           - '14.17'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -197,7 +197,7 @@ jobs:
   # failure if at least one job listed "needs" is not successful.
   test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - lint
       - test-vers

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   compose:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
This is (a) to avoid the warnings in workflow runs, e.g.:

    test-tav (@apollo/server 22) ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636

and (b) to try it out ahead of the switch.
