### PR TITLE
fix(slack notifications): don't attempt to post a slack message if don't have one (#527)

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -117,6 +117,7 @@ jobs:
             f.write("payload={}".format(json.dumps(payload)))
 
       - name: Post Slack message
+        if: ${{ steps.prepare.outputs.payload }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage


### PR DESCRIPTION
This fixes a 'SlackError: Missing input!' error when skipping a
notification, e.g. for a dependabot PR:
https://github.com/elastic/elastic-otel-node/actions/runs/12743214047/job/35512726091?pr=526

Refs: https://github.com/elastic/elastic-otel-node/pull/527
