### PR TITLE
chore: disable dependabot updates of the test app used for the experimental Next.js instrumentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,14 +56,6 @@ updates:
       - "elastic/apm-agent-node-js"
 
   - package-ecosystem: "npm"
-    directory: "/test/instrumentation/modules/next/a-nextjs-app"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "elastic/apm-agent-node-js"
-
-  - package-ecosystem: "npm"
     directory: "/test/opentelemetry-bridge"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The next.js instrumentation is experimental and support is locked to an
old/deprecated version of Next.js and is unlikely to move forward from
there. There is no value in dependabot updates for this test app.
