### PR TITLE
chore(deps): update OTel deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5152,9 +5152,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -5166,11 +5166,11 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -5181,12 +5181,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.0.tgz",
-      "integrity": "sha512-5kcj6APyRMvv6dEIP5plz2qfJAD4OMipBRT11u/pa1a68rHKI2Ln+iXVkAGKgx8o7CXbD7FdPypTUY88ZQgP4Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -20275,29 +20275,29 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "requires": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.0.tgz",
-      "integrity": "sha512-5kcj6APyRMvv6dEIP5plz2qfJAD4OMipBRT11u/pa1a68rHKI2Ln+iXVkAGKgx8o7CXbD7FdPypTUY88ZQgP4Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
       }
     },
     "@opentelemetry/semantic-conventions": {

--- a/test/opentelemetry-metrics/fixtures/package-lock.json
+++ b/test/opentelemetry-metrics/fixtures/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -36,13 +36,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.0.tgz",
-      "integrity": "sha512-yjAfXoHcR+Ik03+eZMrrS5ErL7RcNkNScZc2o5dLnZyoEj5A0cCaQLHX5RJxldck8gg5Utmm0I5iItPqnve21w==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.1.tgz",
+      "integrity": "sha512-lwwOQzyvhzioGCYmIh7mXo+RLSoEVhuO0dFzWeEiQhFkjSUOPgKQKNTgYtl2KO1L7XIbHp5LIgn4nZrYx191Rg==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/sdk-metrics": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-metrics": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -52,11 +52,11 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -67,12 +67,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.0.tgz",
-      "integrity": "sha512-5kcj6APyRMvv6dEIP5plz2qfJAD4OMipBRT11u/pa1a68rHKI2Ln+iXVkAGKgx8o7CXbD7FdPypTUY88ZQgP4Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -97,39 +97,39 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "requires": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       }
     },
     "@opentelemetry/exporter-prometheus": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.0.tgz",
-      "integrity": "sha512-yjAfXoHcR+Ik03+eZMrrS5ErL7RcNkNScZc2o5dLnZyoEj5A0cCaQLHX5RJxldck8gg5Utmm0I5iItPqnve21w==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.1.tgz",
+      "integrity": "sha512-lwwOQzyvhzioGCYmIh7mXo+RLSoEVhuO0dFzWeEiQhFkjSUOPgKQKNTgYtl2KO1L7XIbHp5LIgn4nZrYx191Rg==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/sdk-metrics": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-metrics": "1.30.1"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.0.tgz",
-      "integrity": "sha512-5kcj6APyRMvv6dEIP5plz2qfJAD4OMipBRT11u/pa1a68rHKI2Ln+iXVkAGKgx8o7CXbD7FdPypTUY88ZQgP4Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
       "requires": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
       }
     },
     "@opentelemetry/semantic-conventions": {


### PR DESCRIPTION
@opentelemetry/core: 1.30.0 -> 1.30.1
@opentelemetry/resources: 1.30.0 -> 1.30.1
@opentelemetry/sdk-metrics: 1.30.0 -> 1.30.1
@opentelemetry/exporter-prometheus: 0.57.0 -> 0.57.1

This replaces all current open dependabot updates that are picking off otel deps one at a time, sometimes resulting in installing multiple copies of some otel deps.