### PR TITLE
release 4.11.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,10 +33,8 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
-==== Unreleased
-
-[float]
-===== Breaking changes
+[[release-notes-4.11.0]]
+==== 4.11.0 - 2025/01/20
 
 [float]
 ===== Features
@@ -51,8 +49,6 @@ See the <<upgrade-to-v4>> guide.
   `@aws-sdk/client-sns` for versions 3.723.0 and later. Internally the AWS SDK
   clients updated to `@smithy/smithy-client@4`. ({pull}4398[#4398])
 
-[float]
-===== Chores
 
 [[release-notes-4.10.0]]
 ==== 4.10.0 - 2024/12/24

--- a/docs/esm.asciidoc
+++ b/docs/esm.asciidoc
@@ -36,7 +36,7 @@ when invoked as follows:
 export ELASTIC_APM_SERVER_URL='https://...apm...cloud.es.io:443'
 export ELASTIC_APM_SECRET_TOKEN='...'
 node -r elastic-apm-node/start.js \
-  --experimental-loader=elastic-apm-node/loader.mjs' \
+  --experimental-loader=elastic-apm-node/loader.mjs \
   node server.mjs
 ----
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "The official Elastic APM agent for Node.js",
   "type": "commonjs",
   "main": "index.js",


### PR DESCRIPTION
- Azure Functions Node.js programming model v4 support (#4426)
- Instrumentation fix for release `@aws-sdk/client-*` releases -- versions 3.723.0 and later. (#4398)