### PR TITLE
chore: update alpine base image in Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,3 +109,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,22 @@ Notes:
 
 See the <<upgrade-to-v4>> guide.
 
+==== Unreleased
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+
+[float]
+===== Bug fixes
+
+[float]
+===== Chores
+
+* Update base image of alpine in `Dockerfile` to version `3.21.3`. ({pull}4465[#4465])
+
 [[release-notes-4.11.0]]
 ==== 4.11.0 - 2025/01/20
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-# Pin to Alpine 3.21.3
-# platform: linux; amd64
-# ref: https://github.com/docker-library/repo-info/blob/1d18c8623bddaa866457a10b9eefa3a5be06242e/repos/alpine/remote/3.21.3.md?plain=1#L26
-#
-# For a complete list of hashes, see:
-# https://github.com/docker-library/repo-info/tree/master/repos/alpine/remote
-FROM alpine@sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474
+# Pin the latest Alpine 3
+# https://github.com/docker-library/repo-info/blob/master/repos/alpine/remote/3.md
+
+FROM alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 ARG AGENT_DIR
 COPY ${AGENT_DIR} /opt/nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-# Pin to Alpine 3.9
+# Pin to Alpine 3.21.3
+# platform: linux; amd64
+# ref: https://github.com/docker-library/repo-info/blob/1d18c8623bddaa866457a10b9eefa3a5be06242e/repos/alpine/remote/3.21.3.md?plain=1#L26
+#
 # For a complete list of hashes, see:
 # https://github.com/docker-library/repo-info/tree/master/repos/alpine/remote
-FROM alpine@sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178
+FROM alpine@sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474
 ARG AGENT_DIR
 COPY ${AGENT_DIR} /opt/nodejs


### PR DESCRIPTION
The Docker image of the agent is currently based in `alpine@3.9` which is almost 3y old and have some issues related to libssl@1.1. This PR updates it to version `3.21.3`.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Add CHANGELOG.asciidoc entry
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
