### PR TITLE
chore(slack-lite): switch to pull_request_target so have access to repo secrets

### DIFF
--- a/.github/workflows/slack-lite.yml
+++ b/.github/workflows/slack-lite.yml
@@ -11,7 +11,7 @@
 # 3. Optionally tweak the `if:` and `on:` sections below to control which issue
 #    and PR events are skipped.
 
-name: slack
+name: slack-lite
 
 env:
   SLACK_CHANNEL: "#apm-agent-node"
@@ -19,11 +19,11 @@ env:
 on:
   issues:
     types: [opened, reopened, closed]
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened, closed]
 
 jobs:
-  slack:
+  slack-lite:
     # Skip notification if:
     # - dependabot or renovate PRs, too noisy
     # - draft PRs


### PR DESCRIPTION
No need for us to be running code from the PR itself, so this event is fine.
Before this change, a workflow run for a PR from a *fork* would have
'Secret source: None' and hence not have access to the SLACK_BOT_TOKEN

Also be clearer on the 'slack-lite' brand.

---

Before this change we missed the PRs from Colleen for the coming docs-v3 changes. E.g. this "slack" workflow run failure: https://github.com/elastic/apm-agent-nodejs/actions/runs/13534983291/job/37824876596
