### PR TITLE
Fixes #4508: Ensure `return` in binding definitions is not null or…

### DIFF
--- a/lib/instrumentation/azure-functions.js
+++ b/lib/instrumentation/azure-functions.js
@@ -376,7 +376,9 @@ function instrument(agent) {
         direction: context?.options?.trigger?.direction,
       });
       // Output bindings
-      bindingDefinitions.push(context?.options?.return);
+      if(context?.options?.return) {
+        bindingDefinitions.push(context?.options?.return);
+      }
     }
     let executionContext = context.executionContext;
     if (!executionContext) {

--- a/lib/instrumentation/azure-functions.js
+++ b/lib/instrumentation/azure-functions.js
@@ -376,7 +376,7 @@ function instrument(agent) {
         direction: context?.options?.trigger?.direction,
       });
       // Output bindings
-      if(context?.options?.return) {
+      if (context?.options?.return) {
         bindingDefinitions.push(context?.options?.return);
       }
     }


### PR DESCRIPTION
Fixes #4508 

Ensure `return` in binding definitions is not null or undefined.

Previously, `context?.options?.return` was added to `bindingDefinitions` without checking its presence. This change adds a conditional check to verify its existence before pushing.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
