### PR TITLE
test: avoid an occasional flaky bluebird test failure

### DIFF
--- a/test/instrumentation/modules/bluebird/_coroutine.js
+++ b/test/instrumentation/modules/bluebird/_coroutine.js
@@ -105,19 +105,20 @@ module.exports = function (test, Promise, ins) {
 };
 
 function assertPingPong(t, ins, p) {
-  // Since setTimeout has a weird behavior[1] the function might be called 1ms
-  // before it's scheduled, which is why we allow for only 9ms to have passed
-  // instead of 10ms in the two asserts below
+  // Since setTimeout has a weird behavior[1] the function might be called
+  // slightly before it's scheduled. For pingDelay=10ms we have observed an
+  // actual delay of as low as 8ms.
   //
   // [1] https://twitter.com/wa7son/status/1009048999972818944
+  const tolerance = 3;
   t.ok(
-    p.start + 9 <= p.pingDelay,
+    p.start + (10 - tolerance) <= p.pingDelay,
     'ping should be delayed min 9ms (delayed ' +
       (p.pingDelay - p.start) +
       'ms)',
   );
   t.ok(
-    p.pingDelay + 9 <= p.pongDelay,
+    p.pingDelay + (10 - tolerance) <= p.pongDelay,
     'pong should be delayed min 9ms (delayed ' +
       (p.pongDelay - p.pingDelay) +
       'ms)',

--- a/test/instrumentation/modules/bluebird/bluebird.test.js
+++ b/test/instrumentation/modules/bluebird/bluebird.test.js
@@ -1232,14 +1232,15 @@ test('new Promise -> delay', function (t) {
     var trans = ins.startTransaction();
     var start = Date.now();
 
+    const tolerance = 5; // We've observed scheduling slop up to 2ms.
     Promise.resolve('foo')
       .delay(50)
       .then(function () {
-        var expected = start + 49; // timings are hard
+        var expected = start + (50 - tolerance);
         var now = Date.now();
         t.ok(
           expected <= now,
-          'start + 49 should be <= ' + now + ' - was ' + expected,
+          '(start + 50 - tolerance) should be <= ' + now + ' - was ' + expected,
         );
         t.strictEqual(ins.currTransaction().id, trans.id);
       });


### PR DESCRIPTION
For example:

```
not ok 84 ping should be delayed min 9ms (delayed 8ms)
  ---
    operator: ok
    expected: true
    actual:   false
    at: assertPingPong (/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/test/instrumentation/modules/bluebird/_coroutine.js:113:5)
    stack: |-
      Error: ping should be delayed min 9ms (delayed 8ms)
```

---

@david-luna This is for the flaky test failure you mentioned at https://github.com/elastic/apm-agent-nodejs/issues/3313#issuecomment-2717512344
