### PR TITLE
dependabot: support for docker internal registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+registries:
+  docker-elastic:
+    type: docker-registry
+    url: https://docker.elastic.co
+    username: ${{secrets.ELASTIC_DOCKER_USERNAME}}
+    password: ${{secrets.ELASTIC_DOCKER_PASSWORD}}
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -113,5 +120,6 @@ updates:
   # Docker
   - package-ecosystem: "docker"
     directory: "/"
+    registries: "*"
     schedule:
       interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>elastic/renovate-config:only-chainguard"
-  ]
-}


### PR DESCRIPTION
### What

Use `dependabot` for updating docker images stored in our internal docker registry using [this](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot).

Closes https://github.com/elastic/apm-agent-nodejs/issues/4537

### Why

We already have secrets stored for accessing the internal docker registry. Use one dependency management tool with native support for GitHub actions and the [GH secrets access control](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/). 

This has been already tested in the past in a sandbox repository and also in another GH internal repositories.

### Actions

- [x] Create Dependabot GitHub secret using CasC.


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add release notes to `docs/release-notes/index.md`
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
