### PR TITLE
test: update assertion on self signed cert rejection

### DIFF
--- a/test/apm-client/http-apm-client/config.test.js
+++ b/test/apm-client/http-apm-client/config.test.js
@@ -235,7 +235,10 @@ test('reject unauthorized TLS by default', function (t) {
     client.on('request-error', function (err) {
       t.ok(err instanceof Error);
       let expectedErrorMessage = 'self signed certificate';
-      if (semver.gte(process.version, 'v17.0.0')) {
+      if (semver.gte(process.version, 'v23.11.0')) {
+        expectedErrorMessage =
+          'self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca';
+      } else if (semver.gte(process.version, 'v17.0.0')) {
         expectedErrorMessage = 'self-signed certificate';
       }
       t.equal(err.message, expectedErrorMessage);


### PR DESCRIPTION
Node.js v23.11 has changed the error message when using a self signed certificate in a HTTP connection. It adds more details on how to solve it. This change makes an assertion to fail giving a false positive in test.

This was discovered in test [test FIPS workflow](https://github.com/elastic/apm-agent-nodejs/actions/runs/14326325034/attempts/1) since its installing the latest stable release. The usual test work flow is using v22 and below so it is not failing there.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Update tests
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
