### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/azure-functions.md
+++ b/docs/reference/azure-functions.md
@@ -70,9 +70,7 @@ ELASTIC_APM_SECRET_TOKEN: <your APM secret token from the prerequisites step>
 
 For example:
 
-:::{image} images/azure-functions-configuration.png
-:alt: Configuring the APM Agent in the Azure Portal
-:::
+![Configuring the APM Agent in the Azure Portal](images/azure-functions-configuration.png)
 
 For local testing via `func start`, you can set these environment variables in your terminal, or in the "local.settings.json" file. See the [agent configuration guide](/reference/configuration.md) for full details on supported configuration variables.
 

--- a/docs/reference/nextjs.md
+++ b/docs/reference/nextjs.md
@@ -96,10 +96,7 @@ while true; do sleep 1; curl -i http://localhost:3000/api/hello; done
 
 Visit your Kibana APM app and, after a few seconds, you should see a service entry for your Next.js app. The service name will be pulled from the "name" field in "package.json". It can be overriden with [`serviceName`](/reference/configuration.md#service-name). Here is an example:
 
-:::{image} images/nextjs-my-app-screenshot.png
-:alt: Kibana APM app showing Next.js my-app
-:::
-
+![Kibana APM app showing Next.js my-app](images/nextjs-my-app-screenshot.png)
 
 ## Limitations and future work [nextjs-limitations]
 

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -12,9 +12,7 @@ The Elastic APM Node.js Agent automatically instruments various APIs in Node.js 
 
 Support for the Elastic APM Node.js agent follows the [support schedule of Node.js itself](https://nodejs.org/en/about/releases/) to the end-of-life period of each version after its maintenance term. Versions of Node.js past their end-of-life date are not supported.
 
-:::{image} images/node_release_schedule.svg
-:alt: Node.js release schedule
-:::
+![Node.js release schedule](images/node_release_schedule.svg)
 
 APM agent 4.x releases work with Node.js versions 14.17.0 and later. APM agent 3.x maintenance releases work with Node.js versions 8.6 and later. We will only break support for older Node.js versions with a major version release of the APM agent.
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 