### PR TITLE
tests: update `_is_restify_incompat` checks

### DIFF
--- a/test/_is_restify_incompat.js
+++ b/test/_is_restify_incompat.js
@@ -29,6 +29,9 @@ function isRestifyIncompat() {
   const restifyVer = require('restify/package.json').version;
   const msg = `restify@${restifyVer} is incompatible with node@${nodeVer}`;
 
+  if (semver.satisfies(nodeVer, '>=24.0.0', { includePrerelease: true })) {
+    return msg;
+  }
   if (
     semver.satisfies(restifyVer, '<10.0.0') &&
     semver.satisfies(nodeVer, '>=18.0.0', { includePrerelease: true })


### PR DESCRIPTION
Update `_is_restify_incompat` check so `restify` test do not fail in Node.js v24. The 1st occurrence of the error happened in FIPS tests workflow
https://github.com/elastic/apm-agent-nodejs/actions/runs/15130108346/job/42529298106

The root cause is a issue in `http-deceiver` dependency

```sh
npm ls http-deceiver

elastic-apm-node@4.13.0 /Users/david/Documents/repos/el/apm-agent-nodejs
└─┬ restify@11.1.0
  └─┬ spdy@4.0.2
    └── http-deceiver@1.2.7
```

the module uses the following expression

```js
HTTPParser = process.binding('http_parser').HTTPParser;
```

and the internal `http_parser` module is not present in Node.js v24 so it fails in cascade when trying to load `restify`. I'm not sure if this internal module has been removed intentionally though

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Update tests
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
