### PR TITLE
feat: add ESM support for hapi

### DIFF
--- a/docs/reference/esm.md
+++ b/docs/reference/esm.md
@@ -78,6 +78,7 @@ Automatic instrumentation of ES modules is currently limited as described here. 
 | `@aws-sdk/client-s3` | >=3.15.0 <4 |  |  |
 | `@aws-sdk/client-sns` | >=3.15.0 <4 |  |  |
 | `@aws-sdk/client-sqs` | >=3.15.0 <4 |  |  |
+| `@hapi/hapi` | >=20 |  |  |
 | `cassandra-driver` | >=3.0.0 <5 |  |  |
 | `express` | >=4.0.0 <6 |  |  |
 | `fastify` | >=3.5.0 |  |  |

--- a/lib/instrumentation/index.js
+++ b/lib/instrumentation/index.js
@@ -132,6 +132,7 @@ const IITM_MODULES = {
   // code. If a future aws-sdk v3 version switches to ESM imports internally,
   // then this will be relevant.
   //  '@aws-sdk/smithy-client': { instrumentImportMod: false },
+  '@hapi/hapi': { instrumentImportMod: true },
   'cassandra-driver': { instrumentImportMod: false },
   express: { instrumentImportMod: false },
   fastify: { instrumentImportMod: true },

--- a/lib/instrumentation/modules/@hapi/hapi.js
+++ b/lib/instrumentation/modules/@hapi/hapi.js
@@ -75,7 +75,7 @@ function simpleReprFromVal(val) {
   return val;
 }
 
-module.exports = function (hapi, agent, { version, enabled }) {
+module.exports = function (hapi, agent, { version, enabled, isImportMod }) {
   if (!enabled) {
     return hapi;
   }
@@ -94,6 +94,14 @@ module.exports = function (hapi, agent, { version, enabled }) {
       return res;
     };
   });
+
+  if (isImportMod) {
+    hapi.default = {
+      ...hapi.default,
+      server: hapi.server,
+      Server: hapi.Server,
+    };
+  }
 
   function patchServer(server) {
     // Hooks that are always allowed

--- a/test/instrumentation/modules/fixtures/use-hapi-connectionless.js
+++ b/test/instrumentation/modules/fixtures/use-hapi-connectionless.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+// Usage:
+//    node --require=./start.js test/instrumentation/modules/fixtures/use-hapi-connectionless.js
+
+const semver = require('semver');
+
+const hapi = require('@hapi/hapi');
+
+const server = hapi.server();
+
+async function main() {
+  if (semver.satisfies(server.version, '<17')) {
+    await new Promise((resolve, reject) =>
+      server.initialize(function (err) {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve();
+      }),
+    );
+  } else {
+    await server.initialize();
+  }
+
+  const customError = new Error('custom error');
+
+  server.log(['error'], customError);
+
+  const stringError = 'custom error';
+
+  server.log(['error'], stringError);
+
+  const objectError = {
+    error: 'I forgot to turn this into an actual Error',
+  };
+
+  server.log(['error'], objectError);
+
+  await server.stop();
+}
+
+main();

--- a/test/instrumentation/modules/fixtures/use-hapi.js
+++ b/test/instrumentation/modules/fixtures/use-hapi.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+// Usage:
+//    node --require=./start.js test/instrumentation/modules/fixtures/use-hapi.js
+
+const http = require('http');
+const semver = require('semver');
+
+const agent = require('../../../..');
+
+const hapi = require('@hapi/hapi');
+
+function handler(fn) {
+  if (semver.satisfies(server.version, '>=17')) return fn;
+
+  return function (request, reply) {
+    var p = new Promise(function (resolve, reject) {
+      resolve(fn(request));
+    });
+    p.then(reply, reply);
+  };
+}
+
+function startServer() {
+  if (semver.satisfies(server.version, '>=17')) return server.start();
+
+  return new Promise(function (resolve, reject) {
+    server.start(function (err) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+const server = hapi.server({ port: 3000 });
+server.route({
+  method: 'POST',
+  path: '/hello/{name}',
+  handler: handler(function (request) {
+    return { hello: request.params.name };
+  }),
+});
+server.route({
+  method: 'GET',
+  path: '/error',
+  handler: handler(function (request) {
+    const customError = new Error('custom request error');
+
+    request.log(['elastic-apm', 'error'], customError);
+
+    const stringError = 'custom error';
+
+    request.log(['elastic-apm', 'error'], stringError);
+
+    const objectError = {
+      error: 'I forgot to turn this into an actual Error',
+    };
+
+    request.log(['elastic-apm', 'error'], objectError);
+
+    throw new Error('foo');
+  }),
+});
+server.route({
+  method: 'GET',
+  path: '/captureError',
+  handler: handler(function (request) {
+    agent.captureError(new Error());
+    return '';
+  }),
+});
+
+async function main() {
+  await startServer();
+
+  const customError = new Error('custom error');
+
+  server.log(['error'], customError);
+
+  const stringError = 'custom error';
+
+  server.log(['error'], stringError);
+
+  const objectError = {
+    error: 'I forgot to turn this into an actual Error',
+  };
+
+  server.log(['error'], objectError);
+
+  // Do a POST to test `captureBody`, wait for response, then exit.
+  const port = server.info.port;
+
+  await new Promise((resolve) => {
+    const data = JSON.stringify({ foo: 'bar' });
+    const req = http.request(
+      {
+        method: 'POST',
+        hostname: '127.0.0.1',
+        port,
+        path: '/hello/bob',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data),
+        },
+      },
+      function (res) {
+        console.log('client response:', res.statusCode, res.headers);
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          console.log('body:', body);
+          resolve();
+        });
+      },
+    );
+    req.write(data);
+    req.end();
+  });
+
+  await new Promise((resolve) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        hostname: '127.0.0.1',
+        port,
+        path: '/error',
+      },
+      function (res) {
+        console.log('client response:', res.statusCode, res.headers);
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          console.log('body:', body);
+          resolve();
+        });
+      },
+    );
+    req.end();
+  });
+
+  await new Promise((resolve) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        hostname: '127.0.0.1',
+        port,
+        path: '/captureError?foo=bar',
+      },
+      function (res) {
+        console.log('client response:', res.statusCode, res.headers);
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          console.log('body:', body);
+          resolve();
+        });
+      },
+    );
+    req.end();
+  });
+
+  server.stop();
+}
+
+main();

--- a/test/instrumentation/modules/fixtures/use-hapi.mjs
+++ b/test/instrumentation/modules/fixtures/use-hapi.mjs
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+// Usage:
+//    node --experimental-loader=./loader.mjs --require=./start.js test/instrumentation/modules/fixtures/use-hapi.mjs
+
+import http from 'http';
+import assert from 'assert';
+import semver from 'semver';
+
+import agent from '../../../../index.js';
+
+import hapi, {
+  server as importServer,
+  Server as importServerAlias,
+} from '@hapi/hapi';
+
+// This assert ensures that this import-style works as well:
+//    import { server } from '@hapi/hapi'
+assert(hapi.server === importServer, 'named export server is correct');
+assert(hapi.Server === importServerAlias, 'named export Server is correct');
+
+function handler(fn) {
+  if (semver.satisfies(server.version, '>=17')) return fn;
+
+  return function (request, reply) {
+    var p = new Promise(function (resolve, reject) {
+      resolve(fn(request));
+    });
+    p.then(reply, reply);
+  };
+}
+
+function startServer() {
+  if (semver.satisfies(server.version, '>=17')) return server.start();
+
+  return new Promise(function (resolve, reject) {
+    server.start(function (err) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+const server = hapi.server({ port: 3000 });
+server.route({
+  method: 'POST',
+  path: '/hello/{name}',
+  handler: handler(function (request) {
+    return { hello: request.params.name };
+  }),
+});
+server.route({
+  method: 'GET',
+  path: '/error',
+  handler: handler(function (request) {
+    const customError = new Error('custom request error');
+
+    request.log(['elastic-apm', 'error'], customError);
+
+    const stringError = 'custom error';
+
+    request.log(['elastic-apm', 'error'], stringError);
+
+    const objectError = {
+      error: 'I forgot to turn this into an actual Error',
+    };
+
+    request.log(['elastic-apm', 'error'], objectError);
+
+    throw new Error('foo');
+  }),
+});
+server.route({
+  method: 'GET',
+  path: '/captureError',
+  handler: handler(function (request) {
+    agent.captureError(new Error());
+    return '';
+  }),
+});
+
+async function main() {
+  await startServer();
+
+  const customError = new Error('custom error');
+
+  server.log(['error'], customError);
+
+  const stringError = 'custom error';
+
+  server.log(['error'], stringError);
+
+  const objectError = {
+    error: 'I forgot to turn this into an actual Error',
+  };
+
+  server.log(['error'], objectError);
+
+  // Do a POST to test `captureBody`, wait for response, then exit.
+  const port = server.info.port;
+
+  await new Promise((resolve) => {
+    const data = JSON.stringify({ foo: 'bar' });
+    const req = http.request(
+      {
+        method: 'POST',
+        hostname: '127.0.0.1',
+        port,
+        path: '/hello/bob',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data),
+        },
+      },
+      function (res) {
+        console.log('client response:', res.statusCode, res.headers);
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          console.log('body:', body);
+          resolve();
+        });
+      },
+    );
+    req.write(data);
+    req.end();
+  });
+
+  await new Promise((resolve) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        hostname: '127.0.0.1',
+        port,
+        path: '/error',
+      },
+      function (res) {
+        console.log('client response:', res.statusCode, res.headers);
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          console.log('body:', body);
+          resolve();
+        });
+      },
+    );
+    req.end();
+  });
+
+  await new Promise((resolve) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        hostname: '127.0.0.1',
+        port,
+        path: '/captureError?foo=bar',
+      },
+      function (res) {
+        console.log('client response:', res.statusCode, res.headers);
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          console.log('body:', body);
+          resolve();
+        });
+      },
+    );
+    req.end();
+  });
+
+  server.stop();
+}
+
+main();


### PR DESCRIPTION
<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->
Similarly to what #3381 did, I added ESM support for hapi.

It seems many tests are migrating to `runTestFixtures`, so I followed that while trying to preserve the spirit of previous tests, hopefully it covers as much.

I had some problems with the Windows CI when combined with ESM, I activated debugging for require-in-the-middle, there were traces up to hapi's `lib/server.js`, but I never saw `lib/index.js` in those traces, so I'm not sure what's happening there, it doesn't seem related to my changes.

I guess this contributes a bit to #3445, I don't see the point of adding hapi (unscoped) support since it's been deprecated a very long while ago.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [X] Update documentation
- [ ] Add release notes to `docs/release-notes/index.md`
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
