### PR TITLE
chore: add `koa-router`, `redis` and `next` to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,9 @@ updates:
       - dependency-name: "rimraf" # rimraf@5 min is 14.20, we need >=14.17; rimraf@6 dropped 14, 16, 18
         update-types: ["version-update:semver-major"]
       # Packages whose newer versions are not supported by the agent
-      - dependency-name: "redis" # support is >=2.0.0 <5
+      - dependency-name: "koa-router" # support is >=5.2.0 <14.0.0
       - dependency-name: "next" # support is >=12.0.0 <13.3.0
+      - dependency-name: "redis" # support is >=2.0.0 <5
     groups:
       aws-sdk:
         dependency-type: "development"


### PR DESCRIPTION
We often get dependabot PRs trying to update these packages to the current major version. Such versions are not supported by the agent. This PR adds a couple of ignore rules to reduce the noise in PR list.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Update dependabot rules
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
