### PR TITLE
Add cooldown for npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 10
     ignore:
       # For mimic-response, ignore all versions https://github.com/elastic/apm-agent-nodejs/pull/3349#issuecomment-1549517238
@@ -63,7 +63,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -71,7 +71,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -79,7 +79,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -87,7 +87,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -95,7 +95,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
@@ -103,7 +103,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 14
+      default-days: 14
     open-pull-requests-limit: 5
 
   # GitHub actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 10
     ignore:
       # For mimic-response, ignore all versions https://github.com/elastic/apm-agent-nodejs/pull/3349#issuecomment-1549517238
@@ -60,36 +62,48 @@ updates:
     directory: "/test/instrumentation/azure-functions/fixtures/azfunc3"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/test/instrumentation/azure-functions/fixtures/azfunc4"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/test/opentelemetry-bridge"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/test/opentelemetry-metrics/fixtures"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/examples/opentelemetry-bridge"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/examples/opentelemetry-metrics"
     schedule:
       interval: "weekly"
+    cooldown:
+      days: 14
     open-pull-requests-limit: 5
 
   # GitHub actions


### PR DESCRIPTION
 Dependabot is configured per repo so we need your help to ensure that when “npm” is the package ecosystem that we set a cooldown to 14 days. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add release notes to `docs/release-notes/index.md`
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
