### PR TITLE
feat(lambda): Add 'nodejs22.x' to the set of 'compatible runtimes' for our Lambda layers

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -61,7 +61,7 @@ publish: validate-layer-name validate-aws-default-region
 		--layer-name "$(ELASTIC_LAYER_NAME)" \
 		--description "AWS Lambda Extension Layer for the Elastic APM Node.js Agent" \
 		--license "Apache-2.0" \
-		--compatible-runtimes nodejs20.x nodejs18.x nodejs16.x nodejs14.x \
+		--compatible-runtimes nodejs22.x nodejs20.x nodejs18.x nodejs16.x nodejs14.x \
 		--zip-file "fileb://./$(AWS_FOLDER)/elastic-apm-node-lambda-layer-$(GITHUB_REF_NAME).zip"
 
 # Grant public access to the given LAYER in the given AWS region


### PR DESCRIPTION
Note that my understanding is that the 'compatible runtimes' for Lambda layers is
advisory only. In other words, our Lambda layers before this *will work* with
an AWS Lambda that uses Node.js 22, but the AWS Console user interface just
doesn't list 'nodejs22.x' as compatible.

---


Reviewer note: I'll add a changelog entry on the [current release PR](https://github.com/elastic/apm-agent-nodejs/pull/4794) after this is merged.