### PR TITLE
tests: skip ioredis@4.19.0 in TAV tests

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -67,21 +67,18 @@ redis:
       - node test/instrumentation/modules/redis-disabled.test.js
       - node test/instrumentation/modules/redis4-legacy.test.js
 
-# We want these version ranges:
-#   # v3.1.3 is broken in older versions of Node because of https://github.com/luin/ioredis/commit/d5867f7c7f03a770a8c0ca5680fdcbfcaf8488e7
-#   versions: '>=2 <3.1.3 || >3.1.3 <4'
-#   versions: '^4.0.0'
-# However, there are a *lot* of ioredis releases, so we statically list a
-# subset (the first, plus then the latest in each major.minor).
 ioredis:
   - versions:
       mode: latest-minors
       include: '>=2.0.0 <4'
+      # v3.1.3 is broken in older versions of Node because of https://github.com/luin/ioredis/commit/d5867f7c7f03a770a8c0ca5680fdcbfcaf8488e7
+      exclude: '3.1.3'
     commands: node test/instrumentation/modules/ioredis.test.js
   - versions:
-      # Test v4.0.0, latest v4 and 5 versions in between.
       mode: max-7
       include: '>=4.0.0 <5'
+      # v4.19.0 is broken (https://github.com/redis/ioredis/issues/1215)
+      exclude: '4.19.0'
     commands: node test/instrumentation/modules/ioredis.test.js
   - versions:
       mode: latest-minors


### PR DESCRIPTION
Fixes: https://github.com/elastic/apm-agent-nodejs/issues/4796
