### PR TITLE
Nit typo fixes in release notes

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -71,8 +71,8 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ### Features and enhancements [4-11-1-features-enhancements]
 
-* Update base image of alpine in `Dockerfile` to version `3.21.3`. ([#4465](https://github.com/elastic/apm-agent-nodejs/pulls/4465))
-* Test FIPS 140 compliance. ([#4441](https://github.com/elastic/apm-agent-nodejs/pulls/4441))
+* Update base image of alpine in `Dockerfile` to version `3.21.3`. ([#4465](https://github.com/elastic/apm-agent-nodejs/pull/4465))
+* Test FIPS 140 compliance. ([#4441](https://github.com/elastic/apm-agent-nodejs/pull/4441))
 
 ### Fixes [4-11-1-fixes]
 


### PR DESCRIPTION
Just fixes up 2 links in the release notes having the wrong link

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [ ] Implement code
- [ ] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [x] Add release notes to `docs/release-notes/index.md`
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
