### PR TITLE
chore(deps): bump @opentelemetry deps to v2.x

### DIFF
--- a/examples/opentelemetry-metrics/package.json
+++ b/examples/opentelemetry-metrics/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@opentelemetry/api": "^1.4.1",
-    "@opentelemetry/exporter-prometheus": ">=0.41.0 <2",
-    "@opentelemetry/sdk-metrics": "^1.12.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-prometheus": ">=0.200.0",
+    "@opentelemetry/sdk-metrics": "^2.0.0",
     "elastic-apm-node": "file:../.."
   }
 }

--- a/examples/opentelemetry-metrics/use-otel-metrics-sdk.js
+++ b/examples/opentelemetry-metrics/use-otel-metrics-sdk.js
@@ -29,26 +29,28 @@ const { performance } = require('perf_hooks');
 const otel = require('@opentelemetry/api');
 const {
   MeterProvider,
-  View,
-  ExplicitBucketHistogramAggregation,
+  AggregationType,
 } = require('@opentelemetry/sdk-metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 
 const exporter = new PrometheusExporter({ host: '127.0.0.1', port: 3001 });
 const meterProvider = new MeterProvider({
   views: [
-    new View({
+    {
       instrumentName: 'latency',
-      aggregation: new ExplicitBucketHistogramAggregation(
-        // Use the same default buckets as in `prom-client` for comparison.
-        // This is to demonstrate using a View. The default buckets used by the
-        // APM agent would suffice as well.
-        [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
-      ),
-    }),
+      aggregation: {
+        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+        options: {
+          // Use the same default buckets as in `prom-client` for comparison.
+          // This is to demonstrate using a View. The default buckets used by the
+          // APM agent would suffice as well.
+          boundaries: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+        },
+      },
+    },
   ],
+  readers: [exporter],
 });
-meterProvider.addMetricReader(exporter);
 otel.metrics.setGlobalMeterProvider(meterProvider);
 console.log('Prometheus metrics at http://127.0.0.1:3001/metrics');
 

--- a/lib/instrumentation/modules/@opentelemetry/sdk-metrics.js
+++ b/lib/instrumentation/modules/@opentelemetry/sdk-metrics.js
@@ -40,7 +40,7 @@ module.exports = function (mod, agent, { version, enabled }) {
   // Minimum supported version is 1.11.0 because that version included the fix
   // for side-effects from having two MetricReaders.
   // https://github.com/open-telemetry/opentelemetry-js/issues/3664
-  if (!semver.satisfies(version, '>=1.11.0 <2', { includePrerelease: true })) {
+  if (!semver.satisfies(version, '>=2.0.0 <3', { includePrerelease: true })) {
     log.debug(
       '@opentelemetry/sdk-metrics@%s is not supported, skipping @opentelemetry/sdk-metrics instrumentation',
       version,
@@ -56,15 +56,13 @@ module.exports = function (mod, agent, { version, enabled }) {
   }
 
   class ApmMeterProvider extends mod.MeterProvider {
-    constructor(...args) {
-      super(...args);
-      // We create a new metric reader for each new MeterProvider instance,
-      // because they shutdown independently -- they cannot be shared between
-      // multiple MeterProviders.
+    constructor(options = {}) {
+      const readers = options.readers ? [...options.readers] : [];
+      readers.push(createOTelMetricReader(agent));
       log.trace(
         '@opentelemetry/sdk-metrics ins: create Elastic APM MetricReader',
       );
-      this.addMetricReader(createOTelMetricReader(agent));
+      super({ ...options, readers });
     }
   }
   Object.defineProperty(mod, 'MeterProvider', {

--- a/lib/opentelemetry-metrics/ElasticApmMetricExporter.js
+++ b/lib/opentelemetry-metrics/ElasticApmMetricExporter.js
@@ -8,11 +8,8 @@ const { ExportResultCode } = require('@opentelemetry/core');
 const {
   AggregationTemporality,
   InstrumentType,
-  ExplicitBucketHistogramAggregation,
-  SumAggregation,
-  LastValueAggregation,
-  DropAggregation,
   DataPointType,
+  AggregationType,
 } = require('@opentelemetry/sdk-metrics');
 const { LRUCache } = require('lru-cache');
 
@@ -96,12 +93,15 @@ function fillIntakeHistogramSample(sample, otelDataPoint) {
 class ElasticApmMetricExporter {
   constructor(agent) {
     this._agent = agent;
-    this._histogramAggregation = new ExplicitBucketHistogramAggregation(
-      this._agent._conf.customMetricsHistogramBoundaries,
-    );
-    this._sumAggregation = new SumAggregation();
-    this._lastValueAggregation = new LastValueAggregation();
-    this._dropAggregation = new DropAggregation();
+    this._histogramAggregation = {
+      type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+      options: {
+        boundaries: this._agent._conf.customMetricsHistogramBoundaries,
+      },
+    };
+    this._sumAggregation = { type: AggregationType.SUM };
+    this._lastValueAggregation = { type: AggregationType.LAST_VALUE };
+    this._dropAggregation = { type: AggregationType.DROP };
     this._attrDropWarnCache = new LRUCache({ max: 1000 });
     this._dataPointTypeDropWarnCache = new LRUCache({ max: 1000 });
   }

--- a/lib/opentelemetry-metrics/index.js
+++ b/lib/opentelemetry-metrics/index.js
@@ -38,8 +38,9 @@ function createOTelMetricReader(agent) {
 }
 
 function createOTelMeterProvider(agent) {
-  const meterProvider = new MeterProvider();
-  meterProvider.addMetricReader(createOTelMetricReader(agent));
+  const meterProvider = new MeterProvider({
+    readers: [createOTelMetricReader(agent)],
+  });
   return meterProvider;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.11.0",
-        "@opentelemetry/sdk-metrics": "^1.12.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
         "after-all-results": "^2.0.0",
         "agentkeepalive": "^4.2.1",
         "async-value-promise": "^1.1.1",
@@ -4403,30 +4403,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@elastic/transport/node_modules/@opentelemetry/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@elastic/transport/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-      "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@elastic/transport/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5430,53 +5406,57 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1"
-      },
-      "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
+      "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -20129,21 +20109,6 @@
         "undici": "^7.16.0"
       },
       "dependencies": {
-        "@opentelemetry/core": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-          "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/semantic-conventions": "^1.29.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-          "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
-          "dev": true
-        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -20978,35 +20943,35 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "requires": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
+      "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "requires": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="
     },
     "@pinojs/redact": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
   "homepage": "https://github.com/elastic/apm-agent-nodejs",
   "dependencies": {
     "@elastic/ecs-pino-format": "^1.5.0",
-    "@opentelemetry/api": "^1.4.1",
-    "@opentelemetry/core": "^1.11.0",
-    "@opentelemetry/sdk-metrics": "^1.12.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^2.0.0",
+    "@opentelemetry/sdk-metrics": "^2.0.0",
     "after-all-results": "^2.0.0",
     "agentkeepalive": "^4.2.1",
     "async-value-promise": "^1.1.1",

--- a/test/opentelemetry-metrics/fixtures/package-lock.json
+++ b/test/opentelemetry-metrics/fixtures/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/exporter-prometheus": ">=0.41.2 <2",
-        "@opentelemetry/sdk-metrics": "^1.30.0"
+        "@opentelemetry/exporter-prometheus": ">=0.200.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -22,70 +22,74 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.2.tgz",
-      "integrity": "sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==",
+      "version": "0.211.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.211.0.tgz",
+      "integrity": "sha512-cD0WleEL3TPqJbvxwz5MVdVJ82H8jl8mvMad4bNU24cB5SH2mRW5aMLDTuV4614ll46R//R3RMmci26mc2L99g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-metrics": "1.30.1"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0",
+        "@opentelemetry/sdk-metrics": "2.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1"
-      },
-      "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
+      "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -98,45 +102,45 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/exporter-prometheus": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.2.tgz",
-      "integrity": "sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==",
+      "version": "0.211.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.211.0.tgz",
+      "integrity": "sha512-cD0WleEL3TPqJbvxwz5MVdVJ82H8jl8mvMad4bNU24cB5SH2mRW5aMLDTuV4614ll46R//R3RMmci26mc2L99g==",
       "requires": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/sdk-metrics": "1.30.1"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0",
+        "@opentelemetry/sdk-metrics": "2.5.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "requires": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
+      "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "requires": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1"
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="
     }
   }
 }

--- a/test/opentelemetry-metrics/fixtures/package.json
+++ b/test/opentelemetry-metrics/fixtures/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/exporter-prometheus": ">=0.41.2 <2",
-    "@opentelemetry/sdk-metrics": "^1.30.0"
+    "@opentelemetry/exporter-prometheus": ">=0.200.0",
+    "@opentelemetry/sdk-metrics": "^2.0.0"
   }
 }

--- a/test/opentelemetry-metrics/fixtures/use-just-otel-sdk.js
+++ b/test/opentelemetry-metrics/fixtures/use-just-otel-sdk.js
@@ -16,24 +16,26 @@
 
 const {
   MeterProvider,
-  View,
-  ExplicitBucketHistogramAggregation,
+  AggregationType,
 } = require('@opentelemetry/sdk-metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 
 const exporter = new PrometheusExporter({ host: '127.0.0.1' });
 const meterProvider = new MeterProvider({
   views: [
-    new View({
+    {
       instrumentName: 'test_histogram_viewbuckets',
-      aggregation: new ExplicitBucketHistogramAggregation(
-        // Use the same default buckets as in `prom-client`.
-        [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
-      ),
-    }),
+      aggregation: {
+        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+        options: {
+          // Use the same default buckets as in `prom-client`.
+          boundaries: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+        },
+      },
+    },
   ],
+  readers: [exporter],
 });
-meterProvider.addMetricReader(exporter);
 
 const meter = meterProvider.getMeter('test-meter');
 

--- a/test/opentelemetry-metrics/fixtures/use-otel-api-with-registered-meter-provider.js
+++ b/test/opentelemetry-metrics/fixtures/use-otel-api-with-registered-meter-provider.js
@@ -23,8 +23,9 @@ const { MeterProvider } = require('@opentelemetry/sdk-metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 
 const exporter = new PrometheusExporter({ host: '127.0.0.1' });
-const meterProvider = new MeterProvider();
-meterProvider.addMetricReader(exporter);
+const meterProvider = new MeterProvider({
+  readers: [exporter],
+});
 otel.metrics.setGlobalMeterProvider(meterProvider);
 
 const meter = otel.metrics.getMeter('test-meter');


### PR DESCRIPTION
# Description
Update OpenTelemetry dependencies to v2.x and adapt code to the breaking API changes.

## Summary
- Update `@opentelemetry/sdk-metrics` from v1.x to v2.x
- Update `@opentelemetry/core` to v2.x
- Migrate from class-based aggregations to object-based `AggregationOption` API
- Replace `MeterProvider.addMetricReader()` with constructor-based reader registration
- Update test fixtures and examples to use v2.x API
- Update documentation to reflect new API usage

## Breaking Changes in OTel v2.x Addressed
1. **`MeterProvider.addMetricReader()` removed** - Now pass readers via constructor options
2. **Aggregation classes removed** (`SumAggregation`, `LastValueAggregation`, etc.) - Now use object-based `{ type: AggregationType.SUM }` format
3. **Minimum Node.js version** raised to `^18.19.0 || >=20.6.0` in OTel SDK

## Checklist
- [x] Implement code
~~- [ ] Add tests~~
~~- [ ] Update TypeScript typings~~
- [x] Update documentation
~~- [ ] Add release notes to `docs/release-notes/index.md`~~
- [x] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
