### PR TITLE
test(knex): fix TAV tests for knex

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -160,7 +160,9 @@ knex:
   - versions: '1.0.7 || ^2.5.1' # latest majors subset of '>=1 <3'
     node: '>=12.0.0'
     commands: node test/instrumentation/modules/pg/knex.test.js
-  - versions: '^3.0.1'
+  - versions:
+      mode: max-4
+      include: '^3.0.1'
     node: '>=16'
     commands: node test/instrumentation/modules/pg/knex.test.js
 

--- a/test/instrumentation/modules/pg/knex-no-span-stack-traces.test.js
+++ b/test/instrumentation/modules/pg/knex-no-span-stack-traces.test.js
@@ -25,7 +25,7 @@ require('../../../..').start({
   spanStackTraceMinDuration: -1,
 });
 
-var knexVersion = require('knex/package').version;
+var knexVersion = require('knex/package.json').version;
 var semver = require('semver');
 
 // knex 0.18.0 min supported node is v8, knex 0.21.0 min supported node is v10

--- a/test/instrumentation/modules/pg/knex.test.js
+++ b/test/instrumentation/modules/pg/knex.test.js
@@ -26,7 +26,7 @@ var agent = require('../../../..').start({
   spanCompressionEnabled: false,
 });
 
-var knexVersion = require('knex/package').version;
+var knexVersion = require('knex/package.json').version;
 var semver = require('semver');
 
 if (


### PR DESCRIPTION
knex version 3.2.0 to 3.2.7 (inclusive) includes an "exports"
in package.json that broke deep-package imports. That was reverted
in 3.2.8, because apparently there are some use cases for knex
users doing deep package imports.

In our case, we were doing `require('knex/package')` in tests only
for getting the package version. While the "exports" existed there
was a mapping for "./package.json", so the workaround for us is simple.

Refs: https://github.com/knex/knex/pull/6422

---

TAV tests for knex are failing on knex@3.2.7.
E.g. https://github.com/elastic/apm-agent-nodejs/actions/runs/25679762074/job/75392718232#step:3:307

```
node_tests-1  | -- installing ["knex@3.2.7"]
node_tests-1  | -- running test "node test/instrumentation/modules/pg/knex.test.js" with knex (env: {})
node_tests-1  | node:internal/modules/cjs/loader:657
node_tests-1  |       throw e;
node_tests-1  |       ^
node_tests-1  | 
node_tests-1  | Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package' is not defined by "exports" in /app/node_modules/knex/package.json
node_tests-1  |     at exportsNotFound (node:internal/modules/esm/resolve:314:10)
node_tests-1  |     at packageExportsResolve (node:internal/modules/esm/resolve:661:9)
```

Local repro:

```
npm run docker:start postgres
TAV=knex npx tav
```
