### PR TITLE
fix(http): ensure URL built for HTTP context info on the span correctly uses brackets for IPv6 hostnames

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -37,6 +37,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 * Fix missing AWS SDK Spans for `@smithy/smithy-client` >= 4.13.0.
 
+* Fix the adding of destination context to spans for outgoing HTTP requests to *an IPv6 host*. ([#5127](https://github.com/elastic/apm-agent-nodejs/pull/5127))
 
 ### Chores [4-16-0-chores]
 

--- a/examples/trace-elasticsearch.js
+++ b/examples/trace-elasticsearch.js
@@ -72,7 +72,7 @@ async function main() {
 
   // Example aborting requests using AbortController.
   const t3 = apm.startTransaction('t3');
-  const ac = new AbortController(); // eslint-disable-line no-undef
+  const ac = new AbortController();
   setImmediate(() => {
     ac.abort();
   });

--- a/examples/trace-http-ipv6.js
+++ b/examples/trace-http-ipv6.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node --unhandled-rejections=strict
+
+/*
+ * Copyright Elasticsearch B.V. and other contributors where applicable.
+ * Licensed under the BSD 2-Clause License; you may not use this file except in
+ * compliance with the BSD 2-Clause License.
+ */
+
+// A small example showing Elastic APM tracing of the core 'http' module,
+// using IPv6.
+
+const apm = require('../').start({
+  serviceName: 'example-trace-http-ipv6',
+  // 'usePathAsTransactionName' can be useful when not using a web framework
+  // with a router. See the following for details:
+  // https://www.elastic.co/guide/en/apm/agent/nodejs/current/custom-stack.html#custom-stack-route-naming
+  usePathAsTransactionName: true,
+});
+
+const http = require('http');
+
+const server = http.createServer(function onRequest(req, res) {
+  console.log('incoming request: %s %s %s', req.method, req.url, req.headers);
+
+  req.resume();
+
+  req.on('end', function () {
+    const resBody = 'pong';
+    res.writeHead(200, {
+      server: 'example-trace-http-ipv6',
+      'content-type': 'text/plain',
+      'content-length': Buffer.byteLength(resBody),
+    });
+    res.end(resBody);
+  });
+});
+
+server.listen(3000, '::1', function () {
+  const trans = apm.startTransaction('manual');
+  const clientReq = http.request(
+    'http://user:pass@[::1]:3000/',
+    function (clientRes) {
+      console.log(
+        'client response: %s %s',
+        clientRes.statusCode,
+        clientRes.headers,
+      );
+      const chunks = [];
+      clientRes.on('data', function (chunk) {
+        chunks.push(chunk);
+      });
+      clientRes.on('end', function () {
+        const body = chunks.join('');
+        console.log('client response body: %j', body);
+        trans.end();
+        server.close();
+      });
+    },
+  );
+  clientReq.end();
+});

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -350,8 +350,9 @@ exports.traceOutgoingRequest = function (agent, moduleName, method) {
             span._setDestinationContext(getHTTPDestination(url));
           } catch (e) {
             agent.logger.error(
-              'Could not set destination context: %s',
+              'Could not set destination context: err=%s url=%s',
               e.message,
+              url,
             );
           }
         }
@@ -411,8 +412,19 @@ function getUrlFromRequestAndOptions(req, options, fallbackProtocol) {
 
   const port = options.port ? `:${options.port}` : '';
   // req.host and req.protocol are node versions v14.5.0/v12.19.0 and later
-  const host = req.host || options.hostname || options.host || 'localhost';
+  let host = req.host || options.hostname || options.host || 'localhost';
   const protocol = req.protocol || req.agent.protocol || fallbackProtocol;
+
+  // An IPv6 host must be enclosed in square brackets, per
+  // https://tools.ietf.org/html/rfc3986#section-3.2.2
+  const posColon = host.indexOf(':');
+  if (
+    posColon !== -1 &&
+    host.includes(':', posColon + 1) &&
+    host.charCodeAt(0) !== 91 /* '[' */
+  ) {
+    host = `[${host}]`;
+  }
 
   return `${protocol}//${host}${port}${req.path}`;
 }

--- a/test/instrumentation/modules/@elastic/elasticsearch.test.js
+++ b/test/instrumentation/modules/@elastic/elasticsearch.test.js
@@ -779,7 +779,7 @@ if (semver.gte(process.version, '10.0.0')) {
       agent.startTransaction('myTrans');
 
       const client = new es.Client(clientOpts);
-      // eslint-disable-next-line no-undef
+
       const ac = new AbortController();
       setImmediate(() => {
         ac.abort();

--- a/test/instrumentation/modules/http/request-to-url.test.js
+++ b/test/instrumentation/modules/http/request-to-url.test.js
@@ -159,7 +159,7 @@ tape('getUrlFromRequestAndOptions tests', function (suite) {
   suite.test('ipv6', function (t) {
     const options = {
       hostname: '::1',
-      port: 1234
+      port: 1234,
     };
     const req = requestFromOptions(options);
 

--- a/test/instrumentation/modules/http/request-to-url.test.js
+++ b/test/instrumentation/modules/http/request-to-url.test.js
@@ -155,5 +155,18 @@ tape('getUrlFromRequestAndOptions tests', function (suite) {
     t.equals(url, 'http://localhost/get', 'protocol falls back correctly');
     t.end();
   });
+
+  suite.test('ipv6', function (t) {
+    const options = {
+      hostname: '::1',
+      port: 1234
+    };
+    const req = requestFromOptions(options);
+
+    const url = getUrlFromRequestAndOptions(req, options);
+    t.equals(url, 'http://[::1]:1234/');
+    t.end();
+  });
+
   suite.end();
 });

--- a/test/instrumentation/modules/undici/undici.test.js
+++ b/test/instrumentation/modules/undici/undici.test.js
@@ -218,7 +218,7 @@ if (global.AbortController) {
     const aTrans = apm.startTransaction('aTransName', 'manual');
 
     const url = origin + '/ping';
-    const ac = new AbortController(); // eslint-disable-line no-undef
+    const ac = new AbortController();
     setTimeout(() => {
       ac.abort();
     }, 5); // Abort before the ~10ms expected response time of the request.


### PR DESCRIPTION
When an outgoing HTTP request was made to an IPv6 host, the tracing
would mostly work, but the destination context would not be set on the
span data. Instead, the following would be logged:

    "log.level":"error","message":"Could not set destination context: Invalid URL"
    "log.level":"debug","message":"cannot set \"service.target.name\": TypeError: Invalid URL (ignoring)"

This destination context included the
`span.destination.service.resource` and `service.target.name` attributes
(after ingest). The former is can be used to build the service map.
