### PR TITLE
release 4.17.0

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -26,8 +26,15 @@ To check for security updates, go to [Security announcements for the Elastic sta
 %
 % ### Fixes [next-fixes]
 
-## 4.16.0 [4-16-0]
+## 4.17.0 [4-17-0]
 **Release date:** Jun 30, 2026
+
+### Chores [4-17-0-chores]
+
+* Fix an issue publishing AWS Lambda layers that broke the v4.16.0 release.
+
+## 4.16.0 [4-16-0]
+**Release date:** N/A (release failed)
 
 ### Fixes [4-16-0-fixes]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-apm-node",
-      "version": "4.16.0",
+      "version": "4.17.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-apm-node",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "The official Elastic APM agent for Node.js",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Re-attempt to release after 4.16.0 release failed.
#5129 fixes an issue that broke the release.