### PR TITLE
fix(release): release process was broken by recent change removing .npmrc file

### DIFF
--- a/dev-utils/make-distribution.sh
+++ b/dev-utils/make-distribution.sh
@@ -41,13 +41,11 @@ mkdir -p nodejs/node_modules/elastic-apm-node
     tar --strip-components=1 -xf elastic-apm-node-*.tgz;
     rm elastic-apm-node-*.tgz;
     cp $TOP/package-lock.json ./;
-    cp $TOP/.npmrc ./;
     # Then install the "package-lock.json"-dictated dependencies (excluding
     # devDependencies).  Use '--ignore-scripts' to have confidence no code but
     # ours and npm's is running.
     npm ci --omit=dev --ignore-scripts;
-    rm package-lock.json;
-    rm .npmrc)
+    rm package-lock.json)
 
 # Generate a NOTICE file including the licenses of all included deps.
 NOTICE=nodejs/node_modules/elastic-apm-node/NOTICE.md


### PR DESCRIPTION
Refs: #5178

---

The release process fail was in `make-distribution.sh`.
E.g. from https://github.com/elastic/apm-agent-nodejs/actions/runs/31650818983/job/94294550321

```
Run make -C .ci dist
make: Entering directory '/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/.ci'
../dev-utils/make-distribution.sh
elastic-apm-node-4.18.0.tgz
cp: cannot stat '/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/.npmrc': No such file or directory
make: *** [Makefile:20: dist] Error 1
make: Leaving directory '/home/runner/work/apm-agent-nodejs/apm-agent-nodejs/.ci'
Error: Process completed with exit code 2.
```
