### PR TITLE
chore: update TAV tests for knex

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -142,19 +142,13 @@ bluebird:
     - node test/instrumentation/modules/bluebird/cancel.test.js
 
 # knex (https://github.com/knex/knex/blob/master/UPGRADING.md)
-# - knex 0.18.0 min supported node is v8
 # - knex 0.21.0 min supported node is v10
 # - knex 1.0.0 min supported node is v12
 # - knex 3.0.0 min supported node is v16
 knex:
-  # Latest 0.16 release was in 2019, therefore only test first and last in this range.
-  - versions: '0.10.0 || 0.16.5'
-    commands: node test/instrumentation/modules/pg/knex.test.js
-  # Latest 0.20.x release was 2020-04, there only test first and last in this range.
-  - versions: '0.17.0 || 0.20.15'
-    node: '>=8.6.0'
-    commands: node test/instrumentation/modules/pg/knex.test.js
   - versions: '0.21.21 || ^0.95.15' # latest majors subset of '>=0.21 <1'
+    peerDependencies:
+      - mysql2@^2.1.0
     node: '>=10.22.0'
     commands: node test/instrumentation/modules/pg/knex.test.js
   - versions: '1.0.7 || ^2.5.1' # latest majors subset of '>=1 <3'

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -26,15 +26,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 %
 % ### Fixes [next-fixes]
 
-## Next [next]
-**Release date:** Month day, year
-
-### Features and enhancements [next-features-enhancements]
-
-### Chores [next-chores]
-
-* Update TAV tests for `knex` module to avoid peer dependencies problems. [#5197](https://github.com/elastic/apm-agent-nodejs/pull/5197)
-
 ## 4.18.0 [4-18-0]
 **Release date:** July 9, 2026
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -26,6 +26,15 @@ To check for security updates, go to [Security announcements for the Elastic sta
 %
 % ### Fixes [next-fixes]
 
+## Next [next]
+**Release date:** Month day, year
+
+### Features and enhancements [next-features-enhancements]
+
+### Chores [next-chores]
+
+* Update TAV tests for `knex` module to avoid peer dependencies problems. [#5197](https://github.com/elastic/apm-agent-nodejs/pull/5197)
+
 ## 4.18.0 [4-18-0]
 **Release date:** July 9, 2026
 


### PR DESCRIPTION
Updates on database drivers broke TAV test for `knex` because of peer dependencies not ment. The following message is displayed

```
node_tests-1  | -- installing ["knex@0.21.21"]
node_tests-1  | -- error installing ["knex@0.21.21"] (npm error code ERESOLVE
node_tests-1  | npm error ERESOLVE could not resolve
node_tests-1  | npm error
node_tests-1  | npm error While resolving: knex@0.21.21
node_tests-1  | npm error Found: mysql2@3.22.3
node_tests-1  | npm error node_modules/mysql2
node_tests-1  | npm error   dev mysql2@"^3.22.3" from the root project
node_tests-1  | npm error
node_tests-1  | npm error Could not resolve dependency:
node_tests-1  | npm error peerOptional mysql2@"^2.1.0" from knex@0.21.21
node_tests-1  | npm error node_modules/knex
node_tests-1  | npm error   dev knex@"0.21.21" from the root project
node_tests-1  | npm error
node_tests-1  | npm error Conflicting peer dependency: mysql2@2.3.3
node_tests-1  | npm error node_modules/mysql2
node_tests-1  | npm error   peerOptional mysql2@"^2.1.0" from knex@0.21.21
node_tests-1  | npm error   node_modules/knex
node_tests-1  | npm error     dev knex@"0.21.21" from the root project
node_tests-1  | npm error
node_tests-1  | npm error Fix the upstream dependency conflict, or retry
node_tests-1  | npm error this command with --force or --legacy-peer-deps
node_tests-1  | npm error to accept an incorrect (and potentially broken) dependency resolution.
```

this PR adds the peer dependency needed to test version range `0.21.21 || ^0.95.15` and removes TAV entries for older versions (5y+) that were giving other kind of problems.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] update TAV
- [x] Add release notes to `docs/release-notes/index.md`
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
