### PR TITLE
chore: update TAV tests for mongodb-core

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -115,7 +115,7 @@ pg:
 mongodb-core:
   versions:
     mode: latest-minors
-    include: '>=1.2.19 <4'
+    include: '>=1.3.21 <4'
   commands: node test/instrumentation/modules/mongodb-core.test.js
 
 mongodb:


### PR DESCRIPTION
Similar to https://github.com/elastic/apm-agent-nodejs/pull/5197 but for `mongodb-core`. The new version range for the related TAV test only drops one version.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Update TAV tests
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
