### PR TITLE
test: fix dynamodb TAV tests

### DIFF
--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-dynamodb.js
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-dynamodb.js
@@ -77,7 +77,7 @@ async function useClientDynamoDB(dynamoDBClient, tableName) {
   let command;
   let data;
 
-  command = new ListTablesCommand();
+  command = new ListTablesCommand({});
   data = await dynamoDBClient.send(command);
   assert(
     apm.currentSpan === null,

--- a/test/instrumentation/modules/@aws-sdk/fixtures/use-client-dynamodb.mjs
+++ b/test/instrumentation/modules/@aws-sdk/fixtures/use-client-dynamodb.mjs
@@ -22,7 +22,7 @@ import assert from 'assert';
 
 async function useClientDynamoDB(dynamoDBClient, tableName) {
   // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/command/ListTablesCommand/
-  const command = new ListTablesCommand();
+  const command = new ListTablesCommand({});
   const data = await dynamoDBClient.send(command);
   assert(
     apm.currentSpan === null,


### PR DESCRIPTION
https://github.com/elastic/apm-agent-nodejs/pull/5049 fixed a bad `.tav.yml` configuration. Such configuration was using the wrong test file to test `@aws-sdk/client-dynamodb`

With the change the TAV action started to fail due to earlier versions missing the input in `ListTablesCommand`. See the [docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/command/ListTablesCommand/). It didn't fail in PRs because newer versions were defaulting to an empty object if input was undefined.

This PR updated the fixture files to pass the required parameter for older versions.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Update tests
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
