### PR TITLE
test: fix `@opentelemetry/api` TAV tests

### DIFF
--- a/test/opentelemetry-metrics/fixtures/.tav.yml
+++ b/test/opentelemetry-metrics/fixtures/.tav.yml
@@ -1,5 +1,10 @@
 "@opentelemetry/api":
-  versions: '>=1.3.0 <1.10.0'
-  node: '>=14.0.0'
-  commands:
-    - node ../fixtures.test.js
+  - versions: '>=1.3.0 <1.9.0'
+    peerDependencies: '@opentelemetry/sdk-metrics@1.30.1'
+    node: '>=14.0.0'
+    commands:
+      - node ../fixtures.test.js
+  - versions: '>=1.9.0 <1.10.0'
+    node: '>=14.0.0'
+    commands:
+      - node ../fixtures.test.js


### PR DESCRIPTION
peer dependencies in `@opentelemetry/metrics-sdk` was changed in https://github.com/open-telemetry/opentelemetry-js/pull/5254 to `"@opentelemetry/api": ">=1.9.0 <1.10.0"`

So when TAV tests try to install an API version prior to `1.9.0` in https://github.com/elastic/apm-agent-nodejs/tree/main/test/opentelemetry-metrics/fixtures it gives an install failure and TAV tests fail. This PR sets the right peer dependencies.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Update tests
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
