### PR TITLE
test: fix TAV tests for pg

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -87,25 +87,20 @@ ioredis:
 
 pg:
   # We want this version range:
-  #   versions: '>=4 <9'
-  # but test a subset to reduce the test matrix. The last 4.x release was in
-  # 2017, 5.x in 2017, 6.x in 2017, 7.x in 2020.
-  #
-  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  - versions: '4.0.0 || 4.5.7 || 5.2.1 || 6.4.2 || 7.18.2 || 8.0.3 || 8.1.0 || 8.2.2 || 8.3.3 || 8.4.2 || 8.5.1 || 8.6.0 || 8.7.3 || 8.8.0 || 8.9.0 || 8.10.0 || >8.10.0 <9'
-    node: '<14'
-    peerDependencies:
-      - knex@^0.20 # latest knex that supports back to node v8
+  #   versions: '>=8.0.3 <9' # Prior versions didn't work in Node.js 14
+  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
+  - versions:
+      mode: latest-minors
+      include: '>=8.0.3 <8.16.0'
+      node: '>=14'
     commands:
       - node test/instrumentation/modules/pg/pg.test.js
       - node test/instrumentation/modules/pg/knex.test.js
-  # We want this version range:
-  #   versions: '>=8.0.3 <9' # Prior versions didn't work in Node.js 14
-  # but only the latest MAJOR.MINOR.x to reduce the test matrix.
-  #
-  # Maintenance note: This should be updated for newer MAJOR.MINOR releases.
-  - versions: '8.0.3 || 8.1.0 || 8.2.2 || 8.3.3 || 8.4.2 || 8.5.1 || 8.6.0 || 8.7.3 || 8.8.0 || 8.9.0 || 8.10.0 || >8.10.0 <9'
-    node: '>=14'
+  - versions:
+      mode: latest-minors
+      # 8.16.1 set engines to nodejs v16
+      include: '>=8.16.0 <9'
+      node: '>=16'
     commands:
       - node test/instrumentation/modules/pg/pg.test.js
       - node test/instrumentation/modules/pg/knex.test.js

--- a/.tav.yml
+++ b/.tav.yml
@@ -92,7 +92,7 @@ pg:
   - versions:
       mode: latest-minors
       include: '>=8.0.3 <8.16.0'
-      node: '>=14'
+    node: '>=14'
     commands:
       - node test/instrumentation/modules/pg/pg.test.js
       - node test/instrumentation/modules/pg/knex.test.js
@@ -100,7 +100,7 @@ pg:
       mode: latest-minors
       # 8.16.1 set engines to nodejs v16
       include: '>=8.16.0 <9'
-      node: '>=16'
+    node: '>=16'
     commands:
       - node test/instrumentation/modules/pg/pg.test.js
       - node test/instrumentation/modules/pg/knex.test.js


### PR DESCRIPTION
`pg` removed compatibility code for versions lower than v16 in https://github.com/brianc/node-postgres/pull/3678

This PR tunes the `.tav.yml` file to skip testing some versions in nodejs v14

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [X] Update tests
- [X] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
